### PR TITLE
ci: separate amd64 and arm64 builds

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -13,13 +13,19 @@ permissions:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
         with:
           fetch-depth: '0'
-      - name: qemu
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0 https://github.com/docker/setup-qemu-action/releases/tag/v4.1.0
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0 https://github.com/docker/setup-buildx-action/releases/tag/v4.0.0
       - id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0 https://github.com/docker/metadata-action/releases/tag/v6.1.0
@@ -30,7 +36,6 @@ jobs:
         with:
           context: .
           push: false
-          ### TODO: test multiple platforms
-          # platforms: linux/amd64,linux/arm64
+          platforms: linux/${{ matrix.arch }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,7 +176,15 @@ jobs:
           subject-path: 'bursa'
 
   build-images:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.os }}
     needs: [create-draft-release]
     permissions:
       actions: write
@@ -191,10 +199,62 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
         with:
           fetch-depth: '0'
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0 https://github.com/docker/setup-qemu-action/releases/tag/v4.1.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0 https://github.com/docker/setup-buildx-action/releases/tag/v4.0.0
+      - name: Login to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0 https://github.com/docker/login-action/releases/tag/v4.2.0
+        with:
+          username: blinklabs
+          password: ${{ secrets.DOCKER_PASSWORD }} # uses token
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0 https://github.com/docker/login-action/releases/tag/v4.2.0
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+      - id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0 https://github.com/docker/metadata-action/releases/tag/v6.1.0
+        with:
+          images: |
+            blinklabs/bursa
+            ghcr.io/${{ github.repository }}
+          flavor: |
+            suffix=-${{ matrix.arch }}
+          tags: |
+            # Only version, no revision
+            type=match,pattern=v(.*)-(.*),group=1
+            # branch
+            type=ref,event=branch
+            # semver
+            type=semver,pattern={{version}}
+      - name: Build images
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0 https://github.com/docker/build-push-action/releases/tag/v7.2.0
+        id: push
+        with:
+          outputs: "type=registry,push=true"
+          platforms: linux/${{ matrix.arch }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Attest Docker Hub image
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
+        with:
+          subject-name: index.docker.io/blinklabs/bursa
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+      - name: Attest GHCR image
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  build-image-manifest:
+    runs-on: ubuntu-latest
+    needs: [build-images]
+    permissions:
+      contents: read
+      packages: write
+    steps:
       - name: Login to Docker Hub
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0 https://github.com/docker/login-action/releases/tag/v4.2.0
         with:
@@ -219,26 +279,16 @@ jobs:
             type=ref,event=branch
             # semver
             type=semver,pattern={{version}}
-      - name: Build images
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0 https://github.com/docker/build-push-action/releases/tag/v7.2.0
-        id: push
-        with:
-          outputs: "type=registry,push=true"
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-      - name: Attest Docker Hub image
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
-        with:
-          subject-name: index.docker.io/blinklabs/bursa
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
-      - name: Attest GHCR image
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
-        with:
-          subject-name: ghcr.io/${{ github.repository }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+      - name: Create image manifests
+        shell: bash
+        run: |
+          for tag in `echo '${{ steps.meta.outputs.tags }}'`; do
+            docker manifest create ${tag} \
+              $(docker manifest inspect ${tag}-amd64 | jq -r '.manifests[] | .digest' | sed -e "s|^|${tag%:*}@|") \
+              $(docker manifest inspect ${tag}-arm64 | jq -r '.manifests[] | .digest' | sed -e "s|^|${tag%:*}@|")
+            docker manifest push ${tag}
+          done
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       # Update Docker Hub from README
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0 https://github.com/peter-evans/dockerhub-description/releases/tag/v5.0.0
@@ -253,7 +303,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [create-draft-release, build-binaries, build-images]
+    needs: [create-draft-release, build-binaries, build-images, build-image-manifest]
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 https://github.com/actions/github-script/releases/tag/v9.0.0
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -252,7 +252,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-images]
     permissions:
+      attestations: write
       contents: read
+      id-token: write
       packages: write
     steps:
       - name: Login to Docker Hub
@@ -279,15 +281,32 @@ jobs:
             type=ref,event=branch
             # semver
             type=semver,pattern={{version}}
-      - name: Create image manifests
+      - name: Create and push image manifests
+        id: manifest
         shell: bash
         run: |
-          for tag in `echo '${{ steps.meta.outputs.tags }}'`; do
-            docker manifest create ${tag} \
-              $(docker manifest inspect ${tag}-amd64 | jq -r '.manifests[] | .digest' | sed -e "s|^|${tag%:*}@|") \
-              $(docker manifest inspect ${tag}-arm64 | jq -r '.manifests[] | .digest' | sed -e "s|^|${tag%:*}@|")
-            docker manifest push ${tag}
-          done
+          while IFS= read -r tag; do
+            docker manifest create "${tag}" \
+              "${tag}-amd64" \
+              "${tag}-arm64"
+            docker manifest push "${tag}"
+          done <<< "${{ steps.meta.outputs.tags }}"
+          dockerhub_tag=$(echo "${{ steps.meta.outputs.tags }}" | grep -v '^ghcr' | head -1)
+          ghcr_tag=$(echo "${{ steps.meta.outputs.tags }}" | grep '^ghcr' | head -1)
+          echo "dockerhub-digest=$(docker buildx imagetools inspect --format '{{.Digest}}' ${dockerhub_tag})" >> $GITHUB_OUTPUT
+          echo "ghcr-digest=$(docker buildx imagetools inspect --format '{{.Digest}}' ${ghcr_tag})" >> $GITHUB_OUTPUT
+      - name: Attest Docker Hub manifest
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
+        with:
+          subject-name: index.docker.io/blinklabs/bursa
+          subject-digest: ${{ steps.manifest.outputs.dockerhub-digest }}
+          push-to-registry: true
+      - name: Attest GHCR manifest
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.manifest.outputs.ghcr-digest }}
+          push-to-registry: true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       # Update Docker Hub from README
       - name: Docker Hub Description


### PR DESCRIPTION
Closes: #422 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split Docker image builds for amd64 and arm64 into separate matrix jobs and added a manifest publish and attest step. This removes QEMU, speeds up CI, and provides both arch-suffixed images and a multi-arch tag.

- **Refactors**
  - Matrix builds on `ubuntu-latest` (amd64) and `ubuntu-24.04-arm` (arm64) with `runs-on: ${{ matrix.os }}` in both CI and release.
  - Removed `docker/setup-qemu-action`; use native builds with `docker/setup-buildx-action`.
  - Per-arch builds use `platforms: linux/${{ matrix.arch }}` and tag flavor `suffix=-${{ matrix.arch }}` via `docker/metadata-action`.
  - New `build-image-manifest` job creates, pushes, and attests multi-arch manifests; release waits for it.

<sup>Written for commit 1c58748735023c25aaf0d062cf33693b77147fe0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker image build infrastructure to support multiple processor architectures (amd64 and arm64).
  * Automated creation and distribution of multi-architecture Docker manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->