### PR TITLE
feat(ui): derive read-only CIP-1852 account from mnemonic

### DIFF
--- a/ui/cmd/bursa-wallet/main.go
+++ b/ui/cmd/bursa-wallet/main.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,10 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/bursa/ui/internal/api"
+	"github.com/blinklabs-io/bursa/ui/internal/cardanonet"
+	"github.com/blinklabs-io/bursa/ui/internal/chain"
 	"github.com/blinklabs-io/bursa/ui/internal/supervisor"
+	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 )
 
 func main() {
@@ -47,22 +50,26 @@ func run() error {
 		return err
 	}
 	network := envOr("BURSA_NETWORK", "preview")
-	if !validNetwork(network) {
-		return fmt.Errorf("invalid BURSA_NETWORK %q: must be one of preview, preprod, mainnet", network)
+	if !cardanonet.ValidNetwork(network) {
+		return fmt.Errorf("invalid BURSA_NETWORK %q: must be one of %s", network, cardanonet.SupportedNetworks())
 	}
 	dataDir := filepath.Join(home, ".bursa-wallet", network)
 	if err := os.MkdirAll(dataDir, 0o700); err != nil {
 		return err
 	}
 
+	const blockfrostPort uint = 5556
 	sup := supervisor.New(supervisor.Config{
 		Network:        network,
 		DataDir:        filepath.Join(dataDir, "db"),
 		SocketPath:     filepath.Join(dataDir, "node.socket"),
 		UtxorpcPort:    5555,
-		BlockfrostPort: 5556,
+		BlockfrostPort: blockfrostPort,
 		Logger:         logger,
 	})
+
+	// The wallet queries the node's own loopback Blockfrost endpoint.
+	walletSvc := wallet.NewService(chain.NewClient(blockfrostPort))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -74,7 +81,7 @@ func run() error {
 
 	srv := &http.Server{
 		Addr:              "127.0.0.1:8090", // loopback only
-		Handler:           api.NewHandler(sup),
+		Handler:           api.NewHandler(sup, walletSvc, network),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	srvErr := make(chan error, 1)
@@ -102,17 +109,4 @@ func envOr(key, def string) string {
 		return v
 	}
 	return def
-}
-
-// validNetwork reports whether name is a supported Cardano network. network is
-// used unescaped as a path segment under ~/.bursa-wallet (and for the node's
-// data dir and socket), so it must be restricted to a fixed allowlist to
-// prevent path traversal from a hostile BURSA_NETWORK value.
-func validNetwork(name string) bool {
-	switch name {
-	case "preview", "preprod", "mainnet":
-		return true
-	default:
-		return false
-	}
 }

--- a/ui/go.mod
+++ b/ui/go.mod
@@ -2,7 +2,11 @@ module github.com/blinklabs-io/bursa/ui
 
 go 1.26.0
 
-require github.com/blinklabs-io/dingo v0.50.2
+require (
+	github.com/blinklabs-io/bursa v0.16.0
+	github.com/blinklabs-io/dingo v0.50.2
+	github.com/blinklabs-io/gouroboros v0.179.0
+)
 
 require (
 	cel.dev/expr v0.25.1 // indirect
@@ -60,9 +64,7 @@ require (
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blinklabs-io/bark v0.0.2 // indirect
-	github.com/blinklabs-io/bursa v0.16.0 // indirect
 	github.com/blinklabs-io/go-bip39 v0.2.0 // indirect
-	github.com/blinklabs-io/gouroboros v0.179.0 // indirect
 	github.com/blinklabs-io/plutigo v0.1.13 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.6 // indirect
 	github.com/btcsuite/btcd/btcutil v1.2.0 // indirect

--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,10 +14,14 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/blinklabs-io/bursa/ui/internal/supervisor"
+	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 )
 
 // Statuser is the minimal view the API needs of the supervisor.
@@ -25,16 +29,111 @@ type Statuser interface {
 	Status() supervisor.Status
 }
 
-// NewHandler returns the loopback control-surface mux.
-func NewHandler(st Statuser) http.Handler {
+// Wallet is the read-only wallet surface the API exposes.
+type Wallet interface {
+	SetWallet(mnemonic, network string, windowN int) (*wallet.Account, error)
+	Balance(ctx context.Context) (wallet.Balance, error)
+	Addresses(ctx context.Context) (wallet.AddressView, error)
+	Transactions(ctx context.Context) ([]wallet.Tx, error)
+	Delegation(ctx context.Context) (wallet.DelegationView, error)
+}
+
+const defaultWindow = 20
+
+// NewHandler returns the loopback control-surface mux. network is the network
+// the embedded node runs on; wallet requests must match it (or omit it).
+func NewHandler(st Statuser, wl Wallet, network string) http.Handler {
 	mux := http.NewServeMux()
+
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
 	mux.HandleFunc("/status", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(st.Status())
+		writeJSON(w, http.StatusOK, st.Status())
 	})
+
+	mux.HandleFunc("POST /wallet", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Mnemonic string `json:"mnemonic"`
+			Network  string `json:"network"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+			return
+		}
+		if req.Network == "" {
+			req.Network = network
+		} else if req.Network != network {
+			// A wallet derived for a different network than the node it
+			// queries would always read as empty.
+			writeJSON(w, http.StatusBadRequest, map[string]string{
+				"error": fmt.Sprintf("network mismatch: node is running %s, request says %s", network, req.Network),
+			})
+			return
+		}
+		acct, err := wl.SetWallet(req.Mnemonic, req.Network, defaultWindow)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, acct)
+	})
+
+	mux.HandleFunc("GET /wallet/balance", gated(st, func(w http.ResponseWriter, r *http.Request) {
+		v, err := wl.Balance(r.Context())
+		serve(w, v, err)
+	}))
+	mux.HandleFunc("GET /wallet/addresses", gated(st, func(w http.ResponseWriter, r *http.Request) {
+		v, err := wl.Addresses(r.Context())
+		serve(w, v, err)
+	}))
+	mux.HandleFunc("GET /wallet/transactions", gated(st, func(w http.ResponseWriter, r *http.Request) {
+		v, err := wl.Transactions(r.Context())
+		serve(w, v, err)
+	}))
+	mux.HandleFunc("GET /wallet/delegation", gated(st, func(w http.ResponseWriter, r *http.Request) {
+		v, err := wl.Delegation(r.Context())
+		serve(w, v, err)
+	}))
+
 	return mux
+}
+
+// gated blocks wallet reads until the node can serve queries (ready or syncing).
+func gated(st Statuser, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		state := st.Status().State
+		if state != supervisor.StateReady && state != supervisor.StateSyncing {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+				"error": "node not ready", "state": state,
+			})
+			return
+		}
+		next(w, r)
+	}
+}
+
+// serve writes a query result or a 500 with the error.
+func serve[T any](w http.ResponseWriter, v T, err error) {
+	switch {
+	case errors.Is(err, wallet.ErrNoWallet):
+		// Client precondition: no wallet has been loaded via POST /wallet yet.
+		writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
+	case err != nil:
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	default:
+		writeJSON(w, http.StatusOK, v)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		http.Error(w, "internal error encoding response", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_, _ = w.Write(b)
 }

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,12 +14,16 @@
 package api
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/blinklabs-io/bursa/ui/internal/supervisor"
+	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 )
 
 type fakeStatuser struct{ s supervisor.Status }
@@ -27,7 +31,7 @@ type fakeStatuser struct{ s supervisor.Status }
 func (f fakeStatuser) Status() supervisor.Status { return f.s }
 
 func TestHealthAlwaysOK(t *testing.T) {
-	h := NewHandler(fakeStatuser{})
+	h := NewHandler(fakeStatuser{}, &fakeWallet{}, "preview")
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
 	if rec.Code != http.StatusOK {
@@ -37,7 +41,7 @@ func TestHealthAlwaysOK(t *testing.T) {
 
 func TestStatusReturnsSnapshot(t *testing.T) {
 	want := supervisor.Status{State: supervisor.StateSyncing, Tip: 42, CaughtUp: true}
-	h := NewHandler(fakeStatuser{s: want})
+	h := NewHandler(fakeStatuser{s: want}, &fakeWallet{}, "preview")
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
 	if rec.Code != http.StatusOK {
@@ -49,5 +53,137 @@ func TestStatusReturnsSnapshot(t *testing.T) {
 	}
 	if got.State != want.State || got.Tip != want.Tip || got.CaughtUp != want.CaughtUp {
 		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+// fakeWallet is stateful like the real service: queries return
+// wallet.ErrNoWallet until SetWallet has been called.
+type fakeWallet struct {
+	setErr     error
+	balance    wallet.Balance
+	set        bool
+	gotNetwork string
+}
+
+func (f *fakeWallet) SetWallet(_, network string, _ int) (*wallet.Account, error) {
+	if f.setErr != nil {
+		return nil, f.setErr
+	}
+	f.set = true
+	f.gotNetwork = network
+	return &wallet.Account{StakeAddress: "stake_test1x", ReceiveAddresses: []string{"addr_test1a"}}, nil
+}
+
+func (f *fakeWallet) Balance(_ context.Context) (wallet.Balance, error) {
+	if !f.set {
+		return wallet.Balance{}, wallet.ErrNoWallet
+	}
+	return f.balance, nil
+}
+
+func (f *fakeWallet) Addresses(_ context.Context) (wallet.AddressView, error) {
+	if !f.set {
+		return wallet.AddressView{}, wallet.ErrNoWallet
+	}
+	return wallet.AddressView{}, nil
+}
+func (f *fakeWallet) Transactions(_ context.Context) ([]wallet.Tx, error) {
+	if !f.set {
+		return nil, wallet.ErrNoWallet
+	}
+	return nil, nil
+}
+func (f *fakeWallet) Delegation(_ context.Context) (wallet.DelegationView, error) {
+	if !f.set {
+		return wallet.DelegationView{}, wallet.ErrNoWallet
+	}
+	return wallet.DelegationView{}, nil
+}
+
+func TestWalletSetAndBalanceReady(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	fw := &fakeWallet{balance: wallet.Balance{Lovelace: "1234"}}
+	h := NewHandler(st, fw, "preview")
+
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"mnemonic":"x x x","network":"preview"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /wallet = %d, want 200", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/balance", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /wallet/balance = %d, want 200", rec.Code)
+	}
+	var bal wallet.Balance
+	if err := json.NewDecoder(rec.Body).Decode(&bal); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if bal.Lovelace != "1234" {
+		t.Fatalf("lovelace = %q, want 1234", bal.Lovelace)
+	}
+}
+
+func TestWalletGatedWhileStarting(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
+	h := NewHandler(st, &fakeWallet{}, "preview")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/balance", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /wallet/balance while starting = %d, want 503", rec.Code)
+	}
+}
+
+func TestWalletNoWalletConflict(t *testing.T) {
+	// No POST /wallet first: the natural no-wallet path must yield 409.
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	for _, path := range []string{"/wallet/balance", "/wallet/addresses", "/wallet/transactions", "/wallet/delegation"} {
+		t.Run(path, func(t *testing.T) {
+			h := NewHandler(st, &fakeWallet{}, "preview")
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+			if rec.Code != http.StatusConflict {
+				t.Fatalf("GET %s with no wallet = %d, want 409", path, rec.Code)
+			}
+		})
+	}
+}
+
+func TestWalletNetworkMismatch(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	h := NewHandler(st, &fakeWallet{}, "preview")
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"mnemonic":"x x x","network":"mainnet"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("POST /wallet with mismatched network = %d, want 400", rec.Code)
+	}
+}
+
+func TestWalletDefaultNetworkIsNodeNetwork(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	fw := &fakeWallet{}
+	h := NewHandler(st, fw, "preprod")
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"mnemonic":"x x x"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /wallet without network = %d, want 200", rec.Code)
+	}
+	if fw.gotNetwork != "preprod" {
+		t.Fatalf("SetWallet got network %q, want preprod (node network)", fw.gotNetwork)
+	}
+}
+
+func TestWalletSetError(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	h := NewHandler(st, &fakeWallet{setErr: errors.New("invalid mnemonic")}, "preview")
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"mnemonic":"bad","network":"preview"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("POST /wallet with derive error = %d, want 400", rec.Code)
 	}
 }

--- a/ui/internal/boundary/boundary_test.go
+++ b/ui/internal/boundary/boundary_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/internal/cardanonet/networks.go
+++ b/ui/internal/cardanonet/networks.go
@@ -1,0 +1,52 @@
+package cardanonet
+
+import (
+	"fmt"
+	"strings"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+type network struct {
+	name             string
+	addressNetworkID uint8
+}
+
+var supportedNetworks = []network{
+	{name: "preview", addressNetworkID: lcommon.AddressNetworkTestnet},
+	{name: "preprod", addressNetworkID: lcommon.AddressNetworkTestnet},
+	{name: "mainnet", addressNetworkID: lcommon.AddressNetworkMainnet},
+}
+
+// SupportedNetworks returns the UI-supported Cardano networks in display order.
+func SupportedNetworks() string {
+	names := make([]string, len(supportedNetworks))
+	for i, n := range supportedNetworks {
+		names[i] = n.name
+	}
+	return strings.Join(names, ", ")
+}
+
+// ValidNetwork reports whether name is a supported Cardano network.
+func ValidNetwork(name string) bool {
+	_, ok := lookup(name)
+	return ok
+}
+
+// AddressNetworkID returns the ledger address network id for a supported network.
+func AddressNetworkID(name string) (uint8, error) {
+	n, ok := lookup(name)
+	if !ok {
+		return 0, fmt.Errorf("unknown network %q: must be one of %s", name, SupportedNetworks())
+	}
+	return n.addressNetworkID, nil
+}
+
+func lookup(name string) (network, bool) {
+	for _, n := range supportedNetworks {
+		if n.name == name {
+			return n, true
+		}
+	}
+	return network{}, false
+}

--- a/ui/internal/cardanonet/networks_test.go
+++ b/ui/internal/cardanonet/networks_test.go
@@ -1,0 +1,20 @@
+package cardanonet
+
+import "testing"
+
+func TestNetworkValidationAndAddressIDs(t *testing.T) {
+	for _, name := range []string{"preview", "preprod", "mainnet"} {
+		if !ValidNetwork(name) {
+			t.Fatalf("ValidNetwork(%q) = false, want true", name)
+		}
+		if _, err := AddressNetworkID(name); err != nil {
+			t.Fatalf("AddressNetworkID(%q): %v", name, err)
+		}
+	}
+	if ValidNetwork("mainnte") {
+		t.Fatal("ValidNetwork typo = true, want false")
+	}
+	if _, err := AddressNetworkID("mainnte"); err == nil {
+		t.Fatal("AddressNetworkID typo: expected error, got nil")
+	}
+}

--- a/ui/internal/chain/blockfrost.go
+++ b/ui/internal/chain/blockfrost.go
@@ -1,0 +1,177 @@
+// Package chain is a typed client for the embedded Dingo node's loopback
+// Blockfrost REST API. It is the wallet's only data source and never contacts
+// any external service — only http://127.0.0.1:<port>.
+package chain
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// ErrNotFound is returned when the node reports the queried resource does not
+// exist (HTTP 404) — e.g. an account/stake credential not yet seen on chain.
+// Callers treat it as "empty" rather than a hard failure.
+var ErrNotFound = errors.New("chain: resource not found")
+
+var errPageLimitExceeded = errors.New("chain: pagination limit exceeded")
+
+// Client talks to a Blockfrost-compatible API at BaseURL (the local node).
+type Client struct {
+	BaseURL string
+	http    *http.Client
+}
+
+// NewClient builds a client for the node's loopback Blockfrost port.
+func NewClient(port uint) *Client {
+	return NewClientURL(fmt.Sprintf("http://127.0.0.1:%d", port))
+}
+
+// NewClientURL builds a client for an explicit base URL (used in tests).
+func NewClientURL(baseURL string) *Client {
+	return &Client{BaseURL: baseURL, http: &http.Client{Timeout: 10 * time.Second}}
+}
+
+// AccountInfo mirrors GET /api/v0/accounts/{stake_address}.
+type AccountInfo struct {
+	StakeAddress       string  `json:"stake_address"`
+	Active             bool    `json:"active"`
+	ActiveEpoch        *int64  `json:"active_epoch"`
+	ControlledAmount   string  `json:"controlled_amount"`
+	RewardsSum         string  `json:"rewards_sum"`
+	WithdrawableAmount string  `json:"withdrawable_amount"`
+	PoolID             *string `json:"pool_id"`
+}
+
+// Amount is one asset entry in a UTxO (unit "lovelace" or policy+hexname).
+type Amount struct {
+	Unit     string `json:"unit"`
+	Quantity string `json:"quantity"`
+}
+
+// UTxO mirrors one entry of GET /api/v0/addresses/{address}/utxos.
+type UTxO struct {
+	Address     string   `json:"address"`
+	TxHash      string   `json:"tx_hash"`
+	OutputIndex int      `json:"output_index"`
+	Amount      []Amount `json:"amount"`
+	Block       string   `json:"block"`
+}
+
+// AddressTx mirrors one entry of GET /api/v0/addresses/{address}/transactions.
+type AddressTx struct {
+	TxHash      string `json:"tx_hash"`
+	TxIndex     int    `json:"tx_index"`
+	BlockHeight uint64 `json:"block_height"`
+	BlockTime   int64  `json:"block_time"`
+}
+
+// Delegation mirrors one entry of GET /api/v0/accounts/{stake}/delegations.
+type Delegation struct {
+	ActiveEpoch int32  `json:"active_epoch"`
+	TxHash      string `json:"tx_hash"`
+	Amount      string `json:"amount"`
+	PoolID      string `json:"pool_id"`
+}
+
+// Reward mirrors one entry of GET /api/v0/accounts/{stake}/rewards.
+type Reward struct {
+	Epoch  int32  `json:"epoch"`
+	Amount string `json:"amount"`
+	PoolID string `json:"pool_id"`
+}
+
+type accountAddress struct {
+	Address string `json:"address"`
+}
+
+func (c *Client) get(ctx context.Context, path string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+path, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("GET %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return ErrNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("GET %s: status %d: %s", path, resp.StatusCode, string(body))
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("decode %s: %w", path, err)
+	}
+	return nil
+}
+
+// pageSize is the node's maximum (and default) rows per list response.
+const pageSize = 100
+
+const maxPages = 1000
+
+// getAllPages fetches every page of a list endpoint. The node caps pages at
+// pageSize rows; a page with fewer rows is the last one.
+func getAllPages[T any](ctx context.Context, c *Client, path string) ([]T, error) {
+	return getAllPagesLimit[T](ctx, c, path, maxPages)
+}
+
+func getAllPagesLimit[T any](ctx context.Context, c *Client, path string, maxPages int) ([]T, error) {
+	if maxPages < 1 {
+		return nil, fmt.Errorf("%w: invalid max page count %d", errPageLimitExceeded, maxPages)
+	}
+	var all []T
+	for page := 1; page <= maxPages; page++ {
+		var rows []T
+		paged := fmt.Sprintf("%s?count=%d&page=%d", path, pageSize, page)
+		if err := c.get(ctx, paged, &rows); err != nil {
+			return nil, err
+		}
+		all = append(all, rows...)
+		if len(rows) < pageSize {
+			return all, nil
+		}
+	}
+	return nil, fmt.Errorf("%w: %s exceeded %d pages", errPageLimitExceeded, path, maxPages)
+}
+
+func (c *Client) Account(ctx context.Context, stakeAddr string) (AccountInfo, error) {
+	var out AccountInfo
+	err := c.get(ctx, "/api/v0/accounts/"+stakeAddr, &out)
+	return out, err
+}
+
+func (c *Client) AccountAddresses(ctx context.Context, stakeAddr string) ([]string, error) {
+	rows, err := getAllPages[accountAddress](ctx, c, "/api/v0/accounts/"+stakeAddr+"/addresses")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.Address
+	}
+	return out, nil
+}
+
+func (c *Client) AddressUTxOs(ctx context.Context, addr string) ([]UTxO, error) {
+	return getAllPages[UTxO](ctx, c, "/api/v0/addresses/"+addr+"/utxos")
+}
+
+func (c *Client) AddressTransactions(ctx context.Context, addr string) ([]AddressTx, error) {
+	return getAllPages[AddressTx](ctx, c, "/api/v0/addresses/"+addr+"/transactions")
+}
+
+func (c *Client) AccountDelegations(ctx context.Context, stakeAddr string) ([]Delegation, error) {
+	return getAllPages[Delegation](ctx, c, "/api/v0/accounts/"+stakeAddr+"/delegations")
+}
+
+func (c *Client) AccountRewards(ctx context.Context, stakeAddr string) ([]Reward, error) {
+	return getAllPages[Reward](ctx, c, "/api/v0/accounts/"+stakeAddr+"/rewards")
+}

--- a/ui/internal/chain/blockfrost_test.go
+++ b/ui/internal/chain/blockfrost_test.go
@@ -1,0 +1,258 @@
+package chain
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const blockfrostNotFoundJSON = `{"status_code":404,"error":"Not Found","message":"The requested component has not been found."}`
+
+func newTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return NewClientURL(srv.URL)
+}
+
+func TestAccount(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/accounts/stake_test1xyz" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"stake_address":"stake_test1xyz","active":true,"active_epoch":42,"controlled_amount":"1500000","rewards_sum":"2000","withdrawals_sum":"0","reserves_sum":"0","treasury_sum":"0","withdrawable_amount":"2000","pool_id":"pool1abc"}`))
+	})
+	got, err := c.Account(context.Background(), "stake_test1xyz")
+	if err != nil {
+		t.Fatalf("Account: %v", err)
+	}
+	if got.ControlledAmount != "1500000" || got.PoolID == nil || *got.PoolID != "pool1abc" || !got.Active {
+		t.Fatalf("unexpected account: %+v", got)
+	}
+}
+
+func TestAccountAddresses(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/accounts/stake_test1xyz/addresses" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`[{"address":"addr_test1a"},{"address":"addr_test1b"}]`))
+	})
+	got, err := c.AccountAddresses(context.Background(), "stake_test1xyz")
+	if err != nil {
+		t.Fatalf("AccountAddresses: %v", err)
+	}
+	if len(got) != 2 || got[0] != "addr_test1a" || got[1] != "addr_test1b" {
+		t.Fatalf("unexpected addresses: %v", got)
+	}
+}
+
+func TestAccountAddressesPaginated(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/accounts/stake_test1xyz/addresses" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("count") != "100" {
+			t.Errorf("count = %q", q.Get("count"))
+		}
+		var rows []string
+		switch q.Get("page") {
+		case "1":
+			for i := range 100 {
+				rows = append(rows, fmt.Sprintf(`{"address":"addr_test1_%03d"}`, i))
+			}
+		case "2":
+			for i := 100; i < 103; i++ {
+				rows = append(rows, fmt.Sprintf(`{"address":"addr_test1_%03d"}`, i))
+			}
+		default:
+			t.Errorf("page = %q", q.Get("page"))
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_, _ = w.Write([]byte("[" + strings.Join(rows, ",") + "]"))
+	})
+	got, err := c.AccountAddresses(context.Background(), "stake_test1xyz")
+	if err != nil {
+		t.Fatalf("AccountAddresses: %v", err)
+	}
+	if len(got) != 103 {
+		t.Fatalf("len = %d, want 103", len(got))
+	}
+	for i, addr := range got {
+		if want := fmt.Sprintf("addr_test1_%03d", i); addr != want {
+			t.Fatalf("got[%d] = %q, want %q", i, addr, want)
+		}
+	}
+}
+
+func TestGetAllPagesLimitExceeded(t *testing.T) {
+	requests := 0
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/accounts/stake_test1xyz/addresses" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		requests++
+		rows := make([]string, 0, pageSize)
+		for i := range pageSize {
+			rows = append(rows, fmt.Sprintf(`{"address":"addr_test1_%03d"}`, i))
+		}
+		_, _ = w.Write([]byte("[" + strings.Join(rows, ",") + "]"))
+	})
+	_, err := getAllPagesLimit[accountAddress](context.Background(), c, "/api/v0/accounts/stake_test1xyz/addresses", 2)
+	if !errors.Is(err, errPageLimitExceeded) {
+		t.Fatalf("getAllPagesLimit err = %v, want errPageLimitExceeded", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+}
+
+func TestAddressUTxOs(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/addresses/addr_test1a/utxos" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`[{"address":"addr_test1a","tx_hash":"aa","output_index":0,"amount":[{"unit":"lovelace","quantity":"1000000"},{"unit":"policytoken","quantity":"7"}],"block":"b1"}]`))
+	})
+	got, err := c.AddressUTxOs(context.Background(), "addr_test1a")
+	if err != nil {
+		t.Fatalf("AddressUTxOs: %v", err)
+	}
+	if len(got) != 1 || len(got[0].Amount) != 2 || got[0].Amount[1].Unit != "policytoken" || got[0].Amount[1].Quantity != "7" {
+		t.Fatalf("unexpected utxos: %+v", got)
+	}
+}
+
+func TestAddressTransactions(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/addresses/addr_test1a/transactions" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`[{"tx_hash":"aa","tx_index":0,"block_height":100,"block_time":1700000000}]`))
+	})
+	got, err := c.AddressTransactions(context.Background(), "addr_test1a")
+	if err != nil {
+		t.Fatalf("AddressTransactions: %v", err)
+	}
+	if len(got) != 1 || got[0].TxHash != "aa" || got[0].BlockHeight != 100 || got[0].BlockTime != 1700000000 {
+		t.Fatalf("unexpected txs: %+v", got)
+	}
+}
+
+func TestAccountDelegations(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/accounts/stake_test1xyz/delegations" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"active_epoch":42,"tx_hash":"aa","amount":"5000000","pool_id":"pool1abc"}]`))
+	})
+	got, err := c.AccountDelegations(context.Background(), "stake_test1xyz")
+	if err != nil {
+		t.Fatalf("AccountDelegations: %v", err)
+	}
+	if len(got) != 1 || got[0].ActiveEpoch != 42 || got[0].TxHash != "aa" || got[0].Amount != "5000000" || got[0].PoolID != "pool1abc" {
+		t.Fatalf("unexpected delegations: %+v", got)
+	}
+}
+
+func TestAccountDelegationsNotFound(t *testing.T) {
+	t.Parallel()
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/accounts/stake_test1missing/delegations" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(blockfrostNotFoundJSON))
+	})
+	_, err := c.AccountDelegations(context.Background(), "stake_test1missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("404 should map to ErrNotFound, got %v", err)
+	}
+}
+
+func TestAccountRewards(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/accounts/stake_test1xyz/rewards" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"epoch":42,"amount":"2000","pool_id":"pool1abc"}]`))
+	})
+	got, err := c.AccountRewards(context.Background(), "stake_test1xyz")
+	if err != nil {
+		t.Fatalf("AccountRewards: %v", err)
+	}
+	if len(got) != 1 || got[0].Epoch != 42 || got[0].Amount != "2000" || got[0].PoolID != "pool1abc" {
+		t.Fatalf("unexpected rewards: %+v", got)
+	}
+}
+
+func TestAccountRewardsNotFound(t *testing.T) {
+	t.Parallel()
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/accounts/stake_test1missing/rewards" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(blockfrostNotFoundJSON))
+	})
+	_, err := c.AccountRewards(context.Background(), "stake_test1missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("404 should map to ErrNotFound, got %v", err)
+	}
+}
+
+func TestErrorStatus(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/accounts/stake_test1missing" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(blockfrostNotFoundJSON))
+	})
+	_, err := c.Account(context.Background(), "stake_test1missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("404 should map to ErrNotFound, got %v", err)
+	}
+}

