### PR TITLE
feat(wallet): embedded webview desktop window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 *.so
 *.dylib
 
-# Compiled command binaries (e.g. `go build ./cmd/bursa-wallet` with no -o)
+# Compiled command binary for ./ui/cmd/bursa-wallet when built without -o
 /ui/bursa-wallet
 
 # Test binary, built with `go test -c`

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 *.so
 *.dylib
 
+# Compiled command binaries (e.g. `go build ./cmd/bursa-wallet` with no -o)
+/ui/bursa-wallet
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/ui/cmd/bursa-wallet/main.go
+++ b/ui/cmd/bursa-wallet/main.go
@@ -112,16 +112,16 @@ func run() error {
 		}
 	}()
 
-	select {
-	case <-ctx.Done():
-		logger.Info("shutting down")
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		_ = srv.Shutdown(shutdownCtx)
-		return nil
-	case err := <-srvErr:
-		return fmt.Errorf("control surface: %w", err)
-	}
+	// Block until it's time to shut down. The default (headless) build waits for a
+	// signal and serves the UI over loopback for a browser; the `webview` build
+	// opens a native window onto the same loopback UI and waits for it to close.
+	uiErr := awaitUI(ctx, "http://"+srv.Addr, logger, srvErr)
+
+	logger.Info("shutting down")
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_ = srv.Shutdown(shutdownCtx)
+	return uiErr
 }
 
 func envOr(key, def string) string {

--- a/ui/cmd/bursa-wallet/ui_headless.go
+++ b/ui/cmd/bursa-wallet/ui_headless.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 )
 
@@ -30,6 +29,6 @@ func awaitUI(ctx context.Context, _ string, _ *slog.Logger, srvErr <-chan error)
 	case <-ctx.Done():
 		return nil
 	case err := <-srvErr:
-		return fmt.Errorf("control surface: %w", err)
+		return controlSurfaceError(err)
 	}
 }

--- a/ui/cmd/bursa-wallet/ui_headless.go
+++ b/ui/cmd/bursa-wallet/ui_headless.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !webview
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+// awaitUI (default, headless build) serves the wallet UI over loopback for the
+// user's browser and blocks until a shutdown signal arrives or the control
+// surface fails. This build is pure Go (CGO_ENABLED=0) — no GUI dependency.
+func awaitUI(ctx context.Context, _ string, _ *slog.Logger, srvErr <-chan error) error {
+	select {
+	case <-ctx.Done():
+		return nil
+	case err := <-srvErr:
+		return fmt.Errorf("control surface: %w", err)
+	}
+}

--- a/ui/cmd/bursa-wallet/ui_readiness.go
+++ b/ui/cmd/bursa-wallet/ui_readiness.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+func controlSurfaceError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("control surface: %w", err)
+}
+
+// waitReachable polls url until it answers, startup fails, ctx is canceled, or
+// timeout elapses.
+func waitReachable(ctx context.Context, url string, timeout time.Duration, srvErr <-chan error) error {
+	if timeout <= 0 {
+		return nil
+	}
+
+	client := &http.Client{Timeout: time.Second}
+	timeoutTimer := time.NewTimer(timeout)
+	defer timeoutTimer.Stop()
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-srvErr:
+			return controlSurfaceError(err)
+		default:
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return fmt.Errorf("readiness probe: %w", err)
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			select {
+			case err := <-srvErr:
+				return controlSurfaceError(err)
+			default:
+				return nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-srvErr:
+			return controlSurfaceError(err)
+		case <-timeoutTimer.C:
+			return nil
+		case <-ticker.C:
+		}
+	}
+}

--- a/ui/cmd/bursa-wallet/ui_readiness_test.go
+++ b/ui/cmd/bursa-wallet/ui_readiness_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWaitReachableReturnsWhenURLAnswers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	if err := waitReachable(context.Background(), server.URL, time.Second, make(chan error)); err != nil {
+		t.Fatalf("waitReachable() error = %v", err)
+	}
+}
+
+func TestWaitReachableReturnsStartupErrorDuringPoll(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	url := "http://" + listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	srvErr := make(chan error, 1)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		srvErr <- errors.New("listen failed")
+	}()
+
+	start := time.Now()
+	err = waitReachable(context.Background(), url, 5*time.Second, srvErr)
+	if err == nil {
+		t.Fatal("waitReachable() error = nil, want startup error")
+	}
+	if !strings.Contains(err.Error(), "control surface: listen failed") {
+		t.Fatalf("waitReachable() error = %q, want control surface startup error", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("waitReachable() took %s, want prompt return after startup error", elapsed)
+	}
+}

--- a/ui/cmd/bursa-wallet/ui_webview.go
+++ b/ui/cmd/bursa-wallet/ui_webview.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build webview
+
+// This is Variant A from the design: a self-contained desktop app that opens an
+// embedded webview window onto the loopback control surface. Build it with
+// `-tags webview` (requires CGO + a system webview: webkit2gtk on Linux). The
+// default build omits all of this and stays a pure-Go headless service.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"runtime"
+	"time"
+
+	webview "github.com/webview/webview_go"
+)
+
+// The webview GUI event loop must own the main OS thread; pin the main goroutine
+// to it before main() runs.
+func init() { runtime.LockOSThread() }
+
+// awaitUI (webview build) opens a native window onto the loopback UI and runs the
+// GUI loop until the window closes. A shutdown signal or a failed control surface
+// terminates the window, which unblocks the loop.
+func awaitUI(ctx context.Context, url string, logger *slog.Logger, srvErr <-chan error) error {
+	// Don't paint a connection error before the control surface is listening.
+	waitReachable(ctx, url, 15*time.Second)
+
+	w := webview.New(false)
+	defer w.Destroy()
+	w.SetTitle("Bursa")
+	w.SetSize(1120, 760, webview.HintNone)
+
+	var uiErr error
+	go func() {
+		select {
+		case <-ctx.Done():
+		case err := <-srvErr:
+			uiErr = fmt.Errorf("control surface: %w", err)
+		}
+		w.Terminate() // safe from another goroutine; unblocks w.Run()
+	}()
+
+	logger.Info("opening webview window", "url", url)
+	w.Navigate(url)
+	w.Run()
+	return uiErr
+}
+
+// waitReachable polls url until it answers or the timeout elapses.
+func waitReachable(ctx context.Context, url string, timeout time.Duration) {
+	client := &http.Client{Timeout: time.Second}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return
+		}
+		resp, err := client.Get(url) //nolint:noctx // loopback readiness probe
+		if err == nil {
+			_ = resp.Body.Close()
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}

