### PR TITLE
feat: support CIP-0005 bech32 string encoding

### DIFF
--- a/bip32/bip32.go
+++ b/bip32/bip32.go
@@ -34,6 +34,7 @@ import (
 	"encoding/binary"
 
 	"filippo.io/edwards25519"
+	"github.com/btcsuite/btcd/btcutil/bech32"
 	"github.com/tyler-smith/go-bip39"
 	"golang.org/x/crypto/blake2b"
 )
@@ -46,6 +47,54 @@ type XPub []byte
 
 // PublicKey represents a 32-byte Ed25519 public key.
 type PublicKey []byte
+
+// String returns the Bech32-encoded representation of the extended private key as root_xsk
+func (x XPrv) String() string {
+	if len(x) != 96 {
+		return ""
+	}
+	converted, err := bech32.ConvertBits(x, 8, 5, true)
+	if err != nil {
+		return ""
+	}
+	encoded, err := bech32.Encode("root_xsk", converted)
+	if err != nil {
+		return ""
+	}
+	return encoded
+}
+
+// String returns the Bech32-encoded representation of the extended public key as root_xvk
+func (x XPub) String() string {
+	if len(x) != 64 {
+		return ""
+	}
+	converted, err := bech32.ConvertBits(x, 8, 5, true)
+	if err != nil {
+		return ""
+	}
+	encoded, err := bech32.Encode("root_xvk", converted)
+	if err != nil {
+		return ""
+	}
+	return encoded
+}
+
+// String returns the Bech32-encoded representation of the public key as addr_vk
+func (p PublicKey) String() string {
+	if len(p) != 32 {
+		return ""
+	}
+	converted, err := bech32.ConvertBits(p, 8, 5, true)
+	if err != nil {
+		return ""
+	}
+	encoded, err := bech32.Encode("addr_vk", converted)
+	if err != nil {
+		return ""
+	}
+	return encoded
+}
 
 // PrivateKey returns the 64-byte private key portion (k_L + k_R) of the extended private key.
 func (x XPrv) PrivateKey() []byte {

--- a/bip32/bip32_test.go
+++ b/bip32/bip32_test.go
@@ -16,6 +16,7 @@ package bip32
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -224,5 +225,42 @@ func TestHardenedIndex(t *testing.T) {
 				test.expected,
 			)
 		}
+	}
+}
+
+// TestStringMethods tests the String methods for XPrv, XPub, and PublicKey.
+func TestStringMethods(t *testing.T) {
+	// Test with zero entropy
+	entropy := make([]byte, 32)
+	password := []byte{}
+	xprv := FromBip39Entropy(entropy, password)
+
+	// Test XPrv String
+	xprvStr := xprv.String()
+	if xprvStr == "" {
+		t.Error("XPrv String should not be empty")
+	}
+	if !strings.HasPrefix(xprvStr, "root_xsk") {
+		t.Errorf("XPrv String should start with 'root_xsk', got %s", xprvStr)
+	}
+
+	// Test XPub String
+	xpub := xprv.Public()
+	xpubStr := xpub.String()
+	if xpubStr == "" {
+		t.Error("XPub String should not be empty")
+	}
+	if !strings.HasPrefix(xpubStr, "root_xvk") {
+		t.Errorf("XPub String should start with 'root_xvk', got %s", xpubStr)
+	}
+
+	// Test PublicKey String
+	pubKey := xpub.PublicKey()
+	pubKeyStr := pubKey.String()
+	if pubKeyStr == "" {
+		t.Error("PublicKey String should not be empty")
+	}
+	if !strings.HasPrefix(pubKeyStr, "addr_vk") {
+		t.Errorf("PublicKey String should start with 'addr_vk', got %s", pubKeyStr)
 	}
 }

--- a/bursa.go
+++ b/bursa.go
@@ -31,6 +31,7 @@ import (
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/btcsuite/btcd/btcutil/bech32"
 	bip39 "github.com/tyler-smith/go-bip39"
 )
 