--- a/ui/internal/supervisor/status.go
+++ b/ui/internal/supervisor/status.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/internal/supervisor/status_test.go
+++ b/ui/internal/supervisor/status_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/internal/supervisor/supervisor.go
+++ b/ui/internal/supervisor/supervisor.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/internal/wallet/account.go
+++ b/ui/internal/wallet/account.go
@@ -1,0 +1,74 @@
+// Package wallet derives a read-only CIP-1852 account and aggregates its
+// on-chain state (queried by stake credential) into balance, address, and
+// history views. It holds no private keys beyond what derivation requires
+// in-process and performs no signing.
+package wallet
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/bursa/ui/internal/cardanonet"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// Account is a derived, read-only view of a wallet: its stake address (the
+// query key) and a window of external (receive) payment addresses, all sharing
+// the canonical stake key at index 0.
+type Account struct {
+	Network          string   `json:"network"`
+	StakeAddress     string   `json:"stake_address"`
+	ReceiveAddresses []string `json:"receive_addresses"`
+}
+
+// Derive builds the account for the given mnemonic and network, producing the
+// stake address plus windowN external receive addresses (indices 0..windowN-1),
+// all bound to the canonical stake key m/1852'/1815'/0'/2/0.
+func Derive(mnemonic, network string, windowN int) (*Account, error) {
+	if windowN < 1 {
+		return nil, fmt.Errorf("windowN must be at least 1, got %d", windowN)
+	}
+	netID, err := cardanonet.AddressNetworkID(network)
+	if err != nil {
+		return nil, err
+	}
+
+	root, err := bursa.GetRootKeyFromMnemonic(mnemonic, "")
+	if err != nil {
+		return nil, fmt.Errorf("root key from mnemonic: %w", err)
+	}
+	acctKey, err := bursa.GetAccountKey(root, 0)
+	if err != nil {
+		return nil, fmt.Errorf("account key: %w", err)
+	}
+	stakeKey, err := bursa.GetStakeKey(acctKey, 0)
+	if err != nil {
+		return nil, fmt.Errorf("stake key: %w", err)
+	}
+	stakeHash := stakeKey.Public().PublicKey().Hash()
+
+	stakeAddr, err := lcommon.NewAddressFromParts(lcommon.AddressTypeNoneKey, netID, nil, stakeHash)
+	if err != nil {
+		return nil, fmt.Errorf("stake address: %w", err)
+	}
+
+	receive := make([]string, 0, windowN)
+	for i := 0; i < windowN; i++ {
+		payKey, err := bursa.GetPaymentKey(acctKey, uint32(i))
+		if err != nil {
+			return nil, fmt.Errorf("payment key %d: %w", i, err)
+		}
+		payHash := payKey.Public().PublicKey().Hash()
+		addr, err := lcommon.NewAddressFromParts(lcommon.AddressTypeKeyKey, netID, payHash, stakeHash)
+		if err != nil {
+			return nil, fmt.Errorf("address %d: %w", i, err)
+		}
+		receive = append(receive, addr.String())
+	}
+
+	return &Account{
+		Network:          network,
+		StakeAddress:     stakeAddr.String(),
+		ReceiveAddresses: receive,
+	}, nil
+}

