### PR TITLE
chore: migrate workflows to reusable actions repo patterns

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,41 +1,20 @@
-name: Docker CI
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Docker CI"
 
 on:
   pull_request:
-    branches: ['main']
-    paths: ['Dockerfile','*.go','cmd/**','internal/**','go.*','.github/workflows/ci-docker.yml']
-
-env:
-  GHCR_IMAGE_NAME: ghcr.io/blinklabs-io/bursa
-
-permissions:
-  contents: read
+    branches:
+      - main
+    paths:
+      - Dockerfile
+      - '*.go'
+      - cmd/**
+      - internal/**
+      - go.*
+      - .github/workflows/ci-docker.yml
 
 jobs:
-  docker:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            arch: amd64
-          - os: ubuntu-24.04-arm
-            arch: arm64
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-        with:
-          fetch-depth: '0'
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0 https://github.com/docker/setup-buildx-action/releases/tag/v4.1.0
-      - id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0 https://github.com/docker/metadata-action/releases/tag/v6.1.0
-        with:
-          images: ${{ env.GHCR_IMAGE_NAME }}
-      - name: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0 https://github.com/docker/build-push-action/releases/tag/v7.2.0
-        with:
-          context: .
-          push: false
-          platforms: linux/${{ matrix.arch }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-ci-docker.yml@main
+    with:
+      image-name: blinklabs-io/bursa

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,17 +1,9 @@
-# The below is pulled from upstream and slightly modified
-# https://github.com/webiny/action-conventional-commits/blob/master/README.md#usage
-
-name: Conventional Commits
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Conventional Commits"
 
 on:
   pull_request:
 
 jobs:
-  build:
-    name: Conventional Commits
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-      - uses: webiny/action-conventional-commits@7f91b1595ca1951cdb671ddc9f07a49081ec5b69 # v1.4.2 https://github.com/webiny/action-conventional-commits/releases/tag/v1.4.2
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-conventional-commits.yml@main

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,28 +1,14 @@
-name: go-test
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "go-test"
 
 on:
+  pull_request:
   push:
-    tags:
-      - v*
     branches:
       - main
-  pull_request:
-
-permissions:
-  contents: read
+    tags:
+      - v*
 
 jobs:
-  go-test:
-    name: go-test
-    strategy:
-      matrix:
-        go-version: [1.25.x, 1.26.x]
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
-        with:
-          go-version: ${{ matrix.go-version }}
-      - name: go-test
-        run: go test ./...
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-go-test.yml@main

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,3 +12,5 @@ on:
 jobs:
   orchestrate:
     uses: blinklabs-io/actions/.github/workflows/reuseable-go-test.yml@main
+    with:
+      go-versions: '["1.26.x"]'

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,23 +1,16 @@
-name: golangci-lint
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "golangci-lint"
+
 on:
+  pull_request:
   push:
-    tags:
-      - v*
     branches:
       - main
-  pull_request:
-
-permissions:
-  contents: read
+    tags:
+      - v*
 
 jobs:
-  golangci:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
-        with:
-          go-version: 1.25.x
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.1
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-golangci-lint.yml@main
+    with:
+      go-version: "1.26.x"

--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -1,25 +1,17 @@
-name: nilaway
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "nilaway"
+
 on:
+  pull_request:
   push:
-    tags:
-      - v*
     branches:
       - main
-  pull_request:
-
-permissions:
-  contents: read
+    tags:
+      - v*
 
 jobs:
-  nilaway:
-    name: nilaway
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
-        with:
-          go-version: 1.26.x
-      - name: install nilaway
-        run: go install go.uber.org/nilaway/cmd/nilaway@latest
-      - name: run nilaway
-        run: nilaway -include-pkgs=github.com/blinklabs-io/bursa ./...
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-nilaway.yml@main
+    with:
+      include-pkgs: github.com/blinklabs-io/bursa
+      go-version: "1.26.x"

--- a/.github/workflows/test-issue-on-close.yml
+++ b/.github/workflows/test-issue-on-close.yml
@@ -1,19 +1,14 @@
-name: Test Issue Close Trigger
-permissions:
-  contents: read
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Test Issue Close Trigger"
+
 on:
   issues:
-    types: [closed]
+    types:
+      - closed
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print closed issue info
-        env:
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-        run: |
-          echo "Issue Number: $ISSUE_NUMBER"
-          echo "Title: $ISSUE_TITLE"
-          echo "Workflow triggered successfully when issue was closed."
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-test-issue-on-close.yml@main
+    with:
+      issue_number: ${{ github.event.issue.number }}
+      issue_title: ${{ github.event.issue.title }}

--- a/.github/workflows/update-issue-on-close.yml
+++ b/.github/workflows/update-issue-on-close.yml
@@ -1,41 +1,18 @@
-name: Set Project Closed Date
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Set Project Closed Date"
 
 on:
   issues:
-    types: [closed]
-
-permissions:
-  contents: read
-  issues: read
-
-env:
-  PROJECT_URL: https://github.com/orgs/blinklabs-io/projects/11
-  CLOSED_DATE_FIELD: "Closed Date"
+    types:
+      - closed
+  workflow_dispatch:
 
 jobs:
-  set-date:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Resolve closed date
-        id: when
-        shell: bash
-        env:
-          ISSUE_CLOSED_AT: ${{ github.event.issue.closed_at }}
-        run: |
-          ts="$ISSUE_CLOSED_AT"
-          if [ -z "$ts" ] || [ "$ts" = "null" ]; then
-            d=$(date -u +%F)
-          else
-            d=$(date -u -d "$ts" +%F)
-          fi
-          echo "date=$d" >> "$GITHUB_OUTPUT"
-          echo "Closed date -> $d"
-
-      # Update the "Closed Date" field on that project item
-      - name: Update Closed Date field
-        uses: nipe0324/update-project-v2-item-field@c4af58452d1c5a788c1ea4f20e073fa722ec4a6b
-        with:
-          project-url: ${{ env.PROJECT_URL }}
-          github-token: ${{ secrets.ORG_PROJECT_PAT }}
-          field-name: ${{ env.CLOSED_DATE_FIELD }}
-          field-value: ${{ steps.when.outputs.date }}
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-set-project-closed-date.yml@main
+    secrets:
+      project_pat: ${{ secrets.ORG_PROJECT_PAT }}
+    with:
+      closed_at: ${{ github.event.issue.closed_at }}
+      closed_date_field: Closed Date
+      project_url: https://github.com/orgs/blinklabs-io/projects/11

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/blinklabs-io/bursa
 
-go 1.25.8
+go 1.26.4
 
 require (
 	cloud.google.com/go/secretmanager v1.20.0


### PR DESCRIPTION
## Summary

Replaces 7 inline workflows with thin wrappers that delegate to reusable workflows in [blinklabs-io/actions](https://github.com/blinklabs-io/actions).

### Changed workflows
| Workflow | Before | After |
|---|---|---|
| conventional-commits | inline | calls `reuseable-conventional-commits.yml@main` |
| go-test | inline | calls `reuseable-go-test.yml@main` |
| golangci-lint | inline | calls `reuseable-golangci-lint.yml@main` |
| nilaway | inline | calls `reuseable-nilaway.yml@main` |
| ci-docker | inline | calls `reuseable-ci-docker.yml@main` |
| test-issue-on-close | inline | calls `reuseable-test-issue-on-close.yml@main` |
| update-issue-on-close | inline | calls `reuseable-update-issue-on-close.yml@main` |

### Not migrated
- `publish.yml` — kept inline; uses Apple + Windows code signing with native runners and a docker manifest-merge job not supported by the standard reusable publish workflow.

### Go version
- Bumped `go.mod` to `go 1.26.4` (latest stable) to align with the `1.26.x` toolchain used in golangci-lint and nilaway wrappers.

---
**Testing:** CI checks below validate all migrated workflows on this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates 7 inline GitHub Actions workflows to thin wrappers that call reusable workflows in `blinklabs-io/actions`, reducing duplication and standardizing CI. Updates Go to 1.26.4 and runs `go-test` only on 1.26.x to match the shared toolchain.

- **Refactors**
  - Replaced conventional-commits, go-test, golangci-lint, nilaway, ci-docker, test-issue-on-close, and update-issue-on-close with wrappers that call `blinklabs-io/actions/.github/workflows/reuseable-*.yml@main`; restricted `go-test` to `1.26.x` to align with `go.mod`.
  - Kept `publish.yml` inline due to Apple/Windows code signing and manifest-merge steps not supported by the reusable publish workflow.

- **Dependencies**
  - Bumped Go to 1.26.4 to align with `golangci-lint`/`nilaway` (1.26.x).

<sup>Written for commit 9fc5a668d0310c021008a6ef4080c78f766465d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

