### PR TITLE
ci(ui): build and publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,6 +175,93 @@ jobs:
         with:
           subject-path: 'bursa'
 
+  # Build the embedded-SPA wallet binary (ui/cmd/bursa-wallet) from the nested
+  # ui/ module across the same os/arch matrix as build-binaries. Only the
+  # default (non-webview) build is shipped: it is pure Go and cross-compiles
+  # cleanly. The `webview` variant needs CGO + system webkit and cannot be
+  # cross-compiled, so it is intentionally excluded here.
+  build-wallet-binaries:
+    strategy:
+      matrix:
+        include:
+          - runner: macos-latest
+            os: darwin
+            arch: arm64
+          - runner: ubuntu-latest
+            os: freebsd
+            arch: amd64
+          - runner: ubuntu-latest
+            os: freebsd
+            arch: arm64
+          - runner: ubuntu-latest
+            os: linux
+            arch: amd64
+          - runner: ubuntu-latest
+            os: linux
+            arch: arm64
+          - runner: ubuntu-latest
+            os: windows
+            arch: amd64
+          - runner: ubuntu-latest
+            os: windows
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    needs: [create-draft-release]
+    permissions:
+      actions: write
+      attestations: write
+      checks: write
+      contents: write
+      id-token: write
+      packages: write
+      statuses: write
+    steps:
+      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/releases/tag/v7.0.0
+        with:
+          fetch-depth: '0'
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0 https://github.com/actions/setup-node/releases/tag/v6.0.0
+        with:
+          node-version: 22
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
+        with:
+          go-version: 1.26.x
+      # Build the web bundle first so the //go:embed dist target is populated.
+      - name: Build web bundle
+        run: cd ui/web && npm ci && npm run build
+      - name: Build wallet binary
+        run: CGO_ENABLED=0 GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make wallet-binary
+
+      # TODO: code-signing the wallet binary (Windows jsign / macOS codesign +
+      # notarization) is not yet mirrored from build-binaries. Ship it unsigned
+      # for now; wire up the same signing steps once the wallet is GA.
+
+      - name: Upload release asset
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          _filename=bursa-wallet-${{ env.RELEASE_TAG }}-${{ matrix.os }}-${{ matrix.arch }}
+          if [[ ${{ matrix.os }} == windows ]]; then
+            _filename=${_filename}.exe
+          fi
+          if [[ "${{ matrix.os }}" == "windows" || "${{ matrix.os }}" == "linux" || "${{ matrix.os }}" == "freebsd" ]]; then
+            cp ui/bursa-wallet ${_filename}
+          fi
+          if [[ "${{ matrix.os }}" == "darwin" ]]; then
+            _filename=bursa-wallet-${{ env.RELEASE_TAG }}-${{ matrix.os }}-${{ matrix.arch }}.zip
+            cp ui/bursa-wallet bursa-wallet
+            zip -r ${_filename} bursa-wallet
+          fi
+          curl \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Content-Type: application/octet-stream" \
+            --data-binary @${_filename} \
+            https://uploads.github.com/repos/${{ github.repository_owner }}/bursa/releases/${{ needs.create-draft-release.outputs.RELEASE_ID }}/assets?name=${_filename}
+
+      - name: Attest binary
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
+        with:
+          subject-path: 'ui/bursa-wallet'
+
   build-images:
     strategy:
       fail-fast: false
@@ -322,7 +409,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [create-draft-release, build-binaries, build-images, build-image-manifest]
+    needs: [create-draft-release, build-binaries, build-wallet-binaries, build-images, build-image-manifest]
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 https://github.com/actions/github-script/releases/tag/v9.0.0
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -1,0 +1,80 @@
+name: ui
+
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  web:
+    name: web
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ui/web
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0 https://github.com/actions/setup-node/releases/tag/v6.0.0
+        with:
+          node-version: 22
+      - name: npm ci
+        run: npm ci
+      - name: lint
+        run: npm run lint
+      - name: type-check
+        run: npm run type-check
+      - name: test
+        run: npm run test
+      - name: build
+        run: npm run build
+
+  ui-go:
+    name: ui-go
+    strategy:
+      matrix:
+        go-version: [1.25.x, 1.26.x]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0 https://github.com/actions/setup-node/releases/tag/v6.0.0
+        with:
+          node-version: 22
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
+        with:
+          go-version: ${{ matrix.go-version }}
+      # Build the web bundle first so the //go:embed dist target is populated
+      # before the Go module is built/tested.
+      - name: Build web bundle
+        run: cd ui/web && npm ci && npm run build
+      - name: go vet
+        run: cd ui && go vet ./...
+      - name: go test
+        run: cd ui && go test ./...
+      - name: go build
+        run: cd ui && go build ./cmd/bursa-wallet
+
+  ui-lint:
+    name: ui-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/releases/tag/v7.0.0
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0 https://github.com/actions/setup-node/releases/tag/v6.0.0
+        with:
+          node-version: 22
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
+        with:
+          go-version: 1.26.x
+      # golangci-lint needs the embedded dist to type-check the webui package,
+      # so build the web bundle before linting the nested module.
+      - name: Build web bundle
+        run: cd ui/web && npm ci && npm run build
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.1
+        with:
+          working-directory: ui

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -36,9 +36,6 @@ jobs:
 
   ui-go:
     name: ui-go
