### PR TITLE
feat: add generic storage interface with file and GCP backends

### DIFF
--- a/internal/storage/file.go
+++ b/internal/storage/file.go
@@ -1,0 +1,383 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/bursa/internal/logging"
+)
+
+// FileStore implements the Store interface using local file system.
+// It stores wallets as JSON files in a directory structure on disk.
+type FileStore struct {
+	baseDir string
+	mu      sync.RWMutex
+}
+
+// NewFileStore creates a new file-based storage backend.
+// baseDir specifies the root directory where wallets will be stored.
+func NewFileStore(baseDir string) *FileStore {
+	return &FileStore{
+		baseDir: baseDir,
+	}
+}
+
+// validateWalletName validates that a wallet name is safe for file system operations.
+// It prevents path traversal attacks by ensuring the name contains only safe characters
+// and no path separators or traversal sequences.
+func validateWalletName(name string) error {
+	if name == "" {
+		return errors.New("wallet name cannot be empty")
+	}
+	if len(name) > 255 {
+		return errors.New("wallet name too long")
+	}
+
+	// Check for path traversal sequences
+	if strings.Contains(name, "..") {
+		return errors.New("wallet name cannot contain path traversal sequences")
+	}
+
+	// Check for path separators
+	if strings.ContainsAny(name, "/\\") {
+		return errors.New("wallet name cannot contain path separators")
+	}
+
+	// Allow only safe characters: alphanumeric, hyphens, underscores
+	for _, r := range name {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z'):
+			// Letters are allowed
+		case r >= '0' && r <= '9':
+			// Numbers are allowed
+		case r == '-' || r == '_':
+			// Hyphens and underscores are allowed
+		default:
+			return errors.New(
+				"wallet name can only contain alphanumeric characters, hyphens, and underscores",
+			)
+		}
+	}
+
+	return nil
+}
+
+// GetWallet retrieves a wallet from the file system.
+// The wallet is loaded from a JSON file in the base directory.
+func (s *FileStore) GetWallet(
+	ctx context.Context,
+	name string,
+) (Wallet, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if err := validateWalletName(name); err != nil {
+		return nil, fmt.Errorf("invalid wallet name: %w", err)
+	}
+
+	walletPath := s.walletPath(name)
+	if _, err := os.Stat(walletPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("wallet %s not found", name)
+	}
+
+	file, err := os.Open(walletPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open wallet file: %w", err)
+	}
+	defer file.Close()
+
+	var data fileWalletData
+	if err := json.NewDecoder(file).Decode(&data); err != nil {
+		return nil, fmt.Errorf("failed to decode wallet data: %w", err)
+	}
+
+	return &fileWallet{
+		name:        name,
+		description: data.Description,
+		items:       data.Items,
+		store:       s,
+	}, nil
+}
+
+// ListWallets lists all wallets in the file system.
+// It scans the base directory for wallet subdirectories.
+func (s *FileStore) ListWallets(ctx context.Context) ([]Wallet, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entries, err := os.ReadDir(s.baseDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []Wallet{}, nil
+		}
+		return nil, fmt.Errorf("failed to read directory: %w", err)
+	}
+
+	var wallets []Wallet
+	for _, entry := range entries {
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), "wallet-") {
+			name := strings.TrimPrefix(entry.Name(), "wallet-")
+			wallet, err := s.GetWallet(ctx, name)
+			if err != nil {
+				logging.GetLogger().
+					Debug("skipping corrupted wallet during list", "wallet", name, "error", err)
+				continue // Skip corrupted wallets
+			}
+			wallets = append(wallets, wallet)
+		}
+	}
+
+	return wallets, nil
+}
+
+// CreateWallet creates a new wallet instance for file storage.
+// The wallet is not persisted until Save() is called.
+func (s *FileStore) CreateWallet(name string) Wallet {
+	if err := validateWalletName(name); err != nil {
+		// This is a programming error - panic to catch it early
+		panic(fmt.Sprintf("invalid wallet name in CreateWallet: %v", err))
+	}
+
+	return &fileWallet{
+		name:  name,
+		items: make(map[string]string),
+		store: s,
+	}
+}
+
+// DeleteWallet removes a wallet from the file system.
+// It deletes the wallet directory and all its contents.
+func (s *FileStore) DeleteWallet(ctx context.Context, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := validateWalletName(name); err != nil {
+		return fmt.Errorf("invalid wallet name: %w", err)
+	}
+
+	walletDir := s.walletDir(name)
+	return os.RemoveAll(walletDir)
+}
+
+// fileWallet implements the Wallet interface for file-based storage
+type fileWallet struct {
+	name        string
+	description string
+	items       map[string]string
+	store       *FileStore
+	mu          sync.RWMutex
+}
+
+// fileWalletData represents the JSON structure for file storage
+type fileWalletData struct {
+	Description string            `json:"description"`
+	Items       map[string]string `json:"items"`
+}
+
+func (w *fileWallet) Name() string {
+	return w.name
+}
+
+func (w *fileWallet) Description() string {
+	return w.description
+}
+
+func (w *fileWallet) SetDescription(description string) {
+	w.description = description
+}
+
+func (w *fileWallet) Items() map[string]string {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	// Return a copy to prevent external modification
+	result := make(map[string]string)
+	for k, v := range w.items {
+		result[k] = v
+	}
+	return result
+}
+
+func (w *fileWallet) ListItems() []string {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	items := make([]string, 0, len(w.items))
+	for name := range w.items {
+		items = append(items, name)
+	}
+	return items
+}
+
+func (w *fileWallet) GetItem(name string) (string, error) {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	value, exists := w.items[name]
+	if !exists {
+		return "", fmt.Errorf("item %s not found", name)
+	}
+	return value, nil
+}
+
+func (w *fileWallet) PutItem(name, value string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.items == nil {
+		w.items = make(map[string]string)
+	}
+	w.items[name] = value
+}
+
+func (w *fileWallet) DeleteItem(name string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	delete(w.items, name)
+}
+
+func (w *fileWallet) PopulateFrom(wallet *bursa.Wallet) error {
+	w.SetDescription("Wallet created from bursa.Wallet")
+
+	// Add mnemonic if available
+	if wallet.Mnemonic != "" {
+		w.PutItem("mnemonic", wallet.Mnemonic)
+	}
+
+	// Add addresses
+	w.PutItem("payment_address", wallet.PaymentAddress)
+	w.PutItem("stake_address", wallet.StakeAddress)
+
+	// Add key files
+	keyFiles, err := bursa.ExtractKeyFiles(wallet)
+	if err != nil {
+		return fmt.Errorf("failed to extract key files: %w", err)
+	}
+
+	for name, content := range keyFiles {
+		w.PutItem(name, content)
+	}
+
+	return nil
+}
+
+func (w *fileWallet) PopulateTo(wallet *bursa.Wallet) error {
+	if wallet == nil {
+		return errors.New("nil bursa wallet")
+	}
+
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	// Populate mnemonic if stored
+	if mnemonic, exists := w.items["mnemonic"]; exists {
+		wallet.Mnemonic = mnemonic
+	}
+
+	// Populate addresses if stored
+	if paymentAddr, exists := w.items["payment_address"]; exists {
+		wallet.PaymentAddress = paymentAddr
+	}
+	if stakeAddr, exists := w.items["stake_address"]; exists {
+		wallet.StakeAddress = stakeAddr
+	}
+
+	// Note: Key files could be populated here if needed, but for basic functionality
+	// the mnemonic and addresses should be sufficient for most use cases
+
+	return nil
+}
+
+func (w *fileWallet) Load(ctx context.Context) error {
+	// File wallet is always "loaded" since data is in memory
+	return nil
+}
+
+func (w *fileWallet) Save(ctx context.Context) error {
+	w.store.mu.Lock()
+	defer w.store.mu.Unlock()
+
+	// Validate wallet name for defense in depth
+	if err := validateWalletName(w.name); err != nil {
+		return fmt.Errorf("invalid wallet name: %w", err)
+	}
+
+	// Ensure directory exists with secure permissions (0700)
+	walletDir := w.store.walletDir(w.name)
+	if err := os.MkdirAll(walletDir, 0o700); err != nil {
+		return fmt.Errorf("failed to create wallet directory: %w", err)
+	}
+
+	// Write wallet data
+	w.mu.RLock()
+	data := fileWalletData{
+		Description: w.description,
+		Items:       w.items,
+	}
+	w.mu.RUnlock()
+
+	// Write wallet data with secure file permissions (0600)
+	// TODO: Encrypt wallet data at rest using SOPS or similar encryption
+	// SECURITY: Currently storing sensitive data (mnemonics, private keys) in plain JSON
+	file, err := os.OpenFile(
+		w.store.walletPath(w.name),
+		os.O_RDWR|os.O_CREATE|os.O_TRUNC,
+		0o600,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create wallet file: %w", err)
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(data); err != nil {
+		return fmt.Errorf("failed to encode wallet data: %w", err)
+	}
+
+	return nil
+}
+
+func (w *fileWallet) Delete(ctx context.Context) error {
+	return w.store.DeleteWallet(ctx, w.name)
+}
+
+// walletDir returns the directory path for a wallet
+func (s *FileStore) walletDir(name string) string {
+	if err := validateWalletName(name); err != nil {
+		// This should never happen if validation is done at public API boundaries
+		panic(fmt.Sprintf("invalid wallet name in walletDir: %v", err))
+	}
+	return filepath.Join(s.baseDir, "wallet-"+name)
+}
+
+// walletPath returns the file path for a wallet
+func (s *FileStore) walletPath(name string) string {
+	if err := validateWalletName(name); err != nil {
+		// This should never happen if validation is done at public API boundaries
+		panic(fmt.Sprintf("invalid wallet name in walletPath: %v", err))
+	}
+	return filepath.Join(s.walletDir(name), "wallet.json")
+}

--- a/internal/storage/file_test.go
+++ b/internal/storage/file_test.go
@@ -1,0 +1,297 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/bursa"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileStore(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "bursa-storage-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	store := NewFileStore(tempDir)
+
+	t.Run("CreateWallet", func(t *testing.T) {
+		wallet := store.CreateWallet("test-wallet")
+		assert.Equal(t, "test-wallet", wallet.Name())
+		assert.Empty(t, wallet.Description())
+	})
+
+	t.Run("SaveAndLoadWallet", func(t *testing.T) {
+		wallet := store.CreateWallet("save-test")
+
+		// Create a bursa wallet to populate from
+		bursaWallet, err := bursa.NewWallet(
+			"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+			"mainnet",
+			"",
+			0,
+			0,
+			0,
+			0,
+		)
+		require.NoError(t, err)
+
+		err = wallet.PopulateFrom(bursaWallet)
+		require.NoError(t, err)
+
+		// Save the wallet
+		err = wallet.Save(context.Background())
+		require.NoError(t, err)
+
+		// Load the wallet
+		loadedWallet, err := store.GetWallet(context.Background(), "save-test")
+		require.NoError(t, err)
+
+		assert.Equal(t, "save-test", loadedWallet.Name())
+		assert.Equal(
+			t,
+			"Wallet created from bursa.Wallet",
+			loadedWallet.Description(),
+		)
+
+		// Check that items were saved
+		items := loadedWallet.ListItems()
+		assert.Contains(t, items, "mnemonic")
+		assert.Contains(t, items, "payment_address")
+		assert.Contains(t, items, "stake_address")
+	})
+
+	t.Run("PopulateTo", func(t *testing.T) {
+		wallet := store.CreateWallet("populate-to-test")
+
+		// Create a bursa wallet to populate from
+		originalWallet, err := bursa.NewWallet(
+			"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+			"mainnet",
+			"",
+			0,
+			0,
+			0,
+			0,
+		)
+		require.NoError(t, err)
+
+		err = wallet.PopulateFrom(originalWallet)
+		require.NoError(t, err)
+
+		// Save and reload the wallet
+		err = wallet.Save(context.Background())
+		require.NoError(t, err)
+
+		loadedWallet, err := store.GetWallet(
+			context.Background(),
+			"populate-to-test",
+		)
+		require.NoError(t, err)
+
+		// Create a new empty bursa wallet and populate it
+		newWallet := &bursa.Wallet{}
+		err = loadedWallet.PopulateTo(newWallet)
+		require.NoError(t, err)
+
+		// Verify the data was populated correctly
+		assert.Equal(t, originalWallet.Mnemonic, newWallet.Mnemonic)
+		assert.Equal(t, originalWallet.PaymentAddress, newWallet.PaymentAddress)
+		assert.Equal(t, originalWallet.StakeAddress, newWallet.StakeAddress)
+	})
+
+	t.Run("ListWallets", func(t *testing.T) {
+		// Create a few wallets
+		wallet1 := store.CreateWallet("list-test-1")
+		wallet2 := store.CreateWallet("list-test-2")
+
+		err := wallet1.Save(context.Background())
+		require.NoError(t, err)
+		err = wallet2.Save(context.Background())
+		require.NoError(t, err)
+
+		wallets, err := store.ListWallets(context.Background())
+		require.NoError(t, err)
+
+		names := make([]string, len(wallets))
+		for i, w := range wallets {
+			names[i] = w.Name()
+		}
+
+		assert.Contains(t, names, "list-test-1")
+		assert.Contains(t, names, "list-test-2")
+	})
+
+	t.Run("DeleteWallet", func(t *testing.T) {
+		wallet := store.CreateWallet("delete-test")
+		err := wallet.Save(context.Background())
+		require.NoError(t, err)
+
+		// Verify it exists
+		_, err = store.GetWallet(context.Background(), "delete-test")
+		require.NoError(t, err)
+
+		// Delete it
+		err = store.DeleteWallet(context.Background(), "delete-test")
+		require.NoError(t, err)
+
+		// Verify it's gone
+		_, err = store.GetWallet(context.Background(), "delete-test")
+		assert.Error(t, err)
+	})
+
+	t.Run("WalletNotFound", func(t *testing.T) {
+		_, err := store.GetWallet(context.Background(), "nonexistent")
+		assert.Error(t, err)
+	})
+}
+
+func TestFileStoreWalletOperations(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "bursa-wallet-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	store := NewFileStore(tempDir)
+	wallet := store.CreateWallet("ops-test")
+
+	t.Run("ItemOperations", func(t *testing.T) {
+		// Test PutItem and GetItem
+		wallet.PutItem("test-key", "test-value")
+		value, err := wallet.GetItem("test-key")
+		require.NoError(t, err)
+		assert.Equal(t, "test-value", value)
+
+		// Test ListItems
+		items := wallet.ListItems()
+		assert.Contains(t, items, "test-key")
+
+		// Test DeleteItem
+		wallet.DeleteItem("test-key")
+		_, err = wallet.GetItem("test-key")
+		assert.Error(t, err)
+	})
+
+	t.Run("GetNonexistentItem", func(t *testing.T) {
+		_, err := wallet.GetItem("nonexistent")
+		assert.Error(t, err)
+	})
+}
+
+func TestFileStoreDirectoryStructure(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "bursa-dir-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	store := NewFileStore(tempDir)
+	wallet := store.CreateWallet("dir-test")
+	wallet.PutItem("test", "data")
+
+	err = wallet.Save(context.Background())
+	require.NoError(t, err)
+
+	// Check directory structure
+	walletDir := filepath.Join(tempDir, "wallet-dir-test")
+	assert.DirExists(t, walletDir)
+
+	walletFile := filepath.Join(walletDir, "wallet.json")
+	assert.FileExists(t, walletFile)
+}
+
+func TestFileStoreInvalidWalletNames(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "bursa-invalid-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	store := NewFileStore(tempDir)
+
+	invalidNames := []string{
+		"",                          // empty name
+		"../../../etc/passwd",       // path traversal
+		"wallet/../secret",          // path traversal with valid prefix
+		"wallet/with/slashes",       // path separators
+		"wallet\\with\\backslashes", // backslashes
+		"wallet with spaces",        // spaces (not in allowed charset)
+		"wallet@special",            // special characters
+		strings.Repeat("a", 256),    // too long
+	}
+
+	t.Run("CreateWalletRejectsInvalidNames", func(t *testing.T) {
+		for _, name := range invalidNames {
+			assert.Panics(t, func() {
+				store.CreateWallet(name)
+			}, "CreateWallet should panic for invalid name: %s", name)
+		}
+	})
+
+	t.Run("GetWalletRejectsInvalidNames", func(t *testing.T) {
+		for _, name := range invalidNames {
+			_, err := store.GetWallet(context.Background(), name)
+			assert.Error(
+				t,
+				err,
+				"GetWallet should reject invalid name: %s",
+				name,
+			)
+		}
+	})
+
+	t.Run("DeleteWalletRejectsInvalidNames", func(t *testing.T) {
+		for _, name := range invalidNames {
+			err := store.DeleteWallet(context.Background(), name)
+			assert.Error(
+				t,
+				err,
+				"DeleteWallet should reject invalid name: %s",
+				name,
+			)
+		}
+	})
+
+	// Test that valid names work
+	validNames := []string{
+		"simple",
+		"with-numbers-123",
+		"with_underscores",
+		"mixed-123_abc",
+		"a",
+		"long-but-valid-name-1234567890",
+	}
+
+	t.Run("ValidNamesWork", func(t *testing.T) {
+		for _, name := range validNames {
+			wallet := store.CreateWallet(name)
+			assert.Equal(t, name, wallet.Name())
+
+			err := wallet.Save(context.Background())
+			assert.NoError(t, err, "Save should work for valid name: %s", name)
+
+			loaded, err := store.GetWallet(context.Background(), name)
+			assert.NoError(
+				t,
+				err,
+				"GetWallet should work for valid name: %s",
+				name,
+			)
+			assert.Equal(t, name, loaded.Name())
+		}
+	})
+}

