### PR TITLE
refactor: use With* functional options

### DIFF
--- a/bursa_test.go
+++ b/bursa_test.go
@@ -197,7 +197,7 @@ func TestLoadWalletDir(t *testing.T) {
 
 	// Create a wallet
 	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-	wallet, err := NewWallet(mnemonic, "mainnet", "", 0, 0, 0, 0, 0, 0, 0, 0)
+	wallet, err := NewWallet(mnemonic)
 	assert.NoError(t, err)
 
 	// Extract key files
@@ -257,7 +257,7 @@ func TestLoadWalletDirPartial(t *testing.T) {
 
 	// Create a wallet
 	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-	wallet, err := NewWallet(mnemonic, "mainnet", "", 0, 0, 0, 0, 0, 0, 0, 0)
+	wallet, err := NewWallet(mnemonic)
 	assert.NoError(t, err)
 
 	// Extract key files
@@ -319,7 +319,7 @@ func BenchmarkNewWallet(b *testing.B) {
 	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 
 	for b.Loop() {
-		_, err := NewWallet(mnemonic, "mainnet", "", 0, 0, 0, 0, 0, 0, 0, 0)
+		_, err := NewWallet(mnemonic)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -328,19 +328,7 @@ func BenchmarkNewWallet(b *testing.B) {
 
 func BenchmarkExtractKeyFiles(b *testing.B) {
 	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-	wallet, err := NewWallet(
-		mnemonic,
-		"mainnet",
-		"",
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-	)
+	wallet, err := NewWallet(mnemonic)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -356,19 +344,7 @@ func BenchmarkExtractKeyFiles(b *testing.B) {
 
 func BenchmarkCBORDecode(b *testing.B) {
 	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-	wallet, err := NewWallet(
-		mnemonic,
-		"mainnet",
-		"",
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-	)
+	wallet, err := NewWallet(mnemonic)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -393,7 +369,7 @@ func BenchmarkLoadWalletDir(b *testing.B) {
 	tmpDir := b.TempDir()
 
 	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-	wallet, err := NewWallet(mnemonic, "mainnet", "", 0, 0, 0, 0, 0, 0, 0, 0)
+	wallet, err := NewWallet(mnemonic)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -422,38 +398,14 @@ func BenchmarkLoadWalletDir(b *testing.B) {
 }
 
 func TestNewWalletInvalidMnemonic(t *testing.T) {
-	_, err := NewWallet(
-		"invalid mnemonic",
-		"mainnet",
-		"",
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-	)
+	_, err := NewWallet("invalid mnemonic")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid mnemonic")
 }
 
 func TestNewWalletInvalidIndices(t *testing.T) {
 	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-	_, err := NewWallet(
-		mnemonic,
-		"mainnet",
-		"",
-		0x80000000,
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-	)
+	_, err := NewWallet(mnemonic, WithAccountID(0x80000000))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "derivation indices must be less than 2^31")
 }
@@ -473,25 +425,9 @@ func TestCIP1852Compliance(t *testing.T) {
 	// Test CIP-1852 compliance using a known mnemonic
 	// This test verifies that the derivation paths follow CIP-1852 specification
 	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-	password := ""
-	accountId := uint32(0)
-	paymentId := uint32(0)
-	stakeId := uint32(0)
 
-	// Generate wallet
-	wallet, err := NewWallet(
-		mnemonic,
-		"mainnet",
-		password,
-		accountId,
-		paymentId,
-		stakeId,
-		0,
-		0,
-		0,
-		0,
-		0,
-	)
+	// Generate wallet with default indices (all 0)
+	wallet, err := NewWallet(mnemonic)
 	assert.NoError(t, err)
 	assert.NotNil(t, wallet)
 
@@ -730,30 +666,9 @@ func TestCIP0003KeyGeneration(t *testing.T) {
 	// Test Vector 4: Complete wallet generation pipeline
 	t.Run("TestVector4_FullWallet", func(t *testing.T) {
 		mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-		password := ""
-		network := "mainnet"
-		accountId := uint32(0)
-		paymentId := uint32(0)
-		stakeId := uint32(0)
-		drepId := uint32(0)
-		committeeColdId := uint32(0)
-		committeeHotId := uint32(0)
-		poolColdId := uint32(0)
-		addressId := uint32(0)
 
-		wallet, err := NewWallet(
-			mnemonic,
-			network,
-			password,
-			accountId,
-			paymentId,
-			stakeId,
-			drepId,
-			committeeColdId,
-			committeeHotId,
-			poolColdId,
-			addressId,
-		)
+		// Use defaults: mainnet, no password, all indices = 0
+		wallet, err := NewWallet(mnemonic)
 		assert.NoError(t, err)
 		assert.NotNil(t, wallet)
 
@@ -1702,22 +1617,9 @@ func TestCIP0018MultiStakeKeys(t *testing.T) {
 	// delegating to different stake pools
 
 	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-	password := ""
 
-	// Create wallet with multiple stake keys
-	wallet, err := NewWallet(
-		mnemonic,
-		"mainnet",
-		password,
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-	)
+	// Create wallet with defaults
+	wallet, err := NewWallet(mnemonic)
 	assert.NoError(t, err)
 	assert.NotNil(t, wallet)
 
@@ -1726,7 +1628,7 @@ func TestCIP0018MultiStakeKeys(t *testing.T) {
 	assert.NotEmpty(t, wallet.StakeSKey.CborHex)
 
 	// Test creating additional stake keys by deriving from account key
-	rootKey, err := GetRootKeyFromMnemonic(mnemonic, password)
+	rootKey, err := GetRootKeyFromMnemonic(mnemonic, "")
 	assert.NoError(t, err)
 
 	// Get account key (following CIP-1852 derivation path)
@@ -2307,7 +2209,7 @@ func TestCIP1853KeyFileGeneration(t *testing.T) {
 func TestCIP1853WalletIntegration(t *testing.T) {
 	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 
-	wallet, err := NewWallet(mnemonic, "mainnet", "", 0, 0, 0, 0, 0, 0, 0, 0)
+	wallet, err := NewWallet(mnemonic)
 	assert.NoError(t, err)
 	assert.NotNil(t, wallet)
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -515,16 +515,7 @@ func handleWalletCreate(w http.ResponseWriter, r *http.Request) {
 
 	wallet, err := bursa.NewWallet(
 		mnemonic,
-		cfg.Network,
-		"",
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
+		bursa.WithNetwork(cfg.Network),
 	)
 	if err != nil {
 		logger.Error("failed to initialize wallet", "error", err)
@@ -625,16 +616,16 @@ func handleWalletRestore(w http.ResponseWriter, r *http.Request) {
 	logger := logging.GetLogger()
 	wallet, err := bursa.NewWallet(
 		req.Mnemonic,
-		cfg.Network,
-		req.Password,
-		req.AccountId,
-		req.PaymentId,
-		req.StakeId,
-		req.DrepId,
-		req.CommitteeColdId,
-		req.CommitteeHotId,
-		req.PoolColdId,
-		req.AddressId,
+		bursa.WithNetwork(cfg.Network),
+		bursa.WithPassword(req.Password),
+		bursa.WithAccountID(req.AccountId),
+		bursa.WithPaymentID(req.PaymentId),
+		bursa.WithStakeID(req.StakeId),
+		bursa.WithDRepID(req.DrepId),
+		bursa.WithCommitteeColdID(req.CommitteeColdId),
+		bursa.WithCommitteeHotID(req.CommitteeHotId),
+		bursa.WithPoolColdID(req.PoolColdId),
+		bursa.WithAddressID(req.AddressId),
 	)
 	if err != nil {
 		// Check for client validation errors vs server errors

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -48,7 +48,7 @@ func RunCreate(cfg *config.Config, output string) {
 			os.Exit(1)
 		}
 	}
-	w, err := bursa.NewWallet(mnemonic, cfg.Network, "", 0, 0, 0, 0, 0, 0, 0, 0)
+	w, err := bursa.NewWallet(mnemonic, bursa.WithNetwork(cfg.Network))
 	if err != nil {
 		logger.Error("failed to initialize wallet", "error", err)
 		os.Exit(1)
@@ -169,9 +169,8 @@ func RunRestore(
 
 	w, err := bursa.NewWallet(
 		resolvedMnemonic,
-		cfg.Network,
-		password,
-		0, 0, 0, 0, 0, 0, 0, 0,
+		bursa.WithNetwork(cfg.Network),
+		bursa.WithPassword(password),
 	)
 	if err != nil {
 		logger.Error("failed to restore wallet", "error", err)

--- a/internal/storage/file_test.go
+++ b/internal/storage/file_test.go
@@ -48,16 +48,6 @@ func TestFileStore(t *testing.T) {
 		// Create a bursa wallet to populate from
 		bursaWallet, err := bursa.NewWallet(
 			"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
-			"mainnet",
-			"",
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
 		)
 		require.NoError(t, err)
 
@@ -93,16 +83,6 @@ func TestFileStore(t *testing.T) {
 		// Create a bursa wallet to populate from
 		originalWallet, err := bursa.NewWallet(
 			"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
-			"mainnet",
-			"",
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
 		)
 		require.NoError(t, err)
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored NewWallet to use functional options (With* helpers) with sensible defaults, making wallet creation clearer and easier to extend. Updated API, CLI, and tests to the new pattern with no behavior changes.

- **Refactors**
  - Added WalletConfig and WalletOption.
  - Implemented WithNetwork, WithPassword, and With{Account,Payment,Stake,DRep,CommitteeCold,CommitteeHot,PoolCold,Address}ID.
  - NewWallet now accepts options; defaults: network=mainnet, password="", all indices=0.
  - Updated internal/api, internal/cli, and tests to use options.

- **Migration**
  - Replace positional args with options: NewWallet(mnemonic, WithNetwork(...), WithPassword(...), WithAccountID(...)).
  - Omit options to use defaults; remove trailing zeros.
  - Index validation (< 2^31) remains enforced.

<sup>Written for commit 2fe9e76f7ba5b33dc73543d8f2bf3f6c90492a12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified wallet creation API using a functional options pattern instead of multiple positional parameters, improving flexibility and ease of use.
  * Wallet configuration now supports optional settings for network, password, and derivation indices with sensible defaults.

* **Tests**
  * Updated test suites to use the new wallet creation API.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->