### PR TITLE
feat: `bursa key kes` and `bursa key vrf`

### DIFF
--- a/cmd/bursa/key.go
+++ b/cmd/bursa/key.go
@@ -48,6 +48,8 @@ Examples:
 		keyStakeCommand(),
 		keyPolicyCommand(),
 		keyPoolColdCommand(),
+		keyVRFCommand(),
+		keyKESCommand(),
 	)
 	return &keyCommand
 }
@@ -387,6 +389,123 @@ Examples:
 	)
 	cmd.Flags().
 		Uint32Var(&index, "index", 0, "Pool cold key index (default: 0)")
+
+	return &cmd
+}
+
+func keyVRFCommand() *cobra.Command {
+	var mnemonic string
+	var mnemonicFile string
+	var password string
+	var index uint32
+
+	cmd := cobra.Command{
+		Use:   "vrf",
+		Short: "Derive VRF key pair from mnemonic",
+		Long: `Derives a VRF (Verifiable Random Function) key pair from a BIP-39 mnemonic.
+
+VRF keys are used by stake pool operators for leader election in the Praos
+consensus protocol. The seed is derived deterministically from the mnemonic,
+allowing for key recovery.
+
+Output includes both signing key (vrf_sk) and verification key (vrf_vk)
+in bech32 format.
+
+Examples:
+  bursa key vrf --mnemonic "word1 word2 ... word24"
+  bursa key vrf --mnemonic "word1 word2 ..." --index 0
+  bursa key vrf --mnemonic-file seed.txt --index 1`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := cli.RunKeyVRF(
+				mnemonic,
+				mnemonicFile,
+				password,
+				index,
+			); err != nil {
+				logging.GetLogger().Error(
+					"failed to derive VRF key",
+					"error",
+					err,
+				)
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&mnemonic, "mnemonic", "", "BIP-39 mnemonic phrase")
+	cmd.Flags().StringVar(
+		&mnemonicFile,
+		"mnemonic-file",
+		"",
+		"Path to file containing mnemonic (default: seed.txt)",
+	)
+	cmd.Flags().StringVar(
+		&password,
+		"password",
+		"",
+		"Optional password for key derivation",
+	)
+	cmd.Flags().Uint32Var(&index, "index", 0, "VRF key index (default: 0)")
+
+	return &cmd
+}
+
+func keyKESCommand() *cobra.Command {
+	var mnemonic string
+	var mnemonicFile string
+	var password string
+	var index uint32
+
+	cmd := cobra.Command{
+		Use:   "kes",
+		Short: "Derive KES key pair from mnemonic",
+		Long: `Derives a KES (Key Evolving Signature) key pair from a BIP-39 mnemonic.
+
+KES keys are used by stake pool operators for block signing in the Praos
+consensus protocol. KES provides forward-secure signatures where compromising
+the current key does not compromise past signatures.
+
+This implementation uses Cardano's depth 6, providing 64 time periods.
+The seed is derived deterministically from the mnemonic, allowing for key recovery.
+
+Output includes both signing key (kes_sk, 608 bytes) and verification key
+(kes_vk, 32 bytes) in bech32 format.
+
+Examples:
+  bursa key kes --mnemonic "word1 word2 ... word24"
+  bursa key kes --mnemonic "word1 word2 ..." --index 0
+  bursa key kes --mnemonic-file seed.txt --index 1`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := cli.RunKeyKES(
+				mnemonic,
+				mnemonicFile,
+				password,
+				index,
+			); err != nil {
+				logging.GetLogger().Error(
+					"failed to derive KES key",
+					"error",
+					err,
+				)
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&mnemonic, "mnemonic", "", "BIP-39 mnemonic phrase")
+	cmd.Flags().StringVar(
+		&mnemonicFile,
+		"mnemonic-file",
+		"",
+		"Path to file containing mnemonic (default: seed.txt)",
+	)
+	cmd.Flags().StringVar(
+		&password,
+		"password",
+		"",
+		"Optional password for key derivation",
+	)
+	cmd.Flags().Uint32Var(&index, "index", 0, "KES key index (default: 0)")
 
 	return &cmd
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	cloud.google.com/go/secretmanager v1.16.0
 	filippo.io/edwards25519 v1.1.0
-	github.com/blinklabs-io/gouroboros v0.147.0
+	github.com/blinklabs-io/gouroboros v0.149.0
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/getsops/sops/v3 v3.11.0
 	github.com/go-playground/validator/v10 v10.30.1

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3M
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/blinklabs-io/gouroboros v0.147.0 h1:4A88jYoc1OvmC/EqPhvpk3cfmH8jCASOeQy9P6Ps/vg=
-github.com/blinklabs-io/gouroboros v0.147.0/go.mod h1:qRfnn0az84aaPjsvtQK52yoApww0bxQsMu9LJgQ1ftg=
+github.com/blinklabs-io/gouroboros v0.149.0 h1:Kgnnn6l/ogwdOwppqRzZi8EGtNu0B+/4hjvkgSL/Wes=
+github.com/blinklabs-io/gouroboros v0.149.0/go.mod h1:UqNKi2y70+0s+0QxSwox+pdB++lq2RqUSWtErngs8NQ=
 github.com/blinklabs-io/ouroboros-mock v0.4.0 h1:ppOcTMnC/2f5rYYSlvNqcGfAQOIpMCSDUrNh9K6a4mY=
 github.com/blinklabs-io/ouroboros-mock v0.4.0/go.mod h1:e+Kck8bmdOuaN7IfkbVvbqAVlskXNXB95oHI3YlFG5g=
 github.com/blinklabs-io/plutigo v0.0.18 h1:axw0QVrdiqEjt+ssKs5zY2ycogZ+j5r0IETHkAda+8Q=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds bursa key vrf and bursa key kes to derive VRF and KES key pairs from a mnemonic with deterministic seeds and bech32 output. Uses domain-separated blake2b-256 seeds and Cardano KES depth 6.

- New Features
  - CLI: bursa key vrf and bursa key kes with --mnemonic, --mnemonic-file, --password, and --index.
  - Output: vrf_sk/vrf_vk and kes_sk/kes_vk in bech32.
  - Internals: deterministic seed derivation (bursa-vrf-seed / bursa-kes-seed) and keygen helpers; KES depth 6 (64 periods).

- Dependencies
  - Bump github.com/blinklabs-io/gouroboros to v0.149.0 for kes and vrf support.

<sup>Written for commit 6b72a4eab51f7b8238836bd343dc43b0701d0824. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `key vrf` and `key kes` CLI commands to derive and generate VRF and KES key pairs from a mnemonic.
  * Key pairs are now output in bech32 format for both signing and verification keys.

* **Chores**
  * Updated gouroboros dependency to v0.149.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->