### PR TITLE
feat(ui): dingo mithril sync

### DIFF
--- a/ui/cmd/bursa-wallet/main.go
+++ b/ui/cmd/bursa-wallet/main.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -66,6 +67,8 @@ func run() error {
 		utxorpcPort    uint = 5555
 		blockfrostPort uint = 5556
 	)
+	// Mithril fast-sync is on by default; BURSA_SYNC=genesis opts out.
+	mithrilEnabled := !strings.EqualFold(envOr("BURSA_SYNC", "mithril"), "genesis")
 	sup := supervisor.New(supervisor.Config{
 		Network:        network,
 		DataDir:        filepath.Join(dataDir, "db"),
@@ -73,6 +76,7 @@ func run() error {
 		UtxorpcPort:    utxorpcPort,
 		BlockfrostPort: blockfrostPort,
 		Logger:         logger,
+		MithrilEnabled: mithrilEnabled,
 	})
 
 	// The wallet queries the node's own loopback Blockfrost endpoint.

--- a/ui/go.mod
+++ b/ui/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/blinklabs-io/apollo/v2 v2.0.0-20260610185853-0c47e0b38bd5
 	github.com/blinklabs-io/bursa v0.16.0
-	github.com/blinklabs-io/dingo v0.52.1
+	github.com/blinklabs-io/dingo v0.53.0
 	github.com/blinklabs-io/gouroboros v0.182.0
 	github.com/blinklabs-io/plutigo v0.1.15
 	github.com/utxorpc/go-codegen v0.19.2

--- a/ui/go.sum
+++ b/ui/go.sum
@@ -133,8 +133,8 @@ github.com/blinklabs-io/bark v0.0.2 h1:YcwhDfKu8QuPGjKcaV9/J4Vq+0kYMWMo8C08FW2ak
 github.com/blinklabs-io/bark v0.0.2/go.mod h1:+ufcuLfDoj8yXktYHQSffle/gaCJnJWqL/31PnAP3dc=
 github.com/blinklabs-io/bursa v0.16.0 h1:EyiEJIvRo5u2nxYQAILUNaCpubUuBrCgnWxIHI1YnoU=
 github.com/blinklabs-io/bursa v0.16.0/go.mod h1:QushjySLaOipI158YageIEIRksjCxGpAwtM1WbYx4Qo=
-github.com/blinklabs-io/dingo v0.52.1 h1:Bx1Hnuwi+ag1JDj2xYdGNARZg3SOPKgytA3FGk14iCc=
-github.com/blinklabs-io/dingo v0.52.1/go.mod h1:MNs4bC3/QUC8FKWyLnEYSEYPryl3xL2Whm8Td37K2UI=
+github.com/blinklabs-io/dingo v0.53.0 h1:LHpwihPnTgWboCax7zTHnnDgs/z6caLdHpVGqm6bGe0=
+github.com/blinklabs-io/dingo v0.53.0/go.mod h1:MNs4bC3/QUC8FKWyLnEYSEYPryl3xL2Whm8Td37K2UI=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
 github.com/blinklabs-io/gouroboros v0.182.0 h1:qZN0DCFaSmbWdI7RF9r/J5lzq88VmtdWyysiMGEjPnA=

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -150,6 +150,17 @@ func TestWalletGatedWhileStarting(t *testing.T) {
 	}
 }
 
+func TestWalletGatedWhileBootstrapping(t *testing.T) {
+	// Mithril bootstrap is not a servable state: reads must be gated (503).
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateBootstrapping}}
+	h := NewHandler(st, &fakeWallet{}, &fakeSpender{}, "preview")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/balance", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /wallet/balance while bootstrapping = %d, want 503", rec.Code)
+	}
+}
+
 func TestWalletNoWalletConflict(t *testing.T) {
 	// No POST /wallet first: the natural no-wallet path must yield 409.
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}

--- a/ui/internal/boundary/boundary_test.go
+++ b/ui/internal/boundary/boundary_test.go
@@ -20,7 +20,9 @@ import (
 )
 
 // denylist is import-path substrings for external services the wallet must
