### PR TITLE
style: make format golines

### DIFF
--- a/bip32/bip32_test.go
+++ b/bip32/bip32_test.go
@@ -44,8 +44,40 @@ func TestFromBip39Entropy(t *testing.T) {
 
 func TestDerive(t *testing.T) {
 	// Start with a known root key
-	entropy := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
-		0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f}
+	entropy := []byte{
+		0x00,
+		0x01,
+		0x02,
+		0x03,
+		0x04,
+		0x05,
+		0x06,
+		0x07,
+		0x08,
+		0x09,
+		0x0a,
+		0x0b,
+		0x0c,
+		0x0d,
+		0x0e,
+		0x0f,
+		0x10,
+		0x11,
+		0x12,
+		0x13,
+		0x14,
+		0x15,
+		0x16,
+		0x17,
+		0x18,
+		0x19,
+		0x1a,
+		0x1b,
+		0x1c,
+		0x1d,
+		0x1e,
+		0x1f,
+	}
 	password := []byte{}
 	root := FromBip39Entropy(entropy, password)
 
@@ -138,7 +170,10 @@ func TestCardanoWalletVectors(t *testing.T) {
 	// Verify payment key derivation
 	paymentPubKey := child5.PublicKey()
 	if len(paymentPubKey) != 32 {
-		t.Errorf("Expected payment public key length 32, got %d", len(paymentPubKey))
+		t.Errorf(
+			"Expected payment public key length 32, got %d",
+			len(paymentPubKey),
+		)
 	}
 
 	// Test non-hardened derivation: m/1852'/1815'/0'/0'/0'/0
@@ -147,7 +182,10 @@ func TestCardanoWalletVectors(t *testing.T) {
 	// Verify stake key derivation
 	stakePubKey := child6.PublicKey()
 	if len(stakePubKey) != 32 {
-		t.Errorf("Expected stake public key length 32, got %d", len(stakePubKey))
+		t.Errorf(
+			"Expected stake public key length 32, got %d",
+			len(stakePubKey),
+		)
 	}
 
 	// Verify that payment and stake keys are different
@@ -179,7 +217,12 @@ func TestHardenedIndex(t *testing.T) {
 	for _, test := range tests {
 		result := HardenedIndex(test.input)
 		if result != test.expected {
-			t.Errorf("HardenedIndex(%d) = %x, want %x", test.input, result, test.expected)
+			t.Errorf(
+				"HardenedIndex(%d) = %x, want %x",
+				test.input,
+				result,
+				test.expected,
+			)
 		}
 	}
 }

--- a/cmd/bursa/api.go
+++ b/cmd/bursa/api.go
@@ -62,7 +62,11 @@ func apiCommand() *cobra.Command {
 					}
 					err := debugger.ListenAndServe()
 					if err != nil {
-						slog.Error("failed to start debug listener", "error", err)
+						slog.Error(
+							"failed to start debug listener",
+							"error",
+							err,
+						)
 						return
 					}
 				}()

--- a/cmd/bursa/wallet.go
+++ b/cmd/bursa/wallet.go
@@ -69,8 +69,10 @@ func walletLoadCommand() *cobra.Command {
 			cli.RunLoad(dir, showSecrets)
 		},
 	}
-	walletLoadCommand.Flags().StringVar(&dir, "dir", ".", "Directory containing wallet key files (Ex: *.vkey, *.skey)")
-	walletLoadCommand.Flags().BoolVar(&showSecrets, "show-secrets", false, "Display private key hex values (use with caution)")
+	walletLoadCommand.Flags().
+		StringVar(&dir, "dir", ".", "Directory containing wallet key files (Ex: *.vkey, *.skey)")
+	walletLoadCommand.Flags().
+		BoolVar(&showSecrets, "show-secrets", false, "Display private key hex values (use with caution)")
 
 	return &walletLoadCommand
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Applied golines (80-char line width) and gofmt -s to standardize formatting and improve readability across tests and CLI code. No functional changes.

- **Refactors**
  - Rewrapped long literals and t.Errorf calls in bip32 tests.
  - Broke long slog.Error and cobra flag lines in cmd/bursa (api.go, wallet.go).

<sup>Written for commit e517373a859e360444736c59a31f1fbdaf99bd88. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Code formatting improvements across test files and internal utilities for enhanced readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->