### PR TITLE
chore(deps): use blinklabs-io/go-bip39

### DIFF
--- a/bip32/bip32.go
+++ b/bip32/bip32.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,8 +36,8 @@ import (
 	"strings"
 
 	"filippo.io/edwards25519"
+	"github.com/blinklabs-io/go-bip39"
 	"github.com/btcsuite/btcd/btcutil/bech32"
-	"github.com/tyler-smith/go-bip39"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/bursa.go
+++ b/bursa.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import (
 	"sync"
 
 	"github.com/blinklabs-io/bursa/bip32"
+	bip39 "github.com/blinklabs-io/go-bip39"
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/kes"
@@ -36,7 +37,6 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/vrf"
 	"github.com/btcsuite/btcd/btcutil/bech32"
-	bip39 "github.com/tyler-smith/go-bip39"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/bursa_test.go
+++ b/bursa_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import (
 	"github.com/blinklabs-io/bursa/bip32"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	bip39 "github.com/tyler-smith/go-bip39"
+	bip39 "github.com/blinklabs-io/go-bip39"
 )
 
 // testKeyHash returns a 28-byte test key hash for use in tests

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.24.1
 require (
 	cloud.google.com/go/secretmanager v1.16.0
 	filippo.io/edwards25519 v1.1.0
+	github.com/blinklabs-io/go-bip39 v0.2.0
 	github.com/blinklabs-io/gouroboros v0.152.2
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/fxamacker/cbor/v2 v2.9.0
@@ -20,7 +21,6 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/http-swagger v1.3.4
 	github.com/swaggo/swag v1.16.6
-	github.com/tyler-smith/go-bip39 v1.1.0
 	golang.org/x/crypto v0.47.0
 	golang.org/x/sync v0.19.0
 	google.golang.org/api v0.264.0

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3M
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
+github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
 github.com/blinklabs-io/gouroboros v0.152.2 h1:w2OPBrg+a8bGgk046WvkQNiyn4Yglql7AN5hdurhDFY=
 github.com/blinklabs-io/gouroboros v0.152.2/go.mod h1:BXTv7xGWb0fDpUuRunVLhSvrDrvd+pkSMBpOligo5Ew=
 github.com/blinklabs-io/ouroboros-mock v0.7.0 h1:IbBzOHAtjzh1PWIXy9tMB6wAS6/+HLMVtNtTFSTN4VM=
@@ -425,8 +427,6 @@ github.com/swaggo/http-swagger v1.3.4/go.mod h1:9dAh0unqMBAlbp1uE2Uc2mQTxNMU/ha4
 github.com/swaggo/swag v1.16.6 h1:qBNcx53ZaX+M5dxVyTrgQ0PJ/ACK+NzhwcbieTt+9yI=
 github.com/swaggo/swag v1.16.6/go.mod h1:ngP2etMK5a0P3QBizic5MEwpRmluJZPHjXcMoj4Xesg=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
-github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
-github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/urfave/cli v1.22.17 h1:SYzXoiPfQjHBbkYxbew5prZHS1TOLT3ierW8SYLqtVQ=
 github.com/urfave/cli v1.22.17/go.mod h1:b0ht0aqgH/6pBYzzxURyrM4xXNgsoT/n2ZzwQiEhNVo=
 github.com/utxorpc/go-codegen v0.18.1 h1:2eenzXCkqvB2+g8MCq70MBR6koWs9CeTihZ0AqUvLDY=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch to github.com/blinklabs-io/go-bip39 v0.2.0 and update imports and module files. No behavior changes; also updates copyright headers to 2026.

- **Dependencies**
  - Added github.com/blinklabs-io/go-bip39 v0.2.0; removed github.com/tyler-smith/go-bip39.

<sup>Written for commit 75467cc549e80a0d99ff89cd25032f47ace3f177. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated dependencies to a maintained fork version
* Updated copyright year to 2026

<!-- end of auto-generated comment: release notes by coderabbit.ai -->