--- a/ui/internal/wallet/account_test.go
+++ b/ui/internal/wallet/account_test.go
@@ -1,0 +1,84 @@
+package wallet
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/bursa"
+)
+
+const testMnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+func TestDerivePreview(t *testing.T) {
+	acct, err := Derive(testMnemonic, "preview", 5)
+	if err != nil {
+		t.Fatalf("Derive: %v", err)
+	}
+	if !strings.HasPrefix(acct.StakeAddress, "stake_test1") {
+		t.Fatalf("stake address = %q, want stake_test1… prefix", acct.StakeAddress)
+	}
+	if len(acct.ReceiveAddresses) != 5 {
+		t.Fatalf("got %d receive addresses, want 5", len(acct.ReceiveAddresses))
+	}
+	seen := map[string]bool{}
+	for i, a := range acct.ReceiveAddresses {
+		if !strings.HasPrefix(a, "addr_test1") {
+			t.Fatalf("receive[%d] = %q, want addr_test1… prefix", i, a)
+		}
+		if seen[a] {
+			t.Fatalf("receive[%d] = %q is a duplicate", i, a)
+		}
+		seen[a] = true
+	}
+	w, err := bursa.NewWallet(testMnemonic, bursa.WithNetwork("preview"))
+	if err != nil {
+		t.Fatalf("NewWallet: %v", err)
+	}
+	if acct.ReceiveAddresses[0] != w.PaymentAddress {
+		t.Fatalf("address[0] = %q, want %q (bursa.NewWallet)", acct.ReceiveAddresses[0], w.PaymentAddress)
+	}
+	if acct.StakeAddress != w.StakeAddress {
+		t.Fatalf("stake = %q, want %q (bursa.NewWallet)", acct.StakeAddress, w.StakeAddress)
+	}
+}
+
+func TestDeriveDeterministic(t *testing.T) {
+	a1, err := Derive(testMnemonic, "preview", 3)
+	if err != nil {
+		t.Fatalf("Derive #1: %v", err)
+	}
+	a2, err := Derive(testMnemonic, "preview", 3)
+	if err != nil {
+		t.Fatalf("Derive #2: %v", err)
+	}
+	if a1.StakeAddress != a2.StakeAddress {
+		t.Fatalf("stake not deterministic: %q vs %q", a1.StakeAddress, a2.StakeAddress)
+	}
+	for i := range a1.ReceiveAddresses {
+		if a1.ReceiveAddresses[i] != a2.ReceiveAddresses[i] {
+			t.Fatalf("receive[%d] not deterministic", i)
+		}
+	}
+}
+
+func TestDeriveInvalidMnemonic(t *testing.T) {
+	if _, err := Derive("not a valid mnemonic", "preview", 1); err == nil {
+		t.Fatal("expected error for invalid mnemonic, got nil")
+	}
+}
+
+func TestDeriveInvalidNetwork(t *testing.T) {
+	// "mainnte" (typo) must not silently derive testnet addresses.
+	if _, err := Derive(testMnemonic, "mainnte", 1); err == nil {
+		t.Fatal("expected error for invalid network, got nil")
+	}
+}
+
+func TestDeriveInvalidWindow(t *testing.T) {
+	// windowN < 1 must error, not panic (negative cap) or derive nothing.
+	for _, n := range []int{-1, 0} {
+		if _, err := Derive(testMnemonic, "preview", n); err == nil {
+			t.Fatalf("windowN=%d: expected error, got nil", n)
+		}
+	}
+}

