### PR TITLE
feat: hash command

### DIFF
--- a/cmd/bursa/hash.go
+++ b/cmd/bursa/hash.go
@@ -1,0 +1,140 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+
+	"github.com/blinklabs-io/bursa/internal/cli"
+	"github.com/blinklabs-io/bursa/internal/logging"
+	"github.com/spf13/cobra"
+)
+
+func hashCommand() *cobra.Command {
+	hashCmd := cobra.Command{
+		Use:   "hash",
+		Short: "Hash utility commands",
+		Long: `Commands for generating cryptographic hashes used in Cardano.
+
+These commands create hashes for metadata files and other Cardano constructs.
+
+Hash types:
+  metadata  - Blake2b-256 hash of pool/DRep metadata JSON
+  anchor-data - Blake2b-256 hash of anchor data (constitutions, governance proposals)
+
+Examples:
+  bursa hash metadata pool-metadata.json
+  bursa hash anchor-data --text "Constitution content"
+  bursa hash anchor-data --file-text constitution.txt`,
+	}
+
+	hashCmd.AddCommand(
+		hashMetadataCommand(),
+		hashAnchorDataCommand(),
+	)
+	return &hashCmd
+}
+
+func hashMetadataCommand() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "metadata <file>",
+		Short: "Generate Blake2b-256 hash of metadata JSON file",
+		Long: `Generate a Blake2b-256 hash of a Cardano metadata JSON file.
+
+This is used for pool metadata and DRep metadata registration.
+The hash is calculated from the canonical JSON representation.
+
+Supported metadata types:
+  - pool: Pool registration metadata
+  - drep: DRep registration metadata
+
+Examples:
+  bursa hash metadata pool-metadata.json
+  bursa hash metadata --type pool pool-metadata.json
+  bursa hash metadata --type drep drep-metadata
+		`,
+		Run: func(cmd *cobra.Command, args []string) {
+			// Validate that a file argument is provided
+			if len(args) == 0 {
+				logging.GetLogger().Error("no metadata file specified", "usage", "bursa hash metadata <file>")
+				os.Exit(1)
+			}
+
+			filePath := args[0]
+			if filePath == "" {
+				logging.GetLogger().Error("empty metadata file path specified")
+				os.Exit(1)
+			}
+
+			metadataType, _ := cmd.Flags().GetString("type")
+
+			// Validate metadata type
+			if metadataType != "pool" && metadataType != "drep" {
+				logging.GetLogger().Error("invalid metadata type", "type", metadataType, "valid_types", "pool, drep")
+				os.Exit(1)
+			}
+
+			if err := cli.RunHashMetadata(filePath, metadataType); err != nil {
+				logging.GetLogger().
+					Error("failed to hash metadata", "error", err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().
+		String("type", "pool", "Metadata type (pool or drep)")
+
+	return &cmd
+}
+
+func hashAnchorDataCommand() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "anchor-data",
+		Short: "Generate Blake2b-256 hash of anchor data",
+		Long: `Generate a Blake2b-256 hash of anchor data used in Cardano governance.
+
+This is used for constitutions, governance proposals, and other documents
+that are anchored to on-chain governance actions.
+
+Supported input types:
+  - text: UTF-8 text content
+  - file-text: Text file content
+  - file-binary: Binary file content
+  - url: HTTP/HTTPS URL content`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			text, _ := cmd.Flags().GetString("text")
+			fileText, _ := cmd.Flags().GetString("file-text")
+			fileBinary, _ := cmd.Flags().GetString("file-binary")
+			url, _ := cmd.Flags().GetString("url")
+			expectedHash, _ := cmd.Flags().GetString("expected-hash")
+			outFile, _ := cmd.Flags().GetString("out-file")
+
+			return cli.RunHashAnchorData(text, fileText, fileBinary, url, expectedHash, outFile)
+		},
+	}
+
+	cmd.Flags().String("text", "", "UTF-8 text content to hash")
+	cmd.Flags().String("file-text", "", "Path to text file to hash")
+	cmd.Flags().String("file-binary", "", "Path to binary file to hash")
+	cmd.Flags().String("url", "", "HTTP/HTTPS URL to content to hash")
+	cmd.Flags().String("expected-hash", "", "Expected hash for verification")
+	cmd.Flags().String("out-file", "", "Output file for the hash")
+
+	// Make flags mutually exclusive for input sources
+	cmd.MarkFlagsMutuallyExclusive("text", "file-text", "file-binary", "url")
+
+	return &cmd
+}

--- a/cmd/bursa/main.go
+++ b/cmd/bursa/main.go
@@ -41,6 +41,7 @@ func main() {
 		keyCommand(),
 		certCommand(),
 		addressCommand(),
+		hashCommand(),
 		apiCommand(),
 		scriptCommand(),
 	)

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/getsops/sops/v3 v3.11.0
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/google/uuid v1.6.0
+	github.com/gowebpki/jcs v1.0.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -271,6 +271,8 @@ github.com/googleapis/gax-go/v2 v2.16.0/go.mod h1:o1vfQjjNZn4+dPnRdl/4ZD7S9414Y4
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/goware/prefixer v0.0.0-20160118172347-395022866408 h1:Y9iQJfEqnN3/Nce9cOegemcy/9Ai5k3huT6E80F3zaw=
 github.com/goware/prefixer v0.0.0-20160118172347-395022866408/go.mod h1:PE1ycukgRPJ7bJ9a1fdfQ9j8i/cEcRAoLZzbxYpNB/s=