@@ -49,6 +50,70 @@ type LoadedKey struct {
 	RawCBOR     []byte
 	VKey        []byte
 	SKey        []byte
+}
+
+// String returns the Bech32-encoded representation of the key according to CIP-0005
+func (kf KeyFile) String() string {
+	var prefix string
+	switch kf.Type {
+	case "PaymentVerificationKeyShelley_ed25519":
+		prefix = "addr_vk"
+	case "PaymentSigningKeyShelley_ed25519":
+		prefix = "addr_sk"
+	case "PaymentExtendedSigningKeyShelley_ed25519_bip32":
+		prefix = "addr_xsk"
+	case "StakeVerificationKeyShelley_ed25519":
+		prefix = "stake_vk"
+	case "StakeSigningKeyShelley_ed25519":
+		prefix = "stake_sk"
+	case "StakeExtendedSigningKeyShelley_ed25519_bip32":
+		prefix = "stake_xsk"
+	default:
+		// Fallback to CBOR hex if type not recognized
+		return kf.CborHex
+	}
+
+	cborData, err := hex.DecodeString(kf.CborHex)
+	if err != nil {
+		return kf.CborHex
+	}
+	var decoded []any
+	_, err = cbor.Decode(cborData, &decoded)
+	if err != nil {
+		return kf.CborHex
+	}
+	if len(decoded) < 2 {
+		return kf.CborHex
+	}
+
+	var data []byte
+	if strings.Contains(kf.Type, "_bip32") {
+		if len(decoded) < 3 {
+			return kf.CborHex
+		}
+		priv, ok1 := decoded[1].([]byte)
+		chain, ok2 := decoded[2].([]byte)
+		if !ok1 || !ok2 {
+			return kf.CborHex
+		}
+		data = append(priv, chain...)
+	} else {
+		key, ok := decoded[1].([]byte)
+		if !ok {
+			return kf.CborHex
+		}
+		data = key
+	}
+
+	converted, err := bech32.ConvertBits(data, 8, 5, true)
+	if err != nil {
+		return kf.CborHex
+	}
+	encoded, err := bech32.Encode(prefix, converted)
+	if err != nil {
+		return kf.CborHex
+	}
+	return encoded
 }
 
 // Buffer pool for JSON marshaling

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	cloud.google.com/go/secretmanager v1.16.0
 	filippo.io/edwards25519 v1.1.0
 	github.com/blinklabs-io/gouroboros v0.140.0
+	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/getsops/sops/v3 v3.11.0
 	github.com/google/uuid v1.6.0
 	github.com/kelseyhightower/envconfig v1.4.0
@@ -71,7 +72,6 @@ require (
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blinklabs-io/plutigo v0.0.13 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.5 // indirect
-	github.com/btcsuite/btcd/btcutil v1.1.6 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CIP-0005 Bech32 string encoding for keys, making it easy to print or serialize keys in the expected format.

- **New Features**
  - String() for XPrv, XPub, and PublicKey to emit CIP-0005 Bech32 (root_xsk, root_xvk, addr_vk).
  - KeyFile.String() outputs CIP-0005 Bech32 for payment/stake keys (addr_vk, addr_sk, addr_xsk, stake_vk, stake_sk, stake_xsk). Concatenates priv+chain for bip32 keys. Falls back to CBOR hex on unknown type or decode errors.

- **Dependencies**
  - Added github.com/btcsuite/btcd/btcutil v1.1.6 as a direct dependency for Bech32 encoding.

<sup>Written for commit b61cfa010786e2817ac1247a7a377660d7c36e0e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cryptographic keys and key files now produce Bech32 string representations for serialization and display, including prefixes for root keys and address keys.
* **Tests**
  * Added tests validating the new string outputs and expected prefixes.
* **Chores**
  * Dependency declaration adjusted to make a cryptography-related package a direct dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->