--- a/ui/internal/wallet/aggregate.go
+++ b/ui/internal/wallet/aggregate.go
@@ -1,0 +1,95 @@
+package wallet
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"sort"
+
+	"github.com/blinklabs-io/bursa/ui/internal/chain"
+)
+
+// ErrInvalidAmountQuantity is returned when chain data contains an unparsable
+// or negative asset quantity.
+var ErrInvalidAmountQuantity = errors.New("wallet: invalid amount quantity")
+
+// AssetBalance is a summed native-asset quantity (decimal string).
+type AssetBalance struct {
+	Unit     string `json:"unit"`
+	Quantity string `json:"quantity"`
+}
+
+// Balance is the aggregated wallet balance: total lovelace + native assets.
+type Balance struct {
+	Lovelace string         `json:"lovelace"`
+	Assets   []AssetBalance `json:"assets"`
+}
+
+// Tx is one entry of the merged transaction history.
+type Tx struct {
+	TxHash      string `json:"tx_hash"`
+	TxIndex     int    `json:"tx_index"`
+	BlockHeight uint64 `json:"block_height"`
+	BlockTime   int64  `json:"block_time"`
+}
+
+// AggregateBalance sums all UTxO amounts by unit, separating lovelace from
+// native assets. Quantities are summed with big.Int (token amounts can exceed
+// uint64). Assets are sorted by unit for deterministic output.
+func AggregateBalance(utxos []chain.UTxO) (Balance, error) {
+	lovelace := new(big.Int)
+	assets := map[string]*big.Int{}
+	for _, u := range utxos {
+		for _, a := range u.Amount {
+			n, ok := new(big.Int).SetString(a.Quantity, 10)
+			if !ok || n.Sign() < 0 {
+				return Balance{}, fmt.Errorf("%w: unit %q quantity %q", ErrInvalidAmountQuantity, a.Unit, a.Quantity)
+			}
+			if a.Unit == "lovelace" {
+				lovelace.Add(lovelace, n)
+				continue
+			}
+			if assets[a.Unit] == nil {
+				assets[a.Unit] = new(big.Int)
+			}
+			assets[a.Unit].Add(assets[a.Unit], n)
+		}
+	}
+	units := make([]string, 0, len(assets))
+	for u := range assets {
+		units = append(units, u)
+	}
+	sort.Strings(units)
+	out := make([]AssetBalance, 0, len(units))
+	for _, u := range units {
+		out = append(out, AssetBalance{Unit: u, Quantity: assets[u].String()})
+	}
+	return Balance{Lovelace: lovelace.String(), Assets: out}, nil
+}
+
+// MergeTransactions flattens per-address transaction lists, deduplicates by
+// tx hash, and returns them newest-first (by block height, then tx index).
+func MergeTransactions(perAddress [][]chain.AddressTx) []Tx {
+	seen := map[string]Tx{}
+	for _, list := range perAddress {
+		for _, t := range list {
+			if _, ok := seen[t.TxHash]; !ok {
+				seen[t.TxHash] = Tx{TxHash: t.TxHash, TxIndex: t.TxIndex, BlockHeight: t.BlockHeight, BlockTime: t.BlockTime}
+			}
+		}
+	}
+	out := make([]Tx, 0, len(seen))
+	for _, t := range seen {
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].BlockHeight != out[j].BlockHeight {
+			return out[i].BlockHeight > out[j].BlockHeight
+		}
+		if out[i].TxIndex != out[j].TxIndex {
+			return out[i].TxIndex > out[j].TxIndex
+		}
+		return out[i].TxHash > out[j].TxHash
+	})
+	return out
+}

