### PR TITLE
fix(wallet): show balance/history at derived addresses for unregistered stake

### DIFF
--- a/ui/internal/wallet/service.go
+++ b/ui/internal/wallet/service.go
@@ -105,17 +105,42 @@ func (s *Service) currentAccount() (*Account, error) {
 	return cloneAccount(s.account), nil
 }
 
-// Balance aggregates the UTxO set across the account's chain-seen addresses.
+// scanAddresses returns the addresses to query for funds and history: the
+// node-reported account addresses (used/change addresses, available once the
+// stake key is registered on chain) unioned with the wallet's derived receive
+// addresses. The derived set is essential — a self-sovereign wallet whose stake
+// key is not yet registered on chain gets a 404 (ErrNotFound) from the node's
+// account index, but it still holds funds at its derived receive addresses. The
+// account-reported set still matters once registered: it surfaces used/change
+// addresses outside the derived receive window.
+func (s *Service) scanAddresses(ctx context.Context, acct *Account) ([]string, error) {
+	discovered, err := s.chain.AccountAddresses(ctx, acct.StakeAddress)
+	if err != nil && !errors.Is(err, chain.ErrNotFound) {
+		return nil, err
+	}
+	seen := make(map[string]bool, len(discovered)+len(acct.ReceiveAddresses))
+	out := make([]string, 0, len(discovered)+len(acct.ReceiveAddresses))
+	for _, a := range append(discovered, acct.ReceiveAddresses...) {
+		if a == "" || seen[a] {
+			continue
+		}
+		seen[a] = true
+		out = append(out, a)
+	}
+	return out, nil
+}
+
+// Balance aggregates the UTxO set across the account's addresses (chain-seen and
+// derived; see scanAddresses).
 func (s *Service) Balance(ctx context.Context) (Balance, error) {
 	acct, err := s.currentAccount()
 	if err != nil {
 		return Balance{}, err
 	}
-	addrs, err := s.chain.AccountAddresses(ctx, acct.StakeAddress)
-	if err != nil && !errors.Is(err, chain.ErrNotFound) {
+	addrs, err := s.scanAddresses(ctx, acct)
+	if err != nil {
 		return Balance{}, err
 	}
-	// ErrNotFound: the stake credential isn't on chain yet → empty wallet (zero balance).
 	var all []chain.UTxO
 	for _, a := range addrs {
 		us, err := s.chain.AddressUTxOs(ctx, a)
@@ -161,11 +186,10 @@ func (s *Service) Transactions(ctx context.Context) ([]Tx, error) {
 	if err != nil {
 		return nil, err
 	}
-	addrs, err := s.chain.AccountAddresses(ctx, acct.StakeAddress)
-	if err != nil && !errors.Is(err, chain.ErrNotFound) {
+	addrs, err := s.scanAddresses(ctx, acct)
+	if err != nil {
 		return nil, err
 	}
-	// ErrNotFound: no chain-seen addresses yet → empty history.
 	var per [][]chain.AddressTx
 	for _, a := range addrs {
 		ts, err := s.chain.AddressTransactions(ctx, a)

--- a/ui/internal/wallet/service.go
+++ b/ui/internal/wallet/service.go
@@ -144,6 +144,9 @@ func (s *Service) Balance(ctx context.Context) (Balance, error) {
 	var all []chain.UTxO
 	for _, a := range addrs {
 		us, err := s.chain.AddressUTxOs(ctx, a)
+		if errors.Is(err, chain.ErrNotFound) {
+			continue
+		}
 		if err != nil {
 			return Balance{}, err
 		}
@@ -180,7 +183,7 @@ func (s *Service) Addresses(ctx context.Context) (AddressView, error) {
 }
 
 // Transactions returns the merged, newest-first history across the account's
-// chain-seen addresses.
+// chain-seen and derived addresses.
 func (s *Service) Transactions(ctx context.Context) ([]Tx, error) {
 	acct, err := s.currentAccount()
 	if err != nil {
@@ -193,6 +196,9 @@ func (s *Service) Transactions(ctx context.Context) ([]Tx, error) {
 	var per [][]chain.AddressTx
 	for _, a := range addrs {
 		ts, err := s.chain.AddressTransactions(ctx, a)
+		if errors.Is(err, chain.ErrNotFound) {
+			continue
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/ui/internal/wallet/service_test.go
+++ b/ui/internal/wallet/service_test.go
@@ -14,7 +14,9 @@ type fakeChain struct {
 	addresses    []string
 	addressesErr error
 	utxos        map[string][]chain.UTxO
+	utxoErrs     map[string]error
 	txs          map[string][]chain.AddressTx
+	txErrs       map[string]error
 }
 
 func (f *fakeChain) Account(_ context.Context, _ string) (chain.AccountInfo, error) {
@@ -26,10 +28,16 @@ func (f *fakeChain) AccountAddresses(_ context.Context, _ string) ([]string, err
 }
 
 func (f *fakeChain) AddressUTxOs(_ context.Context, addr string) ([]chain.UTxO, error) {
+	if err := f.utxoErrs[addr]; err != nil {
+		return nil, err
+	}
 	return f.utxos[addr], nil
 }
 
 func (f *fakeChain) AddressTransactions(_ context.Context, addr string) ([]chain.AddressTx, error) {
+	if err := f.txErrs[addr]; err != nil {
+		return nil, err
+	}
 	return f.txs[addr], nil
 }
 
@@ -143,5 +151,47 @@ func TestServiceEmptyAccount(t *testing.T) {
 	}
 	if dv.PoolID != nil || dv.Active || dv.RewardsSum != "0" || dv.Withdrawable != "0" {
 		t.Fatalf("delegation on empty account = %+v, want not active / no pool / zero amounts", dv)
+	}
+}
+
+func TestServiceIgnoresUnusedDerivedAddressNotFound(t *testing.T) {
+	fc := &fakeChain{
+		addresses: []string{"addr_test1used"},
+		utxos: map[string][]chain.UTxO{
+			"addr_test1used": {{Amount: []chain.Amount{{Unit: "lovelace", Quantity: "3000000"}}}},
+		},
+		txs: map[string][]chain.AddressTx{
+			"addr_test1used": {{TxHash: "tx-used", BlockHeight: 42}},
+		},
+	}
+	s := NewService(fc)
+	acct, err := s.SetWallet(testMnemonic, "preview", 3)
+	if err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	fc.utxoErrs = map[string]error{
+		acct.ReceiveAddresses[0]: chain.ErrNotFound,
+		acct.ReceiveAddresses[1]: chain.ErrNotFound,
+		acct.ReceiveAddresses[2]: chain.ErrNotFound,
+	}
+	fc.txErrs = map[string]error{
+		acct.ReceiveAddresses[0]: chain.ErrNotFound,
+		acct.ReceiveAddresses[1]: chain.ErrNotFound,
+		acct.ReceiveAddresses[2]: chain.ErrNotFound,
+	}
+
+	bal, err := s.Balance(context.Background())
+	if err != nil {
+		t.Fatalf("Balance: %v", err)
+	}
+	if bal.Lovelace != "3000000" {
+		t.Fatalf("lovelace = %q, want 3000000", bal.Lovelace)
+	}
+	txs, err := s.Transactions(context.Background())
+	if err != nil {
+		t.Fatalf("Transactions: %v", err)
+	}
+	if len(txs) != 1 || txs[0].TxHash != "tx-used" {
+		t.Fatalf("transactions = %+v, want tx-used only", txs)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show balance and transaction history for wallets with unregistered stake by scanning both chain-seen and derived receive addresses. Also skip 404s on unused derived addresses so balances and history still load.

- **Bug Fixes**
  - Added `scanAddresses` to merge node-reported account addresses with derived `ReceiveAddresses`, dedupe results, and handle `chain.ErrNotFound`.
  - Updated balance/history queries to ignore per-address `chain.ErrNotFound` when fetching UTxOs and transactions.

<sup>Written for commit b457f5cd8554f38cf765ace9aeb3d8b2d590d724. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

