### PR TITLE
feat(signer): improved implementation

### DIFF
--- a/cmd/bursa/signer.go
+++ b/cmd/bursa/signer.go
@@ -48,9 +48,10 @@ func signerCommand() *cobra.Command {
 		Short: "Run the Cardano remote signing service",
 		Long: `Run the Cardano remote signing service.
 
-Authentication note: Phase 1 uses HS256 JWT (single trust domain) — ANY
-valid token may use ANY configured key. Per-caller key scoping arrives with
-the JWKS follow-up.`,
+Authentication: configure exactly one of signer.jwt_secret (HS256, dev/simple)
+or signer.jwks_url (RS256/ES256/EdDSA via JWKS, production). Optional
+signer.jwt_issuer / signer.jwt_audience are enforced when set. Without a
+signer.callers ACL, any valid token may use any configured key.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			logger := logging.GetLogger()
 
@@ -63,6 +64,23 @@ the JWKS follow-up.`,
 			if err != nil {
 				logger.Error("failed to load config", "error", err)
 				os.Exit(1)
+			}
+
+			// Cheap config validation before any expensive I/O.
+			hasSecret := cfg.Signer.JWTSecret != ""
+			hasJWKS := cfg.Signer.JWKSURL != ""
+			if hasSecret == hasJWKS {
+				logger.Error("exactly one of signer.jwt_secret and signer.jwks_url must be set")
+				os.Exit(1)
+			}
+			aclMap, err := signer.BuildCallerACL(cfg.Signer.Callers)
+			if err != nil {
+				logger.Error("invalid signer.callers", "error", err)
+				os.Exit(1)
+			}
+			acl := api.NewCallerACL(aclMap)
+			if !acl.Restricted() {
+				logger.Warn("no signer.callers configured; any valid token may use any configured key")
 			}
 
 			// Signal-cancellable root context for graceful shutdown.
@@ -117,20 +135,32 @@ the JWKS follow-up.`,
 				Metrics:   m,
 			})
 