-// never reach. The only sanctioned outbound link is the embedded node's P2P.
+// never reach. Sanctioned outbound links: the embedded node's P2P, and a
+// one-time Mithril snapshot download at bootstrap (first-party Cardano infra,
+// certificate-verified, leaks no wallet data — see internal/supervisor/bootstrap.go).
 var denylist = []string{
 	"coingecko",
 	"coinmarketcap",

--- a/ui/internal/supervisor/bootstrap.go
+++ b/ui/internal/supervisor/bootstrap.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package supervisor
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/blinklabs-io/dingo"
+	"github.com/blinklabs-io/dingo/database"
+	"github.com/blinklabs-io/dingo/mithril"
+)
+
+// bootstrapMarker is written inside the node DB dir once a Mithril bootstrap
+// completes, so subsequent starts skip the bootstrap and rely on P2P sync.
+const bootstrapMarker = ".mithril-bootstrap-complete"
+
+// BootstrapParams is the minimal input a Bootstrapper needs.
+type BootstrapParams struct {
+	Network    string
+	DataDir    string
+	OnProgress func(BootstrapProgress)
+}
+
+// Bootstrapper populates the node DB from a Mithril snapshot. It is an interface
+// so the supervisor's orchestration can be unit-tested with a fake (no network).
+type Bootstrapper interface {
+	Bootstrap(ctx context.Context, p BootstrapParams) error
+}
+
+// mithrilBootstrapper is the real Bootstrapper backed by dingo's mithril.Sync.
+type mithrilBootstrapper struct{ logger *slog.Logger }
+
+func (b mithrilBootstrapper) Bootstrap(ctx context.Context, p BootstrapParams) error {
+	_, err := mithril.Sync(ctx, syncConfigFor(p, b.logger))
+	return err
+}
+
+// syncConfigFor builds the mithril.SyncConfig for a bootstrap. The storage mode
+// and blob/metadata plugins MUST match the node's, or the imported DB will not
+// open; we bind them to the same dingo defaults the supervisor's node uses
+// (StorageModeAPI + database.DefaultConfig) so they can't silently drift.
+// CardanoNodeConfig is left nil so mithril.Sync loads it from the embedded
+// config for Network (same source the node uses).
+func syncConfigFor(p BootstrapParams, logger *slog.Logger) mithril.SyncConfig {
+	return mithril.SyncConfig{
+		Network:          p.Network,
+		DataDir:          p.DataDir,
+		StorageMode:      string(dingo.StorageModeAPI),
+		BlobPlugin:       database.DefaultConfig.BlobPlugin,
+		MetadataPlugin:   database.DefaultConfig.MetadataPlugin,
+		VerifyCertChain:  true,
+		CleanupAfterLoad: true,
+		Logger:           logger,
+		OnProgress: func(sp mithril.SyncProgress) {
+			if p.OnProgress != nil {
+				p.OnProgress(toBootstrapProgress(sp))
+			}
+		},
+	}
+}
+
+// toBootstrapProgress flattens dingo's SyncProgress into the package's API type.
+// Only the fields surfaced on /status are mapped; the rest (Active, CurrentSlot,
+// TipSlot, Count, Total, Description) are internal pacing signals we omit.
+func toBootstrapProgress(sp mithril.SyncProgress) BootstrapProgress {
+	return BootstrapProgress{
+		Phase:           string(sp.Phase),
+		Percent:         sp.Percent,
+		BytesDownloaded: sp.BytesDownloaded,
+		TotalBytes:      sp.TotalBytes,
+		BytesPerSecond:  sp.BytesPerSecond,
+	}
+}
+
+// shouldBootstrap reports whether a Mithril bootstrap should run: only when
+// enabled and no completed bootstrap is recorded for the DB dir.
+func shouldBootstrap(enabled bool, dataDir string) bool {
+	return enabled && !bootstrapDone(dataDir)
+}
+
+func markerPath(dataDir string) string { return filepath.Join(dataDir, bootstrapMarker) }
+
+// bootstrapDone reports whether a completed-bootstrap marker exists. Only a
+// definitively-missing marker counts as "not bootstrapped": any other stat
+// error (e.g. permissions) reads as done, so we never re-import a snapshot
+// over a DB dir we cannot inspect — launching the node surfaces the real
+// error instead.
+func bootstrapDone(dataDir string) bool {
+	_, err := os.Stat(markerPath(dataDir))
+	return !errors.Is(err, fs.ErrNotExist)
+}
+
+// markBootstrapDone records a completed bootstrap. The DB dir exists by now
+// (mithril.Sync created it).
+func markBootstrapDone(dataDir string) error {
+	return os.WriteFile(markerPath(dataDir), []byte("ok\n"), 0o600)
+}

