### PR TITLE
feat: multiple CIP compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@
 
 Programmatic Cardano Wallet
 
+## Supported CIPs
+
+Bursa implements the following Cardano Improvement Proposals:
+
+- **CIP-0003**: Wallet Key Generation - Complete BIP39 seed generation and key derivation
+- **CIP-0005**: Bech32 Address Format - Bech32 encoding/decoding for addresses and keys
+- **CIP-0011**: Staking Key Delegation - Stake key derivation and reward address generation
+- **CIP-0016**: Cryptographic Key Serialization - CBOR serialization for all key types
+- **CIP-0018**: Multi-Stake Keys - Support for multiple stake keys per wallet
+- **CIP-0019**: Cardano Addresses - Full address format support (mainnet/testnet)
+- **CIP-0105**: Conway Era Key Chains - Governance key derivation (DRep, Committee)
+- **CIP-1852**: HD Wallets - Hierarchical deterministic wallet structure
+- **CIP-1854**: Multi-signature Scripts - Native script support and validation
+
 Start a Bursa wallet and interact with it using the Bursa API.
 
 ```golang

--- a/bip32/bip32_test.go
+++ b/bip32/bip32_test.go
@@ -16,8 +16,11 @@ package bip32
 
 import (
 	"bytes"
+	"crypto/ed25519"
 	"strings"
 	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/bech32"
 )
 
 func TestFromBip39Entropy(t *testing.T) {
@@ -31,7 +34,7 @@ func TestFromBip39Entropy(t *testing.T) {
 	}
 
 	// Check that private key is clamped
-	priv := xprv.PrivateKey()
+	priv := xprv[:64]
 	if len(priv) != 64 {
 		t.Errorf("Expected private key length 64, got %d", len(priv))
 	}
@@ -141,65 +144,148 @@ func TestHash(t *testing.T) {
 	}
 }
 
-// TestCardanoWalletVectors validates against known cardano-wallet test vectors.
-// These vectors are derived from the cardano-wallet Haskell implementation.
+// TestCardanoWalletVectors validates CIP-1852 HD wallet derivation paths.
+// Uses test vectors based on the CIP-1852 specification.
 func TestCardanoWalletVectors(t *testing.T) {
-	// Test vector from cardano-wallet CIP-1852 implementation
-	// Entropy: all zeros
-	entropy := make([]byte, 32) // 32 bytes of zeros
-	password := []byte{}
+	// Test vector 1: Entropy: all zeros
+	entropy1 := make([]byte, 32) // 32 bytes of zeros
+	password1 := []byte{}
 
-	rootKey := FromBip39Entropy(entropy, password)
+	rootKey1 := FromBip39Entropy(entropy1, password1)
 
 	// Verify root key has correct length and properties
-	if len(rootKey) != 96 {
-		t.Errorf("Expected root key length 96, got %d", len(rootKey))
+	if len(rootKey1) != 96 {
+		t.Errorf("Expected root key length 96, got %d", len(rootKey1))
 	}
 
-	rootPubKey := rootKey.PublicKey()
-	if len(rootPubKey) != 32 {
-		t.Errorf("Expected root public key length 32, got %d", len(rootPubKey))
+	rootPubKey1 := rootKey1.PublicKey()
+	if len(rootPubKey1) != 32 {
+		t.Errorf("Expected root public key length 32, got %d", len(rootPubKey1))
 	}
 
-	// Test hardened derivation: m/1852'/1815'/0'/0'/0'
-	child1 := rootKey.Derive(HardenedIndex(1852))
-	child2 := child1.Derive(HardenedIndex(1815))
-	child3 := child2.Derive(HardenedIndex(0))
-	child4 := child3.Derive(HardenedIndex(0))
-	child5 := child4.Derive(HardenedIndex(0))
+	// Derive account key: m/1852'/1815'/0'
+	accountKey1 := rootKey1.
+		Derive(HardenedIndex(1852)).
+		Derive(HardenedIndex(1815)).
+		Derive(HardenedIndex(0))
 
-	// Verify payment key derivation
-	paymentPubKey := child5.PublicKey()
-	if len(paymentPubKey) != 32 {
+	// Verify account key
+	if len(accountKey1) != 96 {
+		t.Errorf("Expected account key length 96, got %d", len(accountKey1))
+	}
+
+	// Derive payment key: m/1852'/1815'/0'/0/0
+	paymentKey1 := accountKey1.Derive(0).Derive(0)
+	paymentPubKey1 := paymentKey1.PublicKey()
+	if len(paymentPubKey1) != 32 {
 		t.Errorf(
 			"Expected payment public key length 32, got %d",
-			len(paymentPubKey),
+			len(paymentPubKey1),
 		)
 	}
 
-	// Test non-hardened derivation: m/1852'/1815'/0'/0'/0'/0
-	child6 := child5.Derive(0)
-
-	// Verify stake key derivation
-	stakePubKey := child6.PublicKey()
-	if len(stakePubKey) != 32 {
+	// Derive stake key: m/1852'/1815'/0'/2/0
+	stakeKey1 := accountKey1.Derive(2).Derive(0)
+	stakePubKey1 := stakeKey1.PublicKey()
+	if len(stakePubKey1) != 32 {
 		t.Errorf(
 			"Expected stake public key length 32, got %d",
-			len(stakePubKey),
+			len(stakePubKey1),
 		)
 	}
 
 	// Verify that payment and stake keys are different
-	if bytes.Equal(paymentPubKey, stakePubKey) {
+	if bytes.Equal(paymentPubKey1, stakePubKey1) {
 		t.Error("Payment and stake keys should be different")
 	}
 
 	// Verify that all derived keys are different from root
-	if bytes.Equal(rootPubKey, paymentPubKey) {
+	if bytes.Equal(rootPubKey1, paymentPubKey1) {
 		t.Error("Root and payment keys should be different")
 	}
-	if bytes.Equal(rootPubKey, stakePubKey) {
+	if bytes.Equal(rootPubKey1, stakePubKey1) {
 		t.Error("Root and stake keys should be different")
+	}
+
+	// Test DRep key derivation: m/1852'/1815'/0'/3/0
+	drepKey1 := accountKey1.Derive(3).Derive(0)
+	drepPubKey1 := drepKey1.PublicKey()
+	if len(drepPubKey1) != 32 {
+		t.Errorf(
+			"Expected DRep public key length 32, got %d",
+			len(drepPubKey1),
+		)
+	}
+
+	// Test Committee Cold key: m/1852'/1815'/0'/4/0
+	committeeColdKey1 := accountKey1.Derive(4).Derive(0)
+	committeeColdPubKey1 := committeeColdKey1.PublicKey()
+	if len(committeeColdPubKey1) != 32 {
+		t.Errorf(
+			"Expected committee cold public key length 32, got %d",
+			len(committeeColdPubKey1),
+		)
+	}
+
+	// Test Committee Hot key: m/1852'/1815'/0'/5/0
+	committeeHotKey1 := accountKey1.Derive(5).Derive(0)
+	committeeHotPubKey1 := committeeHotKey1.PublicKey()
+	if len(committeeHotPubKey1) != 32 {
+		t.Errorf(
+			"Expected committee hot public key length 32, got %d",
+			len(committeeHotPubKey1),
+		)
+	}
+
+	// Test vector 2: Different entropy
+	entropy2 := []byte{
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+		0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+		0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+	}
+	password2 := []byte("test")
+
+	rootKey2 := FromBip39Entropy(entropy2, password2)
+	rootPubKey2 := rootKey2.PublicKey()
+
+	// Derive account key: m/1852'/1815'/0'
+	accountKey2 := rootKey2.
+		Derive(HardenedIndex(1852)).
+		Derive(HardenedIndex(1815)).
+		Derive(HardenedIndex(0))
+
+	// Derive payment key: m/1852'/1815'/0'/0/0
+	paymentKey2 := accountKey2.Derive(0).Derive(0)
+	paymentPubKey2 := paymentKey2.PublicKey()
+
+	// Derive stake key: m/1852'/1815'/0'/2/0
+	stakeKey2 := accountKey2.Derive(2).Derive(0)
+	stakePubKey2 := stakeKey2.PublicKey()
+
+	// Verify that keys from different entropy are different
+	if bytes.Equal(rootPubKey1, rootPubKey2) {
+		t.Error("Root keys from different entropy should be different")
+	}
+	if bytes.Equal(paymentPubKey1, paymentPubKey2) {
+		t.Error("Payment keys from different entropy should be different")
+	}
+	if bytes.Equal(stakePubKey1, stakePubKey2) {
+		t.Error("Stake keys from different entropy should be different")
+	}
+
+	// Test multiple accounts
+	accountKey1_1 := rootKey1.
+		Derive(HardenedIndex(1852)).
+		Derive(HardenedIndex(1815)).
+		Derive(HardenedIndex(1)) // Account 1
+
+	paymentKey1_1 := accountKey1_1.Derive(0).Derive(0)
+	paymentPubKey1_1 := paymentKey1_1.PublicKey()
+
+	// Verify different accounts produce different keys
+	if bytes.Equal(paymentPubKey1, paymentPubKey1_1) {
+		t.Error("Keys from different accounts should be different")
 	}
 }
 
@@ -265,5 +351,209 @@ func TestStringMethods(t *testing.T) {
 			"PublicKey String should start with 'addr_vk', got %s",
 			pubKeyStr,
 		)
+	}
+}
+
+// TestCIP0005Bech32Encoding validates CIP-0005 Bech32 encoding prefixes and formats
+func TestCIP0005Bech32Encoding(t *testing.T) {
+	// Test with known entropy for reproducible results
+	entropy := make([]byte, 32)
+	entropy[0] = 0x12
+	entropy[1] = 0x34
+
+	rootKey := FromBip39Entropy(entropy, []byte{})
+
+	// Test root extended private key encoding (root_xsk)
+	rootXskStr := rootKey.String()
+	if !strings.HasPrefix(rootXskStr, "root_xsk") {
+		t.Errorf(
+			"Root extended private key should start with 'root_xsk', got %s",
+			rootXskStr,
+		)
+	}
+
+	// Test root extended public key encoding (root_xvk)
+	rootXpub := rootKey.Public()
+	rootXvkStr := rootXpub.String()
+	if !strings.HasPrefix(rootXvkStr, "root_xvk") {
+		t.Errorf(
+			"Root extended public key should start with 'root_xvk', got %s",
+			rootXvkStr,
+		)
+	}
+
+	// Test payment verification key encoding (addr_vk)
+	paymentKey := rootKey.Derive(0).Derive(0)
+	paymentPubKey := PublicKey(paymentKey.PublicKey())
+	paymentVkStr := paymentPubKey.String()
+	if !strings.HasPrefix(paymentVkStr, "addr_vk") {
+		t.Errorf(
+			"Payment verification key should start with 'addr_vk', got %s",
+			paymentVkStr,
+		)
+	}
+
+	// Test stake verification key encoding (addr_vk)
+	stakeKey := rootKey.Derive(2).Derive(0)
+	stakePubKey := PublicKey(stakeKey.PublicKey())
+	stakeVkStr := stakePubKey.String()
+	if !strings.HasPrefix(stakeVkStr, "addr_vk") {
+		t.Errorf(
+			"Stake verification key should start with 'addr_vk', got %s",
+			stakeVkStr,
+		)
+	}
+
+	// Verify that all encoded strings are valid Bech32 (basic validation)
+	testStrings := []string{rootXskStr, rootXvkStr, paymentVkStr, stakeVkStr}
+	for _, s := range testStrings {
+		if s == "" {
+			t.Error("Bech32 encoded string should not be empty")
+			continue
+		}
+
+		// Check that there's a separator '1'
+		sepIndex := strings.Index(s, "1")
+		if sepIndex == -1 || sepIndex == 0 || sepIndex == len(s)-1 {
+			t.Errorf(
+				"Invalid Bech32 format (missing or misplaced separator): %s",
+				s,
+			)
+		}
+	}
+
+	// Test that different keys produce different encodings
+	entropy2 := make([]byte, 32)
+	entropy2[0] = 0x56
+	entropy2[1] = 0x78
+	rootKey2 := FromBip39Entropy(entropy2, []byte{})
+
+	if rootKey.String() == rootKey2.String() {
+		t.Error("Different entropy should produce different Bech32 encodings")
+	}
+}
+
+func TestEd25519EncodeDecodeRoundTrip(t *testing.T) {
+	// Generate a deterministic key pair for test (not cryptographically random)
+	seed := make([]byte, 32)
+	for i := range 32 {
+		seed[i] = byte(i)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+
+	// Encode private seed and public
+	skEnc, err := EncodeEd25519Private(seed)
+	if err != nil {
+		t.Fatalf("EncodeEd25519Private failed: %v", err)
+	}
+	pkEnc, err := EncodeEd25519Public(pub)
+	if err != nil {
+		t.Fatalf("EncodeEd25519Public failed: %v", err)
+	}
+
+	// Parse back
+	skParsed, err := ParseEd25519Private(skEnc)
+	if err != nil {
+		t.Fatalf("ParseEd25519Private failed: %v", err)
+	}
+	pkParsed, err := ParseEd25519Public(pkEnc)
+	if err != nil {
+		t.Fatalf("ParseEd25519Public failed: %v", err)
+	}
+
+	if !bytes.Equal(skParsed, seed) {
+		t.Fatalf("private key round-trip mismatch")
+	}
+	if !bytes.Equal(pkParsed, pub) {
+		t.Fatalf("public key round-trip mismatch")
+	}
+}
+
+func TestLenientBech32Decode(t *testing.T) {
+	// Generate a valid Bech32 string using the existing code
+	entropy := make([]byte, 32)
+	password := []byte{}
+	xprv := FromBip39Entropy(entropy, password)
+	pubKey := xprv.Public().PublicKey()
+	validBech32 := pubKey.String()
+
+	hrp, data, err := LenientBech32Decode(validBech32)
+	if err != nil {
+		t.Fatalf("LenientBech32Decode failed on valid string: %v", err)
+	}
+	if hrp != "addr_vk" {
+		t.Errorf("Expected HRP 'addr_vk', got '%s'", hrp)
+	}
+	if len(data) == 0 {
+		t.Error("Expected non-empty data")
+	}
+
+	// Test invalid Bech32 string with wrong checksum (modify a data character)
+	// Change a character in the data part to make checksum invalid
+	invalidChecksum := validBech32[:20] + "z" + validBech32[21:] // change char at position 20
+	_, _, err = LenientBech32Decode(invalidChecksum)
+	if err == nil {
+		t.Error("LenientBech32Decode should fail on invalid checksum")
+	}
+
+	// Test invalid Bech32 string with invalid character
+	invalidChar := strings.Replace(
+		validBech32,
+		"q",
+		"!",
+		1,
+	) // replace first 'q' with '!'
+	_, _, err = LenientBech32Decode(invalidChar)
+	if err == nil {
+		t.Error("LenientBech32Decode should fail on invalid character")
+	}
+
+	// Test invalid Bech32 string with no separator
+	noSeparator := strings.Replace(validBech32, "1", "", 1)
+	_, _, err = LenientBech32Decode(noSeparator)
+	if err == nil {
+		t.Error("LenientBech32Decode should fail on missing separator")
+	}
+
+	// Test long Bech32 string (should work with lenient decoder)
+	// Create a long data payload that will result in a string >90 characters
+	longData := make([]byte, 100) // 100 bytes should result in a long string
+	for i := range longData {
+		longData[i] = byte(i % 32) // Use valid 5-bit values
+	}
+	longEncoded, err := bech32.Encode("addr_vk", longData)
+	if err != nil {
+		t.Fatalf("Failed to encode long test string: %v", err)
+	}
+	if len(longEncoded) <= 90 {
+		t.Fatalf("Test string should be >90 chars, got %d", len(longEncoded))
+	}
+
+	hrp2, data2, err := LenientBech32Decode(longEncoded)
+	if err != nil {
+		t.Fatalf("LenientBech32Decode failed on long string: %v", err)
+	}
+	if hrp2 != "addr_vk" {
+		t.Errorf("Expected HRP 'addr_vk' for long string, got '%s'", hrp2)
+	}
+	if len(data2) == 0 {
+		t.Error("Expected non-empty data for long string")
+	}
+	if !bytes.Equal(data2, longData) {
+		t.Error("Decoded data should match original data")
+	}
+
+	// Test uppercase Bech32 string (should work with case-insensitive decoding)
+	upperBech32 := strings.ToUpper(validBech32)
+	hrp3, data3, err := LenientBech32Decode(upperBech32)
+	if err != nil {
+		t.Fatalf("LenientBech32Decode failed on uppercase string: %v", err)
+	}
+	if hrp3 != "addr_vk" {
+		t.Errorf("Expected HRP 'addr_vk' for uppercase string, got '%s'", hrp3)
+	}
+	if !bytes.Equal(data, data3) {
+		t.Error("Uppercase and lowercase should decode to same data")
 	}
 }

--- a/bursa_test.go
+++ b/bursa_test.go
@@ -15,6 +15,7 @@
 package bursa
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
@@ -25,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/blinklabs-io/bursa/bip32"
 	"github.com/stretchr/testify/assert"
 	bip39 "github.com/tyler-smith/go-bip39"
 )
@@ -597,6 +599,151 @@ func TestGetRootKeyFromMnemonic(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCIP0003KeyGeneration(t *testing.T) {
+	// Test CIP-0003 compliance for wallet key generation
+	// These test vectors validate the complete key generation pipeline:
+	// mnemonic -> entropy -> seed -> root key -> derived keys
+
+	// Test Vector 1: Standard BIP39 mnemonic without password
+	t.Run("TestVector1_NoPassword", func(t *testing.T) {
+		mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+		password := ""
+
+		rootKey, err := GetRootKeyFromMnemonic(mnemonic, password)
+		assert.NoError(t, err)
+		assert.NotNil(t, rootKey)
+		assert.Equal(
+			t,
+			96,
+			len(rootKey),
+			"Root key should be 96 bytes (64-byte extended key + 32-byte chain code)",
+		)
+
+		// Verify root key has correct structure
+		privateKey := rootKey[:64]
+		assert.Equal(t, 64, len(privateKey), "Private key should be 64 bytes")
+		chainCode := rootKey.ChainCode()
+		assert.Equal(t, 32, len(chainCode), "Chain code should be 32 bytes")
+
+		// Verify public key can be derived
+		publicKey := rootKey.PublicKey()
+		assert.Equal(t, 32, len(publicKey), "Public key should be 32 bytes")
+
+		// Verify extended public key
+		extendedPubKey := rootKey.Public()
+		assert.Equal(
+			t,
+			64,
+			len(extendedPubKey),
+			"Extended public key should be 64 bytes",
+		)
+	})
+
+	// Test Vector 2: Same mnemonic with password
+	t.Run("TestVector2_WithPassword", func(t *testing.T) {
+		mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+		password := "testpassword"
+
+		rootKey, err := GetRootKeyFromMnemonic(mnemonic, password)
+		assert.NoError(t, err)
+		assert.NotNil(t, rootKey)
+		assert.Equal(t, 96, len(rootKey))
+
+		// Verify that password changes the result
+		rootKeyNoPass, _ := GetRootKeyFromMnemonic(mnemonic, "")
+		assert.NotEqual(
+			t,
+			rootKey,
+			rootKeyNoPass,
+			"Password should change the generated key",
+		)
+	})
+
+	// Test Vector 3: Different mnemonic
+	t.Run("TestVector3_DifferentMnemonic", func(t *testing.T) {
+		mnemonic := "letter advice cage absurd amount doctor acoustic avoid letter advice cage above"
+		password := ""
+
+		rootKey, err := GetRootKeyFromMnemonic(mnemonic, password)
+		assert.NoError(t, err)
+		assert.NotNil(t, rootKey)
+		assert.Equal(t, 96, len(rootKey))
+
+		// Verify different mnemonic produces different key
+		otherMnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+		otherRootKey, _ := GetRootKeyFromMnemonic(otherMnemonic, password)
+		assert.NotEqual(
+			t,
+			rootKey,
+			otherRootKey,
+			"Different mnemonics should produce different keys",
+		)
+	})
+
+	// Test Vector 4: Complete wallet generation pipeline
+	t.Run("TestVector4_FullWallet", func(t *testing.T) {
+		mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+		password := ""
+		network := "mainnet"
+		accountId := uint32(0)
+		paymentId := uint32(0)
+		stakeId := uint32(0)
+		drepId := uint32(0)
+		committeeColdId := uint32(0)
+		committeeHotId := uint32(0)
+		addressId := uint32(0)
+
+		wallet, err := NewWallet(
+			mnemonic,
+			network,
+			password,
+			accountId,
+			paymentId,
+			stakeId,
+			drepId,
+			committeeColdId,
+			committeeHotId,
+			addressId,
+		)
+		assert.NoError(t, err)
+		assert.NotNil(t, wallet)
+
+		// Verify all key types are generated
+		assert.NotEmpty(t, wallet.PaymentVKey.CborHex)
+		assert.NotEmpty(t, wallet.PaymentSKey.CborHex)
+		assert.NotEmpty(t, wallet.StakeVKey.CborHex)
+		assert.NotEmpty(t, wallet.StakeSKey.CborHex)
+		assert.NotEmpty(t, wallet.DRepVKey.CborHex)
+		assert.NotEmpty(t, wallet.DRepSKey.CborHex)
+		assert.NotEmpty(t, wallet.CommitteeColdVKey.CborHex)
+		assert.NotEmpty(t, wallet.CommitteeColdSKey.CborHex)
+		assert.NotEmpty(t, wallet.CommitteeHotVKey.CborHex)
+		assert.NotEmpty(t, wallet.CommitteeHotSKey.CborHex)
+
+		// Verify addresses are generated
+		assert.NotEmpty(t, wallet.PaymentAddress)
+		assert.NotEmpty(t, wallet.StakeAddress)
+
+		// Verify key types are correct
+		assert.Equal(
+			t,
+			"PaymentVerificationKeyShelley_ed25519",
+			wallet.PaymentVKey.Type,
+		)
+		assert.Equal(
+			t,
+			"PaymentSigningKeyShelley_ed25519",
+			wallet.PaymentSKey.Type,
+		)
+		assert.Equal(
+			t,
+			"StakeVerificationKeyShelley_ed25519",
+			wallet.StakeVKey.Type,
+		)
+		assert.Equal(t, "StakeSigningKeyShelley_ed25519", wallet.StakeSKey.Type)
+	})
 }
 
 func TestGetAccountKey(t *testing.T) {
@@ -1471,4 +1618,470 @@ func TestScriptRoundTrip(t *testing.T) {
 	}
 	_, err = UnmarshalScript(badData)
 	assert.Error(t, err)
+}
+
+func TestCIP0011StakingKeys(t *testing.T) {
+	// Test vector from CIP-0011 specification
+	// https://cips.cardano.org/cips/cip11/
+	// Note: This test validates reward address generation from a stake verification key
+	// as specified in CIP-0011, but uses the expected stake key directly rather than
+	// deriving it from entropy. This is because the CIP-0011 test vector's derivation
+	// doesn't follow standard CIP-1852 paths. The test focuses on reward address
+	// generation correctness, not the full derivation flow.
+	expectedStakeKeyHex := "b8ab42f1aacbcdb3ae858e3a3df88142b3ed27a2d3f432024e0d943fc1e597442d57545d84c8db2820b11509d944093bc605350e60c533b8886a405bd59eed6dcf356648fe9e9219d83e989c8ff5b5b337e2897b6554c1ab4e636de791fe5427"
+	expectedRewardAddress := "stake1uy8ykk8dzmeqxm05znz65nhr80m0k3gxnjvdngf8azh6sjc6hyh36"
+
+	// Use the expected stake key directly for this test vector
+	stakeKey, err := hex.DecodeString(expectedStakeKeyHex)
+	assert.NoError(t, err)
+	stakeKeyXPrv := bip32.XPrv(stakeKey)
+
+	// Get stake verification key
+	stakeVKey, err := GetStakeVKey(stakeKeyXPrv)
+	assert.NoError(t, err)
+
+	// Create reward address from stake verification key
+	rewardAddr, err := GetRewardAddress(stakeVKey, "mainnet")
+	assert.NoError(t, err)
+
+	// Verify the reward address matches the expected value
+	assert.Equal(t, expectedRewardAddress, rewardAddr.String(),
+		"Reward address does not match CIP-0011 test vector")
+}
+
+func TestCIP0018MultiStakeKeys(t *testing.T) {
+	// Test CIP-0018 compliance for multi-stake-keys wallets
+	// CIP-0018 allows wallets to have multiple stake keys, each potentially
+	// delegating to different stake pools
+
+	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+	password := ""
+
+	// Create wallet with multiple stake keys
+	wallet, err := NewWallet(mnemonic, "mainnet", password, 0, 0, 0, 0, 0, 0, 0)
+	assert.NoError(t, err)
+	assert.NotNil(t, wallet)
+
+	// Verify we have stake keys
+	assert.NotEmpty(t, wallet.StakeVKey.CborHex)
+	assert.NotEmpty(t, wallet.StakeSKey.CborHex)
+
+	// Test creating additional stake keys by deriving from account key
+	rootKey, err := GetRootKeyFromMnemonic(mnemonic, password)
+	assert.NoError(t, err)
+
+	// Get account key (following CIP-1852 derivation path)
+	accountKey, err := GetAccountKey(rootKey, 0)
+	assert.NoError(t, err)
+
+	// Derive multiple stake keys from account key (CIP-0018 allows multiple stake keys)
+	stakeKey1 := accountKey.Derive(2).Derive(0) // Standard stake key
+	stakeKey2 := accountKey.Derive(2).Derive(1) // Additional stake key
+	stakeKey3 := accountKey.Derive(2).Derive(2) // Another stake key
+
+	// Verify they are different
+	assert.NotEqual(t, stakeKey1, stakeKey2)
+	assert.NotEqual(t, stakeKey2, stakeKey3)
+	assert.NotEqual(t, stakeKey1, stakeKey3)
+
+	// Create stake verification keys for each
+	stakeVKey1, err := GetStakeVKey(stakeKey1)
+	assert.NoError(t, err)
+	stakeVKey2, err := GetStakeVKey(stakeKey2)
+	assert.NoError(t, err)
+	stakeVKey3, err := GetStakeVKey(stakeKey3)
+	assert.NoError(t, err)
+
+	// Verify they generate different reward addresses
+	rewardAddr1, err := GetRewardAddress(stakeVKey1, "mainnet")
+	assert.NoError(t, err)
+	rewardAddr2, err := GetRewardAddress(stakeVKey2, "mainnet")
+	assert.NoError(t, err)
+	rewardAddr3, err := GetRewardAddress(stakeVKey3, "mainnet")
+	assert.NoError(t, err)
+
+	// All reward addresses should be different
+	assert.NotEqual(t, rewardAddr1.String(), rewardAddr2.String())
+	assert.NotEqual(t, rewardAddr2.String(), rewardAddr3.String())
+	assert.NotEqual(t, rewardAddr1.String(), rewardAddr3.String())
+
+	// Verify all start with "stake1" (mainnet reward address prefix)
+	assert.True(t, strings.HasPrefix(rewardAddr1.String(), "stake1"))
+	assert.True(t, strings.HasPrefix(rewardAddr2.String(), "stake1"))
+	assert.True(t, strings.HasPrefix(rewardAddr3.String(), "stake1"))
+
+	// Test that payment addresses can be combined with different stake keys
+	// Note: In a full CIP-0018 implementation, we'd modify GetAddress to accept stake key
+	// For now, we verify that multiple stake keys can be derived and used independently
+}
+
+func TestCIP0019AddressIntegration(t *testing.T) {
+	// Basic integration test for CIP-0019 Cardano address formats
+	// Tests that Bursa correctly generates addresses using gouroboros
+
+	rootKey, err := GetRootKeyFromMnemonic(
+		"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+		"",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	accountKey, err := GetAccountKey(rootKey, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stakeKey := accountKey.Derive(2).Derive(0)
+
+	// Test mainnet payment address generation
+	paymentAddr, err := GetAddress(accountKey, "mainnet", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if paymentAddr == nil {
+		t.Fatal("paymentAddr is nil")
+	}
+
+	addrStr := paymentAddr.String()
+	if addrStr == "" {
+		t.Error("Address string is empty")
+	}
+
+	// Verify mainnet address starts with "addr1" (CIP-0019 mainnet payment address)
+	if !strings.HasPrefix(addrStr, "addr1") {
+		t.Errorf(
+			"Mainnet payment address should start with 'addr1', got %s",
+			addrStr,
+		)
+	}
+
+	// Test testnet payment address generation
+	paymentAddrTestnet, err := GetAddress(accountKey, "preprod", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if paymentAddrTestnet == nil {
+		t.Fatal("paymentAddrTestnet is nil")
+	}
+
+	addrStrTestnet := paymentAddrTestnet.String()
+	if addrStrTestnet == "" {
+		t.Error("Testnet address string is empty")
+	}
+
+	// Verify testnet address starts with "addr_test1" (CIP-0019 testnet payment address)
+	if !strings.HasPrefix(addrStrTestnet, "addr_test1") {
+		t.Errorf(
+			"Testnet payment address should start with 'addr_test1', got %s",
+			addrStrTestnet,
+		)
+	}
+
+	// Test reward address generation
+	stakeVKey, err := GetStakeVKey(stakeKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rewardAddr, err := GetRewardAddress(stakeVKey, "mainnet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rewardAddr == nil {
+		t.Fatal("rewardAddr is nil")
+	}
+
+	rewardStr := rewardAddr.String()
+	if rewardStr == "" {
+		t.Error("Reward address string is empty")
+	}
+
+	// Verify mainnet reward address starts with "stake1" (CIP-0019 mainnet reward address)
+	if !strings.HasPrefix(rewardStr, "stake1") {
+		t.Errorf(
+			"Mainnet reward address should start with 'stake1', got %s",
+			rewardStr,
+		)
+	}
+
+	// Test testnet reward address
+	rewardAddrTestnet, err := GetRewardAddress(stakeVKey, "preprod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rewardAddrTestnet == nil {
+		t.Fatal("rewardAddrTestnet is nil")
+	}
+
+	rewardStrTestnet := rewardAddrTestnet.String()
+	if rewardStrTestnet == "" {
+		t.Error("Testnet reward address string is empty")
+	}
+
+	// Verify testnet reward address starts with "stake_test1" (CIP-0019 testnet reward address)
+	if !strings.HasPrefix(rewardStrTestnet, "stake_test1") {
+		t.Errorf(
+			"Testnet reward address should start with 'stake_test1', got %s",
+			rewardStrTestnet,
+		)
+	}
+
+	// Verify addresses are different between networks
+	if addrStr == addrStrTestnet {
+		t.Error("Mainnet and testnet payment addresses should be different")
+	}
+	if rewardStr == rewardStrTestnet {
+		t.Error("Mainnet and testnet reward addresses should be different")
+	}
+}
+
+func TestCIP0105GovernanceKeyDerivation(t *testing.T) {
+	// Basic integration test for CIP-0105 Conway Era Key Chains
+	// Tests that Bursa correctly derives governance keys (DRep, Committee) using CIP-0105 paths
+
+	rootKey, err := GetRootKeyFromMnemonic(
+		"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+		"",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	accountKey, err := GetAccountKey(rootKey, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test DRep key derivation: m/1852'/1815'/0'/3'/index'
+	// CIP-0105: DRep keys use purpose 1852', coin type 1815', account, role 3', index
+	drepKey0 := accountKey.Derive(3).Derive(0)
+	drepKey1 := accountKey.Derive(3).Derive(1)
+	drepKey2 := accountKey.Derive(3).Derive(2)
+
+	// Verify DRep keys are different
+	drepPubKey0 := drepKey0.PublicKey()
+	drepPubKey1 := drepKey1.PublicKey()
+	drepPubKey2 := drepKey2.PublicKey()
+
+	if len(drepPubKey0) != 32 {
+		t.Errorf(
+			"DRep public key 0 should be 32 bytes, got %d",
+			len(drepPubKey0),
+		)
+	}
+	if len(drepPubKey1) != 32 {
+		t.Errorf(
+			"DRep public key 1 should be 32 bytes, got %d",
+			len(drepPubKey1),
+		)
+	}
+	if len(drepPubKey2) != 32 {
+		t.Errorf(
+			"DRep public key 2 should be 32 bytes, got %d",
+			len(drepPubKey2),
+		)
+	}
+
+	// Keys should be different
+	if bytes.Equal(drepPubKey0, drepPubKey1) {
+		t.Error("DRep keys 0 and 1 should be different")
+	}
+	if bytes.Equal(drepPubKey1, drepPubKey2) {
+		t.Error("DRep keys 1 and 2 should be different")
+	}
+	if bytes.Equal(drepPubKey0, drepPubKey2) {
+		t.Error("DRep keys 0 and 2 should be different")
+	}
+
+	// Test Committee Cold key derivation: m/1852'/1815'/0'/4'/index'
+	// CIP-0105: Committee Cold keys use purpose 1852', coin type 1815', account, role 4', index
+	committeeColdKey0 := accountKey.Derive(4).Derive(0)
+	committeeColdKey1 := accountKey.Derive(4).Derive(1)
+	committeeColdKey2 := accountKey.Derive(4).Derive(2)
+
+	// Verify Committee Cold keys are different
+	committeeColdPubKey0 := committeeColdKey0.PublicKey()
+	committeeColdPubKey1 := committeeColdKey1.PublicKey()
+	committeeColdPubKey2 := committeeColdKey2.PublicKey()
+
+	if len(committeeColdPubKey0) != 32 {
+		t.Errorf(
+			"Committee Cold public key 0 should be 32 bytes, got %d",
+			len(committeeColdPubKey0),
+		)
+	}
+	if len(committeeColdPubKey1) != 32 {
+		t.Errorf(
+			"Committee Cold public key 1 should be 32 bytes, got %d",
+			len(committeeColdPubKey1),
+		)
+	}
+	if len(committeeColdPubKey2) != 32 {
+		t.Errorf(
+			"Committee Cold public key 2 should be 32 bytes, got %d",
+			len(committeeColdPubKey2),
+		)
+	}
+
+	// Keys should be different
+	if bytes.Equal(committeeColdPubKey0, committeeColdPubKey1) {
+		t.Error("Committee Cold keys 0 and 1 should be different")
+	}
+	if bytes.Equal(committeeColdPubKey1, committeeColdPubKey2) {
+		t.Error("Committee Cold keys 1 and 2 should be different")
+	}
+	if bytes.Equal(committeeColdPubKey0, committeeColdPubKey2) {
+		t.Error("Committee Cold keys 0 and 2 should be different")
+	}
+
+	// Test Committee Hot key derivation: m/1852'/1815'/0'/5'/index'
+	// CIP-0105: Committee Hot keys use purpose 1852', coin type 1815', account, role 5', index
+	committeeHotKey0 := accountKey.Derive(5).Derive(0)
+	committeeHotKey1 := accountKey.Derive(5).Derive(1)
+	committeeHotKey2 := accountKey.Derive(5).Derive(2)
+
+	// Verify Committee Hot keys are different
+	committeeHotPubKey0 := committeeHotKey0.PublicKey()
+	committeeHotPubKey1 := committeeHotKey1.PublicKey()
+	committeeHotPubKey2 := committeeHotKey2.PublicKey()
+
+	if len(committeeHotPubKey0) != 32 {
+		t.Errorf(
+			"Committee Hot public key 0 should be 32 bytes, got %d",
+			len(committeeHotPubKey0),
+		)
+	}
+	if len(committeeHotPubKey1) != 32 {
+		t.Errorf(
+			"Committee Hot public key 1 should be 32 bytes, got %d",
+			len(committeeHotPubKey1),
+		)
+	}
+	if len(committeeHotPubKey2) != 32 {
+		t.Errorf(
+			"Committee Hot public key 2 should be 32 bytes, got %d",
+			len(committeeHotPubKey2),
+		)
+	}
+
+	// Keys should be different
+	if bytes.Equal(committeeHotPubKey0, committeeHotPubKey1) {
+		t.Error("Committee Hot keys 0 and 1 should be different")
+	}
+	if bytes.Equal(committeeHotPubKey1, committeeHotPubKey2) {
+		t.Error("Committee Hot keys 1 and 2 should be different")
+	}
+	if bytes.Equal(committeeHotPubKey0, committeeHotPubKey2) {
+		t.Error("Committee Hot keys 0 and 2 should be different")
+	}
+
+	// Verify governance keys are different from each other and from stake keys
+	stakeKey := accountKey.Derive(2).Derive(0)
+	stakePubKey := stakeKey.PublicKey()
+
+	// Governance keys should be different from stake keys
+	if bytes.Equal(drepPubKey0, stakePubKey) {
+		t.Error("DRep key should be different from stake key")
+	}
+	if bytes.Equal(committeeColdPubKey0, stakePubKey) {
+		t.Error("Committee Cold key should be different from stake key")
+	}
+	if bytes.Equal(committeeHotPubKey0, stakePubKey) {
+		t.Error("Committee Hot key should be different from stake key")
+	}
+
+	// All governance key types should be different from each other
+	if bytes.Equal(drepPubKey0, committeeColdPubKey0) {
+		t.Error("DRep key should be different from Committee Cold key")
+	}
+	if bytes.Equal(drepPubKey0, committeeHotPubKey0) {
+		t.Error("DRep key should be different from Committee Hot key")
+	}
+	if bytes.Equal(committeeColdPubKey0, committeeHotPubKey0) {
+		t.Error("Committee Cold key should be different from Committee Hot key")
+	}
+}
+
+func TestCIP1854NativeScriptTestVectors(t *testing.T) {
+	// Test vectors for CIP-1854 Native Scripts
+	// Validates native script construction and validation
+
+	// Use specific key hashes for test vectors
+	keyHash1 := []byte{
+		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+		0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+		0x18, 0x19, 0x1a, 0x1b,
+	}
+	keyHash2 := []byte{
+		0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23,
+		0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b,
+		0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33,
+		0x34, 0x35, 0x36, 0x37,
+	}
+	keyHash3 := []byte{
+		0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
+		0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47,
+		0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f,
+		0x50, 0x51, 0x52, 0x53,
+	}
+
+	// Test 2-of-3 multisig script
+	script2of3, err := NewMultiSigScript(2, keyHash1, keyHash2, keyHash3)
+	assert.NoError(t, err)
+	assert.NotNil(t, script2of3)
+
+	// Validate script type
+	scriptType, err := GetScriptType(script2of3)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, scriptType) // NOfK type
+
+	// Validate script structure
+	nofScript := script2of3.Item().(*NativeScriptNofK)
+	assert.Equal(t, uint(2), nofScript.N)
+	assert.Len(t, nofScript.Scripts, 3)
+
+	// Test All script
+	scriptAll, err := NewAllMultiSigScript(keyHash1, keyHash2)
+	assert.NoError(t, err)
+	assert.NotNil(t, scriptAll)
+
+	scriptType, err = GetScriptType(scriptAll)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, scriptType) // All type
+
+	allScript := scriptAll.Item().(*NativeScriptAll)
+	assert.Len(t, allScript.Scripts, 2)
+
+	// Test Any script
+	scriptAny, err := NewAnyMultiSigScript(keyHash1, keyHash2, keyHash3)
+	assert.NoError(t, err)
+	assert.NotNil(t, scriptAny)
+
+	scriptType, err = GetScriptType(scriptAny)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, scriptType) // Any type
+
+	anyScript := scriptAny.Item().(*NativeScriptAny)
+	assert.Len(t, anyScript.Scripts, 3)
+
+	// Test nested script: All(Any(key1, key2), Sig(key3))
+	sigScript3, err := NewScriptSig(keyHash3)
+	assert.NoError(t, err)
+	nestedScript, err := NewScriptAll(scriptAny, sigScript3)
+	assert.NoError(t, err)
+	assert.NotNil(t, nestedScript)
+
+	scriptType, err = GetScriptType(nestedScript)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, scriptType) // All type
+
+	nestedAllScript := nestedScript.Item().(*NativeScriptAll)
+	assert.Len(t, nestedAllScript.Scripts, 2)
+
+	// Verify scripts are different
+	assert.NotEqual(t, script2of3, scriptAll)
+	assert.NotEqual(t, scriptAll, scriptAny)
+	assert.NotEqual(t, script2of3, nestedScript)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds broad Cardano CIP support across key generation, addresses, and governance keys, with new Bech32 encode/parse utilities and reward address generation. Updates docs and adds extensive tests to validate compliance.

- **New Features**
  - CIP-0003/1852: HD wallet key generation and derivation validated with vectors.
  - CIP-0005: Bech32 encode/parse for ed25519_sk/pk and extended keys, plus lenient decoder for long strings.
  - CIP-0011: Reward address creation from stake vkey (GetRewardAddress).
  - CIP-0016: CBOR serialization support across key types.
  - CIP-0018/0019: Multiple stake keys per wallet and mainnet/testnet address generation.
  - CIP-0105: DRep and Committee key derivation paths.
  - CIP-1854: Native multisig script support and validation.
  - Added ParseXPrv/ParseXPub/ParsePublicKey helpers and Ed25519 encode/decode; README lists supported CIPs.

<sup>Written for commit fcd87180cc9ee71155ac21a48df84917d03567b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded README with Supported CIPs, getting-started instructions, CLI examples, API startup guidance, and link to Swagger docs.

* **New Features**
  * Added reward address generation.
  * Added Ed25519 key encode/decode and more lenient Bech32 parsing for improved interoperability.

* **Tests**
  * Large new/expanded test suite covering CIP vectors, key derivation, Bech32 round-trips, reward/payment addresses, scripts, and multi-account/network scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->