### PR TITLE
feat: CIP-1853 stake pool cold keys

### DIFF
--- a/bursa_test.go
+++ b/bursa_test.go
@@ -166,6 +166,24 @@ func TestExtractKeyFiles(t *testing.T) {
     "cborHex": ""
 }
 `,
+		"pool-cold.vkey": `{
+    "type": "",
+    "description": "",
+    "cborHex": ""
+}
+`,
+		"pool-cold.skey": `{
+    "type": "",
+    "description": "",
+    "cborHex": ""
+}
+`,
+		"pool-cold-extended.skey": `{
+    "type": "",
+    "description": "",
+    "cborHex": ""
+}
+`,
 	}
 
 	result, err := ExtractKeyFiles(wallet)
@@ -179,7 +197,7 @@ func TestLoadWalletDir(t *testing.T) {
 
 	// Create a wallet
 	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-	wallet, err := NewWallet(mnemonic, "mainnet", "", 0, 0, 0, 0, 0, 0, 0)
+	wallet, err := NewWallet(mnemonic, "mainnet", "", 0, 0, 0, 0, 0, 0, 0, 0)
 	assert.NoError(t, err)
 
 	// Extract key files
@@ -199,8 +217,8 @@ func TestLoadWalletDir(t *testing.T) {
 	assert.Len(
 		t,
 		loadedKeys,
-		15,
-	) // 3 vkeys + 3 skeys per key type (payment, stake, drep, committee cold, committee hot)
+		18,
+	) // 3 vkeys + 3 skeys per key type (payment, stake, drep, committee cold, committee hot, pool cold)
 
 	// Check that keys are loaded correctly
 	keyMap := make(map[string]*LoadedKey)
@@ -239,7 +257,7 @@ func TestLoadWalletDirPartial(t *testing.T) {
 
 	// Create a wallet
 	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-	wallet, err := NewWallet(mnemonic, "mainnet", "", 0, 0, 0, 0, 0, 0, 0)
+	wallet, err := NewWallet(mnemonic, "mainnet", "", 0, 0, 0, 0, 0, 0, 0, 0)
 	assert.NoError(t, err)
 
 	// Extract key files
@@ -301,7 +319,7 @@ func BenchmarkNewWallet(b *testing.B) {
 	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 
 	for b.Loop() {
-		_, err := NewWallet(mnemonic, "mainnet", "", 0, 0, 0, 0, 0, 0, 0)
+		_, err := NewWallet(mnemonic, "mainnet", "", 0, 0, 0, 0, 0, 0, 0, 0)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -314,6 +332,7 @@ func BenchmarkExtractKeyFiles(b *testing.B) {
 		mnemonic,
 		"mainnet",
 		"",
+		0,
 		0,
 		0,
 		0,
@@ -348,6 +367,7 @@ func BenchmarkCBORDecode(b *testing.B) {
 		0,
 		0,
 		0,
+		0,
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -373,7 +393,7 @@ func BenchmarkLoadWalletDir(b *testing.B) {
 	tmpDir := b.TempDir()
 
 	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-	wallet, err := NewWallet(mnemonic, "mainnet", "", 0, 0, 0, 0, 0, 0, 0)
+	wallet, err := NewWallet(mnemonic, "mainnet", "", 0, 0, 0, 0, 0, 0, 0, 0)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -402,14 +422,38 @@ func BenchmarkLoadWalletDir(b *testing.B) {
 }
 
 func TestNewWalletInvalidMnemonic(t *testing.T) {
-	_, err := NewWallet("invalid mnemonic", "mainnet", "", 0, 0, 0, 0, 0, 0, 0)
+	_, err := NewWallet(
+		"invalid mnemonic",
+		"mainnet",
+		"",
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+	)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid mnemonic")
 }
 
 func TestNewWalletInvalidIndices(t *testing.T) {
 	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-	_, err := NewWallet(mnemonic, "mainnet", "", 0x80000000, 0, 0, 0, 0, 0, 0)
+	_, err := NewWallet(
+		mnemonic,
+		"mainnet",
+		"",
+		0x80000000,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+	)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "derivation indices must be less than 2^31")
 }
@@ -442,6 +486,7 @@ func TestCIP1852Compliance(t *testing.T) {
 		accountId,
 		paymentId,
 		stakeId,
+		0,
 		0,
 		0,
 		0,
@@ -693,6 +738,7 @@ func TestCIP0003KeyGeneration(t *testing.T) {
 		drepId := uint32(0)
 		committeeColdId := uint32(0)
 		committeeHotId := uint32(0)
+		poolColdId := uint32(0)
 		addressId := uint32(0)
 
 		wallet, err := NewWallet(
@@ -705,6 +751,7 @@ func TestCIP0003KeyGeneration(t *testing.T) {
 			drepId,
 			committeeColdId,
 			committeeHotId,
+			poolColdId,
 			addressId,
 		)
 		assert.NoError(t, err)
@@ -1658,7 +1705,19 @@ func TestCIP0018MultiStakeKeys(t *testing.T) {
 	password := ""
 
 	// Create wallet with multiple stake keys
-	wallet, err := NewWallet(mnemonic, "mainnet", password, 0, 0, 0, 0, 0, 0, 0)
+	wallet, err := NewWallet(
+		mnemonic,
+		"mainnet",
+		password,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+	)
 	assert.NoError(t, err)
 	assert.NotNil(t, wallet)
 
@@ -2084,4 +2143,271 @@ func TestCIP1854NativeScriptTestVectors(t *testing.T) {
 	assert.NotEqual(t, script2of3, scriptAll)
 	assert.NotEqual(t, scriptAll, scriptAny)
 	assert.NotEqual(t, script2of3, nestedScript)
+}
+
+// TestCIP1853PoolColdKeyDerivation validates CIP-1853 stake pool cold key derivation.
+// CIP-1853 defines HD derivation paths for stake pool cold keys: m/1853'/1815'/usecase'/index'
+func TestCIP1853PoolColdKeyDerivation(t *testing.T) {
+	// Test basic pool cold key derivation
+	rootKey, err := GetRootKeyFromMnemonic(
+		"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+		"",
+	)
+	assert.NoError(t, err)
+
+	// Test pool cold key derivation: m/1853'/1815'/0'/0'
+	// CIP-1853: Pool cold keys use purpose 1853', coin type 1815', usecase 0' (fixed), index'
+	poolColdKey0, err := GetPoolColdKey(rootKey, 0, 0)
+	assert.NoError(t, err)
+	assert.NotNil(t, poolColdKey0)
+
+	poolColdKey1, err := GetPoolColdKey(rootKey, 0, 1)
+	assert.NoError(t, err)
+	assert.NotNil(t, poolColdKey1)
+
+	poolColdKey2, err := GetPoolColdKey(rootKey, 0, 2)
+	assert.NoError(t, err)
+	assert.NotNil(t, poolColdKey2)
+
+	// Verify pool cold keys are different
+	poolColdPubKey0 := poolColdKey0.PublicKey()
+	poolColdPubKey1 := poolColdKey1.PublicKey()
+	poolColdPubKey2 := poolColdKey2.PublicKey()
+
+	assert.Len(
+		t,
+		poolColdPubKey0,
+		32,
+		"Pool cold public key 0 should be 32 bytes",
+	)
+	assert.Len(
+		t,
+		poolColdPubKey1,
+		32,
+		"Pool cold public key 1 should be 32 bytes",
+	)
+	assert.Len(
+		t,
+		poolColdPubKey2,
+		32,
+		"Pool cold public key 2 should be 32 bytes",
+	)
+
+	// Keys should be different
+	assert.NotEqual(
+		t,
+		poolColdPubKey0,
+		poolColdPubKey1,
+		"Pool cold keys 0 and 1 should be different",
+	)
+	assert.NotEqual(
+		t,
+		poolColdPubKey1,
+		poolColdPubKey2,
+		"Pool cold keys 1 and 2 should be different",
+	)
+	assert.NotEqual(
+		t,
+		poolColdPubKey0,
+		poolColdPubKey2,
+		"Pool cold keys 0 and 2 should be different",
+	)
+
+	// Verify pool cold keys are different from wallet keys
+	accountKey, err := GetAccountKey(rootKey, 0)
+	assert.NoError(t, err)
+
+	stakeKey, err := GetStakeKey(accountKey, 0)
+	assert.NoError(t, err)
+	stakePubKey := stakeKey.PublicKey()
+
+	assert.NotEqual(
+		t,
+		poolColdPubKey0,
+		stakePubKey,
+		"Pool cold key should be different from stake key",
+	)
+
+	// Test usecase parameter (should be fixed to 0)
+	poolColdKeyUsecase1, err := GetPoolColdKey(rootKey, 1, 0)
+	assert.NoError(t, err)
+	poolColdPubKeyUsecase1 := poolColdKeyUsecase1.PublicKey()
+	assert.NotEqual(
+		t,
+		poolColdPubKey0,
+		poolColdPubKeyUsecase1,
+		"Different usecases should produce different keys",
+	)
+
+	// Test invalid indices (>= 0x80000000)
+	_, err = GetPoolColdKey(rootKey, 0x80000000, 0)
+	assert.Error(t, err, "Should reject invalid usecase index")
+	assert.ErrorIs(t, err, ErrInvalidDerivationIndex)
+
+	_, err = GetPoolColdKey(rootKey, 0, 0x80000000)
+	assert.Error(t, err, "Should reject invalid pool index")
+	assert.ErrorIs(t, err, ErrInvalidDerivationIndex)
+}
+
+// TestCIP1853KeyFileGeneration validates key file generation for pool cold keys
+func TestCIP1853KeyFileGeneration(t *testing.T) {
+	rootKey, err := GetRootKeyFromMnemonic(
+		"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+		"",
+	)
+	assert.NoError(t, err)
+
+	poolColdKey, err := GetPoolColdKey(rootKey, 0, 0)
+	assert.NoError(t, err)
+
+	// Test verification key generation
+	vkey, err := GetPoolColdVKey(poolColdKey)
+	assert.NoError(t, err)
+	assert.Equal(t, "StakePoolVerificationKeyShelley_ed25519", vkey.Type)
+	assert.Equal(t, "Stake Pool Cold Verification Key", vkey.Description)
+	assert.NotEmpty(t, vkey.CborHex)
+
+	// Test signing key generation
+	skey, err := GetPoolColdSKey(poolColdKey)
+	assert.NoError(t, err)
+	assert.Equal(t, "StakePoolSigningKeyShelley_ed25519", skey.Type)
+	assert.Equal(t, "Stake Pool Cold Signing Key", skey.Description)
+	assert.NotEmpty(t, skey.CborHex)
+
+	// Test extended signing key generation
+	extendedSkey, err := GetPoolColdExtendedSKey(poolColdKey)
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		"StakePoolExtendedSigningKeyShelley_ed25519_bip32",
+		extendedSkey.Type,
+	)
+	assert.Equal(
+		t,
+		"Stake Pool Cold Extended Signing Key (BIP32)",
+		extendedSkey.Description,
+	)
+	assert.NotEmpty(t, extendedSkey.CborHex)
+
+	// Verify CBOR decoding
+	vkeyCbor, err := hex.DecodeString(vkey.CborHex)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, vkeyCbor)
+
+	skeyCbor, err := hex.DecodeString(skey.CborHex)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, skeyCbor)
+
+	extendedSkeyCbor, err := hex.DecodeString(extendedSkey.CborHex)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, extendedSkeyCbor)
+}
+
+// TestCIP1853WalletIntegration validates pool cold key integration in Wallet struct
+func TestCIP1853WalletIntegration(t *testing.T) {
+	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+	wallet, err := NewWallet(mnemonic, "mainnet", "", 0, 0, 0, 0, 0, 0, 0, 0)
+	assert.NoError(t, err)
+	assert.NotNil(t, wallet)
+
+	// Verify pool cold key fields are populated
+	assert.NotEmpty(
+		t,
+		wallet.PoolColdVKey.CborHex,
+		"Pool cold verification key should be populated",
+	)
+	assert.NotEmpty(
+		t,
+		wallet.PoolColdSKey.CborHex,
+		"Pool cold signing key should be populated",
+	)
+	assert.NotEmpty(
+		t,
+		wallet.PoolColdExtendedSKey.CborHex,
+		"Pool cold extended signing key should be populated",
+	)
+
+	// Verify key types
+	assert.Equal(
+		t,
+		"StakePoolVerificationKeyShelley_ed25519",
+		wallet.PoolColdVKey.Type,
+	)
+	assert.Equal(
+		t,
+		"StakePoolSigningKeyShelley_ed25519",
+		wallet.PoolColdSKey.Type,
+	)
+	assert.Equal(
+		t,
+		"StakePoolExtendedSigningKeyShelley_ed25519_bip32",
+		wallet.PoolColdExtendedSKey.Type,
+	)
+
+	// Verify ExtractKeyFiles includes pool cold keys
+	keyFiles, err := ExtractKeyFiles(wallet)
+	assert.NoError(t, err)
+	assert.Contains(t, keyFiles, "pool-cold.vkey")
+	assert.Contains(t, keyFiles, "pool-cold.skey")
+	assert.Contains(t, keyFiles, "pool-cold-extended.skey")
+}
+
+// TestCIP1853MultiplePoolKeys validates multiple pool cold key derivation
+func TestCIP1853MultiplePoolKeys(t *testing.T) {
+	rootKey, err := GetRootKeyFromMnemonic(
+		"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+		"",
+	)
+	assert.NoError(t, err)
+
+	// Test multiple pool cold keys with different indices
+	pools := make([]bip32.XPrv, 5)
+	pubKeys := make([][]byte, 5)
+
+	for i := range 5 {
+		pool, err := GetPoolColdKey(rootKey, 0, uint32(i))
+		assert.NoError(t, err)
+		assert.NotNil(t, pool)
+		pools[i] = pool
+		pubKeys[i] = pool.PublicKey()
+	}
+
+	// Verify all keys are unique
+	for i := range 5 {
+		for j := i + 1; j < 5; j++ {
+			assert.NotEqual(t, pubKeys[i], pubKeys[j],
+				"Pool cold keys %d and %d should be different", i, j)
+		}
+	}
+
+	// Verify key files can be generated for all pools
+	for i, pool := range pools {
+		vkey, err := GetPoolColdVKey(pool)
+		assert.NoError(t, err)
+		assert.NotEmpty(
+			t,
+			vkey.CborHex,
+			"Pool %d verification key should be valid",
+			i,
+		)
+
+		skey, err := GetPoolColdSKey(pool)
+		assert.NoError(t, err)
+		assert.NotEmpty(
+			t,
+			skey.CborHex,
+			"Pool %d signing key should be valid",
+			i,
+		)
+
+		extSkey, err := GetPoolColdExtendedSKey(pool)
+		assert.NoError(t, err)
+		assert.NotEmpty(
+			t,
+			extSkey.CborHex,
+			"Pool %d extended signing key should be valid",
+			i,
+		)
+	}
 }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -585,6 +585,10 @@ const docTemplate = `{
                     "type": "integer",
                     "maximum": 2147483647
                 },
