### PR TITLE
feat(cli): support key-file flags to use files

### DIFF
--- a/bursa_test.go
+++ b/bursa_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/blinklabs-io/bursa/bip32"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	bip39 "github.com/tyler-smith/go-bip39"
 )
 
@@ -2674,4 +2675,10 @@ func TestCIP1855PolicyKeyRoundTrip(t *testing.T) {
 		pextSkey.VKey,
 		"Verification key from vkey and extended skey should match",
 	)
+}
+
+func TestGetKESSKeyNilCheck(t *testing.T) {
+	_, err := GetKESSKey(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "KES secret key cannot be nil")
 }

--- a/cmd/bursa/key.go
+++ b/cmd/bursa/key.go
@@ -69,6 +69,7 @@ func keyRootCommand() *cobra.Command {
 	var mnemonic string
 	var mnemonicFile string
 	var password string
+	var signingKeyFile string
 
 	cmd := cobra.Command{
 		Use:   "root",
@@ -76,7 +77,7 @@ func keyRootCommand() *cobra.Command {
 		Long: `Derives the root extended private key from a BIP-39 mnemonic.
 
 The root key is the master key from which all other keys are derived.
-Output is in bech32 format (root_xsk prefix).
+Output is in bech32 format (root_xsk prefix) unless --signing-key-file is specified.
 
 The mnemonic can be provided via:
   1. --mnemonic flag
@@ -87,12 +88,13 @@ The mnemonic can be provided via:
 Examples:
   bursa key root --mnemonic "word1 word2 ... word24"
   bursa key root --mnemonic-file seed.txt
-  bursa key root --password "optional"`,
+  bursa key root --signing-key-file root.skey`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cli.RunKeyRoot(
 				mnemonic,
 				mnemonicFile,
 				password,
+				signingKeyFile,
 			); err != nil {
 				logging.GetLogger().
 					Error("failed to derive root key", "error", err)
@@ -114,6 +116,12 @@ Examples:
 		"",
 		"Optional password for key derivation",
 	)
+	cmd.Flags().StringVar(
+		&signingKeyFile,
+		"signing-key-file",
+		"",
+		"Path to write signing key in cardano-cli compatible JSON format",
+	)
 
 	return &cmd
 }
@@ -123,6 +131,7 @@ func keyAccountCommand() *cobra.Command {
 	var mnemonicFile string
 	var password string
 	var index uint32
+	var signingKeyFile string
 
 	cmd := cobra.Command{
 		Use:   "account",
@@ -130,17 +139,18 @@ func keyAccountCommand() *cobra.Command {
 		Long: `Derives an account extended private key from a BIP-39 mnemonic.
 
 The account key follows CIP-1852 path: m/1852'/1815'/account'
-Output is in bech32 format (acct_xsk prefix).
+Output is in bech32 format (acct_xsk prefix) unless --signing-key-file is specified.
 
 Examples:
   bursa key account --mnemonic "word1 word2 ... word24"
   bursa key account --mnemonic "word1 word2 ..." --index 1
-  bursa key account --mnemonic-file seed.txt --index 0`,
+  bursa key account --signing-key-file account.skey`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cli.RunKeyAccount(
 				mnemonic,
 				mnemonicFile,
 				password,
+				signingKeyFile,
 				index,
 			); err != nil {
 				logging.GetLogger().Error(
@@ -167,6 +177,12 @@ Examples:
 		"Optional password for key derivation",
 	)
 	cmd.Flags().Uint32Var(&index, "index", 0, "Account index (default: 0)")
+	cmd.Flags().StringVar(
+		&signingKeyFile,
+		"signing-key-file",
+		"",
+		"Path to write signing key in cardano-cli compatible JSON format",
+	)
 
 	return &cmd
 }
@@ -177,6 +193,8 @@ func keyPaymentCommand() *cobra.Command {
 	var password string
 	var accountIndex uint32
 	var paymentIndex uint32
+	var signingKeyFile string
+	var verificationKeyFile string
 
 	cmd := cobra.Command{
 		Use:   "payment",
@@ -184,17 +202,19 @@ func keyPaymentCommand() *cobra.Command {
 		Long: `Derives a payment extended private key from a BIP-39 mnemonic.
 
 The payment key follows CIP-1852 path: m/1852'/1815'/account'/0/index
-Output is in bech32 format (addr_xsk prefix).
+Output is in bech32 format (addr_xsk prefix) unless key files are specified.
 
 Examples:
   bursa key payment --mnemonic "word1 word2 ... word24"
   bursa key payment --mnemonic "word1 word2 ..." --account-index 0 --index 0
-  bursa key payment --mnemonic-file seed.txt`,
+  bursa key payment --signing-key-file payment.skey --verification-key-file payment.vkey`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cli.RunKeyPayment(
 				mnemonic,
 				mnemonicFile,
 				password,
+				signingKeyFile,
+				verificationKeyFile,
 				accountIndex,
 				paymentIndex,
 			); err != nil {
@@ -229,6 +249,18 @@ Examples:
 	)
 	cmd.Flags().
 		Uint32Var(&paymentIndex, "index", 0, "Payment key index (default: 0)")
+	cmd.Flags().StringVar(
+		&signingKeyFile,
+		"signing-key-file",
+		"",
+		"Path to write signing key in cardano-cli compatible JSON format",
+	)
+	cmd.Flags().StringVar(
+		&verificationKeyFile,
+		"verification-key-file",
+		"",
+		"Path to write verification key in cardano-cli compatible JSON format",
+	)
 
 	return &cmd
 }
@@ -239,6 +271,8 @@ func keyStakeCommand() *cobra.Command {
 	var password string
 	var accountIndex uint32
 	var stakeIndex uint32
+	var signingKeyFile string
+	var verificationKeyFile string
 
 	cmd := cobra.Command{
 		Use:   "stake",
@@ -246,17 +280,19 @@ func keyStakeCommand() *cobra.Command {
 		Long: `Derives a stake extended private key from a BIP-39 mnemonic.
 
 The stake key follows CIP-1852 path: m/1852'/1815'/account'/2/index
-Output is in bech32 format (stake_xsk prefix).
+Output is in bech32 format (stake_xsk prefix) unless key files are specified.
 
 Examples:
   bursa key stake --mnemonic "word1 word2 ... word24"
   bursa key stake --mnemonic "word1 word2 ..." --account-index 0 --index 0
-  bursa key stake --mnemonic-file seed.txt`,
+  bursa key stake --signing-key-file stake.skey --verification-key-file stake.vkey`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cli.RunKeyStake(
 				mnemonic,
 				mnemonicFile,
 				password,
+				signingKeyFile,
+				verificationKeyFile,
 				accountIndex,
 				stakeIndex,
 			); err != nil {
@@ -291,6 +327,18 @@ Examples:
 	)
 	cmd.Flags().
 		Uint32Var(&stakeIndex, "index", 0, "Stake key index (default: 0)")
+	cmd.Flags().StringVar(
+		&signingKeyFile,
+		"signing-key-file",
+		"",
+		"Path to write signing key in cardano-cli compatible JSON format",
+	)
+	cmd.Flags().StringVar(
+		&verificationKeyFile,
+		"verification-key-file",
+		"",
+		"Path to write verification key in cardano-cli compatible JSON format",
+	)
 
 	return &cmd
 }
@@ -300,6 +348,8 @@ func keyPolicyCommand() *cobra.Command {
 	var mnemonicFile string
 	var password string
 	var index uint32
+	var signingKeyFile string
+	var verificationKeyFile string
 
 	cmd := cobra.Command{
 		Use:   "policy",
@@ -308,17 +358,19 @@ func keyPolicyCommand() *cobra.Command {
 
 The policy key follows CIP-1855 path: m/1855'/1815'/policy_ix'
 These keys are used for native asset minting/burning policies.
-Output is in bech32 format (policy_xsk prefix).
+Output is in bech32 format (policy_xsk prefix) unless key files are specified.
 
 Examples:
   bursa key policy --mnemonic "word1 word2 ... word24"
   bursa key policy --mnemonic "word1 word2 ..." --index 0
-  bursa key policy --mnemonic-file seed.txt --index 1`,
+  bursa key policy --signing-key-file policy.skey --verification-key-file policy.vkey`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cli.RunKeyPolicy(
 				mnemonic,
 				mnemonicFile,
 				password,
+				signingKeyFile,
+				verificationKeyFile,
 				index,
 			); err != nil {
 				logging.GetLogger().Error(
@@ -345,6 +397,18 @@ Examples:
 		"Optional password for key derivation",
 	)
 	cmd.Flags().Uint32Var(&index, "index", 0, "Policy key index (default: 0)")
+	cmd.Flags().StringVar(
+		&signingKeyFile,
+		"signing-key-file",
+		"",
+		"Path to write signing key in cardano-cli compatible JSON format",
+	)
+	cmd.Flags().StringVar(
+		&verificationKeyFile,
+		"verification-key-file",
+		"",
+		"Path to write verification key in cardano-cli compatible JSON format",
+	)
 
 	return &cmd
 }
@@ -354,6 +418,8 @@ func keyPoolColdCommand() *cobra.Command {
 	var mnemonicFile string
 	var password string
 	var index uint32
+	var signingKeyFile string
+	var verificationKeyFile string
 
 	cmd := cobra.Command{
 		Use:   "pool-cold",
@@ -362,17 +428,19 @@ func keyPoolColdCommand() *cobra.Command {
 
 The pool cold key follows CIP-1853 path: m/1853'/1815'/0'/index'
 These keys are used as the long-term identity keys for stake pool operators.
-Output is in bech32 format (pool_xsk prefix).
+Output is in bech32 format (pool_xsk prefix) unless key files are specified.
 
 Examples:
   bursa key pool-cold --mnemonic "word1 word2 ... word24"
   bursa key pool-cold --mnemonic "word1 word2 ..." --index 0
-  bursa key pool-cold --mnemonic-file seed.txt --index 1`,
+  bursa key pool-cold --signing-key-file pool-cold.skey --verification-key-file pool-cold.vkey`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cli.RunKeyPoolCold(
 				mnemonic,
 				mnemonicFile,
 				password,
+				signingKeyFile,
+				verificationKeyFile,
 				index,
 			); err != nil {
 				logging.GetLogger().Error(
@@ -400,6 +468,18 @@ Examples:
 	)
 	cmd.Flags().
 		Uint32Var(&index, "index", 0, "Pool cold key index (default: 0)")
+	cmd.Flags().StringVar(
+		&signingKeyFile,
+		"signing-key-file",
+		"",
+		"Path to write signing key in cardano-cli compatible JSON format",
+	)
+	cmd.Flags().StringVar(
+		&verificationKeyFile,
+		"verification-key-file",
+		"",
+		"Path to write verification key in cardano-cli compatible JSON format",
+	)
 
 	return &cmd
 }
@@ -409,6 +489,8 @@ func keyVRFCommand() *cobra.Command {
 	var mnemonicFile string
 	var password string
 	var index uint32
+	var signingKeyFile string
+	var verificationKeyFile string
 
 	cmd := cobra.Command{
 		Use:   "vrf",
@@ -420,17 +502,19 @@ consensus protocol. The seed is derived deterministically from the mnemonic,
 allowing for key recovery.
 
 Output includes both signing key (vrf_sk) and verification key (vrf_vk)
-in bech32 format.
+in bech32 format unless key files are specified.
 
 Examples:
   bursa key vrf --mnemonic "word1 word2 ... word24"
   bursa key vrf --mnemonic "word1 word2 ..." --index 0
-  bursa key vrf --mnemonic-file seed.txt --index 1`,
+  bursa key vrf --signing-key-file vrf.skey --verification-key-file vrf.vkey`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cli.RunKeyVRF(
 				mnemonic,
 				mnemonicFile,
 				password,
+				signingKeyFile,
+				verificationKeyFile,
 				index,
 			); err != nil {
 				logging.GetLogger().Error(
@@ -457,6 +541,18 @@ Examples:
 		"Optional password for key derivation",
 	)
 	cmd.Flags().Uint32Var(&index, "index", 0, "VRF key index (default: 0)")
+	cmd.Flags().StringVar(
+		&signingKeyFile,
+		"signing-key-file",
+		"",
+		"Path to write signing key in cardano-cli compatible JSON format",
+	)
+	cmd.Flags().StringVar(
+		&verificationKeyFile,
+		"verification-key-file",
+		"",
+		"Path to write verification key in cardano-cli compatible JSON format",
+	)
 
 	return &cmd
 }
@@ -466,6 +562,8 @@ func keyKESCommand() *cobra.Command {
 	var mnemonicFile string
 	var password string
 	var index uint32
+	var signingKeyFile string
+	var verificationKeyFile string
 
 	cmd := cobra.Command{
 		Use:   "kes",
@@ -480,17 +578,19 @@ This implementation uses Cardano's depth 6, providing 64 time periods.
 The seed is derived deterministically from the mnemonic, allowing for key recovery.
 
 Output includes both signing key (kes_sk, 608 bytes) and verification key
-(kes_vk, 32 bytes) in bech32 format.
+(kes_vk, 32 bytes) in bech32 format unless key files are specified.
 
 Examples:
   bursa key kes --mnemonic "word1 word2 ... word24"
   bursa key kes --mnemonic "word1 word2 ..." --index 0
-  bursa key kes --mnemonic-file seed.txt --index 1`,
+  bursa key kes --signing-key-file kes.skey --verification-key-file kes.vkey`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cli.RunKeyKES(
 				mnemonic,
 				mnemonicFile,
 				password,
+				signingKeyFile,
+				verificationKeyFile,
 				index,
 			); err != nil {
 				logging.GetLogger().Error(
@@ -517,6 +617,18 @@ Examples:
 		"Optional password for key derivation",
 	)
 	cmd.Flags().Uint32Var(&index, "index", 0, "KES key index (default: 0)")
+	cmd.Flags().StringVar(
+		&signingKeyFile,
+		"signing-key-file",
+		"",
+		"Path to write signing key in cardano-cli compatible JSON format",
+	)
+	cmd.Flags().StringVar(
+		&verificationKeyFile,
+		"verification-key-file",
+		"",
+		"Path to write verification key in cardano-cli compatible JSON format",
+	)
 
 	return &cmd
 }
@@ -527,6 +639,8 @@ func keyDRepCommand() *cobra.Command {
 	var password string
 	var accountIndex uint32
 	var index uint32
+	var signingKeyFile string
+	var verificationKeyFile string
 
 	cmd := cobra.Command{
 		Use:   "drep",
@@ -535,17 +649,19 @@ func keyDRepCommand() *cobra.Command {
 
 The DRep key follows CIP-0105 path: m/1852'/1815'/account'/3/index
 These keys are used for governance participation as a Delegated Representative.
-Output is in bech32 format (drep_xsk prefix).
+Output is in bech32 format (drep_xsk prefix) unless key files are specified.
 
 Examples:
   bursa key drep --mnemonic "word1 word2 ... word24"
   bursa key drep --mnemonic "word1 word2 ..." --account-index 0 --index 0
-  bursa key drep --mnemonic-file seed.txt --index 1`,
+  bursa key drep --signing-key-file drep.skey --verification-key-file drep.vkey`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cli.RunKeyDRep(
 				mnemonic,
 				mnemonicFile,
 				password,
+				signingKeyFile,
+				verificationKeyFile,
 				accountIndex,
 				index,
 			); err != nil {
@@ -579,6 +695,18 @@ Examples:
 		"Account index (default: 0)",
 	)
 	cmd.Flags().Uint32Var(&index, "index", 0, "DRep key index (default: 0)")
+	cmd.Flags().StringVar(
+		&signingKeyFile,
+		"signing-key-file",
+		"",
+		"Path to write signing key in cardano-cli compatible JSON format",
+	)
+	cmd.Flags().StringVar(
+		&verificationKeyFile,
+		"verification-key-file",
+		"",
+		"Path to write verification key in cardano-cli compatible JSON format",
+	)
 
 	return &cmd
 }
@@ -589,6 +717,8 @@ func keyCommitteeColdCommand() *cobra.Command {
 	var password string
 	var accountIndex uint32
 	var index uint32
+	var signingKeyFile string
+	var verificationKeyFile string
 
 	cmd := cobra.Command{
 		Use:   "committee-cold",
@@ -597,17 +727,19 @@ func keyCommitteeColdCommand() *cobra.Command {
 
 The committee cold key follows CIP-0105 path: m/1852'/1815'/account'/4/index
 These keys are used for Constitutional Committee membership (long-term identity).
-Output is in bech32 format (cc_cold_xsk prefix).
+Output is in bech32 format (cc_cold_xsk prefix) unless key files are specified.
 
 Examples:
   bursa key committee-cold --mnemonic "word1 word2 ... word24"
   bursa key committee-cold --mnemonic "word1 word2 ..." --account-index 0 --index 0
-  bursa key committee-cold --mnemonic-file seed.txt --index 1`,
+  bursa key committee-cold --signing-key-file committee-cold.skey --verification-key-file committee-cold.vkey`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cli.RunKeyCommitteeCold(
 				mnemonic,
 				mnemonicFile,
 				password,
+				signingKeyFile,
+				verificationKeyFile,
 				accountIndex,
 				index,
 			); err != nil {
@@ -642,6 +774,18 @@ Examples:
 	)
 	cmd.Flags().
 		Uint32Var(&index, "index", 0, "Committee cold key index (default: 0)")
+	cmd.Flags().StringVar(
+		&signingKeyFile,
+		"signing-key-file",
+		"",
+		"Path to write signing key in cardano-cli compatible JSON format",
+	)
+	cmd.Flags().StringVar(
+		&verificationKeyFile,
+		"verification-key-file",
+		"",
+		"Path to write verification key in cardano-cli compatible JSON format",
+	)
 
 	return &cmd
 }
@@ -652,6 +796,8 @@ func keyCommitteeHotCommand() *cobra.Command {
 	var password string
 	var accountIndex uint32
 	var index uint32
+	var signingKeyFile string
+	var verificationKeyFile string
 
 	cmd := cobra.Command{
 		Use:   "committee-hot",
@@ -660,17 +806,19 @@ func keyCommitteeHotCommand() *cobra.Command {
 
 The committee hot key follows CIP-0105 path: m/1852'/1815'/account'/5/index
 These keys are used for Constitutional Committee voting (operational key).
-Output is in bech32 format (cc_hot_xsk prefix).
+Output is in bech32 format (cc_hot_xsk prefix) unless key files are specified.
 
 Examples:
   bursa key committee-hot --mnemonic "word1 word2 ... word24"
   bursa key committee-hot --mnemonic "word1 word2 ..." --account-index 0 --index 0
-  bursa key committee-hot --mnemonic-file seed.txt --index 1`,
+  bursa key committee-hot --signing-key-file committee-hot.skey --verification-key-file committee-hot.vkey`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cli.RunKeyCommitteeHot(
 				mnemonic,
 				mnemonicFile,
 				password,
+				signingKeyFile,
+				verificationKeyFile,
 				accountIndex,
 				index,
 			); err != nil {
@@ -705,6 +853,18 @@ Examples:
 	)
 	cmd.Flags().
 		Uint32Var(&index, "index", 0, "Committee hot key index (default: 0)")
+	cmd.Flags().StringVar(
+		&signingKeyFile,
+		"signing-key-file",
+		"",
+		"Path to write signing key in cardano-cli compatible JSON format",
+	)
+	cmd.Flags().StringVar(
+		&verificationKeyFile,
+		"verification-key-file",
+		"",
+		"Path to write verification key in cardano-cli compatible JSON format",
+	)
 
 	return &cmd
 }

--- a/internal/cli/key_file_output_test.go
+++ b/internal/cli/key_file_output_test.go
@@ -1,0 +1,180 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blinklabs-io/bursa"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyFileOutput(t *testing.T) {
+	// Test mnemonic - CIP-1852 test vector (DO NOT USE FOR REAL FUNDS)
+	testMnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+	tests := []struct {
+		name             string
+		runFunc          func(signingKeyFile, verificationKeyFile string) error
+		expectedVKeyType string
+		expectedSKeyType string
+	}{
+		{
+			name:             "payment key",
+			runFunc:          func(skey, vkey string) error { return RunKeyPayment(testMnemonic, "", "", skey, vkey, 0, 0) },
+			expectedVKeyType: "PaymentVerificationKeyShelley_ed25519",
+			expectedSKeyType: "PaymentSigningKeyShelley_ed25519",
+		},
+		{
+			name:             "stake key",
+			runFunc:          func(skey, vkey string) error { return RunKeyStake(testMnemonic, "", "", skey, vkey, 0, 0) },
+			expectedVKeyType: "StakeVerificationKeyShelley_ed25519",
+			expectedSKeyType: "StakeSigningKeyShelley_ed25519",
+		},
+		{
+			name:             "pool cold key",
+			runFunc:          func(skey, vkey string) error { return RunKeyPoolCold(testMnemonic, "", "", skey, vkey, 0) },
+			expectedVKeyType: "StakePoolVerificationKeyShelley_ed25519",
+			expectedSKeyType: "StakePoolSigningKeyShelley_ed25519",
+		},
+		{
+			name:             "policy key",
+			runFunc:          func(skey, vkey string) error { return RunKeyPolicy(testMnemonic, "", "", skey, vkey, 0) },
+			expectedVKeyType: "PolicyVerificationKeyShelley_ed25519",
+			expectedSKeyType: "PolicySigningKeyShelley_ed25519",
+		},
+		{
+			name:             "drep key",
+			runFunc:          func(skey, vkey string) error { return RunKeyDRep(testMnemonic, "", "", skey, vkey, 0, 0) },
+			expectedVKeyType: "DRepVerificationKeyShelley_ed25519",
+			expectedSKeyType: "DRepSigningKeyShelley_ed25519",
+		},
+		{
+			name:             "committee cold key",
+			runFunc:          func(skey, vkey string) error { return RunKeyCommitteeCold(testMnemonic, "", "", skey, vkey, 0, 0) },
+			expectedVKeyType: "CommitteeColdVerificationKeyShelley_ed25519",
+			expectedSKeyType: "CommitteeColdSigningKeyShelley_ed25519",
+		},
+		{
+			name:             "committee hot key",
+			runFunc:          func(skey, vkey string) error { return RunKeyCommitteeHot(testMnemonic, "", "", skey, vkey, 0, 0) },
+			expectedVKeyType: "CommitteeHotVerificationKeyShelley_ed25519",
+			expectedSKeyType: "CommitteeHotSigningKeyShelley_ed25519",
+		},
+		{
+			name:             "VRF key",
+			runFunc:          func(skey, vkey string) error { return RunKeyVRF(testMnemonic, "", "", skey, vkey, 0) },
+			expectedVKeyType: "VRFVerificationKey_PraosVRF",
+			expectedSKeyType: "VRFSigningKey_PraosVRF",
+		},
+		{
+			name:             "KES key",
+			runFunc:          func(skey, vkey string) error { return RunKeyKES(testMnemonic, "", "", skey, vkey, 0) },
+			expectedVKeyType: "KESVerificationKey_PraosV2",
+			expectedSKeyType: "KESSigningKey_PraosV2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary directory for test files
+			tempDir, err := os.MkdirTemp("", "bursa-key-test")
+			require.NoError(t, err)
+			defer os.RemoveAll(tempDir)
+
+			// Define file paths
+			signingKeyFile := filepath.Join(tempDir, "skey.json")
+			verificationKeyFile := filepath.Join(tempDir, "vkey.json")
+
+			// Run the key generation function
+			err = tt.runFunc(signingKeyFile, verificationKeyFile)
+			require.NoError(t, err)
+
+			// Verify signing key file was created and has correct format
+			skeyData, err := os.ReadFile(signingKeyFile)
+			require.NoError(t, err)
+
+			var skey bursa.KeyFile
+			err = json.Unmarshal(skeyData, &skey)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedSKeyType, skey.Type)
+			assert.NotEmpty(t, skey.CborHex)
+			assert.Contains(t, skey.Description, "Signing Key")
+
+			// Verify verification key file was created and has correct format
+			vkeyData, err := os.ReadFile(verificationKeyFile)
+			require.NoError(t, err)
+
+			var vkey bursa.KeyFile
+			err = json.Unmarshal(vkeyData, &vkey)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedVKeyType, vkey.Type)
+			assert.NotEmpty(t, vkey.CborHex)
+			assert.Contains(t, vkey.Description, "Verification Key")
+
+			// Verify files have correct permissions (should be 0o600 for security)
+			skeyInfo, err := os.Stat(signingKeyFile)
+			require.NoError(t, err)
+			assert.Equal(t, os.FileMode(0o600), skeyInfo.Mode())
+
+			vkeyInfo, err := os.Stat(verificationKeyFile)
+			require.NoError(t, err)
+			assert.Equal(t, os.FileMode(0o600), vkeyInfo.Mode())
+		})
+	}
+}
+
+func TestKeyFileOutputBackwardCompatibility(t *testing.T) {
+	// Test that when no file paths are provided, functions still work (backward compatibility)
+	testMnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+	// Test payment key generation without files (should not error)
+	err := RunKeyPayment(testMnemonic, "", "", "", "", 0, 0)
+	require.NoError(t, err)
+
+	// Test stake key generation without files (should not error)
+	err = RunKeyStake(testMnemonic, "", "", "", "", 0, 0)
+	require.NoError(t, err)
+}
+
+func TestKeyFilePermissionsEnforced(t *testing.T) {
+	// Test mnemonic - CIP-1852 test vector (DO NOT USE FOR REAL FUNDS)
+	testMnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+	// Create temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "bursa-perm-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Define file paths
+	signingKeyFile := filepath.Join(tempDir, "payment.skey")
+
+	// First, create a file with insecure permissions
+	insecureData := `{"type":"test","description":"test","cborHex":"00"}`
+	err = os.WriteFile(signingKeyFile, []byte(insecureData), 0o644) // world-readable
+	require.NoError(t, err)
+
+	// Verify it has insecure permissions
+	info, err := os.Stat(signingKeyFile)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode())
+
+	// Now run key generation which should overwrite with secure permissions
+	err = RunKeyPayment(testMnemonic, "", "", signingKeyFile, "", 0, 0)
+	require.NoError(t, err)
+
+	// Verify the file now has secure permissions
+	info, err = os.Stat(signingKeyFile)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode(), "Key file should have secure permissions (0o600)")
+
+	// Verify the content is correct (not the old insecure content)
+	data, err := os.ReadFile(signingKeyFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "PaymentSigningKeyShelley_ed25519")
+	assert.NotContains(t, string(data), "test")
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add file output to bursa key commands. You can now write signing and verification keys to cardano-cli compatible JSON files with --signing-key-file and --verification-key-file. Default bech32 output remains unchanged.

- **New Features**
  - Added key-file flags to root, account, payment, stake, policy, pool-cold, drep, committee-cold, committee-hot, vrf, and kes commands.
  - Generates cardano-cli compatible JSON (Type, Description, CborHex) and writes with 0600 permissions.
  - Implemented KeyFile helpers for root/account, VRF, and KES keys; added tests for formats, permissions, and backward compatibility.

<sup>Written for commit 794597f0ccb314940e25cc18fe901f02c3d7e699. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--signing-key-file` and `--verification-key-file` flags to all key generation commands (root, account, payment, stake, policy, pool, VRF, KES, DRep, and committee keys).
  * Keys can now be exported in Cardano-cli compatible JSON format for seamless integration with Cardano tools.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->