--- a/ui/internal/wallet/aggregate_test.go
+++ b/ui/internal/wallet/aggregate_test.go
@@ -1,0 +1,73 @@
+package wallet
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/bursa/ui/internal/chain"
+)
+
+func TestAggregateBalance(t *testing.T) {
+	utxos := []chain.UTxO{
+		{Amount: []chain.Amount{{Unit: "lovelace", Quantity: "1000000"}, {Unit: "tokenB", Quantity: "5"}}},
+		{Amount: []chain.Amount{{Unit: "lovelace", Quantity: "2500000"}, {Unit: "tokenA", Quantity: "3"}, {Unit: "tokenB", Quantity: "2"}}},
+	}
+	bal, err := AggregateBalance(utxos)
+	if err != nil {
+		t.Fatalf("AggregateBalance: %v", err)
+	}
+	if bal.Lovelace != "3500000" {
+		t.Fatalf("lovelace = %q, want 3500000", bal.Lovelace)
+	}
+	if len(bal.Assets) != 2 {
+		t.Fatalf("got %d assets, want 2 (%+v)", len(bal.Assets), bal.Assets)
+	}
+	if bal.Assets[0].Unit != "tokenA" || bal.Assets[0].Quantity != "3" {
+		t.Fatalf("assets[0] = %+v, want {tokenA 3}", bal.Assets[0])
+	}
+	if bal.Assets[1].Unit != "tokenB" || bal.Assets[1].Quantity != "7" {
+		t.Fatalf("assets[1] = %+v, want {tokenB 7}", bal.Assets[1])
+	}
+}
+
+func TestAggregateBalanceEmpty(t *testing.T) {
+	bal, err := AggregateBalance(nil)
+	if err != nil {
+		t.Fatalf("AggregateBalance: %v", err)
+	}
+	if bal.Lovelace != "0" || len(bal.Assets) != 0 {
+		t.Fatalf("empty balance = %+v, want lovelace 0 / no assets", bal)
+	}
+}
+
+func TestAggregateBalanceInvalidQuantity(t *testing.T) {
+	for _, quantity := range []string{"bad", "-1"} {
+		t.Run(quantity, func(t *testing.T) {
+			_, err := AggregateBalance([]chain.UTxO{
+				{Amount: []chain.Amount{{Unit: "lovelace", Quantity: quantity}}},
+			})
+			if !errors.Is(err, ErrInvalidAmountQuantity) {
+				t.Fatalf("AggregateBalance err = %v, want ErrInvalidAmountQuantity", err)
+			}
+		})
+	}
+}
+
+func TestMergeTransactions(t *testing.T) {
+	a := []chain.AddressTx{
+		{TxHash: "t1", TxIndex: 0, BlockHeight: 10, BlockTime: 100},
+		{TxHash: "t2", TxIndex: 1, BlockHeight: 20, BlockTime: 200},
+		{TxHash: "z-same-block-lower-index", TxIndex: 0, BlockHeight: 20, BlockTime: 200},
+	}
+	b := []chain.AddressTx{
+		{TxHash: "t2", TxIndex: 1, BlockHeight: 20, BlockTime: 200},
+		{TxHash: "t3", TxIndex: 0, BlockHeight: 30, BlockTime: 300},
+	}
+	got := MergeTransactions([][]chain.AddressTx{a, b})
+	if len(got) != 4 {
+		t.Fatalf("got %d txs, want 4 (dedup): %+v", len(got), got)
+	}
+	if got[0].TxHash != "t3" || got[1].TxHash != "t2" || got[2].TxHash != "z-same-block-lower-index" || got[3].TxHash != "t1" {
+		t.Fatalf("order = %v, want t3,t2,z-same-block-lower-index,t1", []string{got[0].TxHash, got[1].TxHash, got[2].TxHash, got[3].TxHash})
+	}
+}