--- a/ui/internal/supervisor/bootstrap_test.go
+++ b/ui/internal/supervisor/bootstrap_test.go
@@ -1,0 +1,301 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package supervisor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blinklabs-io/dingo/mithril"
+)
+
+func TestSyncConfigForMapsFields(t *testing.T) {
+	sc := syncConfigFor(BootstrapParams{Network: "preview", DataDir: "/data/db"}, nil)
+	if sc.Network != "preview" || sc.DataDir != "/data/db" {
+		t.Fatalf("network/datadir: %+v", sc)
+	}
+	if sc.StorageMode != "api" || sc.BlobPlugin != "badger" || sc.MetadataPlugin != "sqlite" {
+		t.Fatalf("storage/plugins: %+v", sc)
+	}
+	if !sc.VerifyCertChain || !sc.CleanupAfterLoad {
+		t.Fatalf("verify/cleanup should be true: %+v", sc)
+	}
+}
+
+func TestSyncConfigForWiresProgress(t *testing.T) {
+	var got BootstrapProgress
+	sc := syncConfigFor(BootstrapParams{OnProgress: func(b BootstrapProgress) { got = b }}, nil)
+	sc.OnProgress(mithril.SyncProgress{Phase: mithril.PhaseLedgerImport, Percent: 50, BytesDownloaded: 3, TotalBytes: 6, BytesPerSecond: 1.5})
+	if got.Phase != "ledger_import" || got.Percent != 50 || got.BytesDownloaded != 3 || got.TotalBytes != 6 || got.BytesPerSecond != 1.5 {
+		t.Fatalf("progress not mapped: %+v", got)
+	}
+
+	// A nil OnProgress must not panic.
+	syncConfigFor(BootstrapParams{}, nil).OnProgress(mithril.SyncProgress{})
+}
+
+func TestBootstrapMarkerRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	if bootstrapDone(dir) {
+		t.Fatal("marker should be absent initially")
+	}
+	if err := markBootstrapDone(dir); err != nil {
+		t.Fatalf("markBootstrapDone: %v", err)
+	}
+	if !bootstrapDone(dir) {
+		t.Fatal("marker should be present after marking")
+	}
+}
+
+// TestBootstrapDoneUnreadableMarker: when the marker cannot be inspected (a
+// stat error other than not-exist), bootstrapDone must report true so we never
+// re-import a snapshot over a DB we cannot see into; the node launch surfaces
+// the real error instead.
+func TestBootstrapDoneUnreadableMarker(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; permission errors do not apply")
+	}
+	parent := t.TempDir()
+	dataDir := filepath.Join(parent, "db")
+	if err := os.Mkdir(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(parent, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+	if !bootstrapDone(dataDir) {
+		t.Fatal("an unreadable marker must read as bootstrapped (no re-import)")
+	}
+}
+
+func TestShouldBootstrap(t *testing.T) {
+	dir := t.TempDir()
+	if !shouldBootstrap(true, dir) {
+		t.Fatal("enabled + no marker → should bootstrap")
+	}
+	if shouldBootstrap(false, dir) {
+		t.Fatal("disabled → should not bootstrap")
+	}
+	_ = markBootstrapDone(dir)
+	if shouldBootstrap(true, dir) {
+		t.Fatal("enabled + marker present → should not bootstrap")
+	}
+}
+
+// fakeBootstrapper drives progress then returns err.
+type fakeBootstrapper struct {
+	err      error
+	progress []BootstrapProgress
+	called   bool
+}
+
+func (f *fakeBootstrapper) Bootstrap(_ context.Context, p BootstrapParams) error {
+	f.called = true
+	for _, bp := range f.progress {
+		if p.OnProgress != nil {
+			p.OnProgress(bp)
+		}
+	}
+	return f.err
+}
+
+func newTestSupervisor(t *testing.T, b Bootstrapper) *Supervisor {
+	t.Helper()
+	s := New(Config{Network: "preview", DataDir: t.TempDir()})
+	s.bootstrapper = b
+	s.runID = 1
+	s.cancel = func() {} // represent an active run so setState/setError apply
+	return s
+}
+
+func TestOnProgressUpdatesStatus(t *testing.T) {
+	s := newTestSupervisor(t, &fakeBootstrapper{})
+	s.setState(StateBootstrapping)
+	s.onProgress(BootstrapProgress{Phase: "backfill", Percent: 12})
+	got := s.Status().Bootstrap
+	if got == nil || got.Phase != "backfill" || got.Percent != 12 {
+		t.Fatalf("Status.Bootstrap not updated: %+v", got)
+	}
+}
+
+func TestSetStateClearsBootstrap(t *testing.T) {
+	s := newTestSupervisor(t, &fakeBootstrapper{})
+	s.setState(StateBootstrapping)
+	s.onProgress(BootstrapProgress{Phase: "backfill"})
+	s.setState(StateStarting)
+	if s.Status().Bootstrap != nil {
+		t.Fatal("leaving StateBootstrapping should clear Status.Bootstrap")
+	}
+}
+
+func TestBootstrapThenLaunchSuccess(t *testing.T) {
+	fb := &fakeBootstrapper{progress: []BootstrapProgress{{Phase: "bootstrap", Percent: 100}}}
+	s := newTestSupervisor(t, fb)
+	launched := false
+	s.setState(StateBootstrapping)
+	s.bootstrapThenLaunch(context.Background(), s.runID, func() error { launched = true; return nil })
+
+	if !fb.called {
+		t.Fatal("bootstrapper not invoked")
+	}
+	if !launched {
+		t.Fatal("launch not called after successful bootstrap")
+	}
+	if !bootstrapDone(s.cfg.DataDir) {
+		t.Fatal("completion marker not written")
+	}
+	// State transitions are driven by the real launch (setState(StateStarting));
+	// the fake launch here doesn't transition, so that path is covered by
+	// TestSetStateClearsBootstrap instead.
+}
+
+func TestBootstrapThenLaunchFailureSetsError(t *testing.T) {
+	fb := &fakeBootstrapper{
+		progress: []BootstrapProgress{{Phase: "ledger_import", Percent: 40}},
+		err:      errors.New("aggregator unreachable"),
+	}
+	s := newTestSupervisor(t, fb)
+	launched := false
+	s.setState(StateBootstrapping)
+	s.bootstrapThenLaunch(context.Background(), s.runID, func() error { launched = true; return nil })
+
+	if launched {
+		t.Fatal("launch must NOT be called when bootstrap fails")
+	}
+	st := s.Status()
+	if st.State != StateError {
+		t.Fatalf("state = %q, want error", st.State)
+	}
+	// Progress is intentionally retained on error for diagnostics.
+	if st.Bootstrap == nil || st.Bootstrap.Phase != "ledger_import" {
+		t.Fatalf("bootstrap progress should be retained on error, got %+v", st.Bootstrap)
+	}
+	if bootstrapDone(s.cfg.DataDir) {
+		t.Fatal("marker must not be written on failure")
+	}
+}
+
+// TestBootstrapCancellationIsNotError: a bootstrap aborted by context
+// cancellation is an orderly shutdown, not a failure — it must not flip the
+// supervisor to StateError (mirrors the node.Run guard).
+func TestBootstrapCancellationIsNotError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	fb := &fakeBootstrapper{err: context.Canceled}
+	s := newTestSupervisor(t, fb)
+	s.setState(StateBootstrapping)
+	launched := false
+	s.bootstrapThenLaunch(ctx, s.runID, func() error { launched = true; return nil })
+
+	if launched {
+		t.Fatal("launch must NOT be called when bootstrap is cancelled")
+	}
+	if got := s.Status().State; got == StateError {
+		t.Fatalf("cancellation flipped state to error: %s", s.Status().Err)
+	}
+	if bootstrapDone(s.cfg.DataDir) {
+		t.Fatal("marker must not be written on cancellation")
+	}
+}
+
+// TestBootstrapPostSuccessCancellationStopsBeforeLaunch covers cancellation
+// after Bootstrap returns nil but before post-bootstrap work. That late path
+// must not mark the supervisor errored or launch a node for the canceled run.
+func TestBootstrapPostSuccessCancellationStopsBeforeLaunch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	s := newTestSupervisor(t, &fakeBootstrapper{})
+	s.setState(StateBootstrapping)
+	launched := false
+	s.bootstrapThenLaunch(ctx, s.runID, func() error {
+		launched = true
+		return errors.New("late launch failure")
+	})
+
+	if launched {
+		t.Fatal("launch must NOT be called after cancellation")
+	}
+	if got := s.Status().State; got == StateError {
+		t.Fatalf("post-bootstrap cancellation flipped state to error: %s", s.Status().Err)
+	}
+	if bootstrapDone(s.cfg.DataDir) {
+		t.Fatal("marker must not be written after cancellation")
+	}
+}
+
+// TestOnProgressIgnoredAfterStop guards the teardown invariant for progress
+// callbacks: a late OnProgress from an in-flight bootstrap must not write
+// bootstrap data into a stopped snapshot.
+func TestOnProgressIgnoredAfterStop(t *testing.T) {
+	s := newTestSupervisor(t, &fakeBootstrapper{})
+	s.setState(StateBootstrapping)
+	s.Stop()
+	s.onProgress(BootstrapProgress{Phase: "backfill", Percent: 12})
+	if s.Status().Bootstrap != nil {
+		t.Fatal("onProgress after Stop must be a no-op")
+	}
+}
+
+func TestOnProgressIgnoredOutsideBootstrapping(t *testing.T) {
+	s := newTestSupervisor(t, &fakeBootstrapper{})
+	s.setState(StateStarting)
+	s.onProgress(BootstrapProgress{Phase: "backfill", Percent: 12})
+	if s.Status().Bootstrap != nil {
+		t.Fatal("onProgress outside bootstrapping must be a no-op")
+	}
+}
+
+func TestStaleOnProgressIgnoredAfterRestart(t *testing.T) {
+	s := newTestSupervisor(t, &fakeBootstrapper{})
+	oldRunID := s.runID
+	s.runID++
+	s.setState(StateBootstrapping)
+	s.onProgressForRun(oldRunID, BootstrapProgress{Phase: "old", Percent: 12})
+	if s.Status().Bootstrap != nil {
+		t.Fatal("stale onProgress after restart must be a no-op")
+	}
+
+	s.onProgress(BootstrapProgress{Phase: "new", Percent: 34})
+	got := s.Status().Bootstrap
+	if got == nil || got.Phase != "new" || got.Percent != 34 {
+		t.Fatalf("current run progress not recorded: %+v", got)
+	}
+}
+
+// TestSetStateIgnoredAfterStop guards the teardown invariant: once Stop clears
+// cancel, a late goroutine's setState must not resurrect the supervisor.
+func TestSetStateIgnoredAfterStop(t *testing.T) {
+	s := newTestSupervisor(t, &fakeBootstrapper{})
+	s.setState(StateBootstrapping)
+	s.Stop() // → StateStopped, clears cancel
+	s.setState(StateStarting)
+	if got := s.Status().State; got != StateStopped {
+		t.Fatalf("setState after Stop must be a no-op; state = %q, want stopped", got)
+	}
+}
+
+// TestSetErrorIgnoredAfterStop guards the same invariant for setError: a late
+// failure must not overwrite the stopped state.
+func TestSetErrorIgnoredAfterStop(t *testing.T) {
+	s := newTestSupervisor(t, &fakeBootstrapper{})
+	s.Stop()
+	s.setError(errors.New("late failure"))
+	if got := s.Status().State; got != StateStopped {
+		t.Fatalf("setError after Stop must be a no-op; state = %q, want stopped", got)
+	}
+}

