### PR TITLE
feat: support use as a library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Go workspace file
 go.work
+
+# binary
+bursa

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+# Determine root directory
+ROOT_DIR=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+# Gather all .go files for use in dependencies below
+GO_FILES=$(shell find $(ROOT_DIR) -name '*.go')
+
+# Gather list of expected binaries
+BINARIES=$(shell cd $(ROOT_DIR)/cmd && ls -1 | grep -v ^common)
+
+# Extract Go module name from go.mod
+GOMODULE=$(shell grep ^module $(ROOT_DIR)/go.mod | awk '{ print $$2 }')
+
+# Set version strings based on git tag and current ref
+GO_LDFLAGS=-ldflags "-X '$(GOMODULE)/internal/version.Version=$(shell git describe --tags --exact-match 2>/dev/null)' -X '$(GOMODULE)/internal/version.CommitHash=$(shell git rev-parse --short HEAD)'"
+
+.PHONY: build mod-tidy clean test
+
+# Alias for building program binary
+build: $(BINARIES)
+
+mod-tidy:
+	# Needed to fetch new dependencies and add them to go.mod
+	go mod tidy
+
+clean:
+	rm -f $(BINARIES)
+
+test: mod-tidy
+	go test -v ./...
+
+# Build our program binaries
+# Depends on GO_FILES to determine when rebuild is needed
+$(BINARIES): mod-tidy $(GO_FILES)
+	go build \
+		$(GO_LDFLAGS) \
+		-o $(@) \
+		./cmd/$(@)

--- a/cmd/bursa/main.go
+++ b/cmd/bursa/main.go
@@ -1,0 +1,21 @@
+// Copyright 2023 Blink Labs, LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "github.com/blinklabs-io/bursa"
+
+func main() {
+	bursa.Run()
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,44 @@
+// Copyright 2023 Blink Labs, LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/kelseyhightower/envconfig"
+)
+
+type Config struct {
+	Mnemonic string `envconfig:"MNEMONIC"`
+	Network  string `envconfig:"NETWORK"`
+}
+
+// We use a singleton for the config for convenience
+var globalConfig = Config{
+	Mnemonic: "",
+	Network:  "mainnet",
+}
+
+func GetConfig() *Config {
+	return &globalConfig
+}
+
+func LoadConfig() (*Config, error) {
+	if err := envconfig.Process("bursa", &globalConfig); err != nil {
+		return nil, fmt.Errorf("failed loading config from environment: %s", err)
+	}
+	return &globalConfig, nil
+}
+

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,31 @@
+// Copyright 2023 Blink Labs, LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"fmt"
+)
+
+// These are populated at build time
+var Version string
+var CommitHash string
+
+func GetVersionString() string {
+	if Version != "" {
+		return fmt.Sprintf("%s (commit %s)", Version, CommitHash)
+	} else {
+		return fmt.Sprintf("devel (commit %s)", CommitHash)
+	}
+}


### PR DESCRIPTION
Refactor a bit to support use as a library in other applications.

- Rename main package to `bursa`
- Move configuration items to internal/config and config package
- Support multiple addresses per account
- Replace main function with Run function and call it from new main
- Copy version package from blinklabs-io/snek without modification