### PR TITLE
feat(cli): key derivation commands

### DIFF
--- a/cmd/bursa/key.go
+++ b/cmd/bursa/key.go
@@ -1,0 +1,281 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+
+	"github.com/blinklabs-io/bursa/internal/cli"
+	"github.com/blinklabs-io/bursa/internal/logging"
+	"github.com/spf13/cobra"
+)
+
+func keyCommand() *cobra.Command {
+	keyCommand := cobra.Command{
+		Use:   "key",
+		Short: "Key derivation commands",
+		Long: `Commands for deriving individual keys from a mnemonic.
+
+These commands follow CIP-1852 key derivation paths and output keys
+in bech32 format suitable for use with cardano-cli and other tools.
+
+Key derivation hierarchy:
+  mnemonic -> root -> account -> payment/stake
+
+Examples:
+  bursa key root --mnemonic "word1 word2 ..."
+  bursa key account --mnemonic "word1 word2 ..." --index 0
+  bursa key payment --mnemonic "word1 word2 ..."
+  bursa key stake --mnemonic "word1 word2 ..."`,
+	}
+
+	keyCommand.AddCommand(
+		keyRootCommand(),
+		keyAccountCommand(),
+		keyPaymentCommand(),
+		keyStakeCommand(),
+	)
+	return &keyCommand
+}
+
+func keyRootCommand() *cobra.Command {
+	var mnemonic string
+	var mnemonicFile string
+	var password string
+
+	cmd := cobra.Command{
+		Use:   "root",
+		Short: "Derive root key from mnemonic",
+		Long: `Derives the root extended private key from a BIP-39 mnemonic.
+
+The root key is the master key from which all other keys are derived.
+Output is in bech32 format (root_xsk prefix).
+
+The mnemonic can be provided via:
+  1. --mnemonic flag
+  2. MNEMONIC environment variable
+  3. --mnemonic-file flag
+  4. Default file "seed.txt"
+
+Examples:
+  bursa key root --mnemonic "word1 word2 ... word24"
+  bursa key root --mnemonic-file seed.txt
+  bursa key root --password "optional"`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := cli.RunKeyRoot(
+				mnemonic,
+				mnemonicFile,
+				password,
+			); err != nil {
+				logging.GetLogger().
+					Error("failed to derive root key", "error", err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&mnemonic, "mnemonic", "", "BIP-39 mnemonic phrase")
+	cmd.Flags().StringVar(
+		&mnemonicFile,
+		"mnemonic-file",
+		"",
+		"Path to file containing mnemonic (default: seed.txt)",
+	)
+	cmd.Flags().StringVar(
+		&password,
+		"password",
+		"",
+		"Optional password for key derivation",
+	)
+
+	return &cmd
+}
+
+func keyAccountCommand() *cobra.Command {
+	var mnemonic string
+	var mnemonicFile string
+	var password string
+	var index uint32
+
+	cmd := cobra.Command{
+		Use:   "account",
+		Short: "Derive account key from mnemonic",
+		Long: `Derives an account extended private key from a BIP-39 mnemonic.
+
+The account key follows CIP-1852 path: m/1852'/1815'/account'
+Output is in bech32 format (acct_xsk prefix).
+
+Examples:
+  bursa key account --mnemonic "word1 word2 ... word24"
+  bursa key account --mnemonic "word1 word2 ..." --index 1
+  bursa key account --mnemonic-file seed.txt --index 0`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := cli.RunKeyAccount(
+				mnemonic,
+				mnemonicFile,
+				password,
+				index,
+			); err != nil {
+				logging.GetLogger().Error(
+					"failed to derive account key",
+					"error",
+					err,
+				)
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&mnemonic, "mnemonic", "", "BIP-39 mnemonic phrase")
+	cmd.Flags().StringVar(
+		&mnemonicFile,
+		"mnemonic-file",
+		"",
+		"Path to file containing mnemonic (default: seed.txt)",
+	)
+	cmd.Flags().StringVar(
+		&password,
+		"password",
+		"",
+		"Optional password for key derivation",
+	)
+	cmd.Flags().Uint32Var(&index, "index", 0, "Account index (default: 0)")
+
+	return &cmd
+}
+
+func keyPaymentCommand() *cobra.Command {
+	var mnemonic string
+	var mnemonicFile string
+	var password string
+	var accountIndex uint32
+	var paymentIndex uint32
+
+	cmd := cobra.Command{
+		Use:   "payment",
+		Short: "Derive payment key from mnemonic",
+		Long: `Derives a payment extended private key from a BIP-39 mnemonic.
+
+The payment key follows CIP-1852 path: m/1852'/1815'/account'/0/index
+Output is in bech32 format (addr_xsk prefix).
+
+Examples:
+  bursa key payment --mnemonic "word1 word2 ... word24"
+  bursa key payment --mnemonic "word1 word2 ..." --account-index 0 --index 0
+  bursa key payment --mnemonic-file seed.txt`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := cli.RunKeyPayment(
+				mnemonic,
+				mnemonicFile,
+				password,
+				accountIndex,
+				paymentIndex,
+			); err != nil {
+				logging.GetLogger().Error(
+					"failed to derive payment key",
+					"error",
+					err,
+				)
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&mnemonic, "mnemonic", "", "BIP-39 mnemonic phrase")
+	cmd.Flags().StringVar(
+		&mnemonicFile,
+		"mnemonic-file",
+		"",
+		"Path to file containing mnemonic (default: seed.txt)",
+	)
+	cmd.Flags().StringVar(
+		&password,
+		"password",
+		"",
+		"Optional password for key derivation",
+	)
+	cmd.Flags().Uint32Var(
+		&accountIndex,
+		"account-index",
+		0,
+		"Account index (default: 0)",
+	)
+	cmd.Flags().
+		Uint32Var(&paymentIndex, "index", 0, "Payment key index (default: 0)")
+
+	return &cmd
+}
+
+func keyStakeCommand() *cobra.Command {
+	var mnemonic string
+	var mnemonicFile string
+	var password string
+	var accountIndex uint32
+	var stakeIndex uint32
+
+	cmd := cobra.Command{
+		Use:   "stake",
+		Short: "Derive stake key from mnemonic",
+		Long: `Derives a stake extended private key from a BIP-39 mnemonic.
+
+The stake key follows CIP-1852 path: m/1852'/1815'/account'/2/index
+Output is in bech32 format (stake_xsk prefix).
+
+Examples:
+  bursa key stake --mnemonic "word1 word2 ... word24"
+  bursa key stake --mnemonic "word1 word2 ..." --account-index 0 --index 0
+  bursa key stake --mnemonic-file seed.txt`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := cli.RunKeyStake(
+				mnemonic,
+				mnemonicFile,
+				password,
+				accountIndex,
+				stakeIndex,
+			); err != nil {
+				logging.GetLogger().Error(
+					"failed to derive stake key",
+					"error",
+					err,
+				)
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&mnemonic, "mnemonic", "", "BIP-39 mnemonic phrase")
+	cmd.Flags().StringVar(
+		&mnemonicFile,
+		"mnemonic-file",
+		"",
+		"Path to file containing mnemonic (default: seed.txt)",
+	)
+	cmd.Flags().StringVar(
+		&password,
+		"password",
+		"",
+		"Optional password for key derivation",
+	)
+	cmd.Flags().Uint32Var(
+		&accountIndex,
+		"account-index",
+		0,
+		"Account index (default: 0)",
+	)
+	cmd.Flags().
+		Uint32Var(&stakeIndex, "index", 0, "Stake key index (default: 0)")
+
+	return &cmd
+}

--- a/cmd/bursa/main.go
+++ b/cmd/bursa/main.go
@@ -38,6 +38,7 @@ func main() {
 
 	rootCmd.AddCommand(
 		walletCommand(),
+		keyCommand(),
 		apiCommand(),
 		scriptCommand(),
 	)

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -110,7 +110,7 @@ func (g *GoogleWallet) SetDescription(description string) {
 }
 
 func (g *GoogleWallet) ListItems() []string {
-	items := []string{}
+	items := make([]string, 0, len(g.items))
 	for name := range g.items {
 		items = append(items, name)
 	}


### PR DESCRIPTION
This adds more support towards #14 with initial keys

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new CLI “key” command to derive root, account, payment, and stake keys from a mnemonic using CIP-1852, outputting bech32 keys compatible with cardano-cli.

- **New Features**
  - Added “bursa key” with subcommands: root, account, payment, stake.
  - Accepts mnemonic via flag, file (default seed.txt), or MNEMONIC env var; supports optional password.
  - Derives keys via CIP-1852 with account-index and index flags.
  - Outputs bech32 keys with prefixes: root_xsk, acct_xsk, addr_xsk, stake_xsk.

- **Dependencies**
  - Introduced btcsuite/btcd/btcutil/bech32 for key encoding.

<sup>Written for commit b0f194a46360d291b547f5865b1975db9822fafd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New key derivation CLI command with subcommands for root, account, payment, and stake keys
  * Support for multiple mnemonic input methods (direct, file, environment variable)
  * Configurable indices for account and payment key derivation
  * Keys output in bech32 format with appropriate prefixes
  * Optional password-protected key derivation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->