-			if cfg.Signer.JWTSecret == "" {
-				logger.Error("signer.jwt_secret is required")
-				os.Exit(1)
+			var validate api.Validator
+			if hasJWKS {
+				validate, err = api.JWKSValidator(ctx, cfg.Signer.JWKSURL, cfg.Signer.JWTIssuer, cfg.Signer.JWTAudience)
+				if err != nil {
+					logger.Error("failed to initialize JWKS validator", "error", err)
+					os.Exit(1)
+				}
+			} else {
+				// Require a minimum of 32 bytes so the shared secret is not
+				// trivially brute-forceable.
+				if len(cfg.Signer.JWTSecret) < 32 {
+					logger.Error("signer.jwt_secret must be at least 32 bytes")
+					os.Exit(1)
+				}
+				validate = api.HS256Validator([]byte(cfg.Signer.JWTSecret), cfg.Signer.JWTIssuer, cfg.Signer.JWTAudience)
 			}
-			// Fix 3: require a minimum of 32 bytes so the shared secret is not
-			// trivially brute-forceable.
-			if len(cfg.Signer.JWTSecret) < 32 {
-				logger.Error("signer.jwt_secret must be at least 32 bytes")
-				os.Exit(1)
+			// Both auth modes enforce jwt_issuer/jwt_audience when set; warn when
+			// either is unset so operators know any-issuer / any-audience tokens
+			// are accepted.
+			if cfg.Signer.JWTIssuer == "" {
+				logger.Warn("signer.jwt_issuer is not set; tokens from any issuer signed by a trusted key will be accepted")
 			}
-			// Phase 1 HS256 auth is a single trust domain — ANY valid token may
-			// use ANY configured key; per-caller key scoping arrives with the
-			// JWKS follow-up.
-			srv := api.NewServer(coord, resolver, api.HS256Validator([]byte(cfg.Signer.JWTSecret)))
+			if cfg.Signer.JWTAudience == "" {
+				logger.Warn("signer.jwt_audience is not set; tokens for any audience signed by a trusted key will be accepted")
+			}
+			srv := api.NewServer(coord, resolver, eng, acl, validate)
 
 			mux := http.NewServeMux()
 			mux.Handle("/v1/", srv.Handler())

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.8
 require (
 	cloud.google.com/go/secretmanager v1.20.0
 	filippo.io/edwards25519 v1.2.0
+	github.com/MicahParks/keyfunc/v3 v3.8.0
 	github.com/blinklabs-io/go-bip39 v0.2.0
 	github.com/blinklabs-io/gouroboros v0.183.0
 	github.com/btcsuite/btcd/btcutil v1.2.0
@@ -14,6 +15,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/gowebpki/jcs v1.0.1
+	github.com/hashicorp/vault/api v1.23.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
@@ -52,6 +54,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.56.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.56.0 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
+	github.com/MicahParks/jwkset v0.11.0 // indirect
 	github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 // indirect
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.7 // indirect
@@ -124,7 +127,6 @@ require (
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
-	github.com/hashicorp/vault/api v1.23.0 // indirect
 	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.195 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,10 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.56.0/go.mod h1:6ZZMQhZKDvUvkJw2rc+oDP90tMMzuU/J+5HG1ZmPOmE=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
+github.com/MicahParks/jwkset v0.11.0 h1:yc0zG+jCvZpWgFDFmvs8/8jqqVBG9oyIbmBtmjOhoyQ=
+github.com/MicahParks/jwkset v0.11.0/go.mod h1:U2oRhRaLgDCLjtpGL2GseNKGmZtLs/3O7p+OZaL5vo0=
+github.com/MicahParks/keyfunc/v3 v3.8.0 h1:Hx2dgIjAXGk9slakM6rV9BOeaWDPEXXZ4Us8guNBfds=
+github.com/MicahParks/keyfunc/v3 v3.8.0/go.mod h1:z66bkCviwqfg2YUp+Jcc/xRE9IXLcMq6DrgV/+Htru0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,11 +39,22 @@ type SignerConfig struct {
 	ListenAddress string                `yaml:"listen_address" envconfig:"SIGNER_LISTEN_ADDRESS"`
 	ListenPort    uint                  `yaml:"listen_port"    envconfig:"SIGNER_LISTEN_PORT"`
 	JWTSecret     string                `yaml:"jwt_secret"     envconfig:"SIGNER_JWT_SECRET"`
+	JWKSURL       string                `yaml:"jwks_url"       envconfig:"SIGNER_JWKS_URL"`
+	JWTIssuer     string                `yaml:"jwt_issuer"     envconfig:"SIGNER_JWT_ISSUER"`
+	JWTAudience   string                `yaml:"jwt_audience"   envconfig:"SIGNER_JWT_AUDIENCE"`
 	TLSCertFile   string                `yaml:"tls_cert_file"  envconfig:"SIGNER_TLS_CERT_FILE"`
 	TLSKeyFile    string                `yaml:"tls_key_file"   envconfig:"SIGNER_TLS_KEY_FILE"`
 	Watermark     SignerWatermarkConfig `yaml:"watermark"`
 	Backends      []SignerBackendConfig `yaml:"backends"`
 	Keys          []SignerKeyConfig     `yaml:"keys"`
+	Callers       []SignerCallerConfig  `yaml:"callers"`
+}
+
+// SignerCallerConfig grants a JWT subject access to specific keys.
+// When any callers are configured, unlisted subjects are denied all keys.
+type SignerCallerConfig struct {
+	Subject string   `yaml:"subject"`
+	Keys    []string `yaml:"keys"` // key hashes (hex blake2b-224)
 }
 
 // SignerWatermarkConfig configures the anti-double-sign watermark store.
@@ -55,13 +66,21 @@ type SignerWatermarkConfig struct {
 
 // SignerBackendConfig configures a key-custody backend.
 type SignerBackendConfig struct {
-	Name          string `yaml:"name"`
-	Type          string `yaml:"type"`           // "software" | "sops" | "vault"
-	Path          string `yaml:"path"`           // software: key dir
-	PassphraseEnv string `yaml:"passphrase_env"` // reserved for sops follow-up; not yet honored
-	SecretPrefix  string `yaml:"secret_prefix"`  // sops
-	Address       string `yaml:"address"`        // vault
-	TransitMount  string `yaml:"transit_mount"`  // vault
+	Name          string                   `yaml:"name"`
+	Type          string                   `yaml:"type"`           // "software" | "sops" | "vault"
+	Path          string                   `yaml:"path"`           // software: key dir
+	PassphraseEnv string                   `yaml:"passphrase_env"` // software: env var holding the key-file passphrase
+	SecretPrefix  string                   `yaml:"secret_prefix"`  // sops: secret short-name prefix within google.project
+	Address       string                   `yaml:"address"`        // vault
+	TransitMount  string                   `yaml:"transit_mount"`  // vault
+	TokenEnv      string                   `yaml:"token_env"`      // vault: env var holding the token (default VAULT_TOKEN)
+	Keys          []SignerBackendKeyConfig `yaml:"keys"`           // vault: explicit transit key list
+}
+
+// SignerBackendKeyConfig names a remote key and its Cardano key type.
+type SignerBackendKeyConfig struct {
+	Name string `yaml:"name"`
+	Type string `yaml:"type"` // payment|stake|drep|cc-hot|cc-cold|pool|policy
 }
 
 // SignerKeyConfig mirrors policy.KeyPolicy in YAML; mapped at setup time.

--- a/internal/signer/api/acl.go
+++ b/internal/signer/api/acl.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import "github.com/blinklabs-io/bursa/internal/signer/backend"
+
+// CallerACL maps authenticated JWT subjects to the key hashes they may use.
+// A nil or empty ACL is unrestricted (single trust domain). When restricted,
+// unlisted callers are denied all keys (fail closed).
+type CallerACL struct {
+	byCaller map[string]map[backend.KeyHash]bool
+}
+
+// NewCallerACL builds an ACL from subject → permitted key hashes.
+func NewCallerACL(entries map[string][]backend.KeyHash) *CallerACL {
+	if len(entries) == 0 {
+		return &CallerACL{}
+	}
+	m := make(map[string]map[backend.KeyHash]bool, len(entries))
+	for sub, hashes := range entries {
+		set := make(map[backend.KeyHash]bool, len(hashes))
+		for _, h := range hashes {
+			set[h] = true
+		}
+		m[sub] = set
+	}
+	return &CallerACL{byCaller: m}
+}
+
+// Restricted reports whether the ACL constrains callers at all.
+func (a *CallerACL) Restricted() bool { return a != nil && len(a.byCaller) > 0 }
+
+// Allows reports whether caller may use the key. Unrestricted ACLs allow all.
+func (a *CallerACL) Allows(caller string, hash backend.KeyHash) bool {
+	// Explicit nil/empty guard (rather than delegating to Restricted) so the
+	// non-nil receiver is provable at the byCaller dereference below.
+	if a == nil || len(a.byCaller) == 0 {
+		return true
+	}
+	return a.byCaller[caller][hash]
+}

--- a/internal/signer/api/acl_test.go
+++ b/internal/signer/api/acl_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/bursa/internal/signer/backend"
+)
+
+func TestCallerACL(t *testing.T) {
+	var h1, h2 backend.KeyHash
+	h1[0] = 1
+	h2[0] = 2
+
+	var nilACL *CallerACL
+	if !nilACL.Allows("anyone", h1) {
+		t.Fatal("nil ACL must be unrestricted")
+	}
+	if nilACL.Restricted() {
+		t.Fatal("nil ACL must not be restricted")
+	}
+	empty := NewCallerACL(nil)
+	if empty.Restricted() {
+		t.Fatal("empty ACL must be unrestricted")
+	}
+
+	acl := NewCallerACL(map[string][]backend.KeyHash{"alice": {h1}})
+	if !acl.Restricted() {
+		t.Fatal("expected restricted")
+	}
+	if !acl.Allows("alice", h1) {
+		t.Fatal("alice should have h1")
+	}
+	if acl.Allows("alice", h2) {
+		t.Fatal("alice should not have h2")
+	}
+	if acl.Allows("bob", h1) {
+		t.Fatal("unlisted caller should be denied")
+	}
+
+	// A subject explicitly listed with an empty key set must be locked out.
+	carol := NewCallerACL(map[string][]backend.KeyHash{"carol": {}})
+	if !carol.Restricted() {
+		t.Fatal("expected restricted")
+	}
+	if carol.Allows("carol", h1) {
+		t.Fatal("subject with empty keys list must be locked out")
+	}
+}

--- a/internal/signer/api/auth.go
+++ b/internal/signer/api/auth.go
@@ -20,10 +20,14 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
+	"github.com/MicahParks/keyfunc/v3"
+	"github.com/blinklabs-io/bursa/internal/signer/backend"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -41,13 +45,21 @@ func CallerFromContext(ctx context.Context) string {
 type Validator func(token string) (subject string, err error)
 
 // HS256Validator validates HS256 tokens against a shared secret (dev/simple mode).
-// Production deployments use a JWKS-backed validator (RS256/ES256); the interface
-// is identical.
-//
-// Single trust domain: Phase 1 HS256 auth grants ANY holder of a valid token
-// access to ANY configured key. Per-caller key scoping arrives with the JWKS
-// follow-up.
-func HS256Validator(secret []byte) Validator {
+// Production deployments should prefer JWKSValidator. issuer and audience are
+// enforced when non-empty, identically to JWKSValidator. Without a configured
+// caller ACL (signer.callers), any holder of a valid token may use any
+// configured key.
+func HS256Validator(secret []byte, issuer, audience string) Validator {
+	opts := []jwt.ParserOption{
+		jwt.WithExpirationRequired(),
+		jwt.WithValidMethods([]string{"HS256"}),
+	}
+	if issuer != "" {
+		opts = append(opts, jwt.WithIssuer(issuer))
+	}
+	if audience != "" {
+		opts = append(opts, jwt.WithAudience(audience))
+	}
 	return func(token string) (string, error) {
 		claims := jwt.RegisteredClaims{}
 		_, err := jwt.ParseWithClaims(token, &claims, func(t *jwt.Token) (any, error) {
@@ -56,14 +68,56 @@ func HS256Validator(secret []byte) Validator {
 			}
 			return secret, nil
 		},
-			jwt.WithExpirationRequired(),
-			jwt.WithValidMethods([]string{"HS256"}),
+			opts...,
 		)
 		if err != nil {
 			return "", err
 		}
 		return claims.Subject, nil
 	}
+}
+
+// JWKSValidator validates RS256/ES256/EdDSA bearer tokens against a remote
+// JWKS endpoint. The JWKS is fetched at construction — a misconfigured or
+// unreachable endpoint fails boot — and refreshed in the background by keyfunc
+// (1 h interval, rate-limited unknown-kid refresh). issuer and audience are
+// enforced when non-empty. This is the production validator (design §12);
+// HS256Validator remains for dev/simple deployments.
+//
+// Plain http is rejected unless the host is loopback (dev escape hatch).
+func JWKSValidator(ctx context.Context, jwksURL, issuer, audience string) (Validator, error) {
+	u, err := url.Parse(jwksURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid jwks url: %w", err)
+	}
+	if u.Scheme != "https" && !backend.IsLoopbackHost(u.Hostname()) {
+		return nil, errors.New("jwks_url must use https; plain http is allowed only for loopback addresses")
+	}
+
+	noError := false
+	kf, err := keyfunc.NewDefaultOverrideCtx(ctx, []string{jwksURL}, keyfunc.Override{
+		NoErrorReturnFirstHTTPReq: &noError,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fetch jwks %q: %w", jwksURL, err)
+	}
+	opts := []jwt.ParserOption{
+		jwt.WithExpirationRequired(),
+		jwt.WithValidMethods([]string{"RS256", "ES256", "EdDSA"}),
+	}
+	if issuer != "" {
+		opts = append(opts, jwt.WithIssuer(issuer))
+	}
+	if audience != "" {
+		opts = append(opts, jwt.WithAudience(audience))
+	}
+	return func(token string) (string, error) {
+		claims := jwt.RegisteredClaims{}
+		if _, err := jwt.ParseWithClaims(token, &claims, kf.Keyfunc, opts...); err != nil {
+			return "", err
+		}
+		return claims.Subject, nil
+	}, nil
 }
 
 // write401 sends a properly-formed JSON 401 with WWW-Authenticate header.

--- a/internal/signer/api/auth_test.go
+++ b/internal/signer/api/auth_test.go
@@ -15,9 +15,13 @@
 package api
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -48,7 +52,7 @@ func TestJWTMiddleware(t *testing.T) {
 		}
 		w.WriteHeader(http.StatusOK)
 	})
-	h := JWTMiddleware(HS256Validator(secret), next)
+	h := JWTMiddleware(HS256Validator(secret, "", ""), next)
 
 	// valid
 	req := httptest.NewRequest(http.MethodGet, "/v1/keys", nil)
@@ -82,7 +86,7 @@ func Test401JSON(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	h := JWTMiddleware(HS256Validator(secret), next)
+	h := JWTMiddleware(HS256Validator(secret, "", ""), next)
 
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/keys", nil))
@@ -110,7 +114,7 @@ func TestNegativeAuthCases(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	h := JWTMiddleware(HS256Validator(secret), next)
+	h := JWTMiddleware(HS256Validator(secret, "", ""), next)
 
 	t.Run("alg=none", func(t *testing.T) {
 		// Mint a "none" token; HS256Validator must reject it.
@@ -201,7 +205,7 @@ func TestHandlerIntegration(t *testing.T) {
 	srv, _ := newTestServer(t)
 
 	// Replace the validator so it validates our secret.
-	srv.validate = HS256Validator(secret)
+	srv.validate = HS256Validator(secret, "", "")
 
 	handler := srv.Handler()
 
@@ -212,5 +216,204 @@ func TestHandlerIntegration(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("integration GET /v1/keys: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func rsaJWKSServer(t *testing.T, pub *rsa.PublicKey, kid string) *httptest.Server {
+	t.Helper()
+	n := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+	body := fmt.Sprintf(`{"keys":[{"kty":"RSA","kid":"%s","alg":"RS256","use":"sig","n":"%s","e":"%s"}]}`, kid, n, e)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, body)
+	}))
+}
+
+func rs256Token(t *testing.T, priv *rsa.PrivateKey, kid string, claims jwt.RegisteredClaims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = kid
+	s, err := tok.SignedString(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func TestJWKSValidator(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := rsaJWKSServer(t, &priv.PublicKey, "test-kid")
+	defer ts.Close()
+
+	validate, err := JWKSValidator(context.Background(), ts.URL, "https://issuer.example", "")
+	if err != nil {
+		t.Fatalf("JWKSValidator: %v", err)
+	}
+
+	good := jwt.RegisteredClaims{
+		Subject:   "alice",
+		Issuer:    "https://issuer.example",
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}
+	sub, err := validate(rs256Token(t, priv, "test-kid", good))
+	if err != nil {
+		t.Fatalf("valid token rejected: %v", err)
+	}
+	if sub != "alice" {
+		t.Fatalf("expected subject alice, got %q", sub)
+	}
+
+	wrongIssuer := good
+	wrongIssuer.Issuer = "https://evil.example"
+	if _, err := validate(rs256Token(t, priv, "test-kid", wrongIssuer)); err == nil {
+		t.Fatal("wrong issuer accepted")
+	}
+
+	expired := good
+	expired.ExpiresAt = jwt.NewNumericDate(time.Now().Add(-time.Hour))
+	if _, err := validate(rs256Token(t, priv, "test-kid", expired)); err == nil {
+		t.Fatal("expired token accepted")
+	}
+
+	// HS256 tokens must be rejected even if "signed" with something.
+	hsTok := jwt.NewWithClaims(jwt.SigningMethodHS256, good)
+	hs, _ := hsTok.SignedString([]byte("0123456789abcdef0123456789abcdef"))
+	if _, err := validate(hs); err == nil {
+		t.Fatal("HS256 token accepted by JWKS validator")
+	}
+
+	if _, err := validate(rs256Token(t, priv, "unknown-kid", good)); err == nil {
+		t.Fatal("unknown kid accepted")
+	}
+}
+
+// TestJWKSValidator_RejectsPlainHTTPNonLoopback verifies that JWKSValidator
+// refuses to construct when the JWKS URL uses plain http on a non-loopback host.
+// Added as the failing test for Fix 1 (HTTPS enforcement).
+func TestJWKSValidator_RejectsPlainHTTPNonLoopback(t *testing.T) {
+	_, err := JWKSValidator(context.Background(), "http://idp.example.com/jwks.json", "", "")
+	if err == nil {
+		t.Fatal("expected error for plain http JWKS URL on non-loopback host")
+	}
+}
+
+// TestJWKSValidator_FailsFastOnUnreachableJWKS verifies that JWKSValidator
+// returns an error at construction time when the JWKS endpoint is unreachable.
+// Added as the failing test for Fix 2 (fail-fast boot).
+func TestJWKSValidator_FailsFastOnUnreachableJWKS(t *testing.T) {
+	_, err := JWKSValidator(context.Background(), "http://127.0.0.1:1/jwks.json", "", "")
+	if err == nil {
+		t.Fatal("expected construction error for unreachable JWKS endpoint")
+	}
+}
+
+// TestJWKSValidator_NoKidSingleKey pins the behavior for tokens without a kid
+// header when the JWKS contains a single key. keyfunc falls back to trying the
+// full key set, so these tokens should verify successfully.
+// Added as the pinning test for Fix 4.
+func TestJWKSValidator_NoKidSingleKey(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := rsaJWKSServer(t, &priv.PublicKey, "test-kid")
+	defer ts.Close()
+
+	validate, err := JWKSValidator(context.Background(), ts.URL, "", "")
+	if err != nil {
+		t.Fatalf("JWKSValidator: %v", err)
+	}
+	claims := jwt.RegisteredClaims{
+		Subject:   "alice",
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims) // no kid header
+	s, err := tok.SignedString(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// keyfunc falls back to the full key set when kid is absent; with a single
+	// JWKS key this verifies. Pinned so a keyfunc bump can't silently change it.
+	if sub, err := validate(s); err != nil || sub != "alice" {
+		t.Fatalf("no-kid token against single-key JWKS: sub=%q err=%v", sub, err)
+	}
+}
+
+func TestJWKSValidator_Audience(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := rsaJWKSServer(t, &priv.PublicKey, "test-kid")
+	defer ts.Close()
+
+	validate, err := JWKSValidator(context.Background(), ts.URL, "", "bursa-signer")
+	if err != nil {
+		t.Fatalf("JWKSValidator: %v", err)
+	}
+	good := jwt.RegisteredClaims{
+		Subject:   "alice",
+		Audience:  jwt.ClaimStrings{"bursa-signer"},
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}
+	if _, err := validate(rs256Token(t, priv, "test-kid", good)); err != nil {
+		t.Fatalf("valid audience rejected: %v", err)
+	}
+	bad := good
+	bad.Audience = jwt.ClaimStrings{"other-service"}
+	if _, err := validate(rs256Token(t, priv, "test-kid", bad)); err == nil {
+		t.Fatal("wrong audience accepted")
+	}
+}
+
+// hs256Token mints an HS256 token with the given registered claims.
+func hs256Token(t *testing.T, secret []byte, claims jwt.RegisteredClaims) string {
+	t.Helper()
+	s, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(secret)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return s
+}
+
+// TestHS256Validator_IssuerAudience verifies the shared-secret validator
+// enforces issuer and audience claims when configured, matching JWKSValidator.
+func TestHS256Validator_IssuerAudience(t *testing.T) {
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	validate := HS256Validator(secret, "https://issuer.example", "bursa-signer")
+
+	good := jwt.RegisteredClaims{
+		Subject:   "alice",
+		Issuer:    "https://issuer.example",
+		Audience:  jwt.ClaimStrings{"bursa-signer"},
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}
+	if _, err := validate(hs256Token(t, secret, good)); err != nil {
+		t.Fatalf("valid issuer+audience rejected: %v", err)
+	}
+
+	wrongIssuer := good
+	wrongIssuer.Issuer = "https://evil.example"
+	if _, err := validate(hs256Token(t, secret, wrongIssuer)); err == nil {
+		t.Fatal("wrong issuer accepted")
+	}
+
+	wrongAudience := good
+	wrongAudience.Audience = jwt.ClaimStrings{"other-service"}
+	if _, err := validate(hs256Token(t, secret, wrongAudience)); err == nil {
+		t.Fatal("wrong audience accepted")
+	}
+
+	// A token missing the configured claims must also be rejected.
+	missing := jwt.RegisteredClaims{
+		Subject:   "alice",
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}
+	if _, err := validate(hs256Token(t, secret, missing)); err == nil {
+		t.Fatal("token missing issuer/audience accepted")
 	}
 }

--- a/internal/signer/api/server.go
+++ b/internal/signer/api/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/blinklabs-io/bursa/internal/logging"
 	"github.com/blinklabs-io/bursa/internal/signer"
 	"github.com/blinklabs-io/bursa/internal/signer/backend"
+	"github.com/blinklabs-io/bursa/internal/signer/policy"
 	"github.com/google/uuid"
 )
 
@@ -53,27 +54,40 @@ type SignCIP8Response struct {
 	Key       string `json:"key"`
 }
 
+// KeyPolicySummary is the effective policy returned on the key-detail
+// endpoint. Absent policy means the key can sign nothing (deny-by-default).
+type KeyPolicySummary struct {
+	AllowedRequests []string           `json:"allowed_requests"`
+	Tx              *policy.TxPolicy   `json:"tx_policy,omitempty"`
+	CIP8            *policy.CIP8Policy `json:"cip8_policy,omitempty"`
+}
+
 // KeyInfo describes an available key.
 type KeyInfo struct {
-	Hash     string `json:"hash"`
-	Type     string `json:"type"`
-	Extended bool   `json:"extended"`
-	Backend  string `json:"backend"`
+	Hash     string            `json:"hash"`
+	Type     string            `json:"type"`
+	Extended bool              `json:"extended"`
+	Backend  string            `json:"backend"`
+	Policy   *KeyPolicySummary `json:"policy,omitempty"` // detail endpoint only
 }
 
 // Server holds the HTTP dependencies.
 type Server struct {
 	coord    *signer.Coordinator
 	resolver *backend.Resolver
+	policies *policy.Engine
+	acl      *CallerACL
 	validate Validator
 	logger   *slog.Logger
 }
 
 // NewServer builds the API server. The logger defaults to logging.GetLogger().
-func NewServer(coord *signer.Coordinator, resolver *backend.Resolver, validate Validator) *Server {
+func NewServer(coord *signer.Coordinator, resolver *backend.Resolver, policies *policy.Engine, acl *CallerACL, validate Validator) *Server {
 	return &Server{
 		coord:    coord,
 		resolver: resolver,
+		policies: policies,
+		acl:      acl,
 		validate: validate,
 		logger:   logging.GetLogger(),
 	}
@@ -140,7 +154,31 @@ func (s *Server) handleSign(w http.ResponseWriter, r *http.Request) {
 
 	switch req.Type {
 	case "tx":
-		res, perr, err := s.coord.SignTx(r.Context(), []byte(req.Cbor), req.Signers)
+		signers := req.Signers
+		var aclDenied []signer.SignerError
+		if s.acl.Restricted() {
+			signers = make([]string, 0, len(req.Signers))
+			for _, sg := range req.Signers {
+				// Must stay consistent with the coordinator's own ResolveSigner resolution.
+				h, err := signer.ResolveSigner(sg)
+				if err == nil && !s.acl.Allows(caller, h) {
+					// Sign-path ACL denials are counted; list/get-key filtering is view filtering, not a deny event.
+					s.coord.Metrics().ObserveDeny("acl")
+					aclDenied = append(aclDenied, signer.SignerError{
+						Signer: sg, Code: signer.CodeDenied, Reason: "caller is not authorized for this key",
+					})
+					continue
+				}
+				// Unresolvable signers fall through; the coordinator reports them.
+				signers = append(signers, sg)
+			}
+			if len(signers) == 0 && len(aclDenied) > 0 {
+				s.audit(r, caller, "tx", "denied", "audit_id", auditID, "signers", req.Signers, "reason", "caller ACL")
+				writeJSON(w, http.StatusForbidden, SignTxResponse{AuditID: auditID, Errors: aclDenied})
+				return
+			}
+		}
+		res, perr, err := s.coord.SignTx(r.Context(), []byte(req.Cbor), signers)
 		if err != nil {
 			if signer.IsBadRequest(err) {
 				s.audit(r, caller, "tx", "bad_request", "audit_id", auditID, "signers", req.Signers, "error", err.Error())
@@ -157,24 +195,36 @@ func (s *Server) handleSign(w http.ResponseWriter, r *http.Request) {
 			writeErr(w, http.StatusInternalServerError, "internal server error")
 			return
 		}
-		// If nothing signed and we have errors, surface the first error's status.
-		if len(res.Witnesses) == 0 && len(perr) > 0 {
-			st := codeToStatus(perr[0].Code)
-			masked := maskSignerErrors(perr)
+		// ACL pre-filter denials are reported in the response body alongside the
+		// coordinator's per-signer results, but they must NOT drive HTTP status
+		// selection: an ACL denial is always 403, so prepending it would mask a
+		// coordinator bad_request/not_found/backend error (e.g. report 400 as
+		// 403). Keep them separate and pick status from the coordinator errors.
+		allErrs := append(aclDenied, perr...)
+		// If nothing signed and we have errors, surface a representative status.
+		if len(res.Witnesses) == 0 && len(allErrs) > 0 {
+			// Prefer the coordinator's actual signing errors; only fall back to
+			// the ACL denials when there are no coordinator errors.
+			primary := allErrs[0]
+			if len(perr) > 0 {
+				primary = perr[0]
+			}
+			st := codeToStatus(primary.Code)
+			masked := maskSignerErrors(allErrs)
 			// Log original (unmasked) reasons server-side before sending masked response.
 			s.logger.Error("SignTx signer errors",
 				"caller", caller,
 				"audit_id", auditID,
 				"tx_id", res.TxID,
-				"errors", perr,
+				"errors", allErrs,
 			)
-			s.audit(r, caller, "tx", string(perr[0].Code), "audit_id", auditID, "tx_id", res.TxID, "signers", req.Signers, "signer_errors", len(perr))
+			s.audit(r, caller, "tx", string(primary.Code), "audit_id", auditID, "tx_id", res.TxID, "signers", req.Signers, "signer_errors", len(allErrs))
 			writeJSON(w, st, SignTxResponse{AuditID: auditID, TxID: res.TxID, Errors: masked})
 			return
 		}
-		masked := maskSignerErrors(perr)
-		if len(perr) > 0 {
-			s.logger.Warn("SignTx partial failure", "audit_id", auditID, "errors", perr, "caller", caller)
+		masked := maskSignerErrors(allErrs)
+		if len(allErrs) > 0 {
+			s.logger.Warn("SignTx partial failure", "audit_id", auditID, "errors", allErrs, "caller", caller)
 		}
 		resp := SignTxResponse{AuditID: auditID, TxID: res.TxID, Errors: masked}
 		for _, wit := range res.Witnesses {
@@ -197,6 +247,15 @@ func (s *Server) handleSign(w http.ResponseWriter, r *http.Request) {
 			s.audit(r, caller, "cip8", "bad_request", "audit_id", auditID, "key", req.Key, "address", req.Address)
 			writeErr(w, http.StatusBadRequest, "invalid payload hex")
 			return
+		}
+		if s.acl.Restricted() {
+			h, err := backend.ParseKeyHash(req.Key)
+			if err == nil && !s.acl.Allows(caller, h) {
+				s.coord.Metrics().ObserveDeny("acl")
+				s.audit(r, caller, "cip8", "denied", "audit_id", auditID, "key", req.Key, "reason", "caller ACL")
+				writeErr(w, http.StatusForbidden, "caller is not authorized for this key")
+				return
+			}
 		}
 		res, code, err := s.coord.SignCIP8(r.Context(), payload, req.Address, req.Key)
 		if err != nil {
@@ -266,8 +325,12 @@ func (s *Server) handleListKeys(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusInternalServerError, "internal server error")
 		return
 	}
+	caller := CallerFromContext(r.Context())
 	out := make([]KeyInfo, 0, len(keys))
 	for _, k := range keys {
+		if !s.acl.Allows(caller, k.Hash()) {
+			continue
+		}
 		out = append(out, KeyInfo{Hash: k.Hash().String(), Type: string(k.Type()), Extended: k.Extended(), Backend: k.Backend()})
 	}
 	writeJSON(w, http.StatusOK, out)
@@ -278,6 +341,11 @@ func (s *Server) handleGetKey(w http.ResponseWriter, r *http.Request) {
 	h, err := backend.ParseKeyHash(hashStr)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, "invalid key hash")
+		return
+	}
+	if !s.acl.Allows(CallerFromContext(r.Context()), h) {
+		// 404 (not 403) so restricted callers cannot probe for key existence.
+		writeErr(w, http.StatusNotFound, "key not found")
 		return
 	}
 	ref, err := s.resolver.Resolve(r.Context(), h)
@@ -291,7 +359,23 @@ func (s *Server) handleGetKey(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusInternalServerError, "internal server error")
 		return
 	}
-	writeJSON(w, http.StatusOK, KeyInfo{Hash: ref.Hash().String(), Type: string(ref.Type()), Extended: ref.Extended(), Backend: ref.Backend()})
+	info := KeyInfo{Hash: ref.Hash().String(), Type: string(ref.Type()), Extended: ref.Extended(), Backend: ref.Backend()}
+	if s.policies != nil {
+		if p, ok := s.policies.PolicyFor(h); ok {
+			// Normalize to a non-nil slice so the wire format is always an
+			// array, never null.
+			reqs := p.AllowedRequests
+			if reqs == nil {
+				reqs = []string{}
+			}
+			info.Policy = &KeyPolicySummary{
+				AllowedRequests: reqs,
+				Tx:              p.Tx,
+				CIP8:            p.CIP8,
+			}
+		}
+	}
+	writeJSON(w, http.StatusOK, info)
 }
 
 // Handler returns the authenticated mux for the signer API.

--- a/internal/signer/api/server_test.go
+++ b/internal/signer/api/server_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/blinklabs-io/bursa/internal/signer/policy"
 	"github.com/blinklabs-io/bursa/internal/signer/watermark"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // minimal fake Cardano returning a fixed inspection/txid/assembled blob
@@ -57,7 +58,7 @@ func newTestServer(t *testing.T) (*Server, backend.KeyHash) {
 		Watermark: watermark.NewMemWatermark(),
 		Cardano:   operation.Cardano(fakeCardano{pub: pub}),
 	})
-	return NewServer(coord, backend.NewResolver(b), func(string) (string, error) { return "tester", nil }), h
+	return NewServer(coord, backend.NewResolver(b), eng, nil, func(string) (string, error) { return "tester", nil }), h
 }
 
 func TestHandleSignTx(t *testing.T) {
@@ -206,6 +207,372 @@ func TestHandleGetKey(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 		if rr.Code != http.StatusNotFound {
 			t.Fatalf("expected 404, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+}
+
+// withCaller returns a copy of r with the given caller subject injected into
+// its context (mimics what JWTMiddleware does).
+func withCaller(r *http.Request, subject string) *http.Request {
+	ctx := context.WithValue(r.Context(), callerKey, subject)
+	return r.WithContext(ctx)
+}
+
+// gatherDenyACL gathers the current bursa_signer_deny_total{reason="acl"}
+// sample value from g.
+func gatherDenyACL(t *testing.T, g prometheus.Gatherer) float64 {
+	t.Helper()
+	mfs, err := g.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != "bursa_signer_deny_total" {
+			continue
+		}
+		for _, mm := range mf.GetMetric() {
+			for _, lp := range mm.GetLabel() {
+				if lp.GetName() == "reason" && lp.GetValue() == "acl" {
+					return mm.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// TestCallerACLEnforcement verifies per-caller key scoping (design §12).
+func TestCallerACLEnforcement(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	b := backend.NewSoftwareBackend("software")
+	h, err := b.AddKey(&bursa.LoadedKey{SKey: []byte(priv), VKey: pub}, backend.KeyTypePayment)
+	if err != nil {
+		t.Fatalf("AddKey: %v", err)
+	}
+	pol := policy.KeyPolicy{Hash: h.String(), AllowedRequests: []string{"tx", "cip8"}, Tx: &policy.TxPolicy{}, CIP8: &policy.CIP8Policy{}}
+	eng, _ := policy.NewEngine([]policy.KeyPolicy{pol})
+	coord := signer.New(signer.Deps{
+		Resolver:  backend.NewResolver(b),
+		Policy:    eng,
+		Watermark: watermark.NewMemWatermark(),
+		Cardano:   operation.Cardano(fakeCardano{pub: pub}),
+	})
+
+	// Register metrics once into a dedicated registry for all sub-tests.
+	metricsReg := prometheus.NewRegistry()
+	coord.Metrics().Register(metricsReg)
+
+	// ACL: only "alice" may use the test key; "bob" is unlisted.
+	acl := NewCallerACL(map[string][]backend.KeyHash{"alice": {h}})
+	srv := NewServer(coord, backend.NewResolver(b), eng, acl, func(string) (string, error) { return "tester", nil })
+
+	t.Run("bob: sign tx returns 403 with denied signer error and increments deny_total", func(t *testing.T) {
+		before := gatherDenyACL(t, metricsReg)
+		body, _ := json.Marshal(SignRequest{Type: "tx", Cbor: "83a0a0f5f6", Signers: []string{h.String()}})
+		req := httptest.NewRequest(http.MethodPost, "/v1/sign", bytes.NewReader(body))
+		req = withCaller(req, "bob")
+		rr := httptest.NewRecorder()
+		srv.handleSign(rr, req)
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("expected 403 for bob, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var resp SignTxResponse
+		if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(resp.Errors) == 0 || resp.Errors[0].Code != signer.CodeDenied {
+			t.Fatalf("expected denied signer error, got %+v", resp.Errors)
+		}
+		after := gatherDenyACL(t, metricsReg)
+		if delta := after - before; delta != 1 {
+			t.Fatalf("expected deny_total{reason=acl} to increase by 1, got delta %v", delta)
+		}
+	})
+
+	t.Run("bob: cip8 sign returns 403 and increments deny_total", func(t *testing.T) {
+		before := gatherDenyACL(t, metricsReg)
+		body, _ := json.Marshal(SignRequest{
+			Type:    "cip8",
+			Payload: "abcd",
+			Address: "addr1q8gg9j5vkzsgz4dz3gfr4kz0f2nwzrqq0yfktqmwwpmaprkl43c7c4d9rg9rmk6z03rl4xt9gjtywtx0m09flxmqzq46ugh",
+			Key:     h.String(),
+		})
+		req := httptest.NewRequest(http.MethodPost, "/v1/sign", bytes.NewReader(body))
+		req = withCaller(req, "bob")
+		rr := httptest.NewRecorder()
+		srv.handleSign(rr, req)
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("expected 403 for bob cip8, got %d: %s", rr.Code, rr.Body.String())
+		}
+		after := gatherDenyACL(t, metricsReg)
+		if delta := after - before; delta != 1 {
+			t.Fatalf("expected deny_total{reason=acl} to increase by 1, got delta %v", delta)
+		}
+	})
+
+	t.Run("bob: list keys returns empty list (view filter, not counted)", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/keys", nil)
+		req = withCaller(req, "bob")
+		rr := httptest.NewRecorder()
+		srv.handleListKeys(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rr.Code)
+		}
+		var keys []KeyInfo
+		if err := json.Unmarshal(rr.Body.Bytes(), &keys); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(keys) != 0 {
+			t.Fatalf("expected empty key list for bob, got %d keys", len(keys))
+		}
+	})
+
+	t.Run("bob: get key by hash returns 404 (no existence oracle)", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/keys/"+h.String(), nil)
+		req.SetPathValue("hash", h.String())
+		req = withCaller(req, "bob")
+		rr := httptest.NewRecorder()
+		srv.handleGetKey(rr, req)
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("expected 404 for bob on key detail, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("alice: list keys returns the key", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/keys", nil)
+		req = withCaller(req, "alice")
+		rr := httptest.NewRecorder()
+		srv.handleListKeys(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rr.Code)
+		}
+		var keys []KeyInfo
+		if err := json.Unmarshal(rr.Body.Bytes(), &keys); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(keys) != 1 || keys[0].Hash != h.String() {
+			t.Fatalf("expected alice to see test key, got %+v", keys)
+		}
+	})
+
+	t.Run("alice: get key by hash returns 200", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/keys/"+h.String(), nil)
+		req.SetPathValue("hash", h.String())
+		req = withCaller(req, "alice")
+		rr := httptest.NewRecorder()
+		srv.handleGetKey(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200 for alice on key detail, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+}
+
+// TestCallerACL_PartialAllow verifies that a request with two signers — one
+// ACL-allowed (signed successfully) and one ACL-denied — returns 200 with one
+// witness and one error entry with code "denied".
+func TestCallerACL_PartialAllow(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	b := backend.NewSoftwareBackend("software")
+	h, err := b.AddKey(&bursa.LoadedKey{SKey: []byte(priv), VKey: pub}, backend.KeyTypePayment)
+	if err != nil {
+		t.Fatalf("AddKey: %v", err)
+	}
+	pol := policy.KeyPolicy{Hash: h.String(), AllowedRequests: []string{"tx"}, Tx: &policy.TxPolicy{}}
+	eng, _ := policy.NewEngine([]policy.KeyPolicy{pol})
+	coord := signer.New(signer.Deps{
+		Resolver:  backend.NewResolver(b),
+		Policy:    eng,
+		Watermark: watermark.NewMemWatermark(),
+		Cardano:   operation.Cardano(fakeCardano{pub: pub}),
+	})
+
+	// Second signer: valid 56-hex key hash that is not in the backend and not
+	// ACL-allowed for "alice". Any all-zero-ish unique hash works.
+	var deniedHash backend.KeyHash
+	deniedHash[0] = 0xde
+	deniedHash[1] = 0xad
+
+	// ACL: alice may use h but NOT deniedHash.
+	acl := NewCallerACL(map[string][]backend.KeyHash{"alice": {h}})
+	srv := NewServer(coord, backend.NewResolver(b), eng, acl, func(string) (string, error) { return "tester", nil })
+
+	body, _ := json.Marshal(SignRequest{
+		Type:    "tx",
+		Cbor:    "83a0a0f5f6",
+		Signers: []string{h.String(), deniedHash.String()},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/sign", bytes.NewReader(body))
+	req = withCaller(req, "alice")
+	rr := httptest.NewRecorder()
+	srv.handleSign(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for partial allow, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp SignTxResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Witnesses) != 1 {
+		t.Fatalf("expected exactly 1 witness for the allowed signer, got %d", len(resp.Witnesses))
+	}
+	if len(resp.Errors) != 1 {
+		t.Fatalf("expected exactly 1 error for the denied signer, got %d: %+v", len(resp.Errors), resp.Errors)
+	}
+	if resp.Errors[0].Code != signer.CodeDenied {
+		t.Fatalf("expected denied error code, got %q: %+v", resp.Errors[0].Code, resp.Errors[0])
+	}
+	if resp.Errors[0].Reason != "caller is not authorized for this key" {
+		t.Fatalf("unexpected deny reason: %q", resp.Errors[0].Reason)
+	}
+}
+
+// TestSignTx_StatusFromCoordinatorNotACL verifies that when a tx fully fails
+// with a mix of an ACL pre-filter denial (always 403) and a coordinator
+// per-signer error, the HTTP status reflects the coordinator error rather than
+// the ACL denial. Prepending the ACL denial used to mask, e.g., a 404 as a 403.
+func TestSignTx_StatusFromCoordinatorNotACL(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	b := backend.NewSoftwareBackend("software")
+	if _, err := b.AddKey(&bursa.LoadedKey{SKey: []byte(priv), VKey: pub}, backend.KeyTypePayment); err != nil {
+		t.Fatalf("AddKey: %v", err)
+	}
+	eng, _ := policy.NewEngine(nil)
+	coord := signer.New(signer.Deps{
+		Resolver:  backend.NewResolver(b),
+		Policy:    eng,
+		Watermark: watermark.NewMemWatermark(),
+		Cardano:   operation.Cardano(fakeCardano{pub: pub}),
+	})
+
+	// allowedMissing: ACL-allowed for "alice" but absent from the backend, so the
+	// coordinator returns not_found (404). deniedHash: not ACL-allowed (403).
+	var allowedMissing backend.KeyHash
+	allowedMissing[0] = 0xa1
+	var deniedHash backend.KeyHash
+	deniedHash[0] = 0xde
+	deniedHash[1] = 0xad
+
+	acl := NewCallerACL(map[string][]backend.KeyHash{"alice": {allowedMissing}})
+	srv := NewServer(coord, backend.NewResolver(b), eng, acl, func(string) (string, error) { return "tester", nil })
+
+	body, _ := json.Marshal(SignRequest{
+		Type:    "tx",
+		Cbor:    "83a0a0f5f6",
+		Signers: []string{allowedMissing.String(), deniedHash.String()},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/sign", bytes.NewReader(body))
+	req = withCaller(req, "alice")
+	rr := httptest.NewRecorder()
+	srv.handleSign(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 from coordinator not_found, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp SignTxResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Both failures must still be reported in the body.
+	var sawDenied, sawNotFound bool
+	for _, e := range resp.Errors {
+		switch e.Code {
+		case signer.CodeDenied:
+			sawDenied = true
+		case signer.CodeNotFound:
+			sawNotFound = true
+		}
+	}
+	if !sawDenied || !sawNotFound {
+		t.Fatalf("expected both denied and not_found errors in body, got %+v", resp.Errors)
+	}
+}
+
+// TestGetKey_PolicySummary verifies that GET /v1/keys/{hash} includes the
+// effective policy when a policy entry exists, and omits it (null/absent) when
+// the engine has no entry for the key (deny-by-default, design §8 + §10).
+func TestGetKey_PolicySummary(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	b := backend.NewSoftwareBackend("software")
+	h, err := b.AddKey(&bursa.LoadedKey{SKey: []byte(priv), VKey: pub}, backend.KeyTypePayment)
+	if err != nil {
+		t.Fatalf("AddKey: %v", err)
+	}
+
+	t.Run("key with policy returns policy summary", func(t *testing.T) {
+		eng, err := policy.NewEngine([]policy.KeyPolicy{{
+			Hash:            h.String(),
+			AllowedRequests: []string{"tx"},
+			Tx:              &policy.TxPolicy{MaxOutputAda: 5000},
+		}})
+		if err != nil {
+			t.Fatalf("NewEngine: %v", err)
+		}
+		coord := signer.New(signer.Deps{
+			Resolver:  backend.NewResolver(b),
+			Policy:    eng,
+			Watermark: watermark.NewMemWatermark(),
+			Cardano:   operation.Cardano(fakeCardano{pub: pub}),
+		})
+		srv := NewServer(coord, backend.NewResolver(b), eng, nil, func(string) (string, error) { return "tester", nil })
+		handler := srv.Handler()
+
+		req := httptest.NewRequest(http.MethodGet, "/v1/keys/"+h.String(), nil)
+		req.Header.Set("Authorization", "Bearer x")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var info KeyInfo
+		if err := json.Unmarshal(rr.Body.Bytes(), &info); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if info.Policy == nil {
+			t.Fatal("expected non-nil policy summary")
+		}
+		if len(info.Policy.AllowedRequests) != 1 || info.Policy.AllowedRequests[0] != "tx" {
+			t.Errorf("expected AllowedRequests=[tx], got %v", info.Policy.AllowedRequests)
+		}
+		if info.Policy.Tx == nil {
+			t.Fatal("expected non-nil Tx policy")
+		}
+		if info.Policy.Tx.MaxOutputAda != 5000 {
+			t.Errorf("expected MaxOutputAda=5000, got %d", info.Policy.Tx.MaxOutputAda)
+		}
+		if info.Policy.CIP8 != nil {
+			t.Errorf("expected nil CIP8 policy, got %+v", info.Policy.CIP8)
+		}
+	})
+
+	t.Run("key without policy entry returns null policy (deny-by-default)", func(t *testing.T) {
+		// Engine has no entry for h — deny-by-default.
+		eng, err := policy.NewEngine([]policy.KeyPolicy{})
+		if err != nil {
+			t.Fatalf("NewEngine: %v", err)
+		}
+		coord := signer.New(signer.Deps{
+			Resolver:  backend.NewResolver(b),
+			Policy:    eng,
+			Watermark: watermark.NewMemWatermark(),
+			Cardano:   operation.Cardano(fakeCardano{pub: pub}),
+		})
+		srv := NewServer(coord, backend.NewResolver(b), eng, nil, func(string) (string, error) { return "tester", nil })
+		handler := srv.Handler()
+
+		req := httptest.NewRequest(http.MethodGet, "/v1/keys/"+h.String(), nil)
+		req.Header.Set("Authorization", "Bearer x")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var info KeyInfo
+		if err := json.Unmarshal(rr.Body.Bytes(), &info); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if info.Policy != nil {
+			t.Errorf("expected nil policy for key with no policy entry, got %+v", info.Policy)
 		}
 	})
 }

--- a/internal/signer/backend/sops.go
+++ b/internal/signer/backend/sops.go
@@ -61,7 +61,9 @@ func NewSopsBackend(name string, source SecretSource, decrypt DecryptFunc) *Sops
 	}
 }
 
-// Register declares a secret name to load and the key type it holds.
+// Register declares a secret name to load and the key type it holds. An empty
+// typ means the type is derived from the decrypted cardano-cli envelope at
+// Load time (see KeyTypeFromEnvelope).
 func (b *SopsBackend) Register(secretName string, typ KeyType) {
 	b.mu.Lock()
 	b.registered = append(b.registered, registered{name: secretName, typ: typ})
@@ -107,12 +109,17 @@ func (b *SopsBackend) Load(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("derive pubkey %q: %w", r.name, err)
 		}
+		// Empty registered type => infer from the envelope.
+		typ := r.typ
+		if typ == "" {
+			typ = KeyTypeFromEnvelope(lk.Type)
+		}
 		hash := HashPublicKey(pub)
 		newKeys[hash] = &softwareKey{
 			lk:          lk,
 			pub:         ed25519.PublicKey(pub),
 			hash:        hash,
-			typ:         r.typ,
+			typ:         typ,
 			extended:    len(lk.SKey) == 96,
 			backendName: b.name,
 		}

--- a/internal/signer/backend/sops_test.go
+++ b/internal/signer/backend/sops_test.go
@@ -120,3 +120,31 @@ func TestSopsBackend_Load_NilDependencies(t *testing.T) {
 		t.Fatalf("nil decrypt: got %v", err)
 	}
 }
+
+func TestSopsBackend_DerivesTypeFromEnvelope(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	seed := []byte(priv)[:32]
+	cborEncoded, err := cbor.Encode(seed)
+	if err != nil {
+		t.Fatalf("cbor.Encode seed: %v", err)
+	}
+	envelope := fmt.Sprintf(
+		`{"type":"StakeSigningKeyShelley_ed25519","description":"","cborHex":"%s"}`,
+		hex.EncodeToString(cborEncoded),
+	)
+	src := &fakeSecretSource{secrets: map[string][]byte{
+		"stake-1": []byte(envelope),
+	}}
+	b := NewSopsBackend("sops", src, func(d []byte) ([]byte, error) { return d, nil })
+	b.Register("stake-1", "")
+	if err := b.Load(context.Background()); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	keys, _ := b.ListKeys(context.Background())
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(keys))
+	}
+	if keys[0].Type() != KeyTypeStake {
+		t.Fatalf("expected derived type stake, got %q", keys[0].Type())
+	}
+}

--- a/internal/signer/backend/types.go
+++ b/internal/signer/backend/types.go
@@ -18,9 +18,22 @@ import (
 	"crypto/ed25519"
 	"encoding/hex"
 	"fmt"
+	"net/netip"
+	"strings"
 
 	"golang.org/x/crypto/blake2b"
 )
+
+// IsLoopbackHost reports whether host is localhost or a loopback IP.
+// Plaintext transport to a non-loopback host is a credential/key-substitution
+// vector; callers use this to gate http:// endpoints.
+func IsLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	addr, err := netip.ParseAddr(host)
+	return err == nil && addr.IsLoopback()
+}
 
 // KeyHash is the blake2b-224 hash of an Ed25519 public key — the canonical
 // cross-backend key identifier (the same value Cardano uses in addresses and
@@ -79,5 +92,30 @@ func (t KeyType) Valid() bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// KeyTypeFromEnvelope maps a cardano-cli key envelope Type string to the
+// KeyType used by the signer. Only signing-key (.skey) types are expected;
+// unknown types default to payment.
+func KeyTypeFromEnvelope(envelopeType string) KeyType {
+	switch {
+	case strings.HasPrefix(envelopeType, "Payment"):
+		return KeyTypePayment
+	case strings.HasPrefix(envelopeType, "StakePool"):
+		return KeyTypePool
+	case strings.HasPrefix(envelopeType, "Stake"):
+		return KeyTypeStake
+	case strings.HasPrefix(envelopeType, "DRep"):
+		return KeyTypeDRep
+	case strings.HasPrefix(envelopeType, "CommitteeHot"):
+		return KeyTypeCCHot
+	case strings.HasPrefix(envelopeType, "CommitteeCold"):
+		return KeyTypeCCCold
+	case strings.HasPrefix(envelopeType, "Policy"),
+		strings.HasPrefix(envelopeType, "Calidus"):
+		return KeyTypePolicy
+	default:
+		return KeyTypePayment
 	}
 }

--- a/internal/signer/backend/types_test.go
+++ b/internal/signer/backend/types_test.go
@@ -61,3 +61,23 @@ func TestKeyType_Valid(t *testing.T) {
 		t.Fatalf("bogus should be invalid")
 	}
 }
+
+func TestKeyTypeFromEnvelope(t *testing.T) {
+	cases := map[string]KeyType{
+		"PaymentSigningKeyShelley_ed25519":               KeyTypePayment,
+		"PaymentExtendedSigningKeyShelley_ed25519_bip32": KeyTypePayment,
+		"StakePoolSigningKey_ed25519":                    KeyTypePool,
+		"StakeSigningKeyShelley_ed25519":                 KeyTypeStake,
+		"DRepSigningKey_ed25519":                         KeyTypeDRep,
+		"CommitteeHotSigningKey_ed25519":                 KeyTypeCCHot,
+		"CommitteeColdSigningKey_ed25519":                KeyTypeCCCold,
+		"PolicySigningKey_ed25519":                       KeyTypePolicy,
+		"CalidusSigningKey_ed25519":                      KeyTypePolicy,
+		"SomethingUnknown":                               KeyTypePayment,
+	}
+	for in, want := range cases {
+		if got := KeyTypeFromEnvelope(in); got != want {
+			t.Errorf("KeyTypeFromEnvelope(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/signer/coordinator.go
+++ b/internal/signer/coordinator.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/bursa/internal/signer/backend"
@@ -105,11 +106,11 @@ func New(deps Deps) *Coordinator {
 	return &Coordinator{deps: deps}
 }
 
-// resolveSigner accepts a key-hash hex or a bech32 address and returns the key hash.
+// ResolveSigner accepts a key-hash hex or a bech32 address and returns the key hash.
 // For a payment-type address the payment key hash is used; for a stake-only address
 // (AddressTypeNoneKey, e.g. stake1…) the stake key hash is used. Addresses with no
 // key credential (script-only, pointer-only) return an error.
-func resolveSigner(s string) (backend.KeyHash, error) {
+func ResolveSigner(s string) (backend.KeyHash, error) {
 	if h, err := backend.ParseKeyHash(s); err == nil {
 		return h, nil
 	}
@@ -170,11 +171,12 @@ func (c *Coordinator) SignTx(ctx context.Context, cborInput []byte, signers []st
 		errs []SignerError
 	)
 	for _, s := range signers {
-		hash, err := resolveSigner(s)
+		hash, err := ResolveSigner(s)
 		if err != nil {
 			errs = append(errs, SignerError{Signer: s, Code: CodeBadRequest, Reason: err.Error()})
 			c.deps.Logger.Info("sign", "type", "tx", "caller-key", s, "txid", insp.TxId, "result", "denied", "reason", err.Error())
 			c.deps.Metrics.observe("tx", string(CodeBadRequest))
+			c.deps.Metrics.observeDeny(string(CodeBadRequest))
 			continue
 		}
 		ref, err := c.deps.Resolver.Resolve(ctx, hash)
@@ -182,18 +184,21 @@ func (c *Coordinator) SignTx(ctx context.Context, cborInput []byte, signers []st
 			errs = append(errs, SignerError{Signer: s, Code: CodeNotFound, Reason: "key not found"})
 			c.deps.Logger.Info("sign", "type", "tx", "caller-key", hash.String(), "txid", insp.TxId, "result", "denied", "reason", "key not found")
 			c.deps.Metrics.observe("tx", string(CodeNotFound))
+			c.deps.Metrics.observeDeny(string(CodeNotFound))
 			continue
 		}
 		if err != nil {
 			errs = append(errs, SignerError{Signer: s, Code: CodeBackend, Reason: err.Error()})
 			c.deps.Logger.Info("sign", "type", "tx", "caller-key", hash.String(), "txid", insp.TxId, "result", "error", "reason", err.Error())
 			c.deps.Metrics.observe("tx", string(CodeBackend))
+			c.deps.Metrics.observeBackendError("resolver")
 			continue
 		}
 		if dec := c.deps.Policy.EvaluateTx(hash, insp); !dec.Allow {
 			errs = append(errs, SignerError{Signer: s, Code: CodeDenied, Reason: dec.Reason})
 			c.deps.Logger.Info("sign", "type", "tx", "caller-key", hash.String(), "txid", insp.TxId, "result", "denied", "reason", dec.Reason)
 			c.deps.Metrics.observe("tx", string(CodeDenied))
+			c.deps.Metrics.observeDeny(string(CodeDenied))
 			continue
 		}
 		watermarkCommitted := false
@@ -203,11 +208,14 @@ func (c *Coordinator) SignTx(ctx context.Context, cborInput []byte, signers []st
 					errs = append(errs, SignerError{Signer: s, Code: CodeConflict, Reason: werr.Error()})
 					c.deps.Logger.Info("sign", "type", "tx", "caller-key", hash.String(), "txid", insp.TxId, "result", "denied", "reason", "watermark conflict")
 					c.deps.Metrics.observe("tx", string(CodeConflict))
+					c.deps.Metrics.observeDeny(string(CodeConflict))
+					c.deps.Metrics.observeWatermarkConflict()
 					continue
 				}
 				errs = append(errs, SignerError{Signer: s, Code: CodeBackend, Reason: werr.Error()})
 				c.deps.Logger.Info("sign", "type", "tx", "caller-key", hash.String(), "txid", insp.TxId, "result", "error", "reason", werr.Error())
 				c.deps.Metrics.observe("tx", string(CodeBackend))
+				c.deps.Metrics.observeBackendError("watermark")
 				continue
 			}
 			watermarkCommitted = true
@@ -215,15 +223,20 @@ func (c *Coordinator) SignTx(ctx context.Context, cborInput []byte, signers []st
 			if werr := c.deps.Watermark.Check(ctx, hash, scope, txid); werr != nil {
 				if errors.Is(werr, watermark.ErrConflict) {
 					c.deps.Logger.Warn("watermark conflict (warn mode)", "key", hash.String(), "scope", scope)
+					c.deps.Metrics.observeWatermarkConflict()
 				} else {
 					errs = append(errs, SignerError{Signer: s, Code: CodeBackend, Reason: werr.Error()})
 					c.deps.Logger.Info("sign", "type", "tx", "caller-key", hash.String(), "txid", insp.TxId, "result", "error", "reason", werr.Error())
 					c.deps.Metrics.observe("tx", string(CodeBackend))
+					c.deps.Metrics.observeBackendError("watermark")
 					continue
 				}
 			}
 		}
+		signStart := time.Now()
 		sig, err := ref.Sign(ctx, txid)
+		// Attempt latency, including failures — not successful-sign latency.
+		c.deps.Metrics.observeSignDuration(ref.Backend(), time.Since(signStart).Seconds())
 		if err != nil {
 			code := CodeBackend
 			if errors.Is(err, backend.ErrUnsupportedExtended) {
@@ -232,6 +245,11 @@ func (c *Coordinator) SignTx(ctx context.Context, cborInput []byte, signers []st
 			errs = append(errs, SignerError{Signer: s, Code: code, Reason: err.Error()})
 			c.deps.Logger.Info("sign", "type", "tx", "caller-key", hash.String(), "txid", insp.TxId, "result", "error", "reason", err.Error())
 			c.deps.Metrics.observe("tx", string(code))
+			if code == CodeBackend {
+				c.deps.Metrics.observeBackendError(ref.Backend())
+			} else {
+				c.deps.Metrics.observeDeny(string(code))
+			}
 			continue
 		}
 		pub := ref.PublicKey()
@@ -275,6 +293,9 @@ func (c *Coordinator) SignTx(ctx context.Context, cborInput []byte, signers []st
 	}
 	return res, errs, nil
 }
+
+// Metrics returns the coordinator's metrics instance (never nil after New).
+func (c *Coordinator) Metrics() *Metrics { return c.deps.Metrics }
 
 // errBadRequest tags request-level decode failures so the API maps them to 400.
 var errBadRequest = errors.New("bad request")

--- a/internal/signer/coordinator_cip8.go
+++ b/internal/signer/coordinator_cip8.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/bursa/internal/signer/backend"
@@ -35,17 +36,20 @@ func (c *Coordinator) SignCIP8(ctx context.Context, payload []byte, address, key
 	if err != nil {
 		c.deps.Logger.Info("sign", "type", "cip8", "caller-key", keyID, "address", address, "result", "denied", "reason", "invalid key id")
 		c.deps.Metrics.observe("cip8", string(CodeBadRequest))
+		c.deps.Metrics.observeDeny(string(CodeBadRequest))
 		return nil, CodeBadRequest, fmt.Errorf("invalid key id: %w", err)
 	}
 	ref, err := c.deps.Resolver.Resolve(ctx, hash)
 	if errors.Is(err, backend.ErrKeyNotFound) {
 		c.deps.Logger.Info("sign", "type", "cip8", "caller-key", hash.String(), "address", address, "result", "denied", "reason", "key not found")
 		c.deps.Metrics.observe("cip8", string(CodeNotFound))
+		c.deps.Metrics.observeDeny(string(CodeNotFound))
 		return nil, CodeNotFound, errors.New("key not found")
 	}
 	if err != nil {
 		c.deps.Logger.Info("sign", "type", "cip8", "caller-key", hash.String(), "address", address, "result", "error", "reason", err.Error())
 		c.deps.Metrics.observe("cip8", string(CodeBackend))
+		c.deps.Metrics.observeBackendError("resolver")
 		return nil, CodeBackend, err
 	}
 
@@ -56,6 +60,7 @@ func (c *Coordinator) SignCIP8(ctx context.Context, payload []byte, address, key
 	if !ok {
 		c.deps.Logger.Info("sign", "type", "cip8", "caller-key", hash.String(), "address", address, "result", "denied", "reason", "unsupported backend for CIP-8")
 		c.deps.Metrics.observe("cip8", string(CodeUnsupported))
+		c.deps.Metrics.observeDeny(string(CodeUnsupported))
 		return nil, CodeUnsupported, fmt.Errorf("CIP-8 signing is not supported for keys held in the %q backend", ref.Backend())
 	}
 	lk := provider.LoadedKey()
@@ -64,6 +69,7 @@ func (c *Coordinator) SignCIP8(ctx context.Context, payload []byte, address, key
 	if err != nil {
 		c.deps.Logger.Info("sign", "type", "cip8", "caller-key", hash.String(), "address", address, "result", "denied", "reason", "invalid address")
 		c.deps.Metrics.observe("cip8", string(CodeBadRequest))
+		c.deps.Metrics.observeDeny(string(CodeBadRequest))
 		return nil, CodeBadRequest, fmt.Errorf("invalid address: %w", err)
 	}
 	// Mirror message.go validateAddressForVKey: payment-key addresses use
@@ -84,6 +90,7 @@ func (c *Coordinator) SignCIP8(ctx context.Context, payload []byte, address, key
 	if dec := c.deps.Policy.EvaluateCIP8(hash, len(payload), addressMatches); !dec.Allow {
 		c.deps.Logger.Info("sign", "type", "cip8", "caller-key", hash.String(), "address", address, "result", "denied", "reason", dec.Reason)
 		c.deps.Metrics.observe("cip8", string(CodeDenied))
+		c.deps.Metrics.observeDeny(string(CodeDenied))
 		return nil, CodeDenied, fmt.Errorf("%s", dec.Reason)
 	}
 
@@ -96,10 +103,14 @@ func (c *Coordinator) SignCIP8(ctx context.Context, payload []byte, address, key
 		return nil, CodeInternal, fmt.Errorf("address bytes: %w", err)
 	}
 
+	signStart := time.Now()
 	sigHex, keyHex, err := bursa.SignData(addrBytes, payload, lk)
+	// Attempt latency, including failures — not successful-sign latency.
+	c.deps.Metrics.observeSignDuration(ref.Backend(), time.Since(signStart).Seconds())
 	if err != nil {
 		c.deps.Logger.Info("sign", "type", "cip8", "caller-key", hash.String(), "address", address, "result", "error", "reason", err.Error())
 		c.deps.Metrics.observe("cip8", string(CodeBackend))
+		c.deps.Metrics.observeBackendError(ref.Backend())
 		return nil, CodeBackend, fmt.Errorf("cip8 sign: %w", err)
 	}
 

--- a/internal/signer/coordinator_cip8_test.go
+++ b/internal/signer/coordinator_cip8_test.go
@@ -69,7 +69,7 @@ func (k *loadedFakeKey) LoadedKey() *bursa.LoadedKey { return k.lk }
 // (Vault) key: CIP-8 must be rejected as unsupported.
 func TestSignCIP8_UnsupportedOnRemoteKey(t *testing.T) {
 	k := newFakeKey(t)
-	c := newCoordinator(t, k,
+	c, _ := newCoordinator(t, k,
 		policy.KeyPolicy{AllowedRequests: []string{"cip8"}, CIP8: &policy.CIP8Policy{}},
 		watermark.NewMemWatermark(), fakeCardano{})
 	_, code, err := c.SignCIP8(context.Background(), []byte("hi"), "addr1xyz", k.hash.String())

--- a/internal/signer/coordinator_test.go
+++ b/internal/signer/coordinator_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/blinklabs-io/bursa/internal/signer/policy"
 	"github.com/blinklabs-io/bursa/internal/signer/watermark"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 // --- fakes ---
@@ -85,20 +86,22 @@ func newFakeKey(t *testing.T) *fakeKey {
 	return &fakeKey{pub: pub, priv: priv, hash: backend.HashPublicKey(pub)}
 }
 
-func newCoordinator(t *testing.T, k *fakeKey, pol policy.KeyPolicy, wm watermark.Watermark, card operation.Cardano) *Coordinator {
+func newCoordinator(t *testing.T, k *fakeKey, pol policy.KeyPolicy, wm watermark.Watermark, card operation.Cardano) (*Coordinator, *Metrics) {
 	t.Helper()
 	pol.Hash = k.hash.String()
 	eng, err := policy.NewEngine([]policy.KeyPolicy{pol})
 	if err != nil {
 		t.Fatalf("NewEngine: %v", err)
 	}
+	m := NewMetrics()
 	return New(Deps{
 		Resolver:  backend.NewResolver(fakeBackend{key: k}),
 		Policy:    eng,
 		Watermark: wm,
 		WMMode:    watermark.ModeEnforce,
 		Cardano:   card,
-	})
+		Metrics:   m,
+	}), m
 }
 
 func TestSignTx_HappyPath(t *testing.T) {
@@ -108,7 +111,7 @@ func TestSignTx_HappyPath(t *testing.T) {
 		txid:      make([]byte, 32),
 		assembled: []byte{0x01, 0x02},
 	}
-	c := newCoordinator(t, k,
+	c, _ := newCoordinator(t, k,
 		policy.KeyPolicy{AllowedRequests: []string{"tx"}, Tx: &policy.TxPolicy{}},
 		watermark.NewMemWatermark(), card)
 
@@ -127,7 +130,7 @@ func TestSignTx_HappyPath(t *testing.T) {
 func TestSignTx_PolicyDeny(t *testing.T) {
 	k := newFakeKey(t)
 	card := fakeCardano{insp: &bursa.TxInspection{CertificateCount: 1}, txid: make([]byte, 32)}
-	c := newCoordinator(t, k,
+	c, m := newCoordinator(t, k,
 		policy.KeyPolicy{AllowedRequests: []string{"tx"}, Tx: &policy.TxPolicy{}}, // certs not allowed
 		watermark.NewMemWatermark(), card)
 
@@ -138,12 +141,15 @@ func TestSignTx_PolicyDeny(t *testing.T) {
 	if len(res.Witnesses) != 0 || len(perr) != 1 || perr[0].Code != CodeDenied {
 		t.Fatalf("expected one denied signer, got res=%+v perr=%+v", res, perr)
 	}
+	if got := testutil.ToFloat64(m.denials.WithLabelValues(string(CodeDenied))); got != 1 {
+		t.Fatalf("expected 1 policy denial metric, got %v", got)
+	}
 }
 
 func TestSignTx_UnknownKey(t *testing.T) {
 	k := newFakeKey(t)
 	card := fakeCardano{insp: &bursa.TxInspection{}, txid: make([]byte, 32)}
-	c := newCoordinator(t, k,
+	c, _ := newCoordinator(t, k,
 		policy.KeyPolicy{AllowedRequests: []string{"tx"}, Tx: &policy.TxPolicy{}},
 		watermark.NewMemWatermark(), card)
 
@@ -158,7 +164,7 @@ func TestSignTx_ExtendedOnUnsupportedBackend(t *testing.T) {
 	k := newFakeKey(t)
 	k.signErr = backend.ErrUnsupportedExtended
 	card := fakeCardano{insp: &bursa.TxInspection{}, txid: make([]byte, 32)}
-	c := newCoordinator(t, k,
+	c, _ := newCoordinator(t, k,
 		policy.KeyPolicy{AllowedRequests: []string{"tx"}, Tx: &policy.TxPolicy{}},
 		watermark.NewMemWatermark(), card)
 	_, perr, _ := c.SignTx(context.Background(), []byte("11"), []string{k.hash.String()})
@@ -180,12 +186,15 @@ func (conflictWatermark) Commit(context.Context, backend.KeyHash, string, []byte
 func TestSignTx_WatermarkConflict(t *testing.T) {
 	k := newFakeKey(t)
 	card := fakeCardano{insp: &bursa.TxInspection{}, txid: make([]byte, 32)}
-	c := newCoordinator(t, k,
+	c, m := newCoordinator(t, k,
 		policy.KeyPolicy{AllowedRequests: []string{"tx"}, Tx: &policy.TxPolicy{}},
 		conflictWatermark{}, card)
 	_, perr, _ := c.SignTx(context.Background(), []byte("11"), []string{k.hash.String()})
 	if len(perr) != 1 || perr[0].Code != CodeConflict {
 		t.Fatalf("expected conflict, got %+v", perr)
+	}
+	if got := testutil.ToFloat64(m.watermarkConflicts); got != 1 {
+		t.Fatalf("expected 1 watermark conflict metric, got %v", got)
 	}
 }
 
@@ -223,7 +232,7 @@ func stakeAddrForKey(t *testing.T, pub ed25519.PublicKey) string {
 	return addr.String()
 }
 
-// TestResolveSigner_Address verifies that resolveSigner accepts payment addresses,
+// TestResolveSigner_Address verifies that ResolveSigner accepts payment addresses,
 // stake addresses, and rejects garbage strings.
 func TestResolveSigner_Address(t *testing.T) {
 	pub, _, err := ed25519.GenerateKey(nil)
@@ -234,9 +243,9 @@ func TestResolveSigner_Address(t *testing.T) {
 
 	t.Run("payment address", func(t *testing.T) {
 		addr := paymentAddrForKey(t, pub)
-		got, err := resolveSigner(addr)
+		got, err := ResolveSigner(addr)
 		if err != nil {
-			t.Fatalf("resolveSigner(%q): %v", addr, err)
+			t.Fatalf("ResolveSigner(%q): %v", addr, err)
 		}
 		if got != wantHash {
 			t.Fatalf("payment addr: want %s, got %s", wantHash, got)
@@ -245,9 +254,9 @@ func TestResolveSigner_Address(t *testing.T) {
 
 	t.Run("stake address", func(t *testing.T) {
 		addr := stakeAddrForKey(t, pub)
-		got, err := resolveSigner(addr)
+		got, err := ResolveSigner(addr)
 		if err != nil {
-			t.Fatalf("resolveSigner(%q): %v", addr, err)
+			t.Fatalf("ResolveSigner(%q): %v", addr, err)
 		}
 		if got != wantHash {
 			t.Fatalf("stake addr: want %s, got %s", wantHash, got)
@@ -255,7 +264,7 @@ func TestResolveSigner_Address(t *testing.T) {
 	})
 
 	t.Run("garbage string", func(t *testing.T) {
-		_, err := resolveSigner("not-a-valid-anything")
+		_, err := ResolveSigner("not-a-valid-anything")
 		if err == nil {
 			t.Fatal("expected error for garbage signer string, got nil")
 		}
@@ -376,7 +385,7 @@ func TestSignTx_PartialSuccess(t *testing.T) {
 		txid:      make([]byte, 32),
 		assembled: []byte{0xAB},
 	}
-	c := newCoordinator(t, k,
+	c, _ := newCoordinator(t, k,
 		policy.KeyPolicy{AllowedRequests: []string{"tx"}, Tx: &policy.TxPolicy{}},
 		watermark.NewMemWatermark(), card)
 
@@ -397,7 +406,7 @@ func TestSignTx_PartialSuccess(t *testing.T) {
 func TestSignTx_NoSigners(t *testing.T) {
 	k := newFakeKey(t)
 	card := fakeCardano{insp: &bursa.TxInspection{}, txid: make([]byte, 32)}
-	c := newCoordinator(t, k,
+	c, _ := newCoordinator(t, k,
 		policy.KeyPolicy{AllowedRequests: []string{"tx"}, Tx: &policy.TxPolicy{}},
 		watermark.NewMemWatermark(), card)
 

--- a/internal/signer/gcpsecrets.go
+++ b/internal/signer/gcpsecrets.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	secretmanagerclient "cloud.google.com/go/secretmanager/apiv1"
+	secretmanager "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"github.com/blinklabs-io/bursa/internal/config"
+	"github.com/blinklabs-io/bursa/internal/signer/backend"
+	"google.golang.org/api/iterator"
+)
+
+// GCPSecretSource implements backend.SecretSource over GCP Secret Manager.
+// Secrets are matched by short-name prefix within the configured
+// google.project; payloads are the latest enabled secret version.
+// The client is used once at boot (SopsBackend.Load) and intentionally not
+// closed; the daemon holds one idle connection for its lifetime.
+type GCPSecretSource struct {
+	client gcpSecretClient
+	parent string // projects/<project>
+	prefix string // secret short-name prefix
+}
+
+type gcpSecretClient interface {
+	ListSecrets(context.Context, *secretmanager.ListSecretsRequest) gcpSecretIterator
+	ListSecretVersions(context.Context, *secretmanager.ListSecretVersionsRequest) gcpSecretVersionIterator
+	AccessSecretVersion(context.Context, *secretmanager.AccessSecretVersionRequest) (*secretmanager.AccessSecretVersionResponse, error)
+}
+
+type gcpSecretIterator interface {
+	Next() (*secretmanager.Secret, error)
+}
+
+type gcpSecretVersionIterator interface {
+	Next() (*secretmanager.SecretVersion, error)
+}
+
+type gcpSecretManagerClient struct {
+	*secretmanagerclient.Client
+}
+
+func (c gcpSecretManagerClient) ListSecrets(ctx context.Context, req *secretmanager.ListSecretsRequest) gcpSecretIterator {
+	return c.Client.ListSecrets(ctx, req)
+}
+
+func (c gcpSecretManagerClient) ListSecretVersions(ctx context.Context, req *secretmanager.ListSecretVersionsRequest) gcpSecretVersionIterator {
+	return c.Client.ListSecretVersions(ctx, req)
+}
+
+func (c gcpSecretManagerClient) AccessSecretVersion(ctx context.Context, req *secretmanager.AccessSecretVersionRequest) (*secretmanager.AccessSecretVersionResponse, error) {
+	return c.Client.AccessSecretVersion(ctx, req)
+}
+
+// newSopsSecretSource is a constructor seam so wiring tests can inject a fake.
+var newSopsSecretSource = func(ctx context.Context, c config.SignerBackendConfig) (backend.SecretSource, error) {
+	return NewGCPSecretSource(ctx, c.SecretPrefix)
+}
+
+// NewGCPSecretSource builds a SecretSource over GCP Secret Manager. The GCP
+// project comes from the global config singleton (google.project — one
+// project per process, as elsewhere in bursa); the secret prefix is
+// per-backend configuration (signer.backends[].secret_prefix).
+func NewGCPSecretSource(ctx context.Context, prefix string) (*GCPSecretSource, error) {
+	cfg := config.GetConfig()
+	if cfg.Google.Project == "" {
+		return nil, errors.New("google.project is required for the sops backend")
+	}
+	client, err := secretmanagerclient.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("secret manager client: %w", err)
+	}
+	return &GCPSecretSource{
+		client: gcpSecretManagerClient{Client: client},
+		parent: "projects/" + cfg.Google.Project,
+		prefix: prefix,
+	}, nil
+}
+
+// List returns the short names of secrets whose name begins with the prefix.
+func (s *GCPSecretSource) List(ctx context.Context) ([]string, error) {
+	req := &secretmanager.ListSecretsRequest{
+		Parent:   s.parent,
+		PageSize: 100,
+	}
+	if s.prefix != "" {
+		// Server-side narrowing filter to cut paging cost. The "name:" operator
+		// matches by substring containment, not true prefix, so this only
+		// reduces the candidate set; the authoritative prefix match is the
+		// client-side HasPrefix below.
+		req.Filter = "name:" + s.prefix
+	}
+	it := s.client.ListSecrets(ctx, req)
+	var out []string
+	for {
+		secret, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("list secrets: %w", err)
+		}
+		// secret.Name is the full resource name projects/<p>/secrets/<short>.
+		short := secret.GetName()
+		if i := strings.LastIndex(short, "/"); i >= 0 {
+			short = short[i+1:]
+		}
+		if s.prefix == "" || strings.HasPrefix(short, s.prefix) {
+			out = append(out, short)
+		}
+	}
+	return out, nil
+}
+
+// Get fetches the newest enabled version payload of the named secret.
+func (s *GCPSecretSource) Get(ctx context.Context, name string) ([]byte, error) {
+	versionName, err := s.latestEnabledVersion(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.client.AccessSecretVersion(ctx, &secretmanager.AccessSecretVersionRequest{
+		Name: versionName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("access secret %q: %w", name, err)
+	}
+	return resp.GetPayload().GetData(), nil
+}
+
+func (s *GCPSecretSource) latestEnabledVersion(ctx context.Context, name string) (string, error) {
+	it := s.client.ListSecretVersions(ctx, &secretmanager.ListSecretVersionsRequest{
+		Parent:   s.parent + "/secrets/" + name,
+		PageSize: 100,
+	})
+	for {
+		version, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("list secret versions %q: %w", name, err)
+		}
+		if version.GetState() != secretmanager.SecretVersion_ENABLED {
+			continue
+		}
+		if version.GetName() == "" {
+			return "", fmt.Errorf("list secret versions %q: enabled version has empty name", name)
+		}
+		return version.GetName(), nil
+	}
+	return "", fmt.Errorf("no enabled versions for secret %q", name)
+}

--- a/internal/signer/gcpsecrets_test.go
+++ b/internal/signer/gcpsecrets_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signer
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"google.golang.org/api/iterator"
+)
+
+type fakeGCPSecretClient struct {
+	secrets         []*secretmanager.Secret
+	versions        []*secretmanager.SecretVersion
+	accessPayloads  map[string][]byte
+	listVersionsErr error
+
+	listSecretsReq  *secretmanager.ListSecretsRequest
+	listVersionsReq *secretmanager.ListSecretVersionsRequest
+	accessNames     []string
+}
+
+func (f *fakeGCPSecretClient) ListSecrets(_ context.Context, req *secretmanager.ListSecretsRequest) gcpSecretIterator {
+	f.listSecretsReq = req
+	return &fakeGCPSecretIterator{secrets: f.secrets}
+}
+
+func (f *fakeGCPSecretClient) ListSecretVersions(_ context.Context, req *secretmanager.ListSecretVersionsRequest) gcpSecretVersionIterator {
+	f.listVersionsReq = req
+	return &fakeGCPSecretVersionIterator{
+		versions: f.versions,
+		err:      f.listVersionsErr,
+	}
+}
+
+func (f *fakeGCPSecretClient) AccessSecretVersion(_ context.Context, req *secretmanager.AccessSecretVersionRequest) (*secretmanager.AccessSecretVersionResponse, error) {
+	f.accessNames = append(f.accessNames, req.GetName())
+	payload, ok := f.accessPayloads[req.GetName()]
+	if !ok {
+		return nil, fmt.Errorf("unexpected access to %q", req.GetName())
+	}
+	return &secretmanager.AccessSecretVersionResponse{
+		Name:    req.GetName(),
+		Payload: &secretmanager.SecretPayload{Data: payload},
+	}, nil
+}
+
+type fakeGCPSecretIterator struct {
+	secrets []*secretmanager.Secret
+	idx     int
+}
+
+func (i *fakeGCPSecretIterator) Next() (*secretmanager.Secret, error) {
+	if i.idx >= len(i.secrets) {
+		return nil, iterator.Done
+	}
+	secret := i.secrets[i.idx]
+	i.idx++
+	return secret, nil
+}
+
+type fakeGCPSecretVersionIterator struct {
+	versions []*secretmanager.SecretVersion
+	idx      int
+	err      error
+}
+
+func (i *fakeGCPSecretVersionIterator) Next() (*secretmanager.SecretVersion, error) {
+	if i.err != nil {
+		err := i.err
+		i.err = nil
+		return nil, err
+	}
+	if i.idx >= len(i.versions) {
+		return nil, iterator.Done
+	}
+	version := i.versions[i.idx]
+	i.idx++
+	return version, nil
+}
+
+func TestGCPSecretSourceGetUsesNewestEnabledVersion(t *testing.T) {
+	const (
+		parent = "projects/test-project"
+		secret = "signer-payment"
+		v1     = parent + "/secrets/" + secret + "/versions/1"
+		v2     = parent + "/secrets/" + secret + "/versions/2"
+		v3     = parent + "/secrets/" + secret + "/versions/3"
+	)
+	client := &fakeGCPSecretClient{
+		versions: []*secretmanager.SecretVersion{
+			{Name: v3, State: secretmanager.SecretVersion_DISABLED},
+			{Name: v2, State: secretmanager.SecretVersion_DESTROYED},
+			{Name: v1, State: secretmanager.SecretVersion_ENABLED},
+		},
+		accessPayloads: map[string][]byte{
+			v1: []byte("enabled payload"),
+		},
+	}
+	src := &GCPSecretSource{
+		client: client,
+		parent: parent,
+	}
+
+	got, err := src.Get(context.Background(), secret)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != "enabled payload" {
+		t.Fatalf("payload = %q, want %q", string(got), "enabled payload")
+	}
+	if client.listVersionsReq.GetParent() != parent+"/secrets/"+secret {
+		t.Fatalf("ListSecretVersions parent = %q", client.listVersionsReq.GetParent())
+	}
+	if !slices.Equal(client.accessNames, []string{v1}) {
+		t.Fatalf("accessed versions = %v, want [%s]", client.accessNames, v1)
+	}
+}
+
+func TestGCPSecretSourceGetFailsWhenNoEnabledVersion(t *testing.T) {
+	const (
+		parent = "projects/test-project"
+		secret = "signer-payment"
+	)
+	client := &fakeGCPSecretClient{
+		versions: []*secretmanager.SecretVersion{
+			{Name: parent + "/secrets/" + secret + "/versions/2", State: secretmanager.SecretVersion_DISABLED},
+			{Name: parent + "/secrets/" + secret + "/versions/1", State: secretmanager.SecretVersion_DESTROYED},
+		},
+		accessPayloads: map[string][]byte{},
+	}
+	src := &GCPSecretSource{
+		client: client,
+		parent: parent,
+	}
+
+	_, err := src.Get(context.Background(), secret)
+	if err == nil {
+		t.Fatal("Get: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `no enabled versions for secret "signer-payment"`) {
+		t.Fatalf("Get error = %q", err.Error())
+	}
+	if len(client.accessNames) != 0 {
+		t.Fatalf("accessed versions = %v, want none", client.accessNames)
+	}
+}

--- a/internal/signer/metrics.go
+++ b/internal/signer/metrics.go
@@ -16,10 +16,14 @@ package signer
 
 import "github.com/prometheus/client_golang/prometheus"
 
-// Metrics holds Prometheus counters for the signer. Construct one value per
+// Metrics holds Prometheus collectors for the signer. Construct one value per
 // process and pass it in via Deps; call Register to publish to a registerer.
 type Metrics struct {
-	requests *prometheus.CounterVec
+	requests           *prometheus.CounterVec
+	denials            *prometheus.CounterVec
+	signDuration       *prometheus.HistogramVec
+	backendErrors      *prometheus.CounterVec
+	watermarkConflicts prometheus.Counter
 }
 
 // NewMetrics creates a new Metrics instance.
@@ -29,15 +33,51 @@ func NewMetrics() *Metrics {
 			Name: "bursa_signer_requests_total",
 			Help: "Per-signer signing operations by type and result.",
 		}, []string{"type", "result"}),
+		denials: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "bursa_signer_deny_total",
+			Help: "Denied signing operations by reason category (ErrorCode values plus \"acl\" for API-layer caller-ACL denials, which never reach requests_total).",
+		}, []string{"reason"}),
+		signDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "bursa_signer_sign_duration_seconds",
+			Help:    "Time spent producing a signature, by custody backend.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"backend"}),
+		backendErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "bursa_signer_backend_errors_total",
+			Help: "Custody backend failures by backend name.",
+		}, []string{"backend"}),
+		watermarkConflicts: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "bursa_signer_watermark_conflicts_total",
+			Help: "Anti-double-sign watermark conflicts.",
+		}),
 	}
 }
 
-// Register registers the collectors with r (call once at startup; construct one
-// Metrics value per process and pass it in via Deps).
+// Register registers the collectors with r (call once at startup).
 func (m *Metrics) Register(r prometheus.Registerer) {
-	r.MustRegister(m.requests)
+	r.MustRegister(m.requests, m.denials, m.signDuration, m.backendErrors, m.watermarkConflicts)
 }
 
 func (m *Metrics) observe(reqType, result string) {
 	m.requests.WithLabelValues(reqType, result).Inc()
+}
+
+func (m *Metrics) observeDeny(reason string) {
+	m.denials.WithLabelValues(reason).Inc()
+}
+
+// ObserveDeny records a denial decided outside the coordinator (e.g. the API
+// layer's caller ACL). reason must be a low-cardinality category.
+func (m *Metrics) ObserveDeny(reason string) { m.observeDeny(reason) }
+
+func (m *Metrics) observeSignDuration(backendName string, seconds float64) {
+	m.signDuration.WithLabelValues(backendName).Observe(seconds)
+}
+
+func (m *Metrics) observeBackendError(backendName string) {
+	m.backendErrors.WithLabelValues(backendName).Inc()
+}
+
+func (m *Metrics) observeWatermarkConflict() {
+	m.watermarkConflicts.Inc()
 }

--- a/internal/signer/metrics_test.go
+++ b/internal/signer/metrics_test.go
@@ -17,6 +17,7 @@ package signer
 import (
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
@@ -29,5 +30,67 @@ func TestMetrics_CountSign(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(m.requests.WithLabelValues("tx", "denied")); got != 1 {
 		t.Fatalf("expected 1 denied, got %v", got)
+	}
+}
+
+func TestMetrics_NewCollectors(t *testing.T) {
+	m := NewMetrics()
+	m.observeDeny("denied")
+	m.observeDeny("denied")
+	m.observeSignDuration("software", 0.01)
+	m.observeBackendError("vault")
+	m.observeWatermarkConflict()
+
+	if got := testutil.ToFloat64(m.denials.WithLabelValues("denied")); got != 2 {
+		t.Fatalf("expected 2 denials, got %v", got)
+	}
+	if got := testutil.ToFloat64(m.backendErrors.WithLabelValues("vault")); got != 1 {
+		t.Fatalf("expected 1 backend error, got %v", got)
+	}
+	if got := testutil.ToFloat64(m.watermarkConflicts); got != 1 {
+		t.Fatalf("expected 1 watermark conflict, got %v", got)
+	}
+	// Histograms can't use ToFloat64; check sample count via CollectAndCount.
+	if got := testutil.CollectAndCount(m.signDuration); got != 1 {
+		t.Fatalf("expected 1 sign-duration series, got %v", got)
+	}
+}
+
+func TestMetrics_ObserveDenyExported(t *testing.T) {
+	m := NewMetrics()
+	m.ObserveDeny("acl")
+	if got := testutil.ToFloat64(m.denials.WithLabelValues("acl")); got != 1 {
+		t.Fatalf("expected 1 acl denial, got %v", got)
+	}
+}
+
+func TestMetrics_RegisterAll(t *testing.T) {
+	m := NewMetrics()
+	reg := prometheus.NewRegistry()
+	m.Register(reg) // must not panic (MustRegister) and must register all collectors
+	m.observe("tx", "signed")
+	m.observeDeny("conflict")
+	m.observeSignDuration("software", 0.02)
+	m.observeBackendError("software")
+	m.observeWatermarkConflict()
+	names := []string{
+		"bursa_signer_requests_total",
+		"bursa_signer_deny_total",
+		"bursa_signer_sign_duration_seconds",
+		"bursa_signer_backend_errors_total",
+		"bursa_signer_watermark_conflicts_total",
+	}
+	got, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	found := map[string]bool{}
+	for _, mf := range got {
+		found[mf.GetName()] = true
+	}
+	for _, n := range names {
+		if !found[n] {
+			t.Errorf("metric %s not registered", n)
+		}
 	}
 }

--- a/internal/signer/policy/policy.go
+++ b/internal/signer/policy/policy.go
@@ -108,7 +108,8 @@ func NewEngine(policies []KeyPolicy) (*Engine, error) {
 	return &Engine{byHash: byHash}, nil
 }
 
-// PolicyFor returns the policy for a key hash, if any.
+// PolicyFor returns the policy for a key hash, if any. The returned value
+// shares slices/pointers with engine state; callers must treat it as read-only.
 func (e *Engine) PolicyFor(hash backend.KeyHash) (KeyPolicy, bool) {
 	p, ok := e.byHash[hash]
 	return p, ok

--- a/internal/signer/setup.go
+++ b/internal/signer/setup.go
@@ -29,6 +29,7 @@ import (
 	"github.com/blinklabs-io/bursa/internal/signer/backend"
 	"github.com/blinklabs-io/bursa/internal/signer/policy"
 	"github.com/blinklabs-io/bursa/internal/signer/watermark"
+	sops "github.com/blinklabs-io/bursa/internal/sops"
 )
 
 // BuildPolicies maps config key entries (with map-typed tx/cip8 policy) into
@@ -76,37 +77,22 @@ func remap(src map[string]any, dst any) error {
 	return dec.Decode(dst)
 }
 
-// keyTypeFromEnvelope maps a cardano-cli key envelope Type string to the
-// backend.KeyType used by the signer. Only signing key (.skey) types are
-// expected here; verification keys are filtered before this is called.
+// keyTypeFromEnvelope is a package-local alias for backend.KeyTypeFromEnvelope.
 func keyTypeFromEnvelope(envelopeType string) backend.KeyType {
-	switch {
-	case strings.HasPrefix(envelopeType, "Payment"):
-		return backend.KeyTypePayment
-	case strings.HasPrefix(envelopeType, "StakePool"):
-		return backend.KeyTypePool
-	case strings.HasPrefix(envelopeType, "Stake"):
-		return backend.KeyTypeStake
-	case strings.HasPrefix(envelopeType, "DRep"):
-		return backend.KeyTypeDRep
-	case strings.HasPrefix(envelopeType, "CommitteeHot"):
-		return backend.KeyTypeCCHot
-	case strings.HasPrefix(envelopeType, "CommitteeCold"):
-		return backend.KeyTypeCCCold
-	case strings.HasPrefix(envelopeType, "Policy"),
-		strings.HasPrefix(envelopeType, "Calidus"):
-		return backend.KeyTypePolicy
-	default:
-		return backend.KeyTypePayment
-	}
+	return backend.KeyTypeFromEnvelope(envelopeType)
 }
+
+// sopsDecrypt is a seam over sops.Decrypt so wiring tests can inject a fake.
+var sopsDecrypt = sops.Decrypt
 
 // BuildBackends constructs configured backends. Software backends load only
 // *.skey files from their configured directory; other files (.vkey, README,
-// etc.) are skipped silently. SOPS and Vault backend wiring are deliberate
-// staged follow-ups; they return explicit errors rather than silently no-oping.
+// etc.) are skipped silently. All three backend types (software, sops, vault)
+// are fully wired.
 func BuildBackends(ctx context.Context, cfgs []config.SignerBackendConfig) ([]backend.Backend, error) {
-	var backends []backend.Backend
+	// Non-nil slice so callers (and nilaway) can rely on a non-nil result on the
+	// success path; an empty config yields an empty, not nil, slice.
+	backends := make([]backend.Backend, 0, len(cfgs))
 	for _, c := range cfgs {
 		switch c.Type {
 		case "software":
@@ -114,6 +100,10 @@ func BuildBackends(ctx context.Context, cfgs []config.SignerBackendConfig) ([]ba
 			entries, err := os.ReadDir(c.Path)
 			if err != nil {
 				return nil, fmt.Errorf("read key dir %q: %w", c.Path, err)
+			}
+			passphrase := ""
+			if c.PassphraseEnv != "" {
+				passphrase = os.Getenv(c.PassphraseEnv)
 			}
 			for _, e := range entries {
 				if e.IsDir() {
@@ -124,7 +114,23 @@ func BuildBackends(ctx context.Context, cfgs []config.SignerBackendConfig) ([]ba
 					continue
 				}
 				path := filepath.Join(c.Path, e.Name())
-				lk, err := bursa.LoadKeyFromFile(path)
+				data, err := os.ReadFile(path)
+				if err != nil {
+					return nil, fmt.Errorf("read key %q: %w", e.Name(), err)
+				}
+				if sops.IsPassphraseContainer(data) {
+					if passphrase == "" {
+						return nil, fmt.Errorf(
+							"key %q is passphrase-encrypted but no passphrase is available (set passphrase_env and the referenced variable)",
+							e.Name(),
+						)
+					}
+					data, err = sops.DecryptWithPassphrase(data, passphrase)
+					if err != nil {
+						return nil, fmt.Errorf("decrypt key %q: %w", e.Name(), err)
+					}
+				}
+				lk, err := bursa.LoadKeyFromBytes(data)
 				if err != nil {
 					return nil, fmt.Errorf("load key %q: %w", e.Name(), err)
 				}
@@ -135,20 +141,63 @@ func BuildBackends(ctx context.Context, cfgs []config.SignerBackendConfig) ([]ba
 			}
 			backends = append(backends, b)
 		case "sops":
-			// Production wiring: implement a SecretSource over GCP Secret Manager /
-			// sops.Decrypt. Register secrets discovered under SecretPrefix.
-			// This is a deliberate staged follow-up.
-			return nil, errors.New("sops backend wiring is not yet implemented (tracked follow-up)")
+			src, err := newSopsSecretSource(ctx, c)
+			if err != nil {
+				return nil, fmt.Errorf("sops backend %q: %w", c.Name, err)
+			}
+			b := backend.NewSopsBackend(c.Name, src, sopsDecrypt)
+			names, err := src.List(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("sops backend %q: list secrets: %w", c.Name, err)
+			}
+			if len(names) == 0 {
+				return nil, fmt.Errorf("sops backend %q: no secrets found with prefix %q", c.Name, c.SecretPrefix)
+			}
+			for _, n := range names {
+				b.Register(n, "") // key type derived from the decrypted envelope
+			}
+			if err := b.Load(ctx); err != nil {
+				return nil, fmt.Errorf("sops backend %q: %w", c.Name, err)
+			}
+			backends = append(backends, b)
 		case "vault":
-			// Production wiring: implement a Vault Transit sign func and register
-			// keys discovered under TransitMount.
-			// This is a deliberate staged follow-up.
-			return nil, errors.New("vault backend wiring is not yet implemented (tracked follow-up)")
+			b, err := buildVaultBackend(ctx, c)
+			if err != nil {
+				return nil, fmt.Errorf("vault backend %q: %w", c.Name, err)
+			}
+			backends = append(backends, b)
 		default:
 			return nil, fmt.Errorf("unknown backend type %q", c.Type)
 		}
 	}
 	return backends, nil
+}
+
+// BuildCallerACL parses the configured caller list into subject → key hashes.
+// Returns nil when no callers are configured (unrestricted).
+func BuildCallerACL(callers []config.SignerCallerConfig) (map[string][]backend.KeyHash, error) {
+	if len(callers) == 0 {
+		return nil, nil
+	}
+	out := make(map[string][]backend.KeyHash, len(callers))
+	for _, c := range callers {
+		if c.Subject == "" {
+			return nil, errors.New("signer.callers entry missing subject")
+		}
+		if _, dup := out[c.Subject]; dup {
+			return nil, fmt.Errorf("duplicate signer.callers subject %q", c.Subject)
+		}
+		hashes := make([]backend.KeyHash, 0, len(c.Keys))
+		for _, k := range c.Keys {
+			h, err := backend.ParseKeyHash(k)
+			if err != nil {
+				return nil, fmt.Errorf("caller %q key %q: %w", c.Subject, k, err)
+			}
+			hashes = append(hashes, h)
+		}
+		out[c.Subject] = hashes
+	}
+	return out, nil
 }
 
 // BuildWatermark constructs the configured watermark store and mode.

--- a/internal/signer/setup_test.go
+++ b/internal/signer/setup_test.go
@@ -15,10 +15,18 @@
 package signer
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/blinklabs-io/bursa/internal/config"
 	"github.com/blinklabs-io/bursa/internal/signer/backend"
+	sops "github.com/blinklabs-io/bursa/internal/sops"
 )
 
 func TestKeyTypeFromEnvelope(t *testing.T) {
@@ -77,5 +85,187 @@ func TestBuildPolicies_UnknownFieldRejected(t *testing.T) {
 	_, err := BuildPolicies(keys)
 	if err == nil {
 		t.Fatal("expected error for unknown field max_output_lovelace, got nil")
+	}
+}
+
+func writeTestSkey(t *testing.T, dir, name string, encrypt bool, passphrase string) string {
+	t.Helper()
+	seed := bytes.Repeat([]byte{0x42}, 32)
+	envelope := fmt.Sprintf(
+		`{"type":"PaymentSigningKeyShelley_ed25519","description":"Payment Signing Key","cborHex":"5820%x"}`,
+		seed,
+	)
+	data := []byte(envelope)
+	if encrypt {
+		enc, err := sops.EncryptWithPassphrase(data, passphrase)
+		if err != nil {
+			t.Fatalf("encrypt: %v", err)
+		}
+		data = enc
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return path
+}
+
+func TestBuildBackends_SoftwarePassphrase(t *testing.T) {
+	dir := t.TempDir()
+	writeTestSkey(t, dir, "payment.skey", true, "test-passphrase")
+
+	t.Setenv("TEST_BURSA_KEY_PASSPHRASE", "test-passphrase")
+	backends, err := BuildBackends(context.Background(), []config.SignerBackendConfig{
+		{Name: "sw", Type: "software", Path: dir, PassphraseEnv: "TEST_BURSA_KEY_PASSPHRASE"},
+	})
+	if err != nil {
+		t.Fatalf("BuildBackends: %v", err)
+	}
+	keys, err := backends[0].ListKeys(context.Background())
+	if err != nil {
+		t.Fatalf("ListKeys: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(keys))
+	}
+}
+
+func TestBuildBackends_SoftwareEncryptedWithoutPassphrase(t *testing.T) {
+	dir := t.TempDir()
+	writeTestSkey(t, dir, "payment.skey", true, "test-passphrase")
+
+	_, err := BuildBackends(context.Background(), []config.SignerBackendConfig{
+		{Name: "sw", Type: "software", Path: dir},
+	})
+	if err == nil {
+		t.Fatal("expected error for encrypted key without passphrase_env")
+	}
+}
+
+func TestBuildBackends_SoftwareWrongPassphrase(t *testing.T) {
+	dir := t.TempDir()
+	writeTestSkey(t, dir, "payment.skey", true, "correct-passphrase")
+
+	t.Setenv("TEST_BURSA_KEY_PASSPHRASE", "wrong-passphrase")
+	_, err := BuildBackends(context.Background(), []config.SignerBackendConfig{
+		{Name: "sw", Type: "software", Path: dir, PassphraseEnv: "TEST_BURSA_KEY_PASSPHRASE"},
+	})
+	if err == nil {
+		t.Fatal("expected error for wrong passphrase")
+	}
+	if strings.Contains(err.Error(), "wrong-passphrase") {
+		t.Fatalf("error message leaks the passphrase: %q", err.Error())
+	}
+}
+
+func TestBuildBackends_SoftwarePlaintextStillWorks(t *testing.T) {
+	dir := t.TempDir()
+	writeTestSkey(t, dir, "payment.skey", false, "")
+
+	backends, err := BuildBackends(context.Background(), []config.SignerBackendConfig{
+		{Name: "sw", Type: "software", Path: dir, PassphraseEnv: "UNSET_ENV_VAR_FOR_TEST"},
+	})
+	if err != nil {
+		t.Fatalf("BuildBackends: %v", err)
+	}
+	keys, _ := backends[0].ListKeys(context.Background())
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(keys))
+	}
+}
+
+type fakeSecretSource struct {
+	secrets map[string][]byte
+}
+
+func (f *fakeSecretSource) List(_ context.Context) ([]string, error) {
+	names := make([]string, 0, len(f.secrets))
+	for n := range f.secrets {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func (f *fakeSecretSource) Get(_ context.Context, name string) ([]byte, error) {
+	d, ok := f.secrets[name]
+	if !ok {
+		return nil, fmt.Errorf("secret %q not found", name)
+	}
+	return d, nil
+}
+
+func TestBuildBackends_Sops(t *testing.T) {
+	seed := bytes.Repeat([]byte{0x33}, 32)
+	envelope := fmt.Sprintf(
+		`{"type":"PaymentSigningKeyShelley_ed25519","description":"","cborHex":"5820%x"}`,
+		seed,
+	)
+	orig := newSopsSecretSource
+	defer func() { newSopsSecretSource = orig }()
+	newSopsSecretSource = func(_ context.Context, _ config.SignerBackendConfig) (backend.SecretSource, error) {
+		return &fakeSecretSource{secrets: map[string][]byte{"signer-payment-1": []byte(envelope)}}, nil
+	}
+	origDecrypt := sopsDecrypt
+	defer func() { sopsDecrypt = origDecrypt }()
+	sopsDecrypt = func(d []byte) ([]byte, error) { return d, nil } // fake: secrets arrive "decrypted"
+
+	backends, err := BuildBackends(context.Background(), []config.SignerBackendConfig{
+		{Name: "gcp", Type: "sops", SecretPrefix: "signer-"},
+	})
+	if err != nil {
+		t.Fatalf("BuildBackends: %v", err)
+	}
+	keys, err := backends[0].ListKeys(context.Background())
+	if err != nil {
+		t.Fatalf("ListKeys: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(keys))
+	}
+	if keys[0].Backend() != "gcp" {
+		t.Fatalf("expected backend gcp, got %q", keys[0].Backend())
+	}
+	if keys[0].Type() != backend.KeyTypePayment {
+		t.Fatalf("expected derived type payment, got %q", keys[0].Type())
+	}
+}
+
+func TestBuildCallerACL(t *testing.T) {
+	hash := strings.Repeat("ab", 28)
+	m, err := BuildCallerACL([]config.SignerCallerConfig{{Subject: "alice", Keys: []string{hash}}})
+	if err != nil {
+		t.Fatalf("BuildCallerACL: %v", err)
+	}
+	if len(m["alice"]) != 1 {
+		t.Fatalf("expected 1 key for alice, got %d", len(m["alice"]))
+	}
+	if _, err := BuildCallerACL([]config.SignerCallerConfig{{Subject: "", Keys: nil}}); err == nil {
+		t.Fatal("expected error for empty subject")
+	}
+	if _, err := BuildCallerACL([]config.SignerCallerConfig{
+		{Subject: "a"}, {Subject: "a"},
+	}); err == nil {
+		t.Fatal("expected error for duplicate subject")
+	}
+	if _, err := BuildCallerACL([]config.SignerCallerConfig{{Subject: "a", Keys: []string{"zz"}}}); err == nil {
+		t.Fatal("expected error for bad hash")
+	}
+	if m, _ := BuildCallerACL(nil); m != nil {
+		t.Fatal("expected nil map for no callers")
+	}
+}
+
+func TestBuildBackends_SopsNoSecrets(t *testing.T) {
+	orig := newSopsSecretSource
+	defer func() { newSopsSecretSource = orig }()
+	newSopsSecretSource = func(_ context.Context, _ config.SignerBackendConfig) (backend.SecretSource, error) {
+		return &fakeSecretSource{secrets: map[string][]byte{}}, nil
+	}
+	_, err := BuildBackends(context.Background(), []config.SignerBackendConfig{
+		{Name: "gcp", Type: "sops", SecretPrefix: "signer-"},
+	})
+	if err == nil {
+		t.Fatal("expected error when no secrets match the prefix")
 	}
 }

--- a/internal/signer/vault.go
+++ b/internal/signer/vault.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signer
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/blinklabs-io/bursa/internal/config"
+	"github.com/blinklabs-io/bursa/internal/signer/backend"
+	vaultapi "github.com/hashicorp/vault/api"
+)
+
+// buildVaultBackend wires a backend.VaultBackend over Vault's Transit engine.
+// Transit signs Ed25519 natively over the raw input (PureEdDSA, no prehash),
+// which is exactly what Cardano vkey witnesses require. Standard keys only;
+// extended (BIP32-Ed25519) keys cannot live in Vault (design §2).
+//
+// The registered public key is the key's latest version at boot. If the
+// Transit key is rotated, signatures from the new version will fail the
+// coordinator's verify step until the signer is restarted.
+func buildVaultBackend(ctx context.Context, c config.SignerBackendConfig) (*backend.VaultBackend, error) {
+	if c.Address == "" {
+		return nil, errors.New("vault backend requires address")
+	}
+	u, err := url.Parse(c.Address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid vault address: %w", err)
+	}
+	if u.Scheme != "https" && !backend.IsLoopbackHost(u.Hostname()) {
+		return nil, errors.New("vault address must use https; plain http is allowed only for loopback addresses (the token would travel in cleartext)")
+	}
+	if len(c.Keys) == 0 {
+		return nil, errors.New("vault backend requires an explicit keys list (name + type per transit key)")
+	}
+	// Validate key types before any network I/O so config errors surface fast.
+	for _, k := range c.Keys {
+		if !backend.KeyType(k.Type).Valid() {
+			return nil, fmt.Errorf("vault key %q: invalid key type %q", k.Name, k.Type)
+		}
+	}
+	mount := c.TransitMount
+	if mount == "" {
+		mount = "transit"
+	}
+	tokenEnv := c.TokenEnv
+	if tokenEnv == "" {
+		tokenEnv = "VAULT_TOKEN"
+	}
+	token := os.Getenv(tokenEnv)
+	if token == "" {
+		return nil, fmt.Errorf("vault token env var %s is empty", tokenEnv)
+	}
+	vcfg := vaultapi.DefaultConfig()
+	vcfg.Address = c.Address
+	client, err := vaultapi.NewClient(vcfg)
+	if err != nil {
+		return nil, fmt.Errorf("vault client: %w", err)
+	}
+	client.SetToken(token)
+	logical := client.Logical()
+
+	sign := func(ctx context.Context, keyName string, digest []byte) (string, error) {
+		resp, err := logical.WriteWithContext(ctx, mount+"/sign/"+keyName, map[string]any{
+			"input": base64.StdEncoding.EncodeToString(digest),
+		})
+		if err != nil {
+			return "", err
+		}
+		if resp == nil {
+			return "", errors.New("empty transit sign response")
+		}
+		sig, ok := resp.Data["signature"].(string)
+		if !ok {
+			return "", errors.New("transit sign response missing signature")
+		}
+		return sig, nil
+	}
+
+	b := backend.NewVaultBackend(c.Name, sign)
+	// Bound each boot-time key read independently so an unreachable Vault fails
+	// fast, while a config with many keys is not starved by a single shared
+	// deadline: each read gets the full timeout rather than racing all keys
+	// against one 30s budget.
+	for _, k := range c.Keys {
+		pub, err := func() ([]byte, error) {
+			keyCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			defer cancel()
+			return vaultTransitPublicKey(keyCtx, logical, mount, k.Name)
+		}()
+		if err != nil {
+			return nil, fmt.Errorf("vault key %q: %w", k.Name, err)
+		}
+		if _, err := b.AddKey(k.Name, pub, backend.KeyType(k.Type)); err != nil {
+			return nil, fmt.Errorf("vault key %q: %w", k.Name, err)
+		}
+	}
+	return b, nil
+}
+
+// vaultTransitPublicKey reads a Transit key and returns the 32-byte Ed25519
+// public key of its latest version.
+func vaultTransitPublicKey(ctx context.Context, logical *vaultapi.Logical, mount, name string) ([]byte, error) {
+	resp, err := logical.ReadWithContext(ctx, mount+"/keys/"+name)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, errors.New("transit key not found")
+	}
+	if t, _ := resp.Data["type"].(string); t != "ed25519" {
+		return nil, fmt.Errorf("transit key type %q is not ed25519", resp.Data["type"])
+	}
+	version, err := transitLatestVersion(resp.Data)
+	if err != nil {
+		return nil, err
+	}
+	keys, ok := resp.Data["keys"].(map[string]any)
+	if !ok {
+		return nil, errors.New("transit key response missing keys map")
+	}
+	entry, ok := keys[version].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("transit key has no version %s entry", version)
+	}
+	pubB64, ok := entry["public_key"].(string)
+	if !ok {
+		return nil, errors.New("transit key version missing public_key")
+	}
+	pub, err := base64.StdEncoding.DecodeString(pubB64)
+	if err != nil {
+		return nil, fmt.Errorf("decode public key: %w", err)
+	}
+	if len(pub) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("expected %d-byte public key, got %d", ed25519.PublicKeySize, len(pub))
+	}
+	return pub, nil
+}
+
+// transitLatestVersion extracts latest_version from a Transit key read, which
+// the Vault client may decode as json.Number or float64.
+func transitLatestVersion(data map[string]any) (string, error) {
+	switch v := data["latest_version"].(type) {
+	case json.Number:
+		return v.String(), nil
+	case float64:
+		return strconv.FormatInt(int64(v), 10), nil
+	case string:
+		return v, nil
+	default:
+		return "", fmt.Errorf("unexpected latest_version type %T", data["latest_version"])
+	}
+}

--- a/internal/signer/vault_test.go
+++ b/internal/signer/vault_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signer
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/blinklabs-io/bursa/internal/config"
+	"github.com/blinklabs-io/bursa/internal/signer/backend"
+)
+
+// fakeVault emulates the two Transit endpoints buildVaultBackend uses:
+// GET /v1/<mount>/keys/<name> and PUT /v1/<mount>/sign/<name>.
+func fakeVault(t *testing.T, priv ed25519.PrivateKey, keyName string) *httptest.Server {
+	t.Helper()
+	pub := priv.Public().(ed25519.PublicKey)
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v1/transit/keys/"+keyName, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Vault-Token") != "test-token" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		fmt.Fprintf(w, `{"data":{"type":"ed25519","latest_version":1,"keys":{"1":{"public_key":"%s"}}}}`,
+			base64.StdEncoding.EncodeToString(pub))
+	})
+	mux.HandleFunc("PUT /v1/transit/sign/"+keyName, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Vault-Token") != "test-token" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		var body struct {
+			Input string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		msg, err := base64.StdEncoding.DecodeString(body.Input)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		sig := ed25519.Sign(priv, msg)
+		fmt.Fprintf(w, `{"data":{"signature":"vault:v1:%s"}}`, base64.StdEncoding.EncodeToString(sig))
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestBuildVaultBackend_SignAndVerify(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := fakeVault(t, priv, "payment-1")
+	defer ts.Close()
+	t.Setenv("VAULT_TOKEN", "test-token")
+
+	b, err := buildVaultBackend(context.Background(), config.SignerBackendConfig{
+		Name:    "vault",
+		Type:    "vault",
+		Address: ts.URL,
+		Keys:    []config.SignerBackendKeyConfig{{Name: "payment-1", Type: "payment"}},
+	})
+	if err != nil {
+		t.Fatalf("buildVaultBackend: %v", err)
+	}
+
+	hash := backend.HashPublicKey(pub)
+	ref, err := b.GetKey(context.Background(), hash)
+	if err != nil {
+		t.Fatalf("GetKey: %v", err)
+	}
+	digest := make([]byte, 32)
+	for i := range digest {
+		digest[i] = byte(i)
+	}
+	sig, err := ref.Sign(context.Background(), digest)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if !ed25519.Verify(pub, digest, sig) {
+		t.Fatal("vault signature failed ed25519 verification")
+	}
+}
+
+func TestBuildVaultBackend_RejectsNonEd25519(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v1/transit/keys/rsa-1", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"data":{"type":"rsa-2048","latest_version":1,"keys":{"1":{"public_key":"x"}}}}`)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	t.Setenv("VAULT_TOKEN", "test-token")
+
+	_, err := buildVaultBackend(context.Background(), config.SignerBackendConfig{
+		Name: "vault", Type: "vault", Address: ts.URL,
+		Keys: []config.SignerBackendKeyConfig{{Name: "rsa-1", Type: "payment"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for non-ed25519 transit key")
+	}
+}
+
+func TestBuildVaultBackend_RequiresKeysAndToken(t *testing.T) {
+	t.Setenv("VAULT_TOKEN", "test-token")
+	_, err := buildVaultBackend(context.Background(), config.SignerBackendConfig{
+		Name: "vault", Type: "vault", Address: "http://127.0.0.1:1",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing keys list")
+	}
+
+	t.Setenv("VAULT_TOKEN", "")
+	_, err = buildVaultBackend(context.Background(), config.SignerBackendConfig{
+		Name: "vault", Type: "vault", Address: "http://127.0.0.1:1",
+		Keys: []config.SignerBackendKeyConfig{{Name: "k", Type: "payment"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty token")
+	}
+}
+
+func TestBuildVaultBackend_InvalidKeyType(t *testing.T) {
+	t.Setenv("VAULT_TOKEN", "test-token")
+	_, err := buildVaultBackend(context.Background(), config.SignerBackendConfig{
+		Name: "vault", Type: "vault", Address: "http://127.0.0.1:1",
+		Keys: []config.SignerBackendKeyConfig{{Name: "k", Type: "bogus"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid key type")
+	}
+}
+
+func TestBuildVaultBackend_RejectsPlainHTTPNonLoopback(t *testing.T) {
+	t.Setenv("VAULT_TOKEN", "test-token")
+	_, err := buildVaultBackend(context.Background(), config.SignerBackendConfig{
+		Name: "vault", Type: "vault", Address: "http://vault.internal:8200",
+		Keys: []config.SignerBackendKeyConfig{{Name: "k", Type: "payment"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for plain http vault address on non-loopback host")
+	}
+}


### PR DESCRIPTION
Add passphrase-protected software keys, SOPS/GCP Secret Manager and Vault Transit backends, JWKS validation, caller ACLs, effective policy summaries, and signer metrics.

Harden signer startup/auth behavior and expand backend, coordinator, metrics, setup, and API tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds production-ready auth and custody to the signer: JWKS-based JWT validation with issuer/audience checks, per-caller ACLs, new key backends (passphrase software, SOPS via GCP Secret Manager with type inference, Vault Transit), effective key policy in the API, and expanded metrics with stricter startup/transport validation.

- **New Features**
  - Auth: JWKS validator (RS256/ES256/EdDSA) with optional issuer/audience; HS256 remains for dev. JWKS must be https unless the host is loopback; keys fetched at boot. Startup now validates exactly one of jwt_secret or jwks_url.
  - Access control: per-caller ACLs map JWT subjects to allowed key hashes. List/get are filtered; unauthorized sign returns 403.
  - Backends: passphrase‑encrypted `.skey`; SOPS backend loads/decrypts from GCP Secret Manager and can infer key type from the envelope; Vault Transit signs Ed25519 digests. Remote endpoints require https.
  - API: GET /v1/keys/{hash} returns the key’s effective policy summary.
  - Metrics: adds deny_total (by reason), backend_errors_total, watermark_conflicts_total, and sign_duration_seconds by backend.

- **Migration**
  - Configure exactly one of signer.jwt_secret (HS256) or signer.jwks_url (JWKS); set signer.jwt_issuer / signer.jwt_audience if needed. JWKS must use https unless the host is loopback.
  - To restrict key usage, define signer.callers entries; without this ACL, any valid token can use any key.
  - Backends: for passphrase `.skey`, set signer.backends[].passphrase_env; for SOPS, set google.project and signer.backends[].secret_prefix (type may be omitted to derive from the envelope); for Vault, set signer.backends[].address (https), token_env or VAULT_TOKEN, optional transit_mount, and an explicit keys list with name and type.

<sup>Written for commit c49267d3ee2c829c2f2170c8fc50c11904911592. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

