### PR TITLE
feat: `bursa key drep` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Bursa implements the following Cardano Improvement Proposals:
 - **CIP-0019**: Cardano Addresses - Full address format support (mainnet/testnet)
 - **CIP-0105**: Conway Era Key Chains - Governance key derivation (DRep, Committee)
 - **CIP-1852**: HD Wallets - Hierarchical deterministic wallet structure
+- **CIP-1853**: Stake Pool Cold Keys - Pool operator identity keys
 - **CIP-1854**: Multi-signature Scripts - Native script support and validation
+- **CIP-1855**: Forging Policy Keys - Native asset minting/burning policy keys
 
 Start a Bursa wallet and interact with it using the Bursa API.
 
@@ -36,13 +38,15 @@ Access API Swagger documentation: [http://localhost:8080/swagger/index.html](htt
 For more information about Bursa CLI
 
 ```bash
-go run ./cmd/bursa    
+go run ./cmd/bursa
 Usage:
   bursa [command]
 
 Available Commands:
   api         Runs the api
   help        Help about any command
+  key         Key derivation commands
+  script      Multi-signature script commands
   wallet      Wallet commands
 
 Flags:
@@ -50,3 +54,19 @@ Flags:
 
 Use "bursa [command] --help" for more information about a command.
 ```
+
+### Key Derivation Commands
+
+Derive individual keys from a BIP-39 mnemonic:
+
+```bash
+bursa key root --mnemonic "..."           # Root extended private key
+bursa key account --mnemonic "..."        # Account key (CIP-1852)
+bursa key payment --mnemonic "..."        # Payment key (CIP-1852)
+bursa key stake --mnemonic "..."          # Stake key (CIP-1852)
+bursa key policy --mnemonic "..."         # Forging policy key (CIP-1855)
+bursa key pool-cold --mnemonic "..."      # Pool cold key (CIP-1853)
+bursa key drep --mnemonic "..."           # DRep key (CIP-0105)
+```
+
+All keys are output in bech32 format with appropriate prefixes (`root_xsk`, `acct_xsk`, `addr_xsk`, `stake_xsk`, `policy_xsk`, `pool_xsk`, `drep_xsk`).


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new bursa key drep command to derive DRep extended private keys per CIP-0105 and output them in bech32 (drep_xsk). Also updates CLI help and README with key derivation commands and supported CIPs.

- **New Features**
  - Adds bursa key drep with flags: mnemonic, mnemonic-file, password, account-index, index.
  - Uses CIP-0105 path: m/1852'/1815'/account'/3/index.
  - README: adds key command examples and lists CIP-1853 and CIP-1855 support.

- **Refactors**
  - Consolidates bech32 encoding via encodeExtendedPrivateKey and applies it to all key types.

<sup>Written for commit 88210d285e449097921a1fcc267937a567adff03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DRep key derivation and CLI output.
  * New top-level key and script commands with mnemonic-based derivations for root, account, payment, stake, policy, pool-cold, and drep.
  * Support added for CIP-1853 and CIP-1855.

* **Documentation**
  * Updated README, usage examples, and help text to show new key derivation commands, DRep examples, and multi-signature script capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->