--- a/ui/internal/supervisor/status.go
+++ b/ui/internal/supervisor/status.go
@@ -19,20 +19,34 @@ import "time"
 type NodeState string
 
 const (
-	StateStopped  NodeState = "stopped"
-	StateStarting NodeState = "starting"
-	StateSyncing  NodeState = "syncing"
-	StateReady    NodeState = "ready"
-	StateError    NodeState = "error"
+	StateStopped       NodeState = "stopped"
+	StateStarting      NodeState = "starting"
+	StateBootstrapping NodeState = "bootstrapping"
+	StateSyncing       NodeState = "syncing"
+	StateReady         NodeState = "ready"
+	StateError         NodeState = "error"
 )
+
+// BootstrapProgress is a snapshot of an in-flight Mithril bootstrap, flattened
+// from dingo's mithril.SyncProgress for the API. It is set while
+// StateBootstrapping and retained in StateError as a diagnostic (how far the
+// bootstrap got before failing); any other state clears it.
+type BootstrapProgress struct {
+	Phase           string  `json:"phase"`
+	Percent         float64 `json:"percent"`
+	BytesDownloaded int64   `json:"bytes_downloaded,omitempty"`
+	TotalBytes      int64   `json:"total_bytes,omitempty"`
+	BytesPerSecond  float64 `json:"bytes_per_second,omitempty"`
+}
 
 // Status is a point-in-time snapshot of the embedded node, serialised by the API.
 type Status struct {
-	State           NodeState  `json:"state"`
-	Tip             uint64     `json:"tip"` // latest block slot known to the node
-	LatestBlockTime *time.Time `json:"latestBlockTime,omitempty"`
-	CaughtUp        bool       `json:"caughtUp"`
-	Err             string     `json:"error,omitempty"`
+	State           NodeState          `json:"state"`
+	Tip             uint64             `json:"tip"` // latest block slot known to the node
+	LatestBlockTime *time.Time         `json:"latestBlockTime,omitempty"`
+	CaughtUp        bool               `json:"caughtUp"`
+	Bootstrap       *BootstrapProgress `json:"bootstrap,omitempty"`
+	Err             string             `json:"error,omitempty"`
 }
 
 // caughtUp reports whether the latest block is recent enough to consider the

