### PR TITLE
feat(ui): sync view

### DIFF
--- a/ui/internal/supervisor/bootstrap.go
+++ b/ui/internal/supervisor/bootstrap.go
@@ -87,9 +87,10 @@ func syncConfigFor(p BootstrapParams, logger *slog.Logger) mithril.SyncConfig {
 	}
 }
 
-// toBootstrapProgress flattens dingo's SyncProgress into the package's API type.
-// Only the fields surfaced on /status are mapped; the rest (Active, CurrentSlot,
-// TipSlot, Count, Total, Description) are internal pacing signals we omit.
+// toBootstrapProgress flattens dingo's SyncProgress into the package's API type
+// so the UI can show which phase is running and how far it has got. Active is
+// the one field we drop: it only marks a phase's begin/end edge, and Percent
+// already conveys completion within a phase.
 func toBootstrapProgress(sp mithril.SyncProgress) BootstrapProgress {
 	return BootstrapProgress{
 		Phase:           string(sp.Phase),
@@ -97,6 +98,11 @@ func toBootstrapProgress(sp mithril.SyncProgress) BootstrapProgress {
 		BytesDownloaded: sp.BytesDownloaded,
 		TotalBytes:      sp.TotalBytes,
 		BytesPerSecond:  sp.BytesPerSecond,
+		CurrentSlot:     sp.CurrentSlot,
+		TipSlot:         sp.TipSlot,
+		Count:           sp.Count,
+		Total:           sp.Total,
+		Description:     sp.Description,
 	}
 }
 

--- a/ui/internal/supervisor/bootstrap_test.go
+++ b/ui/internal/supervisor/bootstrap_test.go
@@ -48,6 +48,21 @@ func TestSyncConfigForWiresProgress(t *testing.T) {
 		t.Fatalf("progress not mapped: %+v", got)
 	}
 
+	// The block-replay positional fields (slot/count/description) must survive
+	// too — they're what the sync view renders to show "where it is".
+	sc.OnProgress(mithril.SyncProgress{
+		Phase:       mithril.PhaseBackfill,
+		Percent:     71,
+		CurrentSlot: 97740,
+		TipSlot:     132000,
+		Count:       18432,
+		Total:       25900,
+		Description: "Conway",
+	})
+	if got.CurrentSlot != 97740 || got.TipSlot != 132000 || got.Count != 18432 || got.Total != 25900 || got.Description != "Conway" {
+		t.Fatalf("positional progress not mapped: %+v", got)
+	}
+
 	// A nil OnProgress must not panic.
 	syncConfigFor(BootstrapParams{}, nil).OnProgress(mithril.SyncProgress{})
 }

