### PR TITLE
fix: harden signing

### DIFF
--- a/message.go
+++ b/message.go
@@ -308,7 +308,10 @@ func SignData(addr, payload []byte, lk *LoadedKey) (signatureHex, keyHex string,
 	if err != nil {
 		return "", "", err
 	}
-	signature := sign(toBeSigned)
+	signature, err := sign(toBeSigned)
+	if err != nil {
+		return "", "", err
+	}
 	coseSign1Bytes, err := cbor.Encode([]any{
 		protected,
 		map[any]any{"hashed": false},

--- a/message_test.go
+++ b/message_test.go
@@ -15,6 +15,7 @@
 package bursa
 
 import (
+	"crypto/ed25519"
 	"encoding/hex"
 	"testing"
 
@@ -137,11 +138,15 @@ func testCoseSign1Hex(
 	if err != nil {
 		t.Fatalf("buildSigStructure: %v", err)
 	}
+	sig, err := sign(toBeSigned)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
 	coseSign1Bytes, err := cbor.Encode([]any{
 		protected,
 		unprotectedHeaders,
 		cosePayload,
-		sign(toBeSigned),
+		sig,
 	})
 	if err != nil {
 		t.Fatalf("encode COSE_Sign1: %v", err)
@@ -158,6 +163,35 @@ func testCoseSign1Hex(
 
 func TestSignAndVerifyData(t *testing.T) {
 	lk := testLoadedKey(make([]byte, 32))
+	addr := testEnterpriseAddress(t, lk.VKey)
+	payload := []byte("hello cardano")
+
+	sig, key, err := SignData(addr, payload, lk)
+	if err != nil {
+		t.Fatalf("SignData: %v", err)
+	}
+	if len(sig) == 0 || len(key) == 0 {
+		t.Fatalf("empty signature or key")
+	}
+	ok, err := VerifyData(sig, key, payload)
+	if err != nil {
+		t.Fatalf("VerifyData: %v", err)
+	}
+	if !ok {
+		t.Fatalf("signature failed to verify")
+	}
+}
+
+// Standard (non-extended, 64-byte) Ed25519 keys are valid for CIP-8 on the
+// software/SOPS backends, but every other CIP-8 test uses an extended key.
+// This covers the standard-key SignData -> VerifyData round trip end to end,
+// which also exercises the 64-byte branch of the verify-after-sign self-check.
+func TestSignAndVerifyData_StandardKey(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	lk := &LoadedKey{SKey: []byte(priv), VKey: pub}
 	addr := testEnterpriseAddress(t, lk.VKey)
 	payload := []byte("hello cardano")
 
@@ -362,11 +396,15 @@ func TestVerifyData_RejectsProtectedAddressMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("signerForKey: %v", err)
 	}
+	sig, err := sign(toBeSigned)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
 	coseSign1Bytes, err := cbor.Encode([]any{
 		protected,
 		map[any]any{"hashed": false},
 		payload,
-		sign(toBeSigned),
+		sig,
 	})
 	if err != nil {
 		t.Fatalf("encode COSE_Sign1: %v", err)
@@ -440,11 +478,15 @@ func TestVerifyData_RejectsInvalidProtectedAlgorithm(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildSigStructure: %v", err)
 	}
+	sig, err := sign(toBeSigned)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
 	coseSign1Bytes, err := cbor.Encode([]any{
 		protected,
 		map[any]any{"hashed": false},
 		payload,
-		sign(toBeSigned),
+		sig,
 	})
 	if err != nil {
 		t.Fatalf("encode COSE_Sign1: %v", err)

--- a/sign_verify_test.go
+++ b/sign_verify_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bursa
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"testing"
+)
+
+// An honest signer's output is returned unchanged and reports no error.
+func TestVerifyingSigner_PassesHonestSignature(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	msg := []byte("the 32-byte transaction id-ish")
+
+	sign := verifyingSigner(pub, func(m []byte) []byte { return ed25519.Sign(priv, m) })
+	sig, err := sign(msg)
+	if err != nil {
+		t.Fatalf("honest signer rejected: %v", err)
+	}
+	if !ed25519.Verify(pub, msg, sig) {
+		t.Fatalf("returned signature does not verify")
+	}
+}
+
+// A signer whose output is corrupted after signing (modeling a fault-injection
+// glitch or memory corruption) is caught before the signature leaves the func.
+func TestVerifyingSigner_DetectsCorruptedSignature(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	msg := []byte("message")
+
+	sign := verifyingSigner(pub, func(m []byte) []byte {
+		s := ed25519.Sign(priv, m)
+		s[0] ^= 0xff // flip a bit in the nonce point
+		return s
+	})
+	sig, err := sign(msg)
+	if !errors.Is(err, ErrSignatureVerification) {
+		t.Fatalf("want ErrSignatureVerification, got err=%v sig=%x", err, sig)
+	}
+	if sig != nil {
+		t.Fatalf("a bad signature must not be returned, got %x", sig)
+	}
+}
+
+// A signer that signs with a different key than the public key it is paired
+// with is caught (guards against key/closure mismatch in signerForKey).
+func TestVerifyingSigner_DetectsWrongKey(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	_, otherPriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	msg := []byte("message")
+
+	sign := verifyingSigner(pub, func(m []byte) []byte { return ed25519.Sign(otherPriv, m) })
+	if _, err := sign(msg); !errors.Is(err, ErrSignatureVerification) {
+		t.Fatalf("want ErrSignatureVerification, got %v", err)
+	}
+}
+
+// A malformed (non-32-byte) public key cannot silently pass verification.
+func TestVerifyingSigner_RejectsMalformedPublicKey(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	sign := verifyingSigner([]byte{0x01, 0x02}, func(m []byte) []byte { return ed25519.Sign(priv, m) })
+	if _, err := sign([]byte("message")); !errors.Is(err, ErrSignatureVerification) {
+		t.Fatalf("want ErrSignatureVerification for short pubkey, got %v", err)
+	}
+}

--- a/transaction.go
+++ b/transaction.go
@@ -127,22 +127,54 @@ func useTagForTxType(txType uint) bool {
 	return txType >= ledger.TxTypeConway
 }
 
+// ErrSignatureVerification indicates a freshly produced signature failed to
+// verify against its own public key. With correct key material and an intact
+// signing routine this can never happen, so it signals memory corruption, a
+// fault-injection ("glitch") attack on the deterministic EdDSA signer — the
+// standard defense against which is to verify before releasing the signature,
+// since a faulted second signing of the same message would otherwise leak the
+// private scalar — or a signing-math bug. The signature is discarded, never
+// returned.
+var ErrSignatureVerification = errors.New("produced signature failed self-verification")
+
+// verifyingSigner wraps a raw signing function with a verify-after-sign
+// self-check: it signs, then confirms the result verifies against pub before
+// returning it, yielding ErrSignatureVerification otherwise. crypto/ed25519
+// verification is valid for both standard and Cardano extended
+// (BIP32-Ed25519) signatures because both verify against the 32-byte public
+// key, and Go's verifier additionally rejects non-canonical S (malleable)
+// signatures. This is defense-in-depth applied at the lowest signing layer so
+// every caller — offline tx signing, CIP-8 data signing, and the remote
+// signer's custody backends — inherits the same guarantee.
+func verifyingSigner(pub []byte, raw func(msg []byte) []byte) func(msg []byte) ([]byte, error) {
+	return func(msg []byte) ([]byte, error) {
+		sig := raw(msg)
+		if len(pub) != ed25519.PublicKeySize ||
+			!ed25519.Verify(ed25519.PublicKey(pub), msg, sig) {
+			return nil, ErrSignatureVerification
+		}
+		return sig, nil
+	}
+}
+
 // signerForKey returns the 32-byte public (vkey) bytes and a signing closure
 // for a loaded signing key. Extended BIP32 keys (96-byte SKey) use Cardano
 // BIP32-Ed25519 signing; standard keys (64-byte ed25519 private key) use
-// crypto/ed25519.
-func signerForKey(lk *LoadedKey) (vkey []byte, sign func(msg []byte) []byte, err error) {
+// crypto/ed25519. The returned closure verifies every signature it produces
+// against vkey before returning it (see verifyingSigner / ErrSignatureVerification).
+func signerForKey(lk *LoadedKey) (vkey []byte, sign func(msg []byte) ([]byte, error), err error) {
 	if lk == nil {
 		return nil, nil, errors.New("signing key cannot be nil")
 	}
 	switch len(lk.SKey) {
 	case 96:
 		x := bip32.XPrv(lk.SKey)
-		return x.PublicKey(), x.Sign, nil
+		pub := x.PublicKey()
+		return pub, verifyingSigner(pub, x.Sign), nil
 	case 64:
 		priv := ed25519.PrivateKey(lk.SKey)
 		pub := priv.Public().(ed25519.PublicKey)
-		return pub, func(msg []byte) []byte { return ed25519.Sign(priv, msg) }, nil
+		return pub, verifyingSigner(pub, func(msg []byte) []byte { return ed25519.Sign(priv, msg) }), nil
 	default:
 		return nil, nil, fmt.Errorf("unsupported signing key length %d (want 64 or 96)", len(lk.SKey))
 	}
@@ -158,7 +190,11 @@ func CreateWitness(txID []byte, lk *LoadedKey) (lcommon.VkeyWitness, error) {
 	if err != nil {
 		return lcommon.VkeyWitness{}, err
 	}
-	return lcommon.VkeyWitness{Vkey: vkey, Signature: sign(txID)}, nil
+	sig, err := sign(txID)
+	if err != nil {
+		return lcommon.VkeyWitness{}, err
+	}
+	return lcommon.VkeyWitness{Vkey: vkey, Signature: sig}, nil
 }
 
 // SignTransaction adds a vkey witness for each provided signing key and returns
@@ -409,13 +445,25 @@ func MinFee(sizeBytes int, params ProtocolParams) uint64 {
 // SignDigest signs an arbitrary message with the loaded key and returns the raw
 // 64-byte signature. Standard ed25519 keys use crypto/ed25519; extended
 // BIP32-Ed25519 keys use the Cardano signing routine. This is the low-level
-// signing primitive used by the remote signer's custody backends.
+// signing primitive used by the remote signer's custody backends. The produced
+// signature is verified against the key's own public key before return; a
+// failure yields ErrSignatureVerification.
+//
+// SECURITY: SignDigest signs whatever bytes it is handed — it performs no
+// transaction decoding and no policy evaluation. Callers MUST only pass a
+// digest derived from a fully decoded, policy-checked request (e.g. the
+// blake2b-256 tx id from TransactionID after InspectTransaction, or a CIP-8
+// Sig_structure). Never wire this primitive to a caller-supplied, un-inspected
+// digest: doing so would let an attacker obtain a valid witness over an
+// arbitrary transaction body (a drain). The remote signer upholds this by
+// computing the digest itself from decoded CBOR and signing only after policy
+// passes; any new signing entry point must do the same.
 func SignDigest(lk *LoadedKey, msg []byte) ([]byte, error) {
 	_, sign, err := signerForKey(lk)
 	if err != nil {
 		return nil, err
 	}
-	return sign(msg), nil
+	return sign(msg)
 }
 
 // PublicKeyOf returns the canonical 32-byte Ed25519 verification key for the


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened all Ed25519 signing by verifying each signature before returning it and propagating errors, preventing corrupted or faulted signatures from leaving the signer. Adds tests and support coverage for standard 64-byte keys without changing behavior for valid signatures.

- **Bug Fixes**
  - Wrap signers with a verify-after-sign check using `crypto/ed25519`; introduce `ErrSignatureVerification`.
  - Make signing closures return errors; `SignData`, `CreateWitness`, and `SignDigest` now surface verification failures.
  - Add tests for honest vs. corrupted signatures, wrong-key signing, malformed public keys, and a standard-key CIP-8 round trip.
  - Document security guidance in `SignDigest`; ensures both standard and extended keys verify against the 32-byte public key.

<sup>Written for commit 2df004641f697f7a07c68e570d4620fe9bab6f98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

