### PR TITLE
feat(api): switch to net/http

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -29,7 +29,7 @@ const docTemplate = `{
                 "produces": [
                     "application/json"
                 ],
-                "summary": "CreateWallet",
+                "summary": "Create a wallet",
                 "responses": {
                     "200": {
                         "description": "Ok",
@@ -119,6 +119,9 @@ const docTemplate = `{
                 "payment_address": {
                     "type": "string"
                 },
+                "payment_extended_skey": {
+                    "$ref": "#/definitions/bursa.KeyFile"
+                },
                 "payment_kvey": {
                     "$ref": "#/definitions/bursa.KeyFile"
                 },
@@ -127,6 +130,9 @@ const docTemplate = `{
                 },
                 "stake_address": {
                     "type": "string"
+                },
+                "stake_extended_skey": {
+                    "$ref": "#/definitions/bursa.KeyFile"
                 },
                 "stake_skey": {
                     "$ref": "#/definitions/bursa.KeyFile"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -25,7 +25,7 @@
                 "produces": [
                     "application/json"
                 ],
-                "summary": "CreateWallet",
+                "summary": "Create a wallet",
                 "responses": {
                     "200": {
                         "description": "Ok",
@@ -115,6 +115,9 @@
                 "payment_address": {
                     "type": "string"
                 },
+                "payment_extended_skey": {
+                    "$ref": "#/definitions/bursa.KeyFile"
+                },
                 "payment_kvey": {
                     "$ref": "#/definitions/bursa.KeyFile"
                 },
@@ -123,6 +126,9 @@
                 },
                 "stake_address": {
                     "type": "string"
+                },
+                "stake_extended_skey": {
+                    "$ref": "#/definitions/bursa.KeyFile"
                 },
                 "stake_skey": {
                     "$ref": "#/definitions/bursa.KeyFile"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -22,12 +22,16 @@ definitions:
         type: string
       payment_address:
         type: string
+      payment_extended_skey:
+        $ref: '#/definitions/bursa.KeyFile'
       payment_kvey:
         $ref: '#/definitions/bursa.KeyFile'
       payment_skey:
         $ref: '#/definitions/bursa.KeyFile'
       stake_address:
         type: string
+      stake_extended_skey:
+        $ref: '#/definitions/bursa.KeyFile'
       stake_skey:
         $ref: '#/definitions/bursa.KeyFile'
       stake_vkey:
@@ -55,7 +59,7 @@ paths:
           description: Ok
           schema:
             $ref: '#/definitions/bursa.Wallet'
-      summary: CreateWallet
+      summary: Create a wallet
   /api/wallet/restore:
     post:
       consumes:

--- a/go.mod
+++ b/go.mod
@@ -32,11 +32,12 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.5 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
-	github.com/go-openapi/jsonreference v0.19.6 // indirect
-	github.com/go-openapi/spec v0.20.4 // indirect
+	github.com/go-openapi/jsonreference v0.20.0 // indirect
+	github.com/go-openapi/spec v0.20.6 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
@@ -55,11 +56,14 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
+	github.com/swaggo/http-swagger v1.3.4 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,12 @@ github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUe
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.19.6 h1:UBIxjkht+AWIgYzCDSv2GN+E/togfwXUJFRTWhl2Jjs=
 github.com/go-openapi/jsonreference v0.19.6/go.mod h1:diGHMEHg2IqXZGKxqyvWdfWU/aim5Dprw5bqpKkTvns=
+github.com/go-openapi/jsonreference v0.20.0 h1:MYlu0sBgChmCfJxxUKZ8g1cPWFOB37YSZqewK7OKeyA=
+github.com/go-openapi/jsonreference v0.20.0/go.mod h1:Ag74Ico3lPc+zR+qjn4XBUmXymS4zJbYVCZmcgkasdo=
 github.com/go-openapi/spec v0.20.4 h1:O8hJrt0UMnhHcluhIdUgCLRWyM2x7QkBXRvOs7m+O1M=
 github.com/go-openapi/spec v0.20.4/go.mod h1:faYFR1CvsJZ0mNsmsphTMSoRrNV3TEDoAM7FOEWeq8I=
+github.com/go-openapi/spec v0.20.6 h1:ich1RQ3WDbfoeTqTAb+5EIxNmpKVJZWBNah9RAT0jIQ=
+github.com/go-openapi/spec v0.20.6/go.mod h1:2OpW+JddWPrpXSCIX8eOx7lZ5iyuWj3RYR6VaaBKcWA=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.15 h1:D2NRCBzS9/pEY3gP9Nl8aDqGUcPFrwG2p+CNFrLyrCM=
 github.com/go-openapi/swag v0.19.15/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
@@ -306,10 +310,14 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/swaggo/files v1.0.1 h1:J1bVJ4XHZNq0I46UU90611i9/YzdrF7x92oX1ig5IdE=
 github.com/swaggo/files v1.0.1/go.mod h1:0qXmMNH6sXNf+73t65aKeB+ApmgxdnkQzVTAj2uaMUg=
 github.com/swaggo/gin-swagger v1.6.0 h1:y8sxvQ3E20/RCyrXeFfg60r6H0Z+SwpTjMYsMm+zy8M=
 github.com/swaggo/gin-swagger v1.6.0/go.mod h1:BG00cCEy294xtVpyIAHG6+e2Qzj/xKlRdOqDkvq0uzo=
+github.com/swaggo/http-swagger v1.3.4 h1:q7t/XLx0n15H1Q9/tk3Y9L4n210XzJF5WtnDX64a5ww=
+github.com/swaggo/http-swagger v1.3.4/go.mod h1:9dAh0unqMBAlbp1uE2Uc2mQTxNMU/ha4UbucIg1MFkQ=
 github.com/swaggo/swag v1.16.4 h1:clWJtd9LStiG3VeijiCfOVODP6VpHtKdQy9ELFG3s1A=
 github.com/swaggo/swag v1.16.4/go.mod h1:VBsHJRsDvfYvqoiMKnsdwhNV9LEMHgEDZcyVYX0sxPg=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -16,12 +16,22 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/blinklabs-io/bursa/internal/config"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
 )
 
 // Mock JSON data for successful wallet restoration
@@ -50,6 +60,122 @@ var mockWalletResponseJSON = `{
       "cborHex": "5880b0a9a8bcddc391c2cc79dbbac792e21f21fa8a3572e8591235bdc802c9aa6c4210eee620765fb6f569ab6b2916001cdd6d289067b022847d62ea19160463bcf72a786a251854a5f459a856e7ae8f9289be9a3a7a1bf421e35bfaab815868e0fd258df1a6eb6b51f6769afcdf4634594b13dba6433ec3670ea9ea742a09e8711e"
   }
 }`
+
+func startAPI(t *testing.T) (apiBaseURL, metricsBaseURL string, cleanup func()) {
+	t.Helper()
+
+	// Create listeners for API and metrics with ephemeral ports
+	apiListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create API listener: %v", err)
+	}
+	metricsListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create metrics listener: %v", err)
+	}
+
+	// Retrieve the dynamically assigned ports
+	apiPort := apiListener.Addr().(*net.TCPAddr).Port
+	metricsPort := metricsListener.Addr().(*net.TCPAddr).Port
+
+	// Create the configuration
+	cfg := &config.Config{
+		Network: "testnet",
+		Api: config.ApiConfig{
+			ListenAddress: "127.0.0.1",
+			ListenPort:    uint(apiPort),
+		},
+		Metrics: config.MetricsConfig{
+			ListenAddress: "127.0.0.1",
+			ListenPort:    uint(metricsPort),
+		},
+	}
+
+	// Start the API in a separate goroutine
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Define cleanup to be called after the test
+	cleanup = func() {
+		cancel()
+	}
+
+	go func() {
+		if err := Start(ctx, cfg, apiListener, metricsListener); err != nil {
+			// NOTE: This logs the error but does not fail the entire test
+			t.Errorf("failed to start API: %v", err)
+		}
+	}()
+
+	// Construct base URLs
+	apiBaseURL = fmt.Sprintf("http://127.0.0.1:%d", apiPort)
+	metricsBaseURL = fmt.Sprintf("http://127.0.0.1:%d", metricsPort)
+
+	// Verify server readiness by checking the /healthcheck endpoint
+	waitForServer(apiBaseURL)
+
+	return apiBaseURL, metricsBaseURL, cleanup
+}
+
+// waitForServer actively waits for the server to be ready with retries.
+func waitForServer(apiBaseURL string) {
+	const maxRetries = 50
+	const retryInterval = 10 * time.Millisecond
+
+	for i := 0; i < maxRetries; i++ {
+		resp, err := http.Get(fmt.Sprintf("%s/healthcheck", apiBaseURL))
+		if err == nil && resp.StatusCode == http.StatusOK {
+			return // Server is ready
+		}
+		time.Sleep(retryInterval)
+	}
+
+	panic("server did not start within the expected time")
+}
+
+func TestMetricsEndpoint(t *testing.T) {
+	// Start the API
+	_, metricsBaseURL, cleanup := startAPI(t)
+	defer cleanup()
+
+	// Test the /metrics endpoint
+	resp, err := http.Get(fmt.Sprintf("%s/metrics", metricsBaseURL))
+	if err != nil {
+		t.Fatalf("failed to call metrics endpoint: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %v", resp.StatusCode)
+	}
+}
+
+func TestMetricsRegistered(t *testing.T) {
+	// api.init() allows to not start the metrics server
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	assert.NoError(t, err, "Unable to gather metrics from default registry")
+
+	// Flags to check if our metrics exist
+	foundWalletsCreated := false
+	foundWalletsFail := false
+	foundWalletsRestore := false
+
+	for _, mf := range metricFamilies {
+		switch *mf.Name {
+		case "bursa_wallets_created_count":
+			foundWalletsCreated = true
+		case "bursa_wallets_fail_count":
+			foundWalletsFail = true
+		case "bursa_wallets_restore_count":
+			foundWalletsRestore = true
+		}
+	}
+
+	// Verify that all expected metrics are present
+	assert.True(t, foundWalletsCreated,
+		"Expected metric `bursa_wallets_created_count` was not registered")
+	assert.True(t, foundWalletsFail,
+		"Expected metric `bursa_wallets_fail_count` was not registered")
+	assert.True(t, foundWalletsRestore,
+		"Expected metric `bursa_wallets_restore_count` was not registered")
+}
 
 func TestRestoreWallet(t *testing.T) {
 	t.Run("Successful Wallet Restoration", func(t *testing.T) {
@@ -117,4 +243,109 @@ func TestRestoreWallet(t *testing.T) {
 		}
 	})
 
+}
+
+func parseMetric(metricsData []byte, metricName string) float64 {
+	lines := strings.Split(string(metricsData), "\n")
+	for _, line := range lines {
+		// Skip empty lines or comment lines that start with "#"
+		if len(line) == 0 || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Example lines we want to match:
+		//   bursa_wallets_created_count 0
+
+		if strings.HasPrefix(line, metricName) {
+			parts := strings.Fields(line)
+			if len(parts) == 2 {
+				// parts[0] could be "bursa_wallets_created_count"
+				// parts[1] is the numeric value string
+				val, err := strconv.ParseFloat(parts[1], 64)
+				if err == nil {
+					return val
+				}
+			}
+		}
+	}
+	// If the metric wasn't found
+	return -1
+}
+
+func TestWalletCreateIncrementsCounter(t *testing.T) {
+	// Start the API (includes metrics)
+	apiBaseURL, metricsBaseURL, cleanup := startAPI(t)
+	defer cleanup()
+
+	// Fetch the metrics once to get the current count
+	resp, err := http.Get(fmt.Sprintf("%s/metrics", metricsBaseURL))
+	assert.NoError(t, err, "failed to call initial metrics endpoint")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	initialBody, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	assert.NoError(t, err, "failed to read initial metrics response")
+
+	initialCount := parseMetric(initialBody, "bursa_wallets_created_count")
+	// If parseMetric returned -1, the metric wasn't found at all.
+	assert.NotEqual(t, float64(-1), initialCount,
+		"Expected `bursa_wallets_created_count` to be registered initially")
+
+	// Call /api/wallet/create to create a wallet
+	createWalletResp, err := http.Get(fmt.Sprintf("%s/api/wallet/create", apiBaseURL))
+	assert.NoError(t, err, "failed to call /api/wallet/create endpoint")
+	assert.Equal(t, http.StatusOK, createWalletResp.StatusCode,
+		"expected /api/wallet/create to return 200 on success")
+	createWalletResp.Body.Close()
+
+	// Fetch the metrics again
+	resp2, err := http.Get(fmt.Sprintf("%s/metrics", metricsBaseURL))
+	assert.NoError(t, err, "failed to call second metrics endpoint")
+	assert.Equal(t, http.StatusOK, resp2.StatusCode)
+
+	secondBody, err := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+	assert.NoError(t, err, "failed to read second metrics response")
+
+	newCount := parseMetric(secondBody, "bursa_wallets_created_count")
+
+	// Verify that the counter incremented by 1
+	expected := initialCount + 1
+	assert.Equal(t, expected, newCount,
+		"bursa_wallets_created_count should have incremented by 1 after creating a wallet")
+}
+
+func TestCreateWalletReturnsMnemonic(t *testing.T) {
+	apiBaseURL, _, cleanup := startAPI(t)
+	defer cleanup()
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/wallet/create", apiBaseURL))
+	if err != nil {
+		t.Fatalf("Failed to call /api/wallet/create: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read create wallet response body: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	var createWalletResponse map[string]interface{}
+	if err := json.Unmarshal(body, &createWalletResponse); err != nil {
+		t.Fatalf("Failed to unmarshal create wallet response: %v", err)
+	}
+
+	mnemonicVal, ok := createWalletResponse["mnemonic"]
+	if !ok {
+		t.Errorf("Expected key 'mnemonic' in createWalletResponse, but it was missing")
+	} else {
+		mnemonicStr, isString := mnemonicVal.(string)
+		if !isString || mnemonicStr == "" {
+			t.Errorf("Expected 'mnemonic' to be a non-empty string, got %v", mnemonicVal)
+		}
+	}
 }


### PR DESCRIPTION
Closes #90 

- Replace gin with net/http
- Replace ginmetrics with Prometheus
- Add "unit/Integration" tests. Tests use api.Start() to start the API server instead of mock server calls.
- Update Swagger docs
- **Breaking change** metrics are moved to '/metrics' using a standard endpoint
