### PR TITLE
ci: codesign macos binary directly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,7 +131,7 @@ jobs:
 
       # Sign MacOS build
 
-      - name: Create .app package and sign macos binary
+      - name: Sign macos binary
         if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.os == 'darwin' }}
         run: |
           echo "Decoding and importing Apple certificate..."
@@ -142,34 +142,9 @@ jobs:
           security unlock-keychain -p "${{ secrets.APPLE_KEYCHAIN_PASSWORD }}" build.keychain
           security import apple_certificate.p12 -k build.keychain -P "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${{ secrets.APPLE_KEYCHAIN_PASSWORD }}" build.keychain
-          echo "Packaging bursa..."
-          mkdir -p Bursa.app/Contents/MacOS
-          mkdir -p Bursa.app/Contents/Resources
-          cp bursa Bursa.app/Contents/MacOS/bursa
-          chmod +x Bursa.app/Contents/MacOS/bursa
-          cat <<EOF > Bursa.app/Contents/Info.plist
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-              <key>CFBundleExecutable</key>
-              <string>bursa</string>
-              <key>CFBundleIdentifier</key>
-              <string>com.blinklabssoftware.bursa</string>
-              <key>CFBundleName</key>
-              <string>Bursa</string>
-              <key>CFBundleVersion</key>
-              <string>${{ env.RELEASE_TAG }}</string>
-              <key>CFBundleShortVersionString</key>
-              <string>${{ env.RELEASE_TAG }}</string>
-          </dict>
-          </plist>
-          EOF
-          /usr/bin/codesign --force -s "Developer ID Application: Blink Labs Software (${{ secrets.APPLE_TEAM_ID }})" --options runtime Bursa.app -v
+          /usr/bin/codesign --force -s "Developer ID Application: Blink Labs Software (${{ secrets.APPLE_TEAM_ID }})" --timestamp --options runtime -i com.blinklabssoftware.bursa bursa -v
           xcrun notarytool store-credentials "notarytool-profile" --apple-id "${{ secrets.APPLE_ID }}" --team-id "${{ secrets.APPLE_TEAM_ID }}" --password "${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}"
-          ditto -c -k --keepParent "Bursa.app" "notarization.zip"
-          xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
-          xcrun stapler staple "Bursa.app"
+          xcrun notarytool submit bursa --keychain-profile "notarytool-profile" --wait
       - name: Upload release asset
         if: startsWith(github.ref, 'refs/tags/')
         run: |
@@ -182,7 +157,7 @@ jobs:
           fi
           if [[ "${{ matrix.os }}" == "darwin" ]]; then
             _filename=bursa-${{ env.RELEASE_TAG }}-${{ matrix.os }}-${{ matrix.arch }}.zip
-            zip -r ${_filename} Bursa.app
+            zip -r ${_filename} bursa
           fi
           curl \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \


### PR DESCRIPTION
Switch to simple binary signing for MacOS and remove the App packaging, for now.