### PR TITLE
fix(metrics): correct name for wallet updated count

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -100,8 +100,8 @@ var (
 		Help: "Total number of wallets restored",
 	})
 	walletsUpdatedCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "bursa_wallets_updateid_count",
-		Help: "Total number of wallets updatedd",
+		Name: "bursa_wallets_updated_count",
+		Help: "Total number of wallets updated",
 	})
 )
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the Prometheus metric for wallets updated by correcting the counter name and help text, preventing misnamed or duplicated metrics.
Renamed bursa_wallets_updateid_count to bursa_wallets_updated_count and fixed the help text typo.

<sup>Written for commit 52a7d158b2d5b11557f2e89bf733c43d5229d2eb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Prometheus metric for wallet updates by correcting the metric name and fixing the associated help text for better accuracy and clarity in monitoring.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->