### PR TITLE
ci: notarize a zip for macos code signing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -143,8 +143,11 @@ jobs:
           security import apple_certificate.p12 -k build.keychain -P "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${{ secrets.APPLE_KEYCHAIN_PASSWORD }}" build.keychain
           /usr/bin/codesign --force -s "Developer ID Application: Blink Labs Software (${{ secrets.APPLE_TEAM_ID }})" --timestamp --options runtime -i com.blinklabssoftware.bursa bursa -v
+          _filename=bursa-${{ env.RELEASE_TAG }}-${{ matrix.os }}-${{ matrix.arch }}.zip
+          zip -r ${_filename} bursa
           xcrun notarytool store-credentials "notarytool-profile" --apple-id "${{ secrets.APPLE_ID }}" --team-id "${{ secrets.APPLE_TEAM_ID }}" --password "${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}"
-          xcrun notarytool submit bursa --keychain-profile "notarytool-profile" --wait
+          xcrun notarytool submit ${_filename} --keychain-profile "notarytool-profile" --wait
+
       - name: Upload release asset
         if: startsWith(github.ref, 'refs/tags/')
         run: |
@@ -157,7 +160,9 @@ jobs:
           fi
           if [[ "${{ matrix.os }}" == "darwin" ]]; then
             _filename=bursa-${{ env.RELEASE_TAG }}-${{ matrix.os }}-${{ matrix.arch }}.zip
-            zip -r ${_filename} bursa
+            if [[ ! -e ${_filename} ]]; then
+              zip -r ${_filename} bursa
+            fi
           fi
           curl \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \


### PR DESCRIPTION
While you can codesign directly, you should notarize a zip.