### PR TITLE
feat: `bursa key pool-cold` command

### DIFF
--- a/cmd/bursa/key.go
+++ b/cmd/bursa/key.go
@@ -47,6 +47,7 @@ Examples:
 		keyPaymentCommand(),
 		keyStakeCommand(),
 		keyPolicyCommand(),
+		keyPoolColdCommand(),
 	)
 	return &keyCommand
 }
@@ -331,6 +332,61 @@ Examples:
 		"Optional password for key derivation",
 	)
 	cmd.Flags().Uint32Var(&index, "index", 0, "Policy key index (default: 0)")
+
+	return &cmd
+}
+
+func keyPoolColdCommand() *cobra.Command {
+	var mnemonic string
+	var mnemonicFile string
+	var password string
+	var index uint32
+
+	cmd := cobra.Command{
+		Use:   "pool-cold",
+		Short: "Derive stake pool cold key from mnemonic",
+		Long: `Derives a stake pool cold extended private key from a BIP-39 mnemonic.
+
+The pool cold key follows CIP-1853 path: m/1853'/1815'/0'/index'
+These keys are used as the long-term identity keys for stake pool operators.
+Output is in bech32 format (pool_xsk prefix).
+
+Examples:
+  bursa key pool-cold --mnemonic "word1 word2 ... word24"
+  bursa key pool-cold --mnemonic "word1 word2 ..." --index 0
+  bursa key pool-cold --mnemonic-file seed.txt --index 1`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := cli.RunKeyPoolCold(
+				mnemonic,
+				mnemonicFile,
+				password,
+				index,
+			); err != nil {
+				logging.GetLogger().Error(
+					"failed to derive pool cold key",
+					"error",
+					err,
+				)
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&mnemonic, "mnemonic", "", "BIP-39 mnemonic phrase")
+	cmd.Flags().StringVar(
+		&mnemonicFile,
+		"mnemonic-file",
+		"",
+		"Path to file containing mnemonic (default: seed.txt)",
+	)
+	cmd.Flags().StringVar(
+		&password,
+		"password",
+		"",
+		"Optional password for key derivation",
+	)
+	cmd.Flags().
+		Uint32Var(&index, "index", 0, "Pool cold key index (default: 0)")
 
 	return &cmd
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new CLI command to derive stake pool cold extended private keys from a BIP-39 mnemonic using CIP-1853. Outputs the key in bech32 with the pool_xsk prefix for easy use by SPOs.

- New Features
  - New subcommand: bursa key pool-cold
  - Derivation path: m/1853'/1815'/0'/index' (usecase fixed to 0 per CIP-1853)
  - Bech32 output with pool_xsk prefix
  - Flags: --mnemonic, --mnemonic-file, --password, --index (default 0)
  - Prints encoded key to stdout with clear error handling

<sup>Written for commit 79db8726dd5446b359e46b9dff58ec452bb5cff4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Introduced pool-cold command for deriving pool cold keys from mnemonics. Supports multiple mnemonic input methods, including direct input, file-based mnemonics, and password-protected variants. Features configurable index parameter for flexible key derivation and outputs results in industry-standard bech32 format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->