--- a/ui/internal/wallet/service.go
+++ b/ui/internal/wallet/service.go
@@ -1,0 +1,192 @@
+package wallet
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/blinklabs-io/bursa/ui/internal/chain"
+)
+
+// ErrNoWallet is returned by query methods when no wallet has been loaded.
+var ErrNoWallet = errors.New("no wallet set")
+
+// chainQuerier is the slice of the chain client the service needs (satisfied
+// by *chain.Client); it exists so tests can supply a fake.
+type chainQuerier interface {
+	Account(ctx context.Context, stakeAddr string) (chain.AccountInfo, error)
+	AccountAddresses(ctx context.Context, stakeAddr string) ([]string, error)
+	AddressUTxOs(ctx context.Context, addr string) ([]chain.UTxO, error)
+	AddressTransactions(ctx context.Context, addr string) ([]chain.AddressTx, error)
+}
+
+// AddressView is the receive-address view: the derived window, the chain-seen
+// (used) addresses, and the next unused derived address. NextUnused is empty
+// when every address in the derived window is already used on chain (dynamic
+// gap-limit expansion is deferred to a later phase).
+type AddressView struct {
+	Receive    []string `json:"receive"`
+	Used       []string `json:"used"`
+	NextUnused string   `json:"next_unused"`
+}
+
+// DelegationView is the delegation/rewards summary. Rewards are provisional —
+// dingo has open reward-accounting bugs (#2373–#2376).
+type DelegationView struct {
+	PoolID       *string `json:"pool_id"`
+	Active       bool    `json:"active"`
+	RewardsSum   string  `json:"rewards_sum"`
+	Withdrawable string  `json:"withdrawable_amount"`
+	Provisional  bool    `json:"provisional"`
+	Note         string  `json:"note"`
+}
+
+// Service holds the active read-only account and queries the chain for views.
+type Service struct {
+	chain chainQuerier
+
+	mu      sync.RWMutex
+	account *Account
+}
+
+// NewService builds a wallet service over the given chain querier.
+func NewService(c chainQuerier) *Service {
+	return &Service{chain: c}
+}
+
+func cloneAccount(acct *Account) *Account {
+	if acct == nil {
+		return nil
+	}
+	return &Account{
+		Network:          acct.Network,
+		StakeAddress:     acct.StakeAddress,
+		ReceiveAddresses: cloneStringSlice(acct.ReceiveAddresses),
+	}
+}
+
+func cloneStringSlice(in []string) []string {
+	if in == nil {
+		return nil
+	}
+	return append([]string(nil), in...)
+}
+
+// SetWallet derives and stores the active account (windowN receive addresses).
+func (s *Service) SetWallet(mnemonic, network string, windowN int) (*Account, error) {
+	acct, err := Derive(mnemonic, network, windowN)
+	if err != nil {
+		return nil, err
+	}
+	stored := cloneAccount(acct)
+	s.mu.Lock()
+	s.account = stored
+	s.mu.Unlock()
+	return cloneAccount(stored), nil
+}
+
+func (s *Service) currentAccount() (*Account, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.account == nil {
+		return nil, ErrNoWallet
+	}
+	return cloneAccount(s.account), nil
+}
+
+// Balance aggregates the UTxO set across the account's chain-seen addresses.
+func (s *Service) Balance(ctx context.Context) (Balance, error) {
+	acct, err := s.currentAccount()
+	if err != nil {
+		return Balance{}, err
+	}
+	addrs, err := s.chain.AccountAddresses(ctx, acct.StakeAddress)
+	if err != nil && !errors.Is(err, chain.ErrNotFound) {
+		return Balance{}, err
+	}
+	// ErrNotFound: the stake credential isn't on chain yet → empty wallet (zero balance).
+	var all []chain.UTxO
+	for _, a := range addrs {
+		us, err := s.chain.AddressUTxOs(ctx, a)
+		if err != nil {
+			return Balance{}, err
+		}
+		all = append(all, us...)
+	}
+	return AggregateBalance(all)
+}
+
+// Addresses reports the derived receive window, the chain-seen used addresses,
+// and the first derived address not yet seen on chain.
+func (s *Service) Addresses(ctx context.Context) (AddressView, error) {
+	acct, err := s.currentAccount()
+	if err != nil {
+		return AddressView{}, err
+	}
+	used, err := s.chain.AccountAddresses(ctx, acct.StakeAddress)
+	if err != nil && !errors.Is(err, chain.ErrNotFound) {
+		return AddressView{}, err
+	}
+	// ErrNotFound: no chain-seen addresses yet → used stays empty; NextUnused is receive[0].
+	usedSet := map[string]bool{}
+	for _, a := range used {
+		usedSet[a] = true
+	}
+	receive := cloneStringSlice(acct.ReceiveAddresses)
+	next := ""
+	for _, a := range receive {
+		if !usedSet[a] {
+			next = a
+			break
+		}
+	}
+	return AddressView{Receive: receive, Used: cloneStringSlice(used), NextUnused: next}, nil
+}
+
+// Transactions returns the merged, newest-first history across the account's
+// chain-seen addresses.
+func (s *Service) Transactions(ctx context.Context) ([]Tx, error) {
+	acct, err := s.currentAccount()
+	if err != nil {
+		return nil, err
+	}
+	addrs, err := s.chain.AccountAddresses(ctx, acct.StakeAddress)
+	if err != nil && !errors.Is(err, chain.ErrNotFound) {
+		return nil, err
+	}
+	// ErrNotFound: no chain-seen addresses yet → empty history.
+	var per [][]chain.AddressTx
+	for _, a := range addrs {
+		ts, err := s.chain.AddressTransactions(ctx, a)
+		if err != nil {
+			return nil, err
+		}
+		per = append(per, ts)
+	}
+	return MergeTransactions(per), nil
+}
+
+// Delegation returns the current delegation/rewards summary (provisional).
+func (s *Service) Delegation(ctx context.Context) (DelegationView, error) {
+	acct, err := s.currentAccount()
+	if err != nil {
+		return DelegationView{}, err
+	}
+	info, err := s.chain.Account(ctx, acct.StakeAddress)
+	if err != nil && !errors.Is(err, chain.ErrNotFound) {
+		return DelegationView{}, err
+	}
+	if errors.Is(err, chain.ErrNotFound) {
+		info.RewardsSum = "0"
+		info.WithdrawableAmount = "0"
+	}
+	// ErrNotFound: account not seen on chain → zero info (not active, not delegating).
+	return DelegationView{
+		PoolID:       info.PoolID,
+		Active:       info.Active,
+		RewardsSum:   info.RewardsSum,
+		Withdrawable: info.WithdrawableAmount,
+		Provisional:  true,
+		Note:         "rewards are provisional; dingo reward accounting has open issues (#2373-#2376)",
+	}, nil
+}

