### PR TITLE
feat: forging policy keys

### DIFF
--- a/cmd/bursa/key.go
+++ b/cmd/bursa/key.go
@@ -46,6 +46,7 @@ Examples:
 		keyAccountCommand(),
 		keyPaymentCommand(),
 		keyStakeCommand(),
+		keyPolicyCommand(),
 	)
 	return &keyCommand
 }
@@ -276,6 +277,60 @@ Examples:
 	)
 	cmd.Flags().
 		Uint32Var(&stakeIndex, "index", 0, "Stake key index (default: 0)")
+
+	return &cmd
+}
+
+func keyPolicyCommand() *cobra.Command {
+	var mnemonic string
+	var mnemonicFile string
+	var password string
+	var index uint32
+
+	cmd := cobra.Command{
+		Use:   "policy",
+		Short: "Derive forging policy key from mnemonic",
+		Long: `Derives a forging policy extended private key from a BIP-39 mnemonic.
+
+The policy key follows CIP-1855 path: m/1855'/1815'/policy_ix'
+These keys are used for native asset minting/burning policies.
+Output is in bech32 format (policy_xsk prefix).
+
+Examples:
+  bursa key policy --mnemonic "word1 word2 ... word24"
+  bursa key policy --mnemonic "word1 word2 ..." --index 0
+  bursa key policy --mnemonic-file seed.txt --index 1`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := cli.RunKeyPolicy(
+				mnemonic,
+				mnemonicFile,
+				password,
+				index,
+			); err != nil {
+				logging.GetLogger().Error(
+					"failed to derive policy key",
+					"error",
+					err,
+				)
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&mnemonic, "mnemonic", "", "BIP-39 mnemonic phrase")
+	cmd.Flags().StringVar(
+		&mnemonicFile,
+		"mnemonic-file",
+		"",
+		"Path to file containing mnemonic (default: seed.txt)",
+	)
+	cmd.Flags().StringVar(
+		&password,
+		"password",
+		"",
+		"Optional password for key derivation",
+	)
+	cmd.Flags().Uint32Var(&index, "index", 0, "Policy key index (default: 0)")
 
 	return &cmd
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -366,6 +366,35 @@ func RunKeyStake(
 	return nil
 }
 
+// RunKeyPolicy derives a policy key from a mnemonic and outputs it in bech32
+func RunKeyPolicy(
+	mnemonic, mnemonicFile, password string,
+	index uint32,
+) error {
+	resolvedMnemonic, err := resolveMnemonic(mnemonic, mnemonicFile)
+	if err != nil {
+		return err
+	}
+
+	rootKey, err := bursa.GetRootKeyFromMnemonic(resolvedMnemonic, password)
+	if err != nil {
+		return fmt.Errorf("failed to derive root key: %w", err)
+	}
+
+	policyKey, err := bursa.GetPolicyKey(rootKey, index)
+	if err != nil {
+		return fmt.Errorf("failed to derive policy key: %w", err)
+	}
+
+	// Output in bech32 format with policy_xsk prefix
+	encoded, err := encodePolicyKey(policyKey)
+	if err != nil {
+		return fmt.Errorf("failed to encode policy key: %w", err)
+	}
+	fmt.Println(encoded)
+	return nil
+}
+
 // encodeAccountKey encodes an account extended private key in bech32 format
 func encodeAccountKey(key []byte) (string, error) {
 	converted, err := bech32.ConvertBits(key, 8, 5, true)
@@ -399,6 +428,19 @@ func encodeStakeKey(key []byte) (string, error) {
 		return "", fmt.Errorf("failed to convert bits: %w", err)
 	}
 	encoded, err := bech32.Encode("stake_xsk", converted)
+	if err != nil {
+		return "", fmt.Errorf("failed to bech32 encode: %w", err)
+	}
+	return encoded, nil
+}
+
+// encodePolicyKey encodes a policy extended private key in bech32 format
+func encodePolicyKey(key []byte) (string, error) {
+	converted, err := bech32.ConvertBits(key, 8, 5, true)
+	if err != nil {
+		return "", fmt.Errorf("failed to convert bits: %w", err)
+	}
+	encoded, err := bech32.Encode("policy_xsk", converted)
 	if err != nil {
 		return "", fmt.Errorf("failed to bech32 encode: %w", err)
 	}


### PR DESCRIPTION
Closes #387 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CIP-1855 forging policy keys with derivation, key file generation, hashing, and a CLI command to output policy_xsk. Also adds support to load policy key files from wallet dirs.

- **New Features**
  - Derive policy keys at m/1855'/1815'/index' via GetPolicyKey (hardened only).
  - Generate key files: GetPolicyVKey, GetPolicySKey, GetPolicyExtendedSKey; bech32 prefixes policy_vk, policy_sk, policy_xsk.
  - Compute policy key hash (blake2b_224) via GetPolicyKeyHash.
  - CLI: bursa key policy [--mnemonic | --mnemonic-file] [--password] [--index] → outputs policy_xsk.
  - Load/parse policy key files (vkey/skey/xsk) via LoadWalletDir; tests cover derivation, encoding/round-trip, hashing, and invalid index.

<sup>Written for commit 2d071ef23d3096c380671a230d83991cc7e187fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CIP-1855 policy key support: derive policy verification, signing, and extended signing keys; outputs use bech32 prefixes policy_vk, policy_sk, policy_xsk.
  * New CLI command to derive policy keys from mnemonic (password and index flags supported) and print bech32-encoded keys.

* **Tests**
  * Added comprehensive tests: derivation, uniqueness, hash computation, multi-key scenarios, and JSON round-trip loading of policy key files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->