### PR TITLE
chore: update go version to 1.25

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [1.25.x, 1.26.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,7 +82,7 @@ jobs:
           fetch-depth: '0'
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: Build binary
         run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/blinklabs-io/bursa
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.1
+toolchain go1.25.7
 
 require (
 	cloud.google.com/go/secretmanager v1.16.0


### PR DESCRIPTION
Closes #474 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade project to Go 1.25 and refresh CI to test on 1.25.x and 1.26.x, addressing #474. This standardizes the toolchain and prepares for the next Go release.

- **Dependencies**
  - go.mod: set go 1.25.0; toolchain 1.25.7.
  - GitHub Actions: test matrix 1.25.x/1.26.x; publish uses 1.25.x.

- **Migration**
  - Update local Go to 1.25+ before building.

<sup>Written for commit d9082addba4733ad720216ce56a638d908f10e59. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/492?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