-    strategy:
-      matrix:
-        go-version: [1.25.x, 1.26.x]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/releases/tag/v7.0.0
@@ -47,7 +44,7 @@ jobs:
           node-version: 22
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.26.x
       # Build the web bundle first so the //go:embed dist target is populated
       # before the Go module is built/tested.
       - name: Build web bundle

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,32 @@ GOMODULE=$(shell grep ^module $(ROOT_DIR)/go.mod | awk '{ print $$2 }')
 # Set version strings based on git tag and current ref
 GO_LDFLAGS=-ldflags "-X '$(GOMODULE)/internal/version.Version=$(shell git describe --tags --exact-match 2>/dev/null)' -X '$(GOMODULE)/internal/version.CommitHash=$(shell git rev-parse --short HEAD)'"
 
-.PHONY: build mod-tidy clean test
+# The nested ui/ module is a separate Go module; mirror the version-ldflags
+# pattern against its module path for the embedded-SPA wallet binary.
+UI_GOMODULE=$(shell grep ^module $(ROOT_DIR)/ui/go.mod | awk '{ print $$2 }')
+UI_GO_LDFLAGS=-ldflags "-X '$(UI_GOMODULE)/internal/version.Version=$(shell git describe --tags --exact-match 2>/dev/null)' -X '$(UI_GOMODULE)/internal/version.CommitHash=$(shell git rev-parse --short HEAD)'"
+
+.PHONY: build wallet wallet-binary mod-tidy clean test
 
 # Alias for building program binary
 build: $(BINARIES)
+
+# Build the embedded-SPA wallet binary from the nested ui/ module. The web
+# bundle is built first so the //go:embed dist target is populated, then the
+# default (pure-Go, non-webview) bursa-wallet binary is compiled.
+wallet:
+	cd ui/web && npm ci && npm run build
+	$(MAKE) wallet-binary
+
+# Compile only the bursa-wallet Go binary, assuming the web bundle has already
+# been built into the //go:embed dist target. Honors GOOS/GOARCH for the
+# release cross-build matrix; the default build is pure Go and cross-compiles
+# without CGO. The webview variant is intentionally NOT built here.
+wallet-binary:
+	cd ui && go build \
+		$(UI_GO_LDFLAGS) \
+		-o bursa-wallet \
+		./cmd/bursa-wallet
 
 # Builds and installs binary in ~/.local/bin
 install: build

--- a/ui/cmd/bursa-wallet/ui_headless.go
+++ b/ui/cmd/bursa-wallet/ui_headless.go
@@ -19,12 +19,17 @@ package main
 import (
 	"context"
 	"log/slog"
+	"time"
 )
 
 // awaitUI (default, headless build) serves the wallet UI over loopback for the
 // user's browser and blocks until a shutdown signal arrives or the control
 // surface fails. This build is pure Go (CGO_ENABLED=0) — no GUI dependency.
-func awaitUI(ctx context.Context, _ string, _ *slog.Logger, srvErr <-chan error) error {
+func awaitUI(ctx context.Context, url string, _ *slog.Logger, srvErr <-chan error) error {
+	if err := waitReachable(ctx, url, 15*time.Second, srvErr); err != nil {
+		return err
+	}
+
 	select {
 	case <-ctx.Done():
 		return nil

--- a/ui/web/src/app.test.tsx
+++ b/ui/web/src/app.test.tsx
@@ -107,7 +107,8 @@ test("spending-enabled wallet on a ready node can reach Send", async () => {
   fireEvent.change(screen.getByRole("textbox", { name: /mnemonic/i }), {
     target: { value: "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12" },
   });
-  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "s3cretpw" } });
+  // Must clear the client-side minimum (12 chars) so it reaches createKeystore.
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "s3cret-passphrase" } });
   fireEvent.click(screen.getByRole("button", { name: /load wallet/i }));
 
   // Send screen renders (its "Send ADA" card).


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds CI for the UI and builds/publishes the embedded-SPA wallet binary in releases. Ensures the web bundle builds, the `ui` Go module is vetted/tested on Go 1.26, and cross-compiled binaries are uploaded and attested on draft releases.

- **New Features**
  - New `ui` workflow: build/lint/type-check/test `ui/web`; vet/test/build the `ui` Go module on Go 1.26; run `golangci-lint` after bundling.
  - Release pipeline: build pure-Go `bursa-wallet` (non-webview), upload assets, and attest; ships macOS `.zip` and Windows `.exe` (unsigned).
  - Makefile: add `wallet` and `wallet-binary` targets and version ldflags for the nested `ui` module.

- **Bug Fixes**
  - Update test passphrase to meet the 12-char client-side minimum so wallet creation reaches `createKeystore`.
  - Headless wallet now waits for the loopback UI to be reachable before blocking, improving startup reliability.

<sup>Written for commit 2117929affbb2a04c89b2289729fdcdebc3100fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

