### PR TITLE
fix(api): correct ordering for new wallet call

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -367,8 +367,8 @@ func handleWalletRestore(w http.ResponseWriter, r *http.Request) {
 	logger := logging.GetLogger()
 	wallet, err := bursa.NewWallet(
 		req.Mnemonic,
-		req.Password,
 		cfg.Network,
+		req.Password,
 		req.AccountId,
 		req.PaymentId,
 		req.StakeId,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the wallet restore API by correcting the argument order in the NewWallet call. This prevents restore failures caused by passing the password where the network was expected.

- **Bug Fixes**
  - Update handleWalletRestore to call bursa.NewWallet with: mnemonic, network, password, accountId, paymentId, stakeId.

<sup>Written for commit 5216fb945b410d09a70e05f26a300178d149ee1d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected wallet initialization parameter handling to prevent initialization failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->