--- a/ui/internal/supervisor/status.go
+++ b/ui/internal/supervisor/status.go
@@ -31,12 +31,22 @@ const (
 // from dingo's mithril.SyncProgress for the API. It is set while
 // StateBootstrapping and retained in StateError as a diagnostic (how far the
 // bootstrap got before failing); any other state clears it.
+//
+// Bytes* describe the snapshot-download phase; Count/Total and CurrentSlot/
+// TipSlot describe the later block-replay phases (copy, gap-fill, backfill).
+// Whichever pair is populated for the active phase is what the UI renders to
+// show "where it is"; the rest stay zero (omitted).
 type BootstrapProgress struct {
 	Phase           string  `json:"phase"`
 	Percent         float64 `json:"percent"`
 	BytesDownloaded int64   `json:"bytes_downloaded,omitempty"`
 	TotalBytes      int64   `json:"total_bytes,omitempty"`
 	BytesPerSecond  float64 `json:"bytes_per_second,omitempty"`
+	CurrentSlot     uint64  `json:"current_slot,omitempty"`
+	TipSlot         uint64  `json:"tip_slot,omitempty"`
+	Count           int     `json:"count,omitempty"`
+	Total           int     `json:"total,omitempty"`
+	Description     string  `json:"description,omitempty"`
 }
 
 // Status is a point-in-time snapshot of the embedded node, serialised by the API.

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -3,9 +3,16 @@ export type NodeState = "stopped" | "starting" | "bootstrapping" | "syncing" | "
 export interface BootstrapProgress {
   phase: string;
   percent: number;
+  // Snapshot-download phase.
   bytes_downloaded?: number;
   total_bytes?: number;
   bytes_per_second?: number;
+  // Block-replay phases (copy / gap-fill / backfill): how far through the chain.
+  current_slot?: number;
+  tip_slot?: number;
+  count?: number;
+  total?: number;
+  description?: string;
 }
 
 export interface Status {

--- a/ui/web/src/app.test.tsx
+++ b/ui/web/src/app.test.tsx
@@ -10,6 +10,9 @@ const mockAccount: Account = {
   receive_addresses: ["addr_test1abc"],
 };
 
+const MNEMONIC =
+  "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12";
+
 function stubStatus(state: string) {
   vi.spyOn(hooks, "useStatus").mockReturnValue({ data: { state, tip: 0, caughtUp: state === "ready" }, error: null, loading: false, refresh: vi.fn() } as never);
 }
@@ -26,9 +29,30 @@ test("with no wallet loaded, only Setup is shown", async () => {
   await waitFor(() => expect(screen.getAllByText(/set up|load wallet/i).length).toBeGreaterThan(0));
 });
 
-test("Send nav is disabled until the node is ready", async () => {
+test("while syncing with no wallet, the boot Syncing view shows instead of Setup", async () => {
   stubStatus("syncing");
   render(<App />);
+  await waitFor(() =>
+    expect(screen.getByText(/catching up to the chain/i)).toBeInTheDocument(),
+  );
+  // Setup's mnemonic field stays hidden until the user opts in.
+  expect(screen.queryByRole("textbox", { name: /mnemonic/i })).not.toBeInTheDocument();
+  // The escape hatch reveals Setup for a read-only load.
+  fireEvent.click(screen.getByRole("button", { name: /load wallet anyway/i }));
+  expect(screen.getByRole("textbox", { name: /mnemonic/i })).toBeInTheDocument();
+});
+
+test("Send nav is disabled until the node is ready", async () => {
+  stubStatus("syncing");
+  vi.spyOn(hooks, "useBalance").mockReturnValue({ data: null, error: null, loading: true, refresh: vi.fn() } as never);
+  vi.spyOn(hooks, "useDelegation").mockReturnValue({ data: null, error: null, loading: true, refresh: vi.fn() } as never);
+  vi.spyOn(client, "loadWallet").mockResolvedValue(mockAccount);
+  render(<App />);
+  // While syncing with no wallet the boot view is shown; opt in to reach Setup,
+  // then load a read-only wallet so the nav (and its gating) becomes visible.
+  fireEvent.click(await screen.findByRole("button", { name: /load wallet anyway/i }));
+  fireEvent.change(screen.getByRole("textbox", { name: /mnemonic/i }), { target: { value: MNEMONIC } });
+  fireEvent.click(screen.getByRole("button", { name: /^load wallet$/i }));
   // The Send entry is present but disabled while not ready.
   await waitFor(() => expect(screen.getByText("Send").closest("button")).toBeDisabled());
 });
@@ -44,14 +68,16 @@ test("deep-linking #/send while syncing falls back to Portfolio (guard)", async 
   window.location.hash = "#/send";
 
   render(<App />);
-  // Load a read-only wallet to get past Setup into the routed content area.
+  // Past the boot Syncing view into Setup, then load a read-only wallet to reach
+  // the routed content area.
+  fireEvent.click(await screen.findByRole("button", { name: /load wallet anyway/i }));
   fireEvent.change(screen.getByRole("textbox", { name: /mnemonic/i }), {
-    target: { value: "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12" },
+    target: { value: MNEMONIC },
   });
-  fireEvent.click(screen.getByRole("button", { name: /load wallet/i }));
+  fireEvent.click(screen.getByRole("button", { name: /^load wallet$/i }));
 
   // Once the wallet loads, Setup is gone — but the Send screen must not appear.
-  await waitFor(() => expect(screen.queryByRole("button", { name: /load wallet/i })).not.toBeInTheDocument());
+  await waitFor(() => expect(screen.queryByRole("button", { name: /^load wallet$/i })).not.toBeInTheDocument());
   expect(screen.queryByText("Send ADA")).not.toBeInTheDocument();
 });
 
@@ -107,7 +133,8 @@ test("spending-enabled wallet on a ready node can reach Send", async () => {
   fireEvent.change(screen.getByRole("textbox", { name: /mnemonic/i }), {
     target: { value: "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12" },
   });
-  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "s3cretpw" } });
+  // Must clear the client-side minimum (12 chars) so it reaches createKeystore.
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "s3cret-passphrase" } });
   fireEvent.click(screen.getByRole("button", { name: /load wallet/i }));
 
   // Send screen renders (its "Send ADA" card).

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -5,6 +5,7 @@ import { useStatus } from "./api/hooks";
 import { SyncBanner } from "./components/SyncBanner";
 import { useHashRoute, navigate } from "./router";
 import { Setup } from "./screens/Setup";