--- a/ui/internal/supervisor/status_test.go
+++ b/ui/internal/supervisor/status_test.go
@@ -14,6 +14,8 @@
 package supervisor
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -57,5 +59,33 @@ func TestDeriveState(t *testing.T) {
 				t.Fatalf("deriveState() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestStatusBootstrapSerialisation(t *testing.T) {
+	// Omitted when nil.
+	b, err := json.Marshal(Status{State: StateSyncing})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "bootstrap") {
+		t.Fatalf("nil Bootstrap should be omitted, got %s", b)
+	}
+
+	// Present (with progress) when bootstrapping.
+	s := Status{
+		State:     StateBootstrapping,
+		Bootstrap: &BootstrapProgress{Phase: "ledger_import", Percent: 42.5, BytesDownloaded: 10, TotalBytes: 20, BytesPerSecond: 5},
+	}
+	b, err = json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	if !strings.Contains(got, `"state":"bootstrapping"`) {
+		t.Fatalf("missing bootstrapping state: %s", got)
+	}
+	if !strings.Contains(got, `"phase":"ledger_import"`) || !strings.Contains(got, `"percent":42.5`) {
+		t.Fatalf("missing bootstrap progress: %s", got)
 	}
 }

--- a/ui/internal/supervisor/supervisor.go
+++ b/ui/internal/supervisor/supervisor.go
@@ -38,17 +38,23 @@ type Config struct {
 	Logger         *slog.Logger
 	// CaughtUpThreshold is how recent the latest block must be to be "ready".
 	CaughtUpThreshold time.Duration
+	// MithrilEnabled bootstraps a fresh node DB from a Mithril snapshot before
+	// serving. The zero value is false (genesis sync); main.go enables it by
+	// default and BURSA_SYNC=genesis opts out.
+	MithrilEnabled bool
 }
 
 // Supervisor owns the embedded Dingo node's lifecycle and exposes its status.
 type Supervisor struct {
 	cfg    Config
 	cancel context.CancelFunc
+	runID  uint64
 
 	mu     sync.RWMutex
 	status Status
 
-	now func() time.Time // injectable clock for tests
+	now          func() time.Time // injectable clock for tests
+	bootstrapper Bootstrapper     // injectable for tests
 }
 
 func New(cfg Config) *Supervisor {
@@ -59,9 +65,10 @@ func New(cfg Config) *Supervisor {
 		cfg.Logger = slog.Default()
 	}
 	return &Supervisor{
-		cfg:    cfg,
-		status: Status{State: StateStopped},
-		now:    time.Now,
+		cfg:          cfg,
+		status:       Status{State: StateStopped},
+		now:          time.Now,
+		bootstrapper: mithrilBootstrapper{logger: cfg.Logger},
 	}
 }
 