+                "pool_cold_id": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
                 "stake_id": {
                     "type": "integer",
                     "maximum": 2147483647
@@ -670,6 +674,15 @@ const docTemplate = `{
                     "$ref": "#/definitions/bursa.KeyFile"
                 },
                 "payment_vkey": {
+                    "$ref": "#/definitions/bursa.KeyFile"
+                },
+                "pool_cold_extended_skey": {
+                    "$ref": "#/definitions/bursa.KeyFile"
+                },
+                "pool_cold_skey": {
+                    "$ref": "#/definitions/bursa.KeyFile"
+                },
+                "pool_cold_vkey": {
                     "$ref": "#/definitions/bursa.KeyFile"
                 },
                 "stake_address": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -581,6 +581,10 @@
                     "type": "integer",
                     "maximum": 2147483647
                 },
+                "pool_cold_id": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
                 "stake_id": {
                     "type": "integer",
                     "maximum": 2147483647
@@ -666,6 +670,15 @@
                     "$ref": "#/definitions/bursa.KeyFile"
                 },
                 "payment_vkey": {
+                    "$ref": "#/definitions/bursa.KeyFile"
+                },
+                "pool_cold_extended_skey": {
+                    "$ref": "#/definitions/bursa.KeyFile"
+                },
+                "pool_cold_skey": {
+                    "$ref": "#/definitions/bursa.KeyFile"
+                },
+                "pool_cold_vkey": {
                     "$ref": "#/definitions/bursa.KeyFile"
                 },
                 "stake_address": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -152,6 +152,9 @@ definitions:
       payment_id:
         maximum: 2147483647
         type: integer
+      pool_cold_id:
+        maximum: 2147483647
+        type: integer
       stake_id:
         maximum: 2147483647
         type: integer
@@ -213,6 +216,12 @@ definitions:
       payment_skey:
         $ref: '#/definitions/bursa.KeyFile'
       payment_vkey:
+        $ref: '#/definitions/bursa.KeyFile'
+      pool_cold_extended_skey:
+        $ref: '#/definitions/bursa.KeyFile'
+      pool_cold_skey:
+        $ref: '#/definitions/bursa.KeyFile'
+      pool_cold_vkey:
         $ref: '#/definitions/bursa.KeyFile'
       stake_address:
         example: stake1uy9ggsc9qls4pu9qvyyacwnmr9tt0gzcdt5s0zj4au8qkqc65ge8t

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -123,6 +123,7 @@ func toJSONFieldName(goFieldName string) string {
 		"DrepId":            "drep_id",
 		"CommitteeColdId":   "committee_cold_id",
 		"CommitteeHotId":    "committee_hot_id",
+		"PoolColdId":        "pool_cold_id",
 		"AddressId":         "address_id",
 	}
 
@@ -228,6 +229,7 @@ type WalletRestoreRequest struct {
 	DrepId          uint32 `json:"drep_id"           validate:"max=2147483647"`
 	CommitteeColdId uint32 `json:"committee_cold_id" validate:"max=2147483647"`
 	CommitteeHotId  uint32 `json:"committee_hot_id"  validate:"max=2147483647"`
+	PoolColdId      uint32 `json:"pool_cold_id"      validate:"max=2147483647"`
 	AddressId       uint32 `json:"address_id"        validate:"max=2147483647"`
 }
 
@@ -522,6 +524,7 @@ func handleWalletCreate(w http.ResponseWriter, r *http.Request) {
 		0,
 		0,
 		0,
+		0,
 	)
 	if err != nil {
 		logger.Error("failed to initialize wallet", "error", err)
@@ -630,6 +633,7 @@ func handleWalletRestore(w http.ResponseWriter, r *http.Request) {
 		req.DrepId,
 		req.CommitteeColdId,
 		req.CommitteeHotId,
+		req.PoolColdId,
 		req.AddressId,
 	)
 	if err != nil {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -47,7 +47,7 @@ func RunCreate(cfg *config.Config, output string) {
 			os.Exit(1)
 		}
 	}
-	w, err := bursa.NewWallet(mnemonic, cfg.Network, "", 0, 0, 0, 0, 0, 0, 0)
+	w, err := bursa.NewWallet(mnemonic, cfg.Network, "", 0, 0, 0, 0, 0, 0, 0, 0)
 	if err != nil {
 		logger.Error("failed to initialize wallet", "error", err)
 		os.Exit(1)

--- a/internal/storage/file_test.go
+++ b/internal/storage/file_test.go
@@ -57,6 +57,7 @@ func TestFileStore(t *testing.T) {
 			0,
 			0,
 			0,
+			0,
 		)
 		require.NoError(t, err)
 
@@ -94,6 +95,7 @@ func TestFileStore(t *testing.T) {
 			"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
 			"mainnet",
 			"",
+			0,
 			0,
 			0,
 			0,


### PR DESCRIPTION
Closes #340 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CIP-1853 stake pool cold key support to wallet creation and APIs. This enables deriving pool cold keys and exporting pool-cold vkey/skey/extended skey.

- **New Features**
  - Added CIP-1853 derivation: GetPoolColdKey(m/1853'/1815'/usecase'/index'), plus vkey/skey/extended skey generators.
  - Wallet now includes PoolColdVKey, PoolColdSKey, PoolColdExtendedSKey.
  - ExtractKeyFiles now outputs pool-cold.vkey, pool-cold.skey, pool-cold-extended.skey.
  - API/docs: added pool_cold_id to WalletRestoreRequest and wallet responses; Swagger updated.
  - CLI create uses the new parameter; comprehensive tests for derivation and key files.

- **Migration**
  - NewWallet signature adds poolColdId before addressId; update callers to pass this uint32 (use 0 by default).
  - API clients restoring wallets must include pool_cold_id (<= 2147483647).
  - Regenerate API clients to pick up new fields in responses (pool cold key files).

<sup>Written for commit ca31ac024945afa338e39b7b316063866e6bba1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added stake pool cold key derivation and generation for wallet creation
  * Wallets now export pool cold verification keys, signing keys, and extended signing keys

* **Documentation**
  * Updated API schema and wallet definitions to support pool cold key identifiers and associated key files

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->