+import { Syncing } from "./screens/Syncing";
 import { Portfolio } from "./screens/Portfolio";
 import { Receive } from "./screens/Receive";
 import { Activity } from "./screens/Activity";
@@ -34,10 +35,28 @@ const NAV: { key: string; label: string }[] = [
 export function App() {
   const [account, setAccount] = useState<Account | null>(null);
   const [spendingEnabled, setSpendingEnabled] = useState(false);
+  // Set when the user chooses to load a wallet while the node is still syncing,
+  // dismissing the boot Syncing view in favour of Setup (read-only).
+  const [loadAnyway, setLoadAnyway] = useState(false);
   const status = useStatus();
   const route = useHashRoute();
 
   const isReady = status.data?.state === "ready";
+
+  // Boot gate: before any wallet is loaded, if the node isn't ready and the
+  // user hasn't opted to proceed, the Syncing view takes the whole screen —
+  // there is nothing to operate yet, and a balance shown now would be wrong.
+  // The escape hatch drops to Setup for a read-only load against a syncing node.
+  if (account === null && !loadAnyway && status.data && status.data.state !== "ready") {
+    return (
+      <div className="app">
+        <SyncBanner status={status.data} />
+        <main className="content content-boot">
+          <Syncing status={status.data} onLoadAnyway={() => setLoadAnyway(true)} />
+        </main>
+      </div>
+    );
+  }
   // Sending requires BOTH a fully synced node and a spending-enabled wallet (a
   // keystore created with a password). A read-only wallet (loaded without a
   // password) can never complete a send, so it must not enter the send flow.

--- a/ui/web/src/components/SyncBanner.tsx
+++ b/ui/web/src/components/SyncBanner.tsx
@@ -25,7 +25,7 @@ export function SyncBanner({ status }: SyncBannerProps) {
   const tone = stateToTone(status.state);
 
   let detail = "";
-  if (status.bootstrap) {
+  if (status.state === "bootstrapping" && status.bootstrap) {
     detail = `${status.bootstrap.phase} ${status.bootstrap.percent.toFixed(1)}%`;
   } else if (status.state === "ready") {
     detail = `tip ${status.tip} · ${status.caughtUp ? "caught up" : "catching up"}`;

--- a/ui/web/src/components/components.test.tsx
+++ b/ui/web/src/components/components.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { Button } from "./Button";
 import { StatusPill } from "./StatusPill";
 import { CopyButton } from "./CopyButton";
+import { SyncBanner } from "./SyncBanner";
 
 const originalClipboard = navigator.clipboard;
 afterEach(() => {
@@ -29,4 +30,21 @@ test("CopyButton copies its value and shows feedback on success", async () => {
   expect(writeText).toHaveBeenCalledWith("addr_test1abc");
   // "Copied" appears only after the async write resolves.
   expect(await screen.findByText("Copied")).toBeInTheDocument();
+});
+
+test("SyncBanner shows error detail ahead of retained bootstrap diagnostics", () => {
+  render(
+    <SyncBanner
+      status={{
+        state: "error",
+        tip: 0,
+        caughtUp: false,
+        error: "mithril bootstrap: download failed",
+        bootstrap: { phase: "bootstrap", percent: 40 },
+      }}
+    />,
+  );
+  expect(screen.getByText("error")).toBeInTheDocument();
+  expect(screen.getByText("mithril bootstrap: download failed")).toBeInTheDocument();
+  expect(screen.queryByText("bootstrap 40.0%")).not.toBeInTheDocument();
 });

--- a/ui/web/src/screens/Syncing.test.tsx
+++ b/ui/web/src/screens/Syncing.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { Syncing } from "./Syncing";
+
+const noop = () => {};
+
+test("(a) bootstrap download phase shows bytes, ETA, percent and the progress bar", () => {
+  render(
+    <Syncing
+      status={{
+        state: "bootstrapping",
+        tip: 0,
+        caughtUp: false,
+        bootstrap: {
+          phase: "bootstrap",
+          percent: 42.5,
+          bytes_downloaded: 1024 * 1024 * 1024, // 1.0 GB
+          total_bytes: 4 * 1024 * 1024 * 1024, // 4.0 GB
+          bytes_per_second: 18 * 1024 * 1024, // 18.0 MB/s
+        },
+      }}
+      onLoadAnyway={noop}
+    />,
+  );
+  expect(screen.getByText("42.5%")).toBeInTheDocument();
+  expect(screen.getByText(/1\.0 GB \/ 4\.0 GB/)).toBeInTheDocument();
+  expect(screen.getByText(/min left/)).toBeInTheDocument();
+  expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "43");
+});
+
+test("(b) block-replay phase shows block count, slot range and the era label", () => {
+  render(
+    <Syncing
+      status={{
+        state: "bootstrapping",
+        tip: 0,
+        caughtUp: false,
+        bootstrap: {
+          phase: "backfill",
+          percent: 71,
+          count: 18432,
+          total: 25900,
+          current_slot: 97740,
+          tip_slot: 132000,
+          description: "Conway",
+        },
+      }}
+      onLoadAnyway={noop}
+    />,
+  );
+  expect(screen.getByText(/18,432 \/ 25,900 blocks/)).toBeInTheDocument();
+  expect(screen.getByText(/slot 97,740 → 132,000/)).toBeInTheDocument();
+  expect(screen.getByText(/Conway/)).toBeInTheDocument();
+});
+
+test("(c) the phase stepper marks earlier phases done and the current one active", () => {
+  render(
+    <Syncing
+      status={{
+        state: "bootstrapping",
+        tip: 0,
+        caughtUp: false,
+        bootstrap: { phase: "immutable_copy", percent: 10 },
+      }}
+      onLoadAnyway={noop}
+    />,
+  );
+  // The active phase's label also appears in the panel head, so scope to the
+  // stepper list to assert on the steps themselves.
+  const steps = screen.getByRole("list");
+  expect(within(steps).getByText("Copy chain history").closest("li")).toHaveClass("sync-step-active");
+  expect(within(steps).getByText("Download snapshot").closest("li")).toHaveClass("sync-step-done");
+  expect(within(steps).getByText("Backfill blocks").closest("li")).toHaveClass("sync-step-pending");
+});
+
+test("(d) chain sync shows how far behind the tip and the block slot", () => {
+  const threeDaysAgo = new Date(Date.now() - 3 * 86400 * 1000).toISOString();
+  render(
+    <Syncing
+      status={{ state: "syncing", tip: 115748244, caughtUp: false, latestBlockTime: threeDaysAgo }}
+      onLoadAnyway={noop}
+    />,
+  );
+  expect(screen.getByText(/behind/)).toBeInTheDocument();
+  expect(screen.getByText("115,748,244")).toBeInTheDocument();
+});
+
+test("(e) error state surfaces the node error in an alert", () => {
+  render(
+    <Syncing
+      status={{ state: "error", tip: 0, caughtUp: false, error: "genesis import failed" }}
+      onLoadAnyway={noop}
+    />,
+  );
+  expect(screen.getByRole("alert")).toHaveTextContent("genesis import failed");
+});
+
+test("(f) the escape hatch invokes onLoadAnyway", () => {
+  const onLoadAnyway = vi.fn();
+  render(
+    <Syncing status={{ state: "syncing", tip: 0, caughtUp: false }} onLoadAnyway={onLoadAnyway} />,
+  );
+  fireEvent.click(screen.getByRole("button", { name: /load wallet anyway/i }));
+  expect(onLoadAnyway).toHaveBeenCalled();
+});

--- a/ui/web/src/screens/Syncing.test.tsx
+++ b/ui/web/src/screens/Syncing.test.tsx
@@ -84,7 +84,18 @@ test("(d) chain sync shows how far behind the tip and the block slot", () => {
   expect(screen.getByText("115,748,244")).toBeInTheDocument();
 });
 
-test("(e) error state surfaces the node error in an alert", () => {
+test("(e) indeterminate sync progress is announced to assistive technology", () => {
+  render(
+    <Syncing
+      status={{ state: "starting", tip: 0, caughtUp: false }}
+      onLoadAnyway={noop}
+    />,
+  );
+  const bar = screen.getByRole("progressbar", { name: "Syncing…" });
+  expect(bar).not.toHaveAttribute("aria-valuenow");
+});
+
+test("(f) error state surfaces the node error in an alert", () => {
   render(
     <Syncing
       status={{ state: "error", tip: 0, caughtUp: false, error: "genesis import failed" }}
@@ -94,7 +105,25 @@ test("(e) error state surfaces the node error in an alert", () => {
   expect(screen.getByRole("alert")).toHaveTextContent("genesis import failed");
 });
 
-test("(f) the escape hatch invokes onLoadAnyway", () => {
+test("(g) retained bootstrap diagnostics do not override an error state", () => {
+  render(
+    <Syncing
+      status={{
+        state: "error",
+        tip: 0,
+        caughtUp: false,
+        error: "mithril bootstrap: download failed",
+        bootstrap: { phase: "bootstrap", percent: 40 },
+      }}
+      onLoadAnyway={noop}
+    />,
+  );
+  expect(screen.getByRole("heading", { name: "Sync interrupted" })).toBeInTheDocument();
+  expect(screen.getByRole("alert")).toHaveTextContent("mithril bootstrap: download failed");
+  expect(screen.queryByText("40.0%")).not.toBeInTheDocument();
+});
+
+test("(h) the escape hatch invokes onLoadAnyway", () => {
   const onLoadAnyway = vi.fn();
   render(
     <Syncing status={{ state: "syncing", tip: 0, caughtUp: false }} onLoadAnyway={onLoadAnyway} />,

--- a/ui/web/src/screens/Syncing.tsx
+++ b/ui/web/src/screens/Syncing.tsx
@@ -1,0 +1,251 @@
+import type { Status, BootstrapProgress } from "../api/types";
+
+interface SyncingProps {
+  status: Status;
+  onLoadAnyway: () => void;
+}
+
+// The Mithril bootstrap pipeline, in the order dingo emits it, with operator-
+// facing labels. "complete" isn't shown — by the time it fires the node has
+// moved on to chain sync (or ready), so it never needs a step of its own.
+const PHASES: { key: string; label: string }[] = [
+  { key: "bootstrap", label: "Download snapshot" },
+  { key: "ledger_import", label: "Import ledger state" },
+  { key: "immutable_copy", label: "Copy chain history" },
+  { key: "gap_blocks", label: "Fetch gap blocks" },
+  { key: "post_ledger_state", label: "Rebuild ledger state" },
+  { key: "backfill", label: "Backfill blocks" },
+  { key: "index_rebuild", label: "Rebuild indexes" },
+];
+
+function fmtBytes(n?: number): string {
+  if (!n || n <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let v = n;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i += 1;
+  }
+  return `${v.toFixed(i === 0 || v >= 100 ? 0 : 1)} ${units[i]}`;
+}
+
+function fmtInt(n?: number): string {
+  return (n ?? 0).toLocaleString();
+}
+
+// Coarse, honest durations — "~8 min left", not "8:07". Returns "" when there's
+// nothing meaningful to show (no rate / already done).
+function fmtDuration(seconds: number, suffix: string): string {
+  if (!isFinite(seconds) || seconds <= 0) return "";
+  if (seconds < 90) return `~${Math.round(seconds)}s ${suffix}`;
+  const m = seconds / 60;
+  if (m < 90) return `~${Math.round(m)} min ${suffix}`;
+  const h = m / 60;
+  if (h < 36) return `~${Math.round(h)} h ${suffix}`;
+  return `~${Math.round(h / 24)} d ${suffix}`;
+}
+
+// How far the node's latest block lags wall-clock time — the intuitive "where
+// it is" for chain sync, since it shrinks toward zero as the node catches up.
+// Units are spelled out: this is the view's hero readout, not a terse ETA.
+function fmtBehind(latest: string | undefined, nowMs: number): string {
+  if (!latest) return "waiting for first block";
+  const ms = nowMs - Date.parse(latest);
+  if (!isFinite(ms) || ms <= 0) return "at the chain tip";
+  const s = ms / 1000;
+  const pick = (v: number, unit: string) => {
+    const n = Math.round(v);
+    return `${n} ${unit}${n === 1 ? "" : "s"} behind`;
+  };
+  if (s < 90) return pick(s, "second");
+  const m = s / 60;
+  if (m < 90) return pick(m, "minute");
+  const h = m / 60;
+  if (h < 36) return pick(h, "hour");
+  return pick(h / 24, "day");
+}
+
+function Bar({ percent, indeterminate }: { percent?: number; indeterminate?: boolean }) {
+  if (indeterminate) {
+    return (
+      <div className="sync-bar">
+        <div className="sync-bar-fill sync-bar-indeterminate" />
+      </div>
+    );
+  }
+  const p = Math.max(0, Math.min(100, percent ?? 0));
+  return (
+    <div
+      className="sync-bar"
+      role="progressbar"
+      aria-valuenow={Math.round(p)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
+      <div className="sync-bar-fill" style={{ width: `${p}%` }} />
+    </div>
+  );
+}
+
+function PhaseSteps({ active }: { active: string }) {
+  const idx = PHASES.findIndex((p) => p.key === active);
+  return (
+    <ol className="sync-steps">
+      {PHASES.map((p, i) => {
+        const state =
+          idx < 0 ? "pending" : i < idx ? "done" : i === idx ? "active" : "pending";
+        return (
+          <li key={p.key} className={`sync-step sync-step-${state}`}>
+            <span className="sync-step-dot" aria-hidden="true" />
+            <span className="sync-step-label">{p.label}</span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+// The detail readout for an in-flight Mithril bootstrap phase: a percent bar
+// plus whichever positional pair the active phase populates (bytes for the
+// download, count/slot for the block-replay phases).
+function BootstrapDetail({ bp }: { bp: BootstrapProgress }) {
+  const phaseLabel =
+    PHASES.find((p) => p.key === bp.phase)?.label ?? bp.phase.replace(/_/g, " ");
+
+  const readouts: string[] = [];
+  if (bp.total_bytes && bp.total_bytes > 0) {
+    let line = `${fmtBytes(bp.bytes_downloaded)} / ${fmtBytes(bp.total_bytes)}`;
+    if (bp.bytes_per_second && bp.bytes_per_second > 0) {
+      line += ` · ${fmtBytes(bp.bytes_per_second)}/s`;
+      const remaining = (bp.total_bytes - (bp.bytes_downloaded ?? 0)) / bp.bytes_per_second;
+      const eta = fmtDuration(remaining, "left");
+      if (eta) line += ` · ${eta}`;
+    }
+    readouts.push(line);
+  } else if (bp.total && bp.total > 0) {
+    let line = `${fmtInt(bp.count)} / ${fmtInt(bp.total)} blocks`;
+    if (bp.bytes_per_second && bp.bytes_per_second > 0) {
+      line += ` · ${fmtBytes(bp.bytes_per_second)}/s`;
+    }
+    readouts.push(line);
+  }
+  if (bp.tip_slot && bp.tip_slot > 0) {
+    readouts.push(`slot ${fmtInt(bp.current_slot)} → ${fmtInt(bp.tip_slot)}`);
+  }
+
+  return (
+    <div className="sync-panel">
+      <div className="sync-phase-head">
+        <span className="sync-phase-label">
+          {phaseLabel}
+          {bp.description ? ` · ${bp.description}` : ""}
+        </span>
+        <span className="sync-percent">{bp.percent.toFixed(1)}%</span>
+      </div>
+      <Bar percent={bp.percent} />
+      {readouts.map((r) => (
+        <p key={r} className="sync-readout">
+          {r}
+        </p>
+      ))}
+      <PhaseSteps active={bp.phase} />
+    </div>
+  );
+}
+
+// The detail readout for P2P chain sync: how far behind the tip we are, the
+// node's current block, and an indeterminate bar (there's no firm network-tip
+// estimate to make into a percent, so we don't fake one).
+function ChainSyncDetail({ status }: { status: Status }) {
+  const nowMs = Date.now();
+  return (
+    <div className="sync-panel">
+      <p className="sync-behind">{fmtBehind(status.latestBlockTime, nowMs)}</p>
+      <Bar indeterminate />
+      <dl className="sync-stats">
+        <div>
+          <dt>Block slot</dt>
+          <dd>{status.tip > 0 ? fmtInt(status.tip) : "—"}</dd>
+        </div>
+        <div>
+          <dt>Latest block</dt>
+          <dd>
+            {status.latestBlockTime
+              ? new Date(status.latestBlockTime).toLocaleString()
+              : "—"}
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+export function Syncing({ status, onLoadAnyway }: SyncingProps) {
+  let title: string;
+  let subtitle: string;
+  switch (status.state) {
+    case "bootstrapping":
+      title = "Bootstrapping from a Mithril snapshot";
+      subtitle = "Fast-syncing the chain database from a verified snapshot. This runs once.";
+      break;
+    case "syncing":
+      title = "Catching up to the chain";
+      subtitle = "Following the Cardano network from your node’s last known block.";
+      break;
+    case "starting":
+      title = "Starting your node";
+      subtitle = "Bringing the embedded Cardano node online.";
+      break;
+    case "error":
+      title = "Sync interrupted";
+      subtitle = status.error || "The node reported an error.";
+      break;
+    default:
+      title = "Preparing";
+      subtitle = "Getting the node ready.";
+  }
+
+  let detail;
+  if (status.bootstrap) {
+    detail = <BootstrapDetail bp={status.bootstrap} />;
+  } else if (status.state === "syncing") {
+    detail = <ChainSyncDetail status={status} />;
+  } else if (status.state === "error") {
+    detail = (
+      <div className="sync-panel">
+        <p className="error-text" role="alert">
+          {status.error || "The node reported an error."}
+        </p>
+      </div>
+    );
+  } else {
+    // starting / stopped / pre-first-poll: nothing to quantify yet.
+    detail = (
+      <div className="sync-panel">
+        <Bar indeterminate />
+      </div>
+    );
+  }
+
+  return (
+    <div className="syncing">
+      <header className="sync-head">
+        <h1 className="sync-title">{title}</h1>
+        <p className="sync-subtitle">{subtitle}</p>
+      </header>
+
+      {detail}
+
+      <footer className="sync-foot">
+        <button type="button" className="btn ghost sync-escape" onClick={onLoadAnyway}>
+          Load wallet anyway (read-only)
+        </button>
+        <p className="helper-text">
+          You can open a wallet now, but balances and history stay incomplete
+          until syncing finishes.
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/ui/web/src/screens/Syncing.tsx
+++ b/ui/web/src/screens/Syncing.tsx
@@ -69,7 +69,7 @@ function fmtBehind(latest: string | undefined, nowMs: number): string {
 function Bar({ percent, indeterminate }: { percent?: number; indeterminate?: boolean }) {
   if (indeterminate) {
     return (
-      <div className="sync-bar">
+      <div className="sync-bar" role="progressbar" aria-label="Syncing…">
         <div className="sync-bar-fill sync-bar-indeterminate" />
       </div>
     );
@@ -207,7 +207,7 @@ export function Syncing({ status, onLoadAnyway }: SyncingProps) {
   }
 
   let detail;
-  if (status.bootstrap) {
+  if (status.state === "bootstrapping" && status.bootstrap) {
     detail = <BootstrapDetail bp={status.bootstrap} />;
   } else if (status.state === "syncing") {
     detail = <ChainSyncDetail status={status} />;

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -492,6 +492,192 @@ a:hover {
   color: var(--text-faint);
 }
 
+/* ------------------------------------------------- node sync (boot view) -- */
+/* The boot screen centers one column with no sidebar, so it reads as a
+   dedicated "waiting for the node" view rather than a cramped strip. */
+.content-boot {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+.syncing {
+  width: 100%;
+  max-width: 540px;
+  margin-top: clamp(var(--space-4), 7vh, 80px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+.sync-head {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.sync-title {
+  font-size: 1.3rem;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  text-wrap: balance;
+}
+.sync-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+/* The sync detail lives in a panel matching the cockpit's cards. */
+.sync-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.sync-phase-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+.sync-phase-label {
+  font-family: var(--mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.sync-percent {
+  font-family: var(--mono);
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Progress bar — blue (the "working" hue); gold stays reserved for identity. */
+.sync-bar {
+  height: 6px;
+  background: var(--inset);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.sync-bar-fill {
+  height: 100%;
+  background: var(--warn);
+  border-radius: inherit;
+  transition: width 0.4s ease;
+}
+.sync-bar-indeterminate {
+  width: 35%;
+  animation: sync-slide 1.5s ease-in-out infinite;
+}
+@keyframes sync-slide {
+  0% {
+    margin-left: -35%;
+  }
+  100% {
+    margin-left: 100%;
+  }
+}
+
+.sync-readout {
+  font-family: var(--mono);
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* The "X behind" headline for chain sync — a big gold readout. */
+.sync-behind {
+  font-family: var(--mono);
+  font-size: clamp(1.5rem, 4vw, 2rem);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--accent);
+}
+
+.sync-stats {
+  display: flex;
+  flex-direction: column;
+}
+.sync-stats > div {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--border);
+}
+.sync-stats > div:last-child {
+  border-bottom: none;
+}
+.sync-stats dt {
+  font-family: var(--mono);
+  font-size: 0.6875rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.sync-stats dd {
+  font-family: var(--mono);
+  font-size: 0.8125rem;
+  text-align: right;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Phase stepper — a vertical track of the bootstrap stages. */
+.sync-steps {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+}
+.sync-step {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+}
+.sync-step-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--text-faint);
+}
+.sync-step-pending .sync-step-label {
+  color: var(--text-faint);
+}
+.sync-step-done .sync-step-dot {
+  background: var(--accent);
+}
+.sync-step-done .sync-step-label {
+  color: var(--text-muted);
+}
+.sync-step-active .sync-step-dot {
+  background: var(--warn);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--warn) 22%, transparent);
+  animation: pulse 1.6s ease-in-out infinite;
+}
+.sync-step-active .sync-step-label {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.sync-foot {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-2);
+}
+
 /* --------------------------------------------------------------- actions -- */
 .preview-actions {
   display: flex;
@@ -514,7 +700,9 @@ a:hover {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .dot-warn {
+  .dot-warn,
+  .sync-bar-indeterminate,
+  .sync-step-active .sync-step-dot {
     animation: none;
   }
   * {


### PR DESCRIPTION
<img width="1280" height="860" alt="image" src="https://github.com/user-attachments/assets/f9f66409-4eb5-42c8-93a0-a9438d96892d" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated sync view for bootstrap and chain sync that shows clear progress and blocks misleading balances until the node is ready. Extends the status API to expose richer sync telemetry used by the UI.

- New Features
  - New Syncing screen: progress bar, phase stepper, snapshot metrics (bytes, rate, ETA), block replay stats (blocks, slot range, era), and chain lag readout.
  - App gating: if no wallet and node isn’t ready, show Syncing full-screen; “Load wallet anyway (read-only)” drops to Setup.
  - API/types: `BootstrapProgress` adds `current_slot`, `tip_slot`, `count`, `total`, `description`; mapped in `toBootstrapProgress` and surfaced on `/status`.
  - Tests/styles: added Syncing tests and updated app routing tests; new boot-view styles and an accessible determinate/indeterminate progress bar.

- Bug Fixes
  - `SyncBanner` now shows bootstrap detail only while bootstrapping and prioritizes node errors in error state, avoiding misleading retained progress.

<sup>Written for commit 0f02e8d2e0714110ec12f60510b0f41577dd483e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