+github.com/gowebpki/jcs v1.0.1 h1:Qjzg8EOkrOTuWP7DqQ1FbYtcpEbeTzUoTN9bptp8FOU=
+github.com/gowebpki/jcs v1.0.1/go.mod h1:CID1cNZ+sHp1CCpAR8mPf6QRtagFBgPJE0FCUQ6+BrI=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -937,7 +937,9 @@ func TestHandleScriptAddress(t *testing.T) {
 func readTestData(filename string) string {
 	data, err := os.ReadFile(filepath.Join("testdata", filename))
 	if err != nil {
-		panic(fmt.Sprintf("failed to read test data file %s: %v", filename, err))
+		panic(
+			fmt.Sprintf("failed to read test data file %s: %v", filename, err),
+		)
 	}
 	return string(data)
 }

--- a/internal/cli/hash_test.go
+++ b/internal/cli/hash_test.go
@@ -1,0 +1,173 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureStdout captures stdout during the execution of a function
+
+func captureStdout(t *testing.T, f func()) (out string) {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = w
+
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
+	defer func() {
+		os.Stdout = old
+		_ = w.Close()
+		<-done
+		_ = r.Close()
+		out = strings.TrimSpace(buf.String())
+		if rec := recover(); rec != nil {
+			panic(rec)
+		}
+	}()
+
+	f()
+	return out
+}
+
+func TestRunHashMetadata(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "bursa-hash-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Test metadata JSON
+	testMetadata := `{
+		"name": "Test Pool",
+		"description": "A test stake pool for development",
+		"ticker": "TEST",
+		"homepage": "https://example.com",
+		"extended": {
+			"z": "extended metadata"
+		}
+	}`
+
+	// Create test file
+	metadataFile := filepath.Join(tempDir, "metadata.json")
+	err = os.WriteFile(metadataFile, []byte(testMetadata), 0644)
+	require.NoError(t, err)
+
+	// Test pool metadata hashing
+	err = RunHashMetadata(metadataFile, "pool")
+	require.NoError(t, err)
+
+	// Test drep metadata hashing
+	err = RunHashMetadata(metadataFile, "drep")
+	require.NoError(t, err)
+}
+
+func TestRunHashMetadataCanonicalization(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "bursa-hash-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Test that different JSON formatting produces the same hash
+	metadata1 := `{"name":"Test","value":123}`
+	metadata2 := `{
+		"name": "Test",
+		"value": 123
+	}`
+
+	file1 := filepath.Join(tempDir, "metadata1.json")
+	file2 := filepath.Join(tempDir, "metadata2.json")
+
+	err = os.WriteFile(file1, []byte(metadata1), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(file2, []byte(metadata2), 0644)
+	require.NoError(t, err)
+
+	// Capture output from both calls
+	hash1 := captureStdout(t, func() {
+		err := RunHashMetadata(file1, "pool")
+		require.NoError(t, err)
+	})
+
+	hash2 := captureStdout(t, func() {
+		err := RunHashMetadata(file2, "pool")
+		require.NoError(t, err)
+	})
+
+	// Both should produce the same hash due to canonicalization
+	assert.Equal(t, hash1, hash2, "Canonicalization should produce identical hashes for semantically equivalent JSON")
+}
+
+func TestRunHashMetadataErrors(t *testing.T) {
+	// Test with non-existent file
+	err := RunHashMetadata("nonexistent.json", "pool")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read metadata file")
+
+	// Create a temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "bursa-hash-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Test with invalid JSON
+	invalidJSONFile := filepath.Join(tempDir, "invalid.json")
+	err = os.WriteFile(invalidJSONFile, []byte(`{"invalid": json}`), 0644)
+	require.NoError(t, err)
+
+	err = RunHashMetadata(invalidJSONFile, "pool")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid JSON in metadata file")
+}
+
+func TestRunHashMetadataKnownHash(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "bursa-hash-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Test with a known input and expected output
+	// This is a simple test case where we know the expected Blake2b-256 hash
+	testData := `{"test": "data"}`
+
+	file := filepath.Join(tempDir, "test.json")
+	err = os.WriteFile(file, []byte(testData), 0644)
+	require.NoError(t, err)
+
+	// Capture the hash output
+	hash := captureStdout(t, func() {
+		err := RunHashMetadata(file, "pool")
+		require.NoError(t, err)
+	})
+
+	// Verify the hash matches the expected value
+	expectedHash := "d7157feba618cc73df1d0cace17e12b27a5a4354c9272ca6d030496fc2556133"
+	assert.Equal(t, expectedHash, hash, "Hash should match expected Blake2b-256 value")
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new hash command to generate Blake2b-256 hashes for Cardano metadata and governance anchor data. Supports canonical JSON hashing, multiple input sources, optional verification, and file output.

- **New Features**
  - New bursa hash with subcommands:
    - metadata: hashes canonical JSON for pool/drep metadata.
    - anchor-data: hashes from --text, --file-text, --file-binary, or --url (mutually exclusive).
  - Optional --expected-hash verification and --out-file to write the hex hash.
  - Logs context and prints the hex hash to stdout.
  - Tests cover metadata hashing, canonicalization, and error cases.

<sup>Written for commit ace6cec28156f2707ef89832b99ddb8f4e64ddc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level "hash" command with "metadata" and "anchor-data" subcommands. Metadata hashing supports Cardano JSON types ("pool" or "drep"). Anchor-data accepts text, file, binary, or URL input, enforces a single-input selection, supports optional expected-hash verification, and can write output to a file.

* **Tests**
  * Added unit tests for metadata hashing, JSON canonicalization, error cases, and a known-input hash.

* **Chores**
  * Added a JSON canonicalization library dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->