--- a/ui/internal/wallet/service_test.go
+++ b/ui/internal/wallet/service_test.go
@@ -1,0 +1,147 @@
+package wallet
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/bursa/ui/internal/chain"
+)
+
+type fakeChain struct {
+	account      chain.AccountInfo
+	accountErr   error
+	addresses    []string
+	addressesErr error
+	utxos        map[string][]chain.UTxO
+	txs          map[string][]chain.AddressTx
+}
+
+func (f *fakeChain) Account(_ context.Context, _ string) (chain.AccountInfo, error) {
+	return f.account, f.accountErr
+}
+
+func (f *fakeChain) AccountAddresses(_ context.Context, _ string) ([]string, error) {
+	return f.addresses, f.addressesErr
+}
+
+func (f *fakeChain) AddressUTxOs(_ context.Context, addr string) ([]chain.UTxO, error) {
+	return f.utxos[addr], nil
+}
+
+func (f *fakeChain) AddressTransactions(_ context.Context, addr string) ([]chain.AddressTx, error) {
+	return f.txs[addr], nil
+}
+
+func TestServiceNoWallet(t *testing.T) {
+	s := NewService(&fakeChain{})
+	if _, err := s.Balance(context.Background()); !errors.Is(err, ErrNoWallet) {
+		t.Fatalf("Balance without wallet: err = %v, want ErrNoWallet", err)
+	}
+}
+
+func TestServiceBalanceAndAddresses(t *testing.T) {
+	fc := &fakeChain{
+		account:   chain.AccountInfo{ControlledAmount: "3000000"},
+		addresses: []string{"addr_test1a"},
+		utxos: map[string][]chain.UTxO{
+			"addr_test1a": {{Amount: []chain.Amount{{Unit: "lovelace", Quantity: "3000000"}}}},
+		},
+	}
+	s := NewService(fc)
+	acct, err := s.SetWallet(testMnemonic, "preview", 3)
+	if err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	wantFirstReceive := acct.ReceiveAddresses[0]
+	acct.ReceiveAddresses[0] = "addr_test1mutated_from_setwallet"
+	bal, err := s.Balance(context.Background())
+	if err != nil {
+		t.Fatalf("Balance: %v", err)
+	}
+	if bal.Lovelace != "3000000" {
+		t.Fatalf("lovelace = %q, want 3000000", bal.Lovelace)
+	}
+	av, err := s.Addresses(context.Background())
+	if err != nil {
+		t.Fatalf("Addresses: %v", err)
+	}
+	if len(av.Receive) != 3 {
+		t.Fatalf("receive window = %d, want 3", len(av.Receive))
+	}
+	if av.Receive[0] != wantFirstReceive {
+		t.Fatalf("receive[0] = %q, want %q", av.Receive[0], wantFirstReceive)
+	}
+	if len(av.Used) != 1 || av.Used[0] != "addr_test1a" {
+		t.Fatalf("used = %v, want [addr_test1a]", av.Used)
+	}
+	if av.NextUnused == "" {
+		t.Fatal("NextUnused empty, want a derived address")
+	}
+	wantNextUnused := av.NextUnused
+	av.Receive[0] = "addr_test1mutated_receive"
+	av.Used[0] = "addr_test1mutated_used"
+	av.NextUnused = "addr_test1mutated_next"
+
+	av, err = s.Addresses(context.Background())
+	if err != nil {
+		t.Fatalf("Addresses after caller mutation: %v", err)
+	}
+	if len(av.Receive) != 3 {
+		t.Fatalf("receive window after caller mutation = %d, want 3", len(av.Receive))
+	}
+	if av.Receive[0] != wantFirstReceive {
+		t.Fatalf("receive[0] after caller mutation = %q, want %q", av.Receive[0], wantFirstReceive)
+	}
+	if len(av.Used) != 1 || av.Used[0] != "addr_test1a" {
+		t.Fatalf("used after caller mutation = %v, want [addr_test1a]", av.Used)
+	}
+	if av.NextUnused != wantNextUnused {
+		t.Fatalf("NextUnused after caller mutation = %q, want %q", av.NextUnused, wantNextUnused)
+	}
+	bal, err = s.Balance(context.Background())
+	if err != nil {
+		t.Fatalf("Balance after caller mutation: %v", err)
+	}
+	if bal.Lovelace != "3000000" {
+		t.Fatalf("lovelace after caller mutation = %q, want 3000000", bal.Lovelace)
+	}
+}
+
+func TestServiceEmptyAccount(t *testing.T) {
+	// A fresh/unknown stake credential: the node returns 404 (chain.ErrNotFound)
+	// for the account and its addresses. Read-only views must treat this as an
+	// empty wallet, not a hard error.
+	fc := &fakeChain{accountErr: chain.ErrNotFound, addressesErr: chain.ErrNotFound}
+	s := NewService(fc)
+	if _, err := s.SetWallet(testMnemonic, "preview", 3); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	bal, err := s.Balance(context.Background())
+	if err != nil {
+		t.Fatalf("Balance on empty account: %v", err)
+	}
+	if bal.Lovelace != "0" || len(bal.Assets) != 0 {
+		t.Fatalf("empty balance = %+v, want 0 / no assets", bal)
+	}
+	av, err := s.Addresses(context.Background())
+	if err != nil {
+		t.Fatalf("Addresses on empty account: %v", err)
+	}
+	if len(av.Used) != 0 {
+		t.Fatalf("used = %v, want empty", av.Used)
+	}
+	if av.NextUnused != av.Receive[0] {
+		t.Fatalf("NextUnused = %q, want receive[0] %q", av.NextUnused, av.Receive[0])
+	}
+	if _, err := s.Transactions(context.Background()); err != nil {
+		t.Fatalf("Transactions on empty account: %v", err)
+	}
+	dv, err := s.Delegation(context.Background())
+	if err != nil {
+		t.Fatalf("Delegation on empty account: %v", err)
+	}
+	if dv.PoolID != nil || dv.Active || dv.RewardsSum != "0" || dv.Withdrawable != "0" {
+		t.Fatalf("delegation on empty account = %+v, want not active / no pool / zero amounts", dv)
+	}
+}

