### PR TITLE
test: increase API and CLI coverage

### DIFF
--- a/bursa_test.go
+++ b/bursa_test.go
@@ -28,9 +28,9 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/bursa/bip32"
+	bip39 "github.com/blinklabs-io/go-bip39"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	bip39 "github.com/blinklabs-io/go-bip39"
 )
 
 // testKeyHash returns a 28-byte test key hash for use in tests

--- a/internal/cli/key_commands_test.go
+++ b/internal/cli/key_commands_test.go
@@ -1,0 +1,563 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testKeyMnemonic is a well-known CIP-1852 test vector mnemonic.
+// DO NOT USE FOR REAL FUNDS.
+const testKeyMnemonic = "abandon abandon abandon abandon " +
+	"abandon abandon abandon abandon " +
+	"abandon abandon abandon about"
+
+func TestRunKeyRoot_Bech32Output(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunKeyRoot(testKeyMnemonic, "", "", "")
+		require.NoError(t, err)
+	})
+	assert.True(
+		t,
+		strings.HasPrefix(output, "root_xsk"),
+		"root key should start with root_xsk prefix",
+	)
+}
+
+func TestRunKeyRoot_MissingMnemonic(t *testing.T) {
+	err := RunKeyRoot("", "", "", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no mnemonic provided")
+}
+
+func TestRunKeyRoot_SigningKeyFile(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "bursa-root-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	skeyFile := filepath.Join(tempDir, "root.skey")
+	err = RunKeyRoot(testKeyMnemonic, "", "", skeyFile)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(skeyFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "cborHex")
+}
+
+func TestRunKeyAccount_Bech32Output(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunKeyAccount(
+			testKeyMnemonic, "", "", "", 0,
+		)
+		require.NoError(t, err)
+	})
+	assert.True(
+		t,
+		strings.HasPrefix(output, "acct_xsk"),
+		"account key should start with acct_xsk prefix",
+	)
+}
+
+func TestRunKeyAccount_MissingMnemonic(t *testing.T) {
+	err := RunKeyAccount("", "", "", "", 0)
+	assert.Error(t, err)
+}
+
+func TestRunKeyAccount_SigningKeyFile(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "bursa-acct-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	skeyFile := filepath.Join(tempDir, "acct.skey")
+	err = RunKeyAccount(
+		testKeyMnemonic, "", "", skeyFile, 0,
+	)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(skeyFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "cborHex")
+}
+
+func TestRunKeyPayment_Bech32Output(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunKeyPayment(
+			testKeyMnemonic, "", "", "", "", 0, 0,
+		)
+		require.NoError(t, err)
+	})
+	assert.True(
+		t,
+		strings.HasPrefix(output, "addr_xsk"),
+		"payment key should start with addr_xsk prefix",
+	)
+}
+
+func TestRunKeyPayment_MissingMnemonic(t *testing.T) {
+	err := RunKeyPayment("", "", "", "", "", 0, 0)
+	assert.Error(t, err)
+}
+
+func TestRunKeyStake_Bech32Output(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunKeyStake(
+			testKeyMnemonic, "", "", "", "", 0, 0,
+		)
+		require.NoError(t, err)
+	})
+	assert.True(
+		t,
+		strings.HasPrefix(output, "stake_xsk"),
+		"stake key should start with stake_xsk prefix",
+	)
+}
+
+func TestRunKeyStake_MissingMnemonic(t *testing.T) {
+	err := RunKeyStake("", "", "", "", "", 0, 0)
+	assert.Error(t, err)
+}
+
+func TestRunKeyPolicy_Bech32Output(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunKeyPolicy(
+			testKeyMnemonic, "", "", "", "", 0,
+		)
+		require.NoError(t, err)
+	})
+	assert.True(
+		t,
+		strings.HasPrefix(output, "policy_xsk"),
+		"policy key should start with policy_xsk prefix",
+	)
+}
+
+func TestRunKeyPolicy_MissingMnemonic(t *testing.T) {
+	err := RunKeyPolicy("", "", "", "", "", 0)
+	assert.Error(t, err)
+}
+
+func TestRunKeyPoolCold_Bech32Output(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunKeyPoolCold(
+			testKeyMnemonic, "", "", "", "", 0,
+		)
+		require.NoError(t, err)
+	})
+	assert.True(
+		t,
+		strings.HasPrefix(output, "pool_xsk"),
+		"pool cold key should start with pool_xsk prefix",
+	)
+}
+
+func TestRunKeyPoolCold_MissingMnemonic(t *testing.T) {
+	err := RunKeyPoolCold("", "", "", "", "", 0)
+	assert.Error(t, err)
+}
+
+func TestRunKeyDRep_Bech32Output(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunKeyDRep(
+			testKeyMnemonic, "", "", "", "", 0, 0,
+		)
+		require.NoError(t, err)
+	})
+	assert.True(
+		t,
+		strings.HasPrefix(output, "drep_xsk"),
+		"drep key should start with drep_xsk prefix",
+	)
+}
+
+func TestRunKeyDRep_MissingMnemonic(t *testing.T) {
+	err := RunKeyDRep("", "", "", "", "", 0, 0)
+	assert.Error(t, err)
+}
+
+func TestRunKeyCommitteeCold_Bech32Output(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunKeyCommitteeCold(
+			testKeyMnemonic, "", "", "", "", 0, 0,
+		)
+		require.NoError(t, err)
+	})
+	assert.True(
+		t,
+		strings.HasPrefix(output, "cc_cold_xsk"),
+		"committee cold key should have cc_cold_xsk prefix",
+	)
+}
+
+func TestRunKeyCommitteeCold_MissingMnemonic(t *testing.T) {
+	err := RunKeyCommitteeCold("", "", "", "", "", 0, 0)
+	assert.Error(t, err)
+}
+
+func TestRunKeyCommitteeHot_Bech32Output(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunKeyCommitteeHot(
+			testKeyMnemonic, "", "", "", "", 0, 0,
+		)
+		require.NoError(t, err)
+	})
+	assert.True(
+		t,
+		strings.HasPrefix(output, "cc_hot_xsk"),
+		"committee hot key should have cc_hot_xsk prefix",
+	)
+}
+
+func TestRunKeyCommitteeHot_MissingMnemonic(t *testing.T) {
+	err := RunKeyCommitteeHot("", "", "", "", "", 0, 0)
+	assert.Error(t, err)
+}
+
+func TestRunKeyVRF_Bech32Output(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunKeyVRF(
+			testKeyMnemonic, "", "", "", "", 0,
+		)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, output, "vrf_skey:")
+	assert.Contains(t, output, "vrf_vkey:")
+	// Extract the vrf_skey value
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "vrf_skey:") {
+			key := strings.TrimSpace(
+				strings.TrimPrefix(line, "vrf_skey:"),
+			)
+			assert.True(
+				t,
+				strings.HasPrefix(key, "vrf_sk"),
+				"VRF signing key should have vrf_sk prefix",
+			)
+		}
+		if strings.HasPrefix(line, "vrf_vkey:") {
+			key := strings.TrimSpace(
+				strings.TrimPrefix(line, "vrf_vkey:"),
+			)
+			assert.True(
+				t,
+				strings.HasPrefix(key, "vrf_vk"),
+				"VRF verification key should have vrf_vk prefix",
+			)
+		}
+	}
+}
+
+func TestRunKeyVRF_MissingMnemonic(t *testing.T) {
+	err := RunKeyVRF("", "", "", "", "", 0)
+	assert.Error(t, err)
+}
+
+func TestRunKeyKES_Bech32Output(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunKeyKES(
+			testKeyMnemonic, "", "", "", "", 0,
+		)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, output, "kes_skey:")
+	assert.Contains(t, output, "kes_vkey:")
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "kes_skey:") {
+			key := strings.TrimSpace(
+				strings.TrimPrefix(line, "kes_skey:"),
+			)
+			assert.True(
+				t,
+				strings.HasPrefix(key, "kes_sk"),
+				"KES signing key should have kes_sk prefix",
+			)
+		}
+		if strings.HasPrefix(line, "kes_vkey:") {
+			key := strings.TrimSpace(
+				strings.TrimPrefix(line, "kes_vkey:"),
+			)
+			assert.True(
+				t,
+				strings.HasPrefix(key, "kes_vk"),
+				"KES verification key should have kes_vk prefix",
+			)
+		}
+	}
+}
+
+func TestRunKeyKES_MissingMnemonic(t *testing.T) {
+	err := RunKeyKES("", "", "", "", "", 0)
+	assert.Error(t, err)
+}
+
+func TestRunKeyPayment_NonZeroIndex(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunKeyPayment(
+			testKeyMnemonic, "", "", "", "", 1, 2,
+		)
+		require.NoError(t, err)
+	})
+	assert.True(
+		t,
+		strings.HasPrefix(output, "addr_xsk"),
+		"payment key with non-zero index should work",
+	)
+}
+
+func TestRunKeyStake_NonZeroIndex(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunKeyStake(
+			testKeyMnemonic, "", "", "", "", 1, 1,
+		)
+		require.NoError(t, err)
+	})
+	assert.True(
+		t,
+		strings.HasPrefix(output, "stake_xsk"),
+		"stake key with non-zero index should work",
+	)
+}
+
+func TestRunKeyRoot_WithPassword(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunKeyRoot(
+			testKeyMnemonic, "", "testpassword", "",
+		)
+		require.NoError(t, err)
+	})
+	assert.True(
+		t,
+		strings.HasPrefix(output, "root_xsk"),
+		"root key with password should work",
+	)
+}
+
+func TestRunKeyPayment_DifferentIndicesProduceDifferentKeys(
+	t *testing.T,
+) {
+	output0 := captureStdout(t, func() {
+		err := RunKeyPayment(
+			testKeyMnemonic, "", "", "", "", 0, 0,
+		)
+		require.NoError(t, err)
+	})
+	output1 := captureStdout(t, func() {
+		err := RunKeyPayment(
+			testKeyMnemonic, "", "", "", "", 0, 1,
+		)
+		require.NoError(t, err)
+	})
+	assert.NotEqual(
+		t, output0, output1,
+		"different indices should produce different keys",
+	)
+}
+
+func TestResolveMnemonic_DirectMnemonic(t *testing.T) {
+	result, err := resolveMnemonic(testKeyMnemonic, "")
+	require.NoError(t, err)
+	assert.Equal(t, testKeyMnemonic, result)
+}
+
+func TestResolveMnemonic_EnvVariable(t *testing.T) {
+	t.Setenv("MNEMONIC", testKeyMnemonic)
+	result, err := resolveMnemonic("", "")
+	require.NoError(t, err)
+	assert.Equal(t, testKeyMnemonic, result)
+}
+
+func TestResolveMnemonic_File(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "bursa-mnemonic-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	mnemonicFile := filepath.Join(tempDir, "seed.txt")
+	err = os.WriteFile(
+		mnemonicFile,
+		[]byte(testKeyMnemonic+"\n"),
+		0o600,
+	)
+	require.NoError(t, err)
+
+	result, err := resolveMnemonic("", mnemonicFile)
+	require.NoError(t, err)
+	assert.Equal(t, testKeyMnemonic, result)
+}
+
+func TestResolveMnemonic_NonexistentFile(t *testing.T) {
+	_, err := resolveMnemonic("", "/nonexistent/path/seed.txt")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read mnemonic file")
+}
+
+func TestResolveMnemonic_NoSource(t *testing.T) {
+	// Ensure MNEMONIC env var is not set
+	t.Setenv("MNEMONIC", "")
+	_, err := resolveMnemonic("", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no mnemonic provided")
+}
+
+func TestResolveMnemonic_TrimsWhitespace(t *testing.T) {
+	result, err := resolveMnemonic(
+		"  "+testKeyMnemonic+"  \n",
+		"",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, testKeyMnemonic, result)
+}
+
+func TestEncodeExtendedPrivateKey(t *testing.T) {
+	// Create a 64-byte test key
+	key := make([]byte, 64)
+	for i := range key {
+		key[i] = byte(i)
+	}
+
+	encoded, err := encodeExtendedPrivateKey(key, "test_xsk")
+	require.NoError(t, err)
+	assert.True(
+		t,
+		strings.HasPrefix(encoded, "test_xsk"),
+		"encoded key should have the correct prefix",
+	)
+}
+
+func TestEncodeAccountKey(t *testing.T) {
+	key := make([]byte, 64)
+	encoded, err := encodeAccountKey(key)
+	require.NoError(t, err)
+	assert.True(
+		t,
+		strings.HasPrefix(encoded, "acct_xsk"),
+	)
+}
+
+func TestEncodePaymentKey(t *testing.T) {
+	key := make([]byte, 64)
+	encoded, err := encodePaymentKey(key)
+	require.NoError(t, err)
+	assert.True(
+		t,
+		strings.HasPrefix(encoded, "addr_xsk"),
+	)
+}
+
+func TestEncodeStakeKey(t *testing.T) {
+	key := make([]byte, 64)
+	encoded, err := encodeStakeKey(key)
+	require.NoError(t, err)
+	assert.True(
+		t,
+		strings.HasPrefix(encoded, "stake_xsk"),
+	)
+}
+
+func TestEncodePolicyKey(t *testing.T) {
+	key := make([]byte, 64)
+	encoded, err := encodePolicyKey(key)
+	require.NoError(t, err)
+	assert.True(
+		t,
+		strings.HasPrefix(encoded, "policy_xsk"),
+	)
+}
+
+func TestEncodePoolColdKey(t *testing.T) {
+	key := make([]byte, 64)
+	encoded, err := encodePoolColdKey(key)
+	require.NoError(t, err)
+	assert.True(
+		t,
+		strings.HasPrefix(encoded, "pool_xsk"),
+	)
+}
+
+func TestEncodeDRepKey(t *testing.T) {
+	key := make([]byte, 64)
+	encoded, err := encodeDRepKey(key)
+	require.NoError(t, err)
+	assert.True(
+		t,
+		strings.HasPrefix(encoded, "drep_xsk"),
+	)
+}
+
+func TestEncodeCommitteeColdKey(t *testing.T) {
+	key := make([]byte, 64)
+	encoded, err := encodeCommitteeColdKey(key)
+	require.NoError(t, err)
+	assert.True(
+		t,
+		strings.HasPrefix(encoded, "cc_cold_xsk"),
+	)
+}
+
+func TestEncodeCommitteeHotKey(t *testing.T) {
+	key := make([]byte, 64)
+	encoded, err := encodeCommitteeHotKey(key)
+	require.NoError(t, err)
+	assert.True(
+		t,
+		strings.HasPrefix(encoded, "cc_hot_xsk"),
+	)
+}
+
+func TestEncodeVRFSigningKey(t *testing.T) {
+	key := make([]byte, 64)
+	encoded, err := encodeVRFSigningKey(key)
+	require.NoError(t, err)
+	assert.True(
+		t,
+		strings.HasPrefix(encoded, "vrf_sk"),
+	)
+}
+
+func TestEncodeVRFVerificationKey(t *testing.T) {
+	key := make([]byte, 32)
+	encoded, err := encodeVRFVerificationKey(key)
+	require.NoError(t, err)
+	assert.True(
+		t,
+		strings.HasPrefix(encoded, "vrf_vk"),
+	)
+}
+
+func TestEncodeKESSigningKey(t *testing.T) {
+	key := make([]byte, 64)
+	encoded, err := encodeKESSigningKey(key)
+	require.NoError(t, err)
+	assert.True(
+		t,
+		strings.HasPrefix(encoded, "kes_sk"),
+	)
+}
+
+func TestEncodeKESVerificationKey(t *testing.T) {
+	key := make([]byte, 32)
+	encoded, err := encodeKESVerificationKey(key)
+	require.NoError(t, err)
+	assert.True(
+		t,
+		strings.HasPrefix(encoded, "kes_vk"),
+	)
+}

--- a/internal/cli/script_commands_test.go
+++ b/internal/cli/script_commands_test.go
@@ -1,0 +1,606 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blinklabs-io/bursa"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunScriptCreate_NOf(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "bursa-script-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	outputFile := filepath.Join(tempDir, "script.json")
+	hashes := []string{
+		"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c",
+		"02030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d",
+	}
+
+	err = RunScriptCreate(
+		1, hashes, outputFile, "mainnet",
+		false, false, 0, 0,
+	)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+
+	var scriptData bursa.ScriptData
+	err = json.Unmarshal(data, &scriptData)
+	require.NoError(t, err)
+	assert.Equal(t, "NativeScript", scriptData.Type)
+	assert.NotEmpty(t, scriptData.Address)
+}
+
+func TestRunScriptCreate_All(t *testing.T) {
+	hashes := []string{
+		"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c",
+	}
+
+	output := captureStdout(t, func() {
+		err := RunScriptCreate(
+			0, hashes, "", "mainnet",
+			true, false, 0, 0,
+		)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, output, "NativeScript")
+}
+
+func TestRunScriptCreate_Any(t *testing.T) {
+	hashes := []string{
+		"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c",
+	}
+
+	output := captureStdout(t, func() {
+		err := RunScriptCreate(
+			0, hashes, "", "mainnet",
+			false, true, 0, 0,
+		)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, output, "NativeScript")
+}
+
+func TestRunScriptCreate_BothAllAndAny(t *testing.T) {
+	hashes := []string{
+		"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c",
+	}
+	err := RunScriptCreate(
+		0, hashes, "", "mainnet",
+		true, true, 0, 0,
+	)
+	assert.Error(t, err)
+	assert.Contains(
+		t, err.Error(),
+		"cannot specify both --all and --any",
+	)
+}
+
+func TestRunScriptCreate_AllWithRequired(t *testing.T) {
+	hashes := []string{
+		"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c",
+	}
+	err := RunScriptCreate(
+		1, hashes, "", "mainnet",
+		true, false, 0, 0,
+	)
+	assert.Error(t, err)
+	assert.Contains(
+		t, err.Error(),
+		"cannot specify --required with --all",
+	)
+}
+
+func TestRunScriptCreate_AnyWithRequired(t *testing.T) {
+	hashes := []string{
+		"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c",
+	}
+	err := RunScriptCreate(
+		1, hashes, "", "mainnet",
+		false, true, 0, 0,
+	)
+	assert.Error(t, err)
+	assert.Contains(
+		t, err.Error(),
+		"cannot specify --required with --any",
+	)
+}
+
+func TestRunScriptCreate_NoTypeSpecified(t *testing.T) {
+	hashes := []string{
+		"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c",
+	}
+	err := RunScriptCreate(
+		0, hashes, "", "mainnet",
+		false, false, 0, 0,
+	)
+	assert.Error(t, err)
+	assert.Contains(
+		t, err.Error(),
+		"must specify --required, --all, or --any",
+	)
+}
+
+func TestRunScriptCreate_NoKeyHashes(t *testing.T) {
+	err := RunScriptCreate(
+		1, []string{}, "", "mainnet",
+		false, false, 0, 0,
+	)
+	assert.Error(t, err)
+	assert.Contains(
+		t, err.Error(),
+		"must provide at least one key hash",
+	)
+}
+
+func TestRunScriptCreate_InvalidKeyHash(t *testing.T) {
+	hashes := []string{"not-hex"}
+	err := RunScriptCreate(
+		1, hashes, "", "mainnet",
+		false, false, 0, 0,
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid key hash format")
+}
+
+func TestRunScriptCreate_WrongKeyHashLength(t *testing.T) {
+	hashes := []string{"0102030405"}
+	err := RunScriptCreate(
+		1, hashes, "", "mainnet",
+		false, false, 0, 0,
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid key hash length")
+}
+
+func TestRunScriptCreate_RequiredExceedsKeyCount(t *testing.T) {
+	hashes := []string{
+		"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c",
+	}
+	err := RunScriptCreate(
+		5, hashes, "", "mainnet",
+		false, false, 0, 0,
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot exceed")
+}
+
+func TestRunScriptCreate_BothTimelocks(t *testing.T) {
+	hashes := []string{
+		"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c",
+	}
+	err := RunScriptCreate(
+		1, hashes, "", "mainnet",
+		false, false, 1000, 500,
+	)
+	assert.Error(t, err)
+	assert.Contains(
+		t, err.Error(),
+		"cannot specify both",
+	)
+}
+
+func TestRunScriptCreate_WithTimelockBefore(t *testing.T) {
+	hashes := []string{
+		"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c",
+	}
+
+	output := captureStdout(t, func() {
+		err := RunScriptCreate(
+			0, hashes, "", "mainnet",
+			true, false, 1000000, 0,
+		)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, output, "NativeScript")
+}
+
+func TestRunScriptCreate_WithTimelockAfter(t *testing.T) {
+	hashes := []string{
+		"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c",
+	}
+
+	output := captureStdout(t, func() {
+		err := RunScriptCreate(
+			0, hashes, "", "mainnet",
+			true, false, 0, 500000,
+		)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, output, "NativeScript")
+}
+
+func TestRunAddressBuild_BaseMainnet(t *testing.T) {
+	// Generate keys from the test mnemonic first
+	paymentVk := "addr_vk18nqps65rh0azud77qruff3dctszahutmrhkxg87mlfny0addcles83lnyc"
+	stakeVk := "stake_vk1swf4qsf28mzdn2kexqumas5fj43psj674xathpv45mcj04y2lv5scvw4uv"
+
+	output := captureStdout(t, func() {
+		err := RunAddressBuild(
+			paymentVk, stakeVk, "mainnet", "base",
+		)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, output, "addr1")
+}
+
+func TestRunAddressBuild_Enterprise(t *testing.T) {
+	paymentVk := "addr_vk18nqps65rh0azud77qruff3dctszahutmrhkxg87mlfny0addcles83lnyc"
+
+	output := captureStdout(t, func() {
+		err := RunAddressBuild(
+			paymentVk, "", "mainnet", "enterprise",
+		)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, output, "addr1")
+}
+
+func TestRunAddressBuild_Reward(t *testing.T) {
+	stakeVk := "stake_vk1swf4qsf28mzdn2kexqumas5fj43psj674xathpv45mcj04y2lv5scvw4uv"
+
+	output := captureStdout(t, func() {
+		err := RunAddressBuild(
+			"", stakeVk, "mainnet", "reward",
+		)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, output, "stake1")
+}
+
+func TestRunAddressBuild_Testnet(t *testing.T) {
+	paymentVk := "addr_vk18nqps65rh0azud77qruff3dctszahutmrhkxg87mlfny0addcles83lnyc"
+	stakeVk := "stake_vk1swf4qsf28mzdn2kexqumas5fj43psj674xathpv45mcj04y2lv5scvw4uv"
+
+	output := captureStdout(t, func() {
+		err := RunAddressBuild(
+			paymentVk, stakeVk, "testnet", "base",
+		)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, output, "addr_test1")
+}
+
+func TestRunAddressBuild_InvalidNetwork(t *testing.T) {
+	paymentVk := "addr_vk18nqps65rh0azud77qruff3dctszahutmrhkxg87mlfny0addcles83lnyc"
+	err := RunAddressBuild(
+		paymentVk, "", "invalid", "enterprise",
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid network")
+}
+
+func TestRunAddressBuild_BaseMissingStakeKey(t *testing.T) {
+	paymentVk := "addr_vk18nqps65rh0azud77qruff3dctszahutmrhkxg87mlfny0addcles83lnyc"
+	err := RunAddressBuild(
+		paymentVk, "", "mainnet", "base",
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "require both")
+}
+
+func TestRunAddressBuild_EnterpriseMissingPaymentKey(
+	t *testing.T,
+) {
+	err := RunAddressBuild("", "", "mainnet", "enterprise")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "require a payment key")
+}
+
+func TestRunAddressBuild_RewardMissingStakeKey(t *testing.T) {
+	err := RunAddressBuild("", "", "mainnet", "reward")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "require a stake key")
+}
+
+func TestRunAddressBuild_UnsupportedType(t *testing.T) {
+	err := RunAddressBuild(
+		"some_key", "", "mainnet", "unsupported",
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported address type")
+}
+
+func TestRunAddressEnterprise_WithBech32Key(t *testing.T) {
+	paymentVk := "addr_vk18nqps65rh0azud77qruff3dctszahutmrhkxg87mlfny0addcles83lnyc"
+
+	output := captureStdout(t, func() {
+		err := RunAddressEnterprise(
+			paymentVk, "", "mainnet",
+		)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, output, "addr1")
+}
+
+func TestRunAddressEnterprise_InvalidNetwork(t *testing.T) {
+	paymentVk := "addr_vk18nqps65rh0azud77qruff3dctszahutmrhkxg87mlfny0addcles83lnyc"
+	err := RunAddressEnterprise(paymentVk, "", "invalid")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid network")
+}
+
+func TestRunAddressEnterprise_NoKeyProvided(t *testing.T) {
+	err := RunAddressEnterprise("", "", "mainnet")
+	assert.Error(t, err)
+	assert.Contains(
+		t, err.Error(),
+		"payment key or payment key file must be specified",
+	)
+}
+
+func TestRunAddressEnterprise_Testnet(t *testing.T) {
+	paymentVk := "addr_vk18nqps65rh0azud77qruff3dctszahutmrhkxg87mlfny0addcles83lnyc"
+
+	output := captureStdout(t, func() {
+		err := RunAddressEnterprise(
+			paymentVk, "", "testnet",
+		)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, output, "addr_test1")
+}
+
+func TestRunAddressInfo_MainnetBaseAddress(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunAddressInfo(
+			"addr1qxwqkfd3qz5pdwmemtv2llmetegdyku4ffxuldjcfrs05nfjtw33ktf3j6amgxsgnj9u3fa5nrle79nv2g24npnth0esk2dy7q",
+		)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, output, "Base")
+	assert.Contains(t, output, "mainnet")
+	assert.Contains(t, output, "Payment Credential")
+	assert.Contains(t, output, "Stake Credential")
+}
+
+func TestRunAddressInfo_TestnetAddress(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunAddressInfo(
+			"addr_test1qqqcea9cpx0480yjvvklp0tw4yw56r6q9qc437gpqwg6swwc3w03xmxfgcfw6v7asa6vdapakdr6ukq5mrhawfwnjvfsqeaxws",
+		)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, output, "Base")
+	assert.Contains(t, output, "testnet")
+}
+
+func TestRunAddressInfo_EnterpriseAddress(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunAddressInfo(
+			"addr_test1vqqcea9cpx0480yjvvklp0tw4yw56r6q9qc437gpqwg6swg560kjv",
+		)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, output, "Enterprise")
+	assert.Contains(t, output, "Payment Credential")
+}
+
+func TestRunAddressInfo_StakeAddress(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunAddressInfo(
+			"stake1uye9hgcm95cedwa5rgyfez7g576f3lulzek9y92ese4mhucu439t0",
+		)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, output, "Reward")
+	assert.Contains(t, output, "Stake Credential")
+}
+
+func TestRunAddressInfo_InvalidAddressString(t *testing.T) {
+	err := RunAddressInfo("invalid")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid address")
+}
+
+func TestRunHashAnchorData_TextInput(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := RunHashAnchorData(
+			"test data", "", "", "", "", "",
+		)
+		require.NoError(t, err)
+	})
+	// Should produce a 64-character hex hash
+	assert.Len(t, output, 64)
+}
+
+func TestRunHashAnchorData_FileTextInput(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "bursa-anchor-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	testFile := filepath.Join(tempDir, "test.txt")
+	err = os.WriteFile(
+		testFile, []byte("test file content"), 0o644,
+	)
+	require.NoError(t, err)
+
+	output := captureStdout(t, func() {
+		err := RunHashAnchorData(
+			"", testFile, "", "", "", "",
+		)
+		require.NoError(t, err)
+	})
+	assert.Len(t, output, 64)
+}
+
+func TestRunHashAnchorData_FileBinaryInput(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "bursa-anchor-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	testFile := filepath.Join(tempDir, "test.bin")
+	err = os.WriteFile(
+		testFile, []byte{0x00, 0x01, 0x02}, 0o644,
+	)
+	require.NoError(t, err)
+
+	output := captureStdout(t, func() {
+		err := RunHashAnchorData(
+			"", "", testFile, "", "", "",
+		)
+		require.NoError(t, err)
+	})
+	assert.Len(t, output, 64)
+}
+
+func TestRunHashAnchorData_NoInput(t *testing.T) {
+	err := RunHashAnchorData("", "", "", "", "", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no input source specified")
+}
+
+func TestRunHashAnchorData_ExpectedHash_Match(t *testing.T) {
+	// First compute hash of "test data"
+	hash := captureStdout(t, func() {
+		err := RunHashAnchorData(
+			"test data", "", "", "", "", "",
+		)
+		require.NoError(t, err)
+	})
+
+	// Now verify with expected hash
+	err := RunHashAnchorData(
+		"test data", "", "", "", hash, "",
+	)
+	assert.NoError(t, err)
+}
+
+func TestRunHashAnchorData_ExpectedHash_Mismatch(t *testing.T) {
+	err := RunHashAnchorData(
+		"test data", "", "", "",
+		"0000000000000000000000000000000000000000000000000000000000000000",
+		"",
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "hash verification failed")
+}
+
+func TestRunHashAnchorData_OutputToFile(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "bursa-anchor-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	outFile := filepath.Join(tempDir, "hash.txt")
+	err = RunHashAnchorData(
+		"test data", "", "", "", "", outFile,
+	)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+	// Hash + newline = 65 chars
+	assert.Len(t, string(data), 65)
+}
+
+func TestRunHashAnchorData_NonexistentTextFile(t *testing.T) {
+	err := RunHashAnchorData(
+		"", "/nonexistent/file.txt", "", "", "", "",
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read text file")
+}
+
+func TestRunHashAnchorData_NonexistentBinaryFile(t *testing.T) {
+	err := RunHashAnchorData(
+		"", "", "/nonexistent/file.bin", "", "", "",
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read binary file")
+}
+
+func TestParseVerificationKey_JSONEnvelope(t *testing.T) {
+	// Valid KES verification key in JSON envelope format
+	// 5820 + 32 bytes of zeros
+	envelope := `{
+		"type": "KESVerificationKey_PraosV2",
+		"description": "KES Verification Key",
+		"cborHex": "5820` +
+		"0000000000000000000000000000000000000000000000000000000000000000" +
+		`"
+	}`
+
+	key, err := parseVerificationKey([]byte(envelope))
+	require.NoError(t, err)
+	assert.Len(t, key, 32)
+}
+
+func TestParseVerificationKey_HexFormat(t *testing.T) {
+	hexKey := "0000000000000000000000000000000000000000000000000000000000000000"
+	key, err := parseVerificationKey([]byte(hexKey))
+	require.NoError(t, err)
+	assert.Len(t, key, 32)
+}
+
+func TestParseVerificationKey_InvalidFormat(t *testing.T) {
+	_, err := parseVerificationKey([]byte("invalid"))
+	assert.Error(t, err)
+}
+
+func TestParseSigningKey_HexFormat32(t *testing.T) {
+	hexKey := "0000000000000000000000000000000000000000000000000000000000000000"
+	key, err := parseSigningKey([]byte(hexKey))
+	require.NoError(t, err)
+	assert.Len(t, key, 32)
+}
+
+func TestParseSigningKey_HexFormat64(t *testing.T) {
+	hexKey := "0000000000000000000000000000000000000000000000000000000000000000" +
+		"0000000000000000000000000000000000000000000000000000000000000000"
+	key, err := parseSigningKey([]byte(hexKey))
+	require.NoError(t, err)
+	// Extended keys return first 32 bytes
+	assert.Len(t, key, 32)
+}
+
+func TestParseSigningKey_InvalidFormat(t *testing.T) {
+	_, err := parseSigningKey([]byte("invalid"))
+	assert.Error(t, err)
+}
+
+func TestEncodeCredentialBech32(t *testing.T) {
+	hash := make([]byte, 28)
+	encoded, err := encodeCredentialBech32(hash, "addr_vkh")
+	require.NoError(t, err)
+	assert.True(
+		t,
+		len(encoded) > 0,
+		"encoded credential should not be empty",
+	)
+}
+
+func TestParseBech32VerificationKey_InvalidBech32(t *testing.T) {
+	_, err := parseBech32VerificationKey("not-bech32", true)
+	assert.Error(t, err)
+}
+
+func TestParseBech32VerificationKey_WrongHRP(t *testing.T) {
+	// Use a valid bech32 string but with wrong HRP
+	_, err := parseBech32VerificationKey(
+		"stake_vk1swf4qsf28mzdn2kexqumas5fj43psj674xathpv45mcj04y2lv5scvw4uv",
+		true, // expecting payment key
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid key type")
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expand API and CLI test coverage with success and error-path cases across wallet, script, address, health, and key utilities to improve reliability and document behavior. Adds metrics polling for wallet-create, validates 405/invalid JSON, covers timelock before/after (and conflict), exercises “testnet” error paths, defaults address type, and tests mnemonic resolution (env/file), VRF/KES and derivation output prefixes and file writes, bech32 HRP validation, JSON-envelope/hex key parsing, and anchor hashing from text/binary/files with optional verification.

<sup>Written for commit b11294306614229d2879f7db40fbaa692da517a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

