### PR TITLE
feat(ui): encrypted mnemonic keystore (scrypt + AES-256-GCM)

### DIFF
--- a/ui/go.mod
+++ b/ui/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/blinklabs-io/bursa v0.16.0
 	github.com/blinklabs-io/dingo v0.50.2
 	github.com/blinklabs-io/gouroboros v0.179.0
+	golang.org/x/crypto v0.52.0
 )
 
 require (
@@ -31,7 +32,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.1 // indirect
-	github.com/ClickHouse/ch-go v0.65.0 // indirect
+	github.com/ClickHouse/ch-go v0.61.5 // indirect
 	github.com/ClickHouse/clickhouse-go/v2 v2.30.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.56.0 // indirect
@@ -181,7 +182,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/ui/go.sum
+++ b/ui/go.sum
@@ -59,8 +59,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.7.1 h1:edShSHV3DV9
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.1/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/ClickHouse/ch-go v0.65.0 h1:vZAXfTQliuNNefqkPDewX3kgRxN6Q4vUENnnY+ynTRY=
-github.com/ClickHouse/ch-go v0.65.0/go.mod h1:tCM0XEH5oWngoi9Iu/8+tjPBo04I/FxNIffpdjtwx3k=
+github.com/ClickHouse/ch-go v0.61.5 h1:zwR8QbYI0tsMiEcze/uIMK+Tz1D3XZXLdNrlaOpeEI4=
+github.com/ClickHouse/ch-go v0.61.5/go.mod h1:s1LJW/F/LcFs5HJnuogFMta50kKDO0lf9zzfrbl0RQg=
 github.com/ClickHouse/clickhouse-go/v2 v2.30.0 h1:AG4D/hW39qa58+JHQIFOSnxyL46H6h2lrmGGk17dhFo=
 github.com/ClickHouse/clickhouse-go/v2 v2.30.0/go.mod h1:i9ZQAojcayW3RsdCb3YR+n+wC2h65eJsZCscZ1Z1wyo=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=

--- a/ui/internal/keystore/keystore.go
+++ b/ui/internal/keystore/keystore.go
@@ -1,0 +1,226 @@
+// Package keystore stores the wallet mnemonic encrypted at rest with a spending
+// password (scrypt + AES-256-GCM). It is decrypted only transiently, to derive
+// signing keys for a single transaction.
+package keystore
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"unicode/utf8"
+
+	"golang.org/x/crypto/scrypt"
+)
+
+const (
+	containerVersion = 1
+
+	minPasswordLen = 8
+	keyLen         = 32
+	gcmNonceLen    = 12
+	saltLen        = 16
+
+	// maxContainerLen caps Unlock's read of the keystore file. A real
+	// container is under 1 KiB; anything larger is not one of ours.
+	maxContainerLen = 64 * 1024
+)
+
+// kdfParams is the scrypt cost Create writes plus the range Unlock accepts,
+// so cost can be raised in future releases without a format break, while
+// refusing absurd params from a crafted file.
+type kdfParams struct {
+	n, r, p                            int
+	minN, maxN, minR, maxR, minP, maxP int
+}
+
+// productionKDF uses the x/crypto/scrypt-recommended cost for file
+// encryption (~1 GiB, ~1 s per derivation).
+var productionKDF = kdfParams{
+	n: 1 << 20, r: 8, p: 1,
+	minN: 1 << 20, maxN: 1 << 22,
+	minR: 8, maxR: 32,
+	minP: 1, maxP: 4,
+}
+
+// Keystore is an encrypted mnemonic file at Path (mode 0600).
+type Keystore struct {
+	Path string
+
+	// kdf overrides productionKDF; only tests set it, to keep scrypt cheap.
+	kdf *kdfParams
+}
+
+func New(path string) *Keystore { return &Keystore{Path: path} }
+
+func (k *Keystore) params() kdfParams {
+	if k.kdf != nil {
+		return *k.kdf
+	}
+	return productionKDF
+}
+
+// Exists reports whether a keystore file is present.
+func (k *Keystore) Exists() bool {
+	_, err := os.Stat(k.Path)
+	return err == nil
+}
+
+type container struct {
+	Version    int    `json:"version"`
+	KDF        string `json:"kdf"`
+	N          int    `json:"n"`
+	R          int    `json:"r"`
+	P          int    `json:"p"`
+	Salt       string `json:"salt"`
+	Nonce      string `json:"nonce"`
+	Ciphertext string `json:"ciphertext"`
+}
+
+// Create encrypts the mnemonic under password (minimum 8 characters) and
+// writes the keystore. It refuses to overwrite an existing keystore.
+func (k *Keystore) Create(mnemonic, password string) error {
+	if utf8.RuneCountInString(password) < minPasswordLen {
+		return fmt.Errorf("password must be at least %d characters", minPasswordLen)
+	}
+	if mnemonic == "" {
+		return errors.New("mnemonic must not be empty")
+	}
+	// Fast-fail before the expensive KDF; the O_EXCL open below remains the
+	// authoritative overwrite guard.
+	if k.Exists() {
+		return fmt.Errorf("keystore already exists at %s", k.Path)
+	}
+	salt := make([]byte, saltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return err
+	}
+	kdf := k.params()
+	key, err := scrypt.Key([]byte(password), salt, kdf.n, kdf.r, kdf.p, keyLen)
+	if err != nil {
+		return fmt.Errorf("scrypt: %w", err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return err
+	}
+	ct := gcm.Seal(nil, nonce, []byte(mnemonic), nil)
+	blob, err := json.Marshal(container{
+		Version: containerVersion,
+		KDF:     "scrypt", N: kdf.n, R: kdf.r, P: kdf.p,
+		Salt: hex.EncodeToString(salt), Nonce: hex.EncodeToString(nonce),
+		Ciphertext: hex.EncodeToString(ct),
+	})
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(k.Path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("keystore already exists at %s", k.Path)
+		}
+		return err
+	}
+	n, err := f.Write(blob)
+	if err == nil && n != len(blob) {
+		err = io.ErrShortWrite
+	}
+	if err == nil {
+		err = f.Sync()
+	}
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		// Remove the partial file: leaving it behind would block every
+		// future Create via the write-once guard above.
+		_ = os.Remove(k.Path)
+		return err
+	}
+	return nil
+}
+
+// Unlock decrypts and returns the mnemonic. A wrong password or tampered file
+// fails (AES-GCM authentication). Callers should Zero the returned bytes as
+// soon as the mnemonic is no longer needed.
+func (k *Keystore) Unlock(password string) ([]byte, error) {
+	f, err := os.Open(k.Path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	blob, err := io.ReadAll(io.LimitReader(f, maxContainerLen+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(blob) > maxContainerLen {
+		return nil, fmt.Errorf("keystore file exceeds %d bytes", maxContainerLen)
+	}
+	var c container
+	if err := json.Unmarshal(blob, &c); err != nil {
+		return nil, fmt.Errorf("not a keystore container: %w", err)
+	}
+	if c.Version != containerVersion {
+		return nil, fmt.Errorf("unsupported keystore version %d", c.Version)
+	}
+	kdf := k.params()
+	if c.KDF != "scrypt" ||
+		c.N < kdf.minN || c.N > kdf.maxN ||
+		c.R < kdf.minR || c.R > kdf.maxR ||
+		c.P < kdf.minP || c.P > kdf.maxP {
+		return nil, fmt.Errorf("unsupported KDF params (kdf=%q n=%d r=%d p=%d)", c.KDF, c.N, c.R, c.P)
+	}
+	salt, err := hex.DecodeString(c.Salt)
+	if err != nil {
+		return nil, err
+	}
+	nonce, err := hex.DecodeString(c.Nonce)
+	if err != nil {
+		return nil, err
+	}
+	if len(nonce) != gcmNonceLen {
+		return nil, fmt.Errorf("invalid nonce length %d", len(nonce))
+	}
+	ct, err := hex.DecodeString(c.Ciphertext)
+	if err != nil {
+		return nil, err
+	}
+	key, err := scrypt.Key([]byte(password), salt, c.N, c.R, c.P, keyLen)
+	if err != nil {
+		return nil, fmt.Errorf("scrypt: %w", err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	pt, err := gcm.Open(nil, nonce, ct, nil)
+	if err != nil {
+		return nil, errors.New("decryption failed (wrong password or corrupt keystore)")
+	}
+	return pt, nil
+}
+
+// Zero overwrites b in place, e.g. a mnemonic returned by Unlock once signing
+// keys have been derived from it.
+func Zero(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/ui/internal/keystore/keystore_test.go
+++ b/ui/internal/keystore/keystore_test.go
@@ -1,0 +1,290 @@
+package keystore
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/crypto/scrypt"
+)
+
+// testKDF keeps scrypt cheap (~4 MiB, sub-millisecond) so the suite stays
+// fast. The production cost is exercised once in
+// TestRoundTripProductionParams, which is skipped under -short.
+var testKDF = kdfParams{
+	n: 1 << 12, r: 8, p: 1,
+	minN: 1 << 12, maxN: 1 << 14,
+	minR: 8, maxR: 32,
+	minP: 1, maxP: 4,
+}
+
+func newTestKeystore(t *testing.T) *Keystore {
+	t.Helper()
+	ks := New(filepath.Join(t.TempDir(), "keystore.json"))
+	ks.kdf = &testKDF
+	return ks
+}
+
+func TestCreateUnlockRoundTrip(t *testing.T) {
+	ks := newTestKeystore(t)
+	if ks.Exists() {
+		t.Fatal("Exists() true before Create")
+	}
+	const mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+	if err := ks.Create(mnemonic, "s3cret-pass"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !ks.Exists() {
+		t.Fatal("Exists() false after Create")
+	}
+	got, err := ks.Unlock("s3cret-pass")
+	if err != nil {
+		t.Fatalf("Unlock: %v", err)
+	}
+	if string(got) != mnemonic {
+		t.Fatalf("round-trip mismatch: got %q", got)
+	}
+}
+
+// One full round trip at production scrypt cost (~1 GiB, seconds per
+// derivation), so the shipped defaults are known to work end to end.
+func TestRoundTripProductionParams(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping production-cost scrypt in -short mode")
+	}
+	ks := New(filepath.Join(t.TempDir(), "keystore.json"))
+	const mnemonic = "abandon abandon about"
+	if err := ks.Create(mnemonic, "s3cret-pass"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := ks.Unlock("s3cret-pass")
+	if err != nil {
+		t.Fatalf("Unlock: %v", err)
+	}
+	if string(got) != mnemonic {
+		t.Fatalf("round-trip mismatch: got %q", got)
+	}
+}
+
+func TestUnlockWrongPassword(t *testing.T) {
+	ks := newTestKeystore(t)
+	if err := ks.Create("abandon about", "right-password"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := ks.Unlock("wrong-password"); err == nil {
+		t.Fatal("Unlock with wrong password should fail")
+	}
+}
+
+func TestCreateRefusesOverwrite(t *testing.T) {
+	ks := newTestKeystore(t)
+	if err := ks.Create("m", "password1"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := ks.Create("m2", "password2"); err == nil {
+		t.Fatal("Create should refuse to overwrite an existing keystore")
+	}
+}
+
+func TestCreateRejectsEmptyMnemonic(t *testing.T) {
+	ks := newTestKeystore(t)
+	if err := ks.Create("", "password1"); err == nil {
+		t.Fatal("Create should reject an empty mnemonic")
+	}
+	if ks.Exists() {
+		t.Fatal("Create persisted a keystore for an empty mnemonic")
+	}
+}
+
+func TestCreateRejectsShortPassword(t *testing.T) {
+	ks := newTestKeystore(t)
+	if err := ks.Create("m", "1234567"); err == nil {
+		t.Fatal("Create should reject a password shorter than 8 characters")
+	}
+	if ks.Exists() {
+		t.Fatal("Create persisted a keystore for a too-short password")
+	}
+}
+
+func TestContainerFormat(t *testing.T) {
+	ks := newTestKeystore(t)
+	if err := ks.Create("m", "longpassword"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	blob, err := os.ReadFile(ks.Path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var c struct {
+		Version int    `json:"version"`
+		KDF     string `json:"kdf"`
+		N       int    `json:"n"`
+		R       int    `json:"r"`
+		P       int    `json:"p"`
+	}
+	if err := json.Unmarshal(blob, &c); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if c.Version != 1 {
+		t.Errorf("version = %d, want 1", c.Version)
+	}
+	if c.KDF != "scrypt" {
+		t.Errorf("kdf = %q, want scrypt", c.KDF)
+	}
+	if c.N != testKDF.n || c.R != testKDF.r || c.P != testKDF.p {
+		t.Errorf("scrypt params = n=%d r=%d p=%d, want n=%d r=%d p=%d",
+			c.N, c.R, c.P, testKDF.n, testKDF.r, testKDF.p)
+	}
+}
+
+// Pins the shipped scrypt cost (the x/crypto-recommended file-encryption
+// cost) and the acceptance ranges, without running the KDF.
+func TestProductionKDFDefaults(t *testing.T) {
+	want := kdfParams{
+		n: 1 << 20, r: 8, p: 1,
+		minN: 1 << 20, maxN: 1 << 22,
+		minR: 8, maxR: 32,
+		minP: 1, maxP: 4,
+	}
+	if productionKDF != want {
+		t.Fatalf("productionKDF = %+v, want %+v", productionKDF, want)
+	}
+	if got := New("unused").params(); got != want {
+		t.Fatalf("New().params() = %+v, want %+v", got, want)
+	}
+}
+
+func TestUnlockRejectsUnknownVersion(t *testing.T) {
+	ks := newTestKeystore(t)
+	if err := ks.Create("m", "longpassword"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	blob, err := os.ReadFile(ks.Path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(blob, &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	m["version"] = 99
+	tampered, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(ks.Path, tampered, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := ks.Unlock("longpassword"); err == nil {
+		t.Fatal("Unlock should reject an unknown container version")
+	}
+}
+
+// A keystore written with stronger-than-default scrypt params (here p=2) must
+// still unlock, so params can be raised later without a format break.
+func TestUnlockAcceptsStrongerParams(t *testing.T) {
+	ks := newTestKeystore(t)
+	const mnemonic = "abandon abandon about"
+	const password = "correct horse battery staple"
+	salt := make([]byte, 16)
+	nonce := make([]byte, 12)
+	key, err := scrypt.Key([]byte(password), salt, testKDF.n, testKDF.r, testKDF.p+1, 32)
+	if err != nil {
+		t.Fatalf("scrypt: %v", err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("NewGCM: %v", err)
+	}
+	ct := gcm.Seal(nil, nonce, []byte(mnemonic), nil)
+	blob, err := json.Marshal(map[string]any{
+		"version": 1, "kdf": "scrypt", "n": testKDF.n, "r": testKDF.r, "p": testKDF.p + 1,
+		"salt":       hex.EncodeToString(salt),
+		"nonce":      hex.EncodeToString(nonce),
+		"ciphertext": hex.EncodeToString(ct),
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(ks.Path, blob, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := ks.Unlock(password)
+	if err != nil {
+		t.Fatalf("Unlock: %v", err)
+	}
+	if string(got) != mnemonic {
+		t.Fatalf("mnemonic mismatch: got %q", got)
+	}
+}
+
+// A crafted container with sub-minimum scrypt cost must be refused before the
+// KDF runs, so an attacker can't swap in a cheap-to-brute-force file.
+func TestUnlockRejectsWeakParams(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "keystore.json")
+	blob, err := json.Marshal(map[string]any{
+		"version": 1, "kdf": "scrypt", "n": 1 << 10, "r": 8, "p": 1,
+		"salt": "00", "nonce": "00", "ciphertext": "00",
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(path, blob, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := New(path).Unlock("longpassword"); err == nil {
+		t.Fatal("Unlock should reject scrypt params below the production minimum")
+	}
+}
+
+func TestUnlockRejectsOversizedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "keystore.json")
+	junk := bytes.Repeat([]byte("a"), maxContainerLen+1)
+	if err := os.WriteFile(path, junk, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := New(path).Unlock("longpassword"); err == nil {
+		t.Fatal("Unlock should reject a file larger than maxContainerLen")
+	}
+}
+
+// Unlock returns mutable bytes so callers can wipe the mnemonic after use.
+func TestUnlockReturnsZeroableBytes(t *testing.T) {
+	ks := newTestKeystore(t)
+	if err := ks.Create("abandon about", "s3cret-pass"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := ks.Unlock("s3cret-pass")
+	if err != nil {
+		t.Fatalf("Unlock: %v", err)
+	}
+	Zero(got)
+	for i, b := range got {
+		if b != 0 {
+			t.Fatalf("byte %d not zeroed after Zero()", i)
+		}
+	}
+}
+
+func TestCreateWritesOwnerOnlyPermissions(t *testing.T) {
+	ks := newTestKeystore(t)
+	if err := ks.Create("m", "password1"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	info, err := os.Stat(ks.Path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("keystore permissions = %o, want 600", got)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an encrypted wallet mnemonic keystore using scrypt + AES-256-GCM to protect mnemonics at rest. Supports a write-once keystore and unlocking with a spending password.

- **New Features**
  - New `ui/internal/keystore` with `New`, `Exists`, `Create`, `Unlock`, `Zero`; JSON container stores `version`, `kdf` (`scrypt`), `n/r/p`, `salt`, `nonce`, `ciphertext`; writes with mode 0600.
  - scrypt (N=1<<20, r=8, p=1; accepts N up to 1<<22, r 8–32, p up to 4) + AES-256-GCM; enforces 8+ char passwords; caps keystore read to 64 KiB; wrong passwords or tampering fail decryption.
  - Tests cover round-trip, wrong password, overwrite protection, version/KDF param validation (reject weak params), oversized file, rejecting empty mnemonic/short password, accepting stronger scrypt params, zeroable bytes, and 0600 perms.

- **Dependencies**
  - Add `golang.org/x/crypto v0.52.0`.
  - Downgrade `github.com/ClickHouse/ch-go` to v0.61.5.

<sup>Written for commit 0d9cda8624b755533e4ede63d56d4c604d0906eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added encrypted wallet keystore for secure mnemonic storage with password protection
  * Keystores can now be created with password-based access and unlocked with the same password
  * Built-in validation prevents accidental overwrites of existing keystores

<!-- end of auto-generated comment: release notes by coderabbit.ai -->