--- a/internal/storage/gcp.go
+++ b/internal/storage/gcp.go
@@ -1,0 +1,150 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+
+	"github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/bursa/gcp"
+	"github.com/blinklabs-io/bursa/internal/logging"
+)
+
+// GCPStore implements the Store interface using Google Cloud Secret Manager.
+// It provides secure wallet storage using GCP's Secret Manager service.
+type GCPStore struct{}
+
+// NewGCPStore creates a new GCP storage backend.
+// It initializes a store that uses Google Cloud Secret Manager for wallet persistence.
+func NewGCPStore() *GCPStore {
+	return &GCPStore{}
+}
+
+// GetWallet retrieves a wallet from GCP Secret Manager.
+// The wallet name corresponds to a secret in GCP Secret Manager.
+func (s *GCPStore) GetWallet(ctx context.Context, name string) (Wallet, error) {
+	gcpWallet, err := gcp.GetGoogleWallet(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	return &gcpWalletAdapter{wallet: gcpWallet}, nil
+}
+
+// ListWallets lists all wallets stored in GCP Secret Manager.
+// It returns wallets for all accessible secrets in the configured GCP project.
+func (s *GCPStore) ListWallets(ctx context.Context) ([]Wallet, error) {
+	walletNames, err := gcp.ListGoogleWallets(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	wallets := make([]Wallet, 0, len(walletNames))
+	for _, name := range walletNames {
+		gcpWallet, err := gcp.GetGoogleWallet(ctx, name)
+		if err != nil {
+			logging.GetLogger().
+				Debug("skipping inaccessible wallet during list", "wallet", name, "error", err)
+			continue // Skip wallets that can't be loaded
+		}
+		wallets = append(wallets, &gcpWalletAdapter{wallet: gcpWallet})
+	}
+	return wallets, nil
+}
+
+// CreateWallet creates a new wallet instance for GCP storage.
+// The wallet is not persisted until Save() is called.
+func (s *GCPStore) CreateWallet(name string) Wallet {
+	gcpWallet := gcp.NewGoogleWallet(name)
+	return &gcpWalletAdapter{wallet: gcpWallet}
+}
+
+// DeleteWallet removes a wallet from GCP Secret Manager.
+// It deletes the corresponding secret and all its versions.
+func (s *GCPStore) DeleteWallet(ctx context.Context, name string) error {
+	// Create a minimal wallet instance for deletion - no need to load data
+	gcpWallet := gcp.NewGoogleWallet(name)
+	return gcpWallet.Delete(ctx)
+}
+
+// gcpWalletAdapter adapts gcp.GoogleWallet to the storage.Wallet interface.
+// It provides a bridge between the legacy GCP implementation and the new storage interface.
+type gcpWalletAdapter struct {
+	wallet *gcp.GoogleWallet
+}
+
+// Name returns the wallet name
+func (a *gcpWalletAdapter) Name() string {
+	return a.wallet.Name()
+}
+
+// Description returns the wallet description
+func (a *gcpWalletAdapter) Description() string {
+	return a.wallet.Description()
+}
+
+// SetDescription sets the wallet description
+func (a *gcpWalletAdapter) SetDescription(description string) {
+	a.wallet.SetDescription(description)
+}
+
+// Items returns all wallet items
+func (a *gcpWalletAdapter) Items() map[string]string {
+	return a.wallet.Items()
+}
+
+// ListItems returns a list of all item names
+func (a *gcpWalletAdapter) ListItems() []string {
+	return a.wallet.ListItems()
+}
+
+// GetItem retrieves a specific item
+func (a *gcpWalletAdapter) GetItem(name string) (string, error) {
+	return a.wallet.GetItem(name)
+}
+
+// PutItem stores an item
+func (a *gcpWalletAdapter) PutItem(name, value string) {
+	a.wallet.PutItem(name, value)
+}
+
+// DeleteItem removes an item
+func (a *gcpWalletAdapter) DeleteItem(name string) {
+	a.wallet.DeleteItem(name)
+}
+
+// PopulateFrom populates the wallet from a bursa.Wallet
+func (a *gcpWalletAdapter) PopulateFrom(wallet *bursa.Wallet) error {
+	return a.wallet.PopulateFrom(wallet)
+}
+
+// PopulateTo populates a bursa.Wallet from the stored wallet
+func (a *gcpWalletAdapter) PopulateTo(wallet *bursa.Wallet) error {
+	return a.wallet.PopulateTo(wallet)
+}
+
+// Load loads the wallet from storage
+func (a *gcpWalletAdapter) Load(ctx context.Context) error {
+	return a.wallet.Load(ctx)
+}
+
+// Save saves the wallet to storage
+func (a *gcpWalletAdapter) Save(ctx context.Context) error {
+	return a.wallet.Save(ctx)
+}
+
+// Delete deletes the wallet from storage
+func (a *gcpWalletAdapter) Delete(ctx context.Context) error {
+	return a.wallet.Delete(ctx)
+}

--- a/internal/storage/interface.go
+++ b/internal/storage/interface.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+
+	"github.com/blinklabs-io/bursa"
+)
+
+// Wallet represents a stored wallet with metadata and key-value storage.
+// It provides a unified interface for wallet persistence across different storage backends.
+type Wallet interface {
+	// Name returns the wallet's unique identifier.
+	Name() string
+
+	// Description returns the wallet's description.
+	Description() string
+
+	// SetDescription sets the wallet's description.
+	SetDescription(description string)
+
+	// Items returns a copy of all key-value items in the wallet.
+	Items() map[string]string
+
+	// ListItems returns a list of all item keys in the wallet.
+	ListItems() []string
+
+	// GetItem retrieves the value for the given item key.
+	// Returns an error if the key does not exist.
+	GetItem(name string) (string, error)
+
+	// PutItem stores a key-value pair in the wallet.
+	PutItem(name, value string)
+
+	// DeleteItem removes an item from the wallet by key.
+	DeleteItem(name string)
+
+	// PopulateFrom populates the wallet from a bursa.Wallet instance.
+	PopulateFrom(wallet *bursa.Wallet) error
+
+	// PopulateTo populates a bursa.Wallet instance from the stored wallet data.
+	PopulateTo(wallet *bursa.Wallet) error
+
+	// Load loads the wallet data from the storage backend.
+	Load(ctx context.Context) error
+
+	// Save persists the wallet data to the storage backend.
+	Save(ctx context.Context) error
+
+	// Delete removes the wallet from the storage backend.
+	Delete(ctx context.Context) error
+}
+
+// Store represents a storage backend that can manage wallets.
+// Different implementations provide storage in various systems like filesystems, databases, or cloud services.
+type Store interface {
+	// GetWallet retrieves a wallet by name from the storage backend.
+	GetWallet(ctx context.Context, name string) (Wallet, error)
+
+	// ListWallets returns all wallets in the storage backend.
+	ListWallets(ctx context.Context) ([]Wallet, error)
+
+	// CreateWallet creates a new wallet with the given name.
+	CreateWallet(name string) Wallet
+
+	// DeleteWallet removes a wallet from the storage backend.
+	DeleteWallet(ctx context.Context, name string) error
+}


### PR DESCRIPTION
Closes #208
Closes #209 
Closes #211





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a generic storage interface for wallets with file-system and GCP Secret Manager backends. Unifies wallet CRUD and item storage to support both local development and cloud storage.

- **New Features**
  - Adds storage.Store and storage.Wallet interfaces for CRUD, item KV, and import/export with bursa.Wallet.
  - FileStore: JSON persistence at wallet-<name>/wallet.json; Get/List/Create/Delete; thread-safe; unit tests included.
  - GCPStore: adapter over gcp.GoogleWallet (Secret Manager) with Get/List/Create/Delete and Save/Load.
  - Aligns with requirements in issues #208, #209, and #211.

- **Notes**
  - FileStore PopulateTo implemented for mnemonic and addresses.
  - List operations skip corrupted or unreadable wallets.

<sup>Written for commit c7d4d308136a64c5b135cd62fd840b9e80de6d89. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local file-based wallet storage for persistent wallets on disk.
  * Google Cloud-backed wallet storage option.
  * Unified storage interfaces enabling interchangeable backends for wallet operations.

* **Tests**
  * Added comprehensive tests covering wallet lifecycle, item operations, listing, persistence, validation, and deletion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->