--- a/ui/internal/wallet/wallet_integration_test.go
+++ b/ui/internal/wallet/wallet_integration_test.go
@@ -1,0 +1,109 @@
+//go:build integration
+
+package wallet_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/bursa/ui/internal/chain"
+	"github.com/blinklabs-io/bursa/ui/internal/supervisor"
+	"github.com/blinklabs-io/bursa/ui/internal/wallet"
+)
+
+func TestWalletQueriesLivePreview(t *testing.T) {
+	dir := t.TempDir()
+
+	var lastErr error
+	for attempt := 1; attempt <= 5; attempt++ {
+		err := runWalletQueriesLivePreview(t, dir, attempt)
+		if err == nil {
+			return
+		}
+		if !isAddrInUse(err) {
+			t.Fatal(err)
+		}
+		lastErr = err
+		t.Logf("Blockfrost port raced on attempt %d; retrying with a new port: %v", attempt, err)
+	}
+	t.Fatalf("preview node Blockfrost port still unavailable after retries: %v", lastErr)
+}
+
+func runWalletQueriesLivePreview(t *testing.T, dir string, attempt int) error {
+	t.Helper()
+	bfPort, err := freeTCPPort()
+	if err != nil {
+		return err
+	}
+	sup := supervisor.New(supervisor.Config{
+		Network:        "preview",
+		DataDir:        filepath.Join(dir, fmt.Sprintf("db-%d", attempt)),
+		SocketPath:     filepath.Join(dir, fmt.Sprintf("node-%d.socket", attempt)),
+		UtxorpcPort:    0,
+		BlockfrostPort: bfPort,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := sup.Start(ctx); err != nil {
+		return fmt.Errorf("Start: %w", err)
+	}
+	defer sup.Stop()
+
+	deadline := time.Now().Add(90 * time.Second)
+	for {
+		st := sup.Status()
+		if st.State == supervisor.StateSyncing || st.State == supervisor.StateReady {
+			break
+		}
+		if st.State == supervisor.StateError {
+			return fmt.Errorf("node errored: %s", st.Err)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("node not syncing within 90s; last state: %s", st.State)
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	svc := wallet.NewService(chain.NewClient(bfPort))
+	acct, err := svc.SetWallet(
+		"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+		"preview", 5,
+	)
+	if err != nil {
+		return fmt.Errorf("SetWallet: %w", err)
+	}
+	t.Logf("stake address: %s", acct.StakeAddress)
+
+	if _, err := svc.Addresses(ctx); err != nil {
+		return fmt.Errorf("Addresses: %w", err)
+	}
+	if _, err := svc.Balance(ctx); err != nil {
+		return fmt.Errorf("Balance: %w", err)
+	}
+	return nil
+}
+
+func freeTCPPort() (uint, error) {
+	// Dingo's Blockfrost API accepts a numeric port only, and port 0 disables the
+	// server. Pick an ephemeral port, then let the caller retry if another process
+	// binds it before Dingo starts.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, fmt.Errorf("Listen: %w", err)
+	}
+	bfPort := uint(l.Addr().(*net.TCPAddr).Port)
+	if err := l.Close(); err != nil {
+		return 0, fmt.Errorf("close port probe: %w", err)
+	}
+	return bfPort, nil
+}
+
+func isAddrInUse(err error) bool {
+	return strings.Contains(err.Error(), "address already in use") ||
+		strings.Contains(err.Error(), "EADDRINUSE")
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only CIP-1852 account derived from a mnemonic and exposes wallet read APIs backed by the node’s loopback Blockfrost. Supports balance, addresses, transactions, and delegation; enforces node/network constraints; no signing or external calls.

- **New Features**
  - Read-only wallet: derive stake address and receive window (default 20) from mnemonic/network; no signing.
  - API: POST /wallet (mnemonic; network defaults to node network, 400 on mismatch/invalid), GET /wallet/balance, /wallet/addresses, /wallet/transactions, /wallet/delegation (rewards marked provisional).
  - Local chain client: typed Blockfrost client to 127.0.0.1:<port> with pagination; HTTP 404 treated as empty.
  - Behavior: wallet reads gated until node is ready or syncing (503 while starting); 409 until wallet is set.
  - Wiring: main starts wallet service with the supervisor’s Blockfrost port; network validation via `cardanonet`.

- **Dependencies**
  - Add `github.com/blinklabs-io/bursa` and `github.com/blinklabs-io/gouroboros` as direct deps.

<sup>Written for commit fc10839704ab997161e7fcb07fae7ee4ccf4b346. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Full wallet support: Import wallets from mnemonic phrases and access comprehensive wallet data
  - Query wallet balance, view addresses, and browse transaction history
  - Check delegation and staking status across accounts
  - Multi-network compatibility (mainnet, preview, preprod) with automatic validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->