### PR TITLE
feat: calidus keys and pool certs

### DIFF
--- a/bursa_test.go
+++ b/bursa_test.go
@@ -28,9 +28,9 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/bursa/bip32"
+	bip39 "github.com/blinklabs-io/go-bip39"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	bip39 "github.com/blinklabs-io/go-bip39"
 )
 
 // testKeyHash returns a 28-byte test key hash for use in tests


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Calidus key derivation (CIP-88/151) and stake pool registration/retirement certificates to support SPO authentication and on-chain pool ops, compatible with cardano-cli.

- **New Features**
  - Calidus keys: derive m/1852'/1815'/account'/0/index; prints bech32 calidus_xsk by default; optional cardano-cli JSON skey/vkey via --signing-key-file/--verification-key-file.
  - Pool certificates: bursa cert pool-registration (pledge, cost, margin, reward stake address, optional metadata) and pool-retirement (cold vkey, epoch); outputs cardano-cli compatible JSON or a summary.
  - Core: CBOR encoders for cert types 3 (registration) and 4 (retirement), VRF vkey parsing from JSON/bech32/hex, and margin float→rational conversion.

<sup>Written for commit 9b7b2655c2974e8872ea72c4b5b70ee087ba9dde. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