@@ -76,6 +83,8 @@ func (s *Supervisor) Start(ctx context.Context) error {
 		return errors.New("supervisor already started")
 	}
 	runCtx, cancel := context.WithCancel(ctx)
+	s.runID++
+	runID := s.runID
 	s.cancel = cancel
 	s.mu.Unlock()
 
@@ -83,7 +92,9 @@ func (s *Supervisor) Start(ctx context.Context) error {
 	// before the node goroutine is launched.
 	fail := func(err error) error {
 		s.mu.Lock()
-		s.cancel = nil
+		if s.activeRunLocked(runID) {
+			s.cancel = nil
+		}
 		s.mu.Unlock()
 		cancel()
 		return err
@@ -114,19 +125,94 @@ func (s *Supervisor) Start(ctx context.Context) error {
 		}),
 		dingo.WithLogger(s.cfg.Logger),
 	)
-	node, err := dingo.New(nodeCfg)
-	if err != nil {
-		return fail(fmt.Errorf("create node: %w", err))
-	}
-	s.setState(StateStarting)
-
-	go func() {
-		if err := node.Run(runCtx); err != nil && runCtx.Err() == nil {
-			s.setError(err)
+	// launch creates the node, marks it starting, and begins serving + polling.
+	// Used by both the direct and post-bootstrap paths.
+	launch := func() error {
+		node, err := dingo.New(nodeCfg)
+		if err != nil {
+			return err
 		}
-	}()
-	go s.pollLoop(runCtx)
+		s.setStateForRun(runID, StateStarting)
+		go func() {
+			if err := node.Run(runCtx); err != nil && runCtx.Err() == nil {
+				s.setErrorForRun(runID, err)
+			}
+		}()
+		go s.pollLoop(runCtx, runID)
+		return nil
+	}
+
+	if !shouldBootstrap(s.cfg.MithrilEnabled, s.cfg.DataDir) {
+		if err := launch(); err != nil {
+			return fail(fmt.Errorf("create node: %w", err))
+		}
+		return nil
+	}
+
+	// Mithril bootstrap path: run asynchronously so /status stays live; node
+	// creation is deferred until the snapshot import finishes (mithril.Sync and
+	// the node cannot both hold the DB).
+	s.setStateForRun(runID, StateBootstrapping)
+	go s.bootstrapThenLaunch(runCtx, runID, launch)
 	return nil
+}
+
+// bootstrapThenLaunch runs the Mithril bootstrap and, on success, records the
+// completion marker and launches the node. Any failure → StateError (no fallback).
+func (s *Supervisor) bootstrapThenLaunch(ctx context.Context, runID uint64, launch func() error) {
+	err := s.bootstrapper.Bootstrap(ctx, BootstrapParams{
+		Network: s.cfg.Network,
+		DataDir: s.cfg.DataDir,
+		OnProgress: func(bp BootstrapProgress) {
+			s.onProgressForRun(runID, bp)
+		},
+	})
+	if err != nil {
+		// A bootstrap aborted by context cancellation (Stop or parent shutdown)
+		// is an orderly wind-down, not a failure — same guard as node.Run.
+		if ctx.Err() == nil {
+			s.setErrorForRun(runID, fmt.Errorf("mithril bootstrap: %w", err))
+		}
+		return
+	}
+	if ctx.Err() != nil {
+		return
+	}
+	// Record completion before launch, deliberately: mithril.Sync's success
+	// contract is a complete, servable DB, while a launch failure (dingo.New
+	// only validates config) is not something a re-bootstrap can fix. An
+	// unwritten marker here would make the next start re-download the entire
+	// snapshot over an already-complete DB.
+	if err := markBootstrapDone(s.cfg.DataDir); err != nil {
+		if ctx.Err() == nil {
+			s.setErrorForRun(runID, fmt.Errorf("record bootstrap completion: %w", err))
+		}
+		return
+	}
+	if ctx.Err() != nil {
+		return
+	}
+	if err := launch(); err != nil {
+		if ctx.Err() == nil {
+			s.setErrorForRun(runID, fmt.Errorf("create node: %w", err))
+		}
+	}
+}
+
+// onProgress stores the latest bootstrap progress on the status snapshot.
+func (s *Supervisor) onProgress(bp BootstrapProgress) {
+	s.onProgressForRun(s.currentRunID(), bp)
+}
+
+func (s *Supervisor) onProgressForRun(runID uint64, bp BootstrapProgress) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Once the supervisor is torn down or a newer run has started, a late
+	// callback from an old bootstrap must not write into the current snapshot.
+	if !s.activeRunLocked(runID) || s.status.State != StateBootstrapping {
+		return
+	}
+	s.status.Bootstrap = &bp
 }
 
 // Stop cancels the node's context and marks the supervisor stopped.
