### PR TITLE
feat(cli): initial address commands

### DIFF
--- a/cmd/bursa/address.go
+++ b/cmd/bursa/address.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+
+	"github.com/blinklabs-io/bursa/internal/cli"
+	"github.com/blinklabs-io/bursa/internal/logging"
+	"github.com/spf13/cobra"
+)
+
+func addressCommand() *cobra.Command {
+	addressCmd := cobra.Command{
+		Use:   "address",
+		Short: "Address utility commands",
+		Long: `Commands for working with Cardano addresses.
+
+Supports all CIP-0019 address types including base, enterprise, pointer,
+reward, and legacy Byron addresses.
+
+Examples:
+  bursa address info addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer...
+  bursa address info stake1uy9ggsc9qls4pu46g9...`,
+	}
+
+	addressCmd.AddCommand(
+		addressInfoCommand(),
+	)
+	return &addressCmd
+}
+
+func addressInfoCommand() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "info <address>",
+		Short: "Display information about a Cardano address",
+		Long: `Parses a Cardano address and displays its components.
+
+Supports all CIP-0019 address types:
+  - Base addresses (payment + stake credentials)
+  - Enterprise addresses (payment only)
+  - Pointer addresses (payment + stake pointer)
+  - Reward addresses (stake only)
+  - Byron/Bootstrap addresses (legacy)
+
+Credentials are displayed in both bech32 and hex formats.
+
+Examples:
+  bursa address info addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer...
+  bursa address info addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jh...
+  bursa address info stake1uy9ggsc9qls4pu46g9...`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := cli.RunAddressInfo(args[0]); err != nil {
+				logging.GetLogger().
+					Error("failed to parse address", "error", err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	return &cmd
+}

--- a/cmd/bursa/main.go
+++ b/cmd/bursa/main.go
@@ -40,6 +40,7 @@ func main() {
 		walletCommand(),
 		keyCommand(),
 		certCommand(),
+		addressCommand(),
 		apiCommand(),
 		scriptCommand(),
 	)

--- a/internal/cli/address_test.go
+++ b/internal/cli/address_test.go
@@ -1,0 +1,104 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAddressTypeInfo(t *testing.T) {
+	tests := []struct {
+		addrType    uint8
+		wantName    string
+		wantDescSub string // substring to check in description
+	}{
+		{lcommon.AddressTypeKeyKey, "Base", "payment key"},
+		{lcommon.AddressTypeScriptKey, "Base", "payment script"},
+		{lcommon.AddressTypeKeyNone, "Enterprise", "payment key only"},
+		{lcommon.AddressTypeScriptNone, "Enterprise", "payment script"},
+		{lcommon.AddressTypeNoneKey, "Reward", "stake key"},
+		{lcommon.AddressTypeNoneScript, "Reward", "stake script"},
+		{lcommon.AddressTypeKeyPointer, "Pointer", "payment key"},
+		{lcommon.AddressTypeByron, "Byron", "legacy"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.wantName, func(t *testing.T) {
+			name, desc := getAddressTypeInfo(tt.addrType)
+			assert.Equal(t, tt.wantName, name)
+			assert.Contains(t, desc, tt.wantDescSub)
+		})
+	}
+}
+
+func TestFormatPaymentCredential(t *testing.T) {
+	// 28-byte test hash
+	hash := lcommon.Blake2b224{}
+	copy(hash[:], []byte{
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+		0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+		0x19, 0x1a, 0x1b, 0x1c,
+	})
+
+	// Test key hash
+	bech32Str, hexStr, err := formatPaymentCredential(hash, false)
+	assert.NoError(t, err)
+	assert.Contains(t, bech32Str, "addr_vkh")
+	assert.Equal(
+		t,
+		"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c",
+		hexStr,
+	)
+
+	// Test script hash (CIP-0005: script hashes use "script" prefix)
+	bech32Str, _, err = formatPaymentCredential(hash, true)
+	assert.NoError(t, err)
+	assert.Contains(t, bech32Str, "script")
+}
+
+func TestFormatStakeCredential(t *testing.T) {
+	hash := lcommon.Blake2b224{}
+	copy(hash[:], []byte{
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+		0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+		0x19, 0x1a, 0x1b, 0x1c,
+	})
+
+	// Test key hash
+	bech32Str, hexStr, err := formatStakeCredential(hash, false)
+	assert.NoError(t, err)
+	assert.Contains(t, bech32Str, "stake_vkh")
+	assert.Equal(
+		t,
+		"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c",
+		hexStr,
+	)
+
+	// Test script hash (CIP-0005: script hashes use "script" prefix)
+	bech32Str, _, err = formatStakeCredential(hash, true)
+	assert.NoError(t, err)
+	assert.Contains(t, bech32Str, "script")
+}
+
+func TestRunAddressInfo_InvalidAddress(t *testing.T) {
+	err := RunAddressInfo("invalid")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid address")
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new CLI address command to parse and display Cardano address details. It shows the address type, network, and payment/stake credentials in bech32 and hex, with support for all modern types and Byron.

- **New Features**
  - New command: bursa address info <address>.
  - Supports base, enterprise, pointer, reward, and Byron (CIP-0019).
  - Displays type and network; prints payment/stake credentials (bech32 + hex).
  - Placeholder output for stake pointer details.
  - Unit tests for type info, credential formatting, and invalid address handling.

<sup>Written for commit a976e733b1091ac0b2a17a2e0c8461cb2fee1d2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `address info` CLI command that displays detailed information about Cardano addresses, including address type, network identification, and payment/stake credentials formatted in both bech32 and hexadecimal representations.

* **Tests**
  * Added comprehensive test coverage for address parsing and credential formatting functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->