### PR TITLE
feat: rename env config NETWORK->CARDANO_NETWORK for clarity

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	Logging  LoggingConfig `yaml:"logging"`
 	Metrics  MetricsConfig `yaml:"metrics"`
 	Mnemonic string        `yaml:"mnemonic" envconfig:"MNEMONIC"`
-	Network  string        `yaml:"network"  envconfig:"NETWORK"`
+	Network  string        `yaml:"cardano_network"  envconfig:"CARDANO_NETWORK"`
 }
 
 type ApiConfig struct {


### PR DESCRIPTION
**Breaking change**
With this change, you must set the `CARDANO_NETWORK` environment variable instead of `NETWORK. '