@@ -138,6 +224,7 @@ func (s *Supervisor) Stop() {
 	// can't race between the unlock and the state write.
 	s.cancel = nil
 	s.status.State = StateStopped
+	s.status.Bootstrap = nil // a clean shutdown is not a diagnostic failure
 	s.mu.Unlock()
 	if cancel != nil {
 		cancel()
@@ -152,22 +239,61 @@ func (s *Supervisor) Status() Status {
 }
 
 func (s *Supervisor) setState(st NodeState) {
+	s.setStateForRun(s.currentRunID(), st)
+}
+
+func (s *Supervisor) setStateForRun(runID uint64, st NodeState) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Once the supervisor is torn down or a newer run has started, a late
+	// goroutine must not resurrect or mutate the current run's state.
+	if !s.activeRunLocked(runID) {
+		return
+	}
 	s.status.State = st
+	if st != StateBootstrapping {
+		s.status.Bootstrap = nil
+	}
 }
 
 func (s *Supervisor) setError(err error) {
+	s.setErrorForRun(s.currentRunID(), err)
+}
+
+func (s *Supervisor) setErrorForRun(runID uint64, err error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	// If the supervisor was already torn down or a newer run has started, don't
+	// override the current run's terminal state.
+	if !s.activeRunLocked(runID) {
+		s.mu.Unlock()
+		return
+	}
+	cancel := s.cancel
+	s.cancel = nil
 	s.status.State = StateError
+	// Status.Bootstrap is intentionally retained on error so /status shows how
+	// far a bootstrap got before failing (diagnostics).
 	s.status.Err = err.Error()
+	s.mu.Unlock()
+	// Wind down the node/poll-loop goroutines and free the start guard so the
+	// supervisor can be started again after the failure.
+	cancel()
+}
+
+func (s *Supervisor) currentRunID() uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.runID
+}
+
+func (s *Supervisor) activeRunLocked(runID uint64) bool {
+	return s.cancel != nil && s.runID == runID
 }
 
 // pollLoop polls the node's own loopback Blockfrost endpoint for the latest
 // block and updates Status. Reaching the node over the wire (not via internals)
 // is deliberate — it is the same pattern every subsystem uses.
-func (s *Supervisor) pollLoop(ctx context.Context) {
+func (s *Supervisor) pollLoop(ctx context.Context, runID uint64) {
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 	url := fmt.Sprintf("http://127.0.0.1:%d/api/v0/blocks/latest", s.cfg.BlockfrostPort)
@@ -182,7 +308,7 @@ func (s *Supervisor) pollLoop(ctx context.Context) {
 			s.mu.Lock()
 			// Don't move off a terminal/stopped state; once Stop sets
 			// StateStopped, a late poll must not revert it to syncing/ready.
-			if s.status.State != StateError && s.status.State != StateStopped {
+			if s.activeRunLocked(runID) && s.status.State != StateError && s.status.State != StateStopped {
 				s.status.State = deriveState(ok, isCaughtUp)
 				// CaughtUp must reflect every poll, not just successful ones: a
 				// failed poll yields isCaughtUp=false, so updating it here keeps

--- a/ui/internal/supervisor/supervisor_integration_test.go
+++ b/ui/internal/supervisor/supervisor_integration_test.go
@@ -54,3 +54,57 @@ func TestSupervisorBootsPreview(t *testing.T) {
 	}
 	t.Fatalf("node did not reach syncing within deadline; last state=%s", s.Status().State)
 }
+
+func TestMithrilBootstrapLivePreview(t *testing.T) {
+	dir := t.TempDir()
+	sup := New(Config{
+		Network:        "preview",
+		DataDir:        filepath.Join(dir, "db"),
+		SocketPath:     filepath.Join(dir, "node.socket"),
+		UtxorpcPort:    0,
+		BlockfrostPort: 0, // disabled; this test checks bootstrap→serving transitions, not the HTTP surface
+		MithrilEnabled: true,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := sup.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer sup.Stop()
+
+	// Expect a bootstrapping phase first, with progress, then a servable node.
+	sawBootstrapping := false
+	deadline := time.Now().Add(20 * time.Minute) // a preview snapshot import can take a while
+	// Clamp to the harness deadline (default -timeout is 10m) so the test fails
+	// its own check with a real message instead of the binary's timeout panic.
+	if d, ok := t.Deadline(); ok && d.Before(deadline) {
+		deadline = d.Add(-15 * time.Second)
+	}
+	for {
+		st := sup.Status()
+		switch st.State {
+		case StateBootstrapping:
+			sawBootstrapping = true
+			if st.Bootstrap != nil {
+				t.Logf("bootstrap: phase=%s percent=%.1f", st.Bootstrap.Phase, st.Bootstrap.Percent)
+			}
+		case StateSyncing, StateReady:
+			// The DB dir is a fresh TempDir and Start sets StateBootstrapping
+			// synchronously, so missing the window means the Mithril path was
+			// never exercised — that's a failure, not a benign race.
+			if !sawBootstrapping {
+				t.Fatal("node became servable without an observed bootstrapping window; Mithril path not exercised")
+			}
+			if st.Bootstrap != nil {
+				t.Fatalf("Bootstrap should be cleared once serving, got %+v", st.Bootstrap)
+			}
+			return // success
+		case StateError:
+			t.Fatalf("bootstrap errored: %s", st.Err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("did not reach a servable state in time (a full run needs -timeout 25m or more); last = %s", st.State)
+		}
+		time.Sleep(3 * time.Second)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable Mithril fast-sync for the embedded node to cut first-run sync time. Adds a bootstrapping phase with live progress and gates wallet reads until the node is serving.

- New Features
  - Fast-sync via Mithril is on by default; set BURSA_SYNC=genesis to opt out.
  - New bootstrapping state with `/status.bootstrap` progress (phase, percent, bytes, rate); progress is retained on error and cleared once serving.
  - Wallet endpoints return 503 while bootstrapping to avoid inconsistent reads.
  - Writes `.mithril-bootstrap-complete` to skip bootstrap on later starts.
  - Allows a one-time, certificate-verified Mithril snapshot download; no wallet data egress.

- Dependencies
  - Upgrade `github.com/blinklabs-io/dingo` to v0.53.0.

<sup>Written for commit a309ea01e868db2bcd43dd25638f1fdf294c3278. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