--- a/ui/cmd/bursa-wallet/ui_webview.go
+++ b/ui/cmd/bursa-wallet/ui_webview.go
@@ -22,9 +22,7 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
-	"net/http"
 	"runtime"
 	"time"
 
@@ -40,42 +38,45 @@ func init() { runtime.LockOSThread() }
 // terminates the window, which unblocks the loop.
 func awaitUI(ctx context.Context, url string, logger *slog.Logger, srvErr <-chan error) error {
 	// Don't paint a connection error before the control surface is listening.
-	waitReachable(ctx, url, 15*time.Second)
+	if err := waitReachable(ctx, url, 15*time.Second, srvErr); err != nil {
+		return err
+	}
 
 	w := webview.New(false)
-	defer w.Destroy()
 	w.SetTitle("Bursa")
 	w.SetSize(1120, 760, webview.HintNone)
 
-	var uiErr error
+	uiErr := make(chan error, 1)
+	done := make(chan struct{})
+	stopped := make(chan struct{})
 	go func() {
+		defer close(stopped)
+
+		var err error
 		select {
+		case <-done:
+			return
 		case <-ctx.Done():
-		case err := <-srvErr:
-			uiErr = fmt.Errorf("control surface: %w", err)
+		case err = <-srvErr:
+			err = controlSurfaceError(err)
 		}
+		uiErr <- err
 		w.Terminate() // safe from another goroutine; unblocks w.Run()
+	}()
+	defer func() {
+		close(done)
+		<-stopped
+		w.Destroy()
 	}()
 
 	logger.Info("opening webview window", "url", url)
 	w.Navigate(url)
 	w.Run()
-	return uiErr
-}
 
-// waitReachable polls url until it answers or the timeout elapses.
-func waitReachable(ctx context.Context, url string, timeout time.Duration) {
-	client := &http.Client{Timeout: time.Second}
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if ctx.Err() != nil {
-			return
-		}
-		resp, err := client.Get(url) //nolint:noctx // loopback readiness probe
-		if err == nil {
-			_ = resp.Body.Close()
-			return
-		}
-		time.Sleep(200 * time.Millisecond)
+	select {
+	case err := <-uiErr:
+		return err
+	default:
+		return nil
 	}
 }

--- a/ui/go.mod
+++ b/ui/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/blinklabs-io/gouroboros v0.185.0
 	github.com/blinklabs-io/plutigo v0.1.15
 	github.com/utxorpc/go-codegen v0.19.2
+	github.com/webview/webview_go v0.0.0-20240831120633-6173450d4dd6
 	golang.org/x/crypto v0.53.0
 )
 

--- a/ui/go.sum
+++ b/ui/go.sum
@@ -502,6 +502,8 @@ github.com/utxorpc/go-codegen v0.19.2 h1:IG8OhSc0GILy6emTeUM1/+t/PXbzJTmpJuRAhoW
 github.com/utxorpc/go-codegen v0.19.2/go.mod h1:QG/UEOXM8HVrm6H7LhuYAeMSA1OFgL2kTjzIeNUWFNg=
 github.com/utxorpc/go-sdk v0.0.4 h1:taU2B2FXXuokcXu+Zb33BrvSm13Q+dM3Ij+fJ3mv9mU=
 github.com/utxorpc/go-sdk v0.0.4/go.mod h1:zTghoIs70MW8yobU/ZH+ZuNdzc40FsPeqyAXv5D+KoQ=
+github.com/webview/webview_go v0.0.0-20240831120633-6173450d4dd6 h1:VQpB2SpK88C6B5lPHTuSZKb2Qee1QWwiFlC5CKY4AW0=
+github.com/webview/webview_go v0.0.0-20240831120633-6173450d4dd6/go.mod h1:yE65LFCeWf4kyWD5re+h4XNvOHJEXOCOuJZ4v8l5sgk=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an optional embedded desktop window for the wallet UI with robust readiness polling. The default build stays headless; build with `-tags webview` to open a native window.

- **New Features**
  - New `webview` build opens a native window onto the loopback UI (uses `github.com/webview/webview_go`).
  - New `awaitUI` blocks until shutdown: headless waits for signal; webview waits for the window to close.
  - Readiness polling waits for the UI server before opening and returns promptly on startup errors.

- **Migration**
  - Build desktop app: enable CGO and a system webview (Linux: `webkit2gtk`), then `go build -tags webview ./ui/cmd/bursa-wallet`.
  - Headless (pure Go) remains: `go build ./ui/cmd/bursa-wallet` and open the served URL in a browser.

<sup>Written for commit b6aa381105dddefa8287cd71c4279dd2e71ba018. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

