### PR TITLE
fix: Use plain text logs for CLI commands

### DIFF
--- a/cmd/bursa/api.go
+++ b/cmd/bursa/api.go
@@ -36,6 +36,8 @@ func apiCommand() *cobra.Command {
 		Use:   "api",
 		Short: "Runs the api",
 		Run: func(cmd *cobra.Command, args []string) {
+			logging.ConfigureJSON()
+
 			cfg, err := config.LoadConfig()
 			if err != nil {
 				logging.GetLogger().Error("failed to load config", "error", err)

--- a/cmd/bursa/api.go
+++ b/cmd/bursa/api.go
@@ -43,6 +43,7 @@ func apiCommand() *cobra.Command {
 				logging.GetLogger().Error("failed to load config", "error", err)
 				os.Exit(1)
 			}
+			logging.ConfigureJSON()
 
 			// Start debug listener
 			if cfg.Debug.ListenPort > 0 {

--- a/cmd/bursa/main.go
+++ b/cmd/bursa/main.go
@@ -26,8 +26,8 @@ const (
 )
 
 func main() {
-	// Configure logging
-	logging.Configure()
+	// CLI commands default to text logs. Server commands override this to JSON.
+	logging.ConfigureText()
 
 	rootCmd := &cobra.Command{
 		Use: programName,

--- a/cmd/bursa/signer.go
+++ b/cmd/bursa/signer.go
@@ -67,6 +67,8 @@ signer.callers ACL, any valid token may use any configured key.`,
 				logger.Error("failed to load config", "error", err)
 				os.Exit(1)
 			}
+			logging.ConfigureJSON()
+			logger = logging.GetLogger()
 
 			// Cheap config validation before any expensive I/O.
 			hasSecret := cfg.Signer.JWTSecret != ""

--- a/cmd/bursa/signer.go
+++ b/cmd/bursa/signer.go
@@ -53,6 +53,8 @@ or signer.jwks_url (RS256/ES256/EdDSA via JWKS, production). Optional
 signer.jwt_issuer / signer.jwt_audience are enforced when set. Without a
 signer.callers ACL, any valid token may use any configured key.`,
 		Run: func(cmd *cobra.Command, args []string) {
+			logging.ConfigureJSON()
+
 			logger := logging.GetLogger()
 
 			// Honor BURSA_CONFIG env if --config was not provided.

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -15,6 +15,7 @@
 package logging
 
 import (
+	"io"
 	"log/slog"
 	"os"
 	"time"
@@ -29,6 +30,27 @@ var (
 
 // Configure initializes the global logger.
 func Configure() {
+	ConfigureJSON()
+}
+
+// ConfigureJSON initializes the global logger with JSON output.
+func ConfigureJSON() {
+	configure(func(w io.Writer, opts *slog.HandlerOptions) slog.Handler {
+		return slog.NewJSONHandler(w, opts)
+	}, os.Stdout)
+}
+
+// ConfigureText initializes the global logger with plain text output.
+func ConfigureText() {
+	configure(func(w io.Writer, opts *slog.HandlerOptions) slog.Handler {
+		return slog.NewTextHandler(w, opts)
+	}, os.Stderr)
+}
+
+func configure(
+	newHandler func(io.Writer, *slog.HandlerOptions) slog.Handler,
+	output *os.File,
+) {
 	cfg := config.GetConfig()
 	var level slog.Level
 	switch cfg.Logging.Level {
@@ -44,7 +66,7 @@ func Configure() {
 		level = slog.LevelInfo
 	}
 
-	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+	handler := newHandler(output, &slog.HandlerOptions{
 		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 			if a.Key == slog.TimeKey {
 				return slog.String(
@@ -57,6 +79,7 @@ func Configure() {
 		Level: level,
 	})
 	globalLogger = slog.New(handler).With("component", "main")
+	slog.SetDefault(globalLogger)
 
 	// Configure access logger
 	accessHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{


### PR DESCRIPTION
1. Added `ConfigureText()` for plain text CLI logging.
2. Added `ConfigureJSON()` for API/service logging.
3. Updated `bursa` startup to default to text logging.
4. Updated `bursa api` to switch back to JSON logging.
5. Updated `bursa signer` to use JSON logging.
6. Set the global `slog` default logger during configuration so direct `slog.Info` / `slog.Error` calls use the selected format

Closes #226

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches CLI commands to plain text logs; `bursa api` and `bursa signer` stay on JSON. Services now initialize JSON logging before config load and reconfigure after so runtime logs honor level/env overrides.

- **Bug Fixes**
  - CLI entrypoint defaults to `ConfigureText()`; `bursa api` and `bursa signer` override with `ConfigureJSON()`.
  - API and signer set JSON logging before loading config to capture early failures, then re-run `ConfigureJSON()` after config loads to apply level/env settings.
  - Added `ConfigureText()` and `ConfigureJSON()` via a shared helper; text logs to stderr, JSON to stdout. Set `slog.SetDefault(...)` so direct `slog` calls use the configured format.

<sup>Written for commit d161e2098b92b6e0e8d7589e2a68a5455193184b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

