### PR TITLE
feat: verify CIP-8 sig and recover signer address

### DIFF
--- a/message.go
+++ b/message.go
@@ -371,54 +371,76 @@ func extractCoseKeyPub(keyBytes []byte) ([]byte, error) {
 // VerifyData verifies a CIP-8/CIP-30 signData signature (hex COSE_Sign1) using
 // the public key from the supplied COSE_Key (hex), over the expected payload.
 func VerifyData(signatureHex, keyHex string, expectedPayload []byte) (bool, error) {
+	valid, _, err := VerifyDataWithAddress(signatureHex, keyHex, expectedPayload)
+	return valid, err
+}
+
+// VerifyDataWithAddress is VerifyData that additionally returns the signer's
+// address. The COSE_Sign1 protected header carries the address the message was
+// signed for (set by SignData); when verification succeeds that address is
+// returned bech32-encoded so callers can show *which* address signed. The
+// returned address is only meaningful when valid is true and err is nil; it is
+// also returned (best-effort) on a clean signature mismatch (valid=false,
+// err=nil) so callers can report the address that failed.
+func VerifyDataWithAddress(
+	signatureHex, keyHex string,
+	expectedPayload []byte,
+) (valid bool, address string, err error) {
 	sigBytes, err := decodeHex(signatureHex)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 	keyBytes, err := decodeHex(keyHex)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 	var c coseSign1
 	if _, err := cbor.Decode(sigBytes, &c); err != nil {
-		return false, fmt.Errorf("failed to decode COSE_Sign1: %w", err)
+		return false, "", fmt.Errorf("failed to decode COSE_Sign1: %w", err)
 	}
 	if err := validateProtectedHeaders(c.Protected); err != nil {
-		return false, err
+		return false, "", err
 	}
 	payload := c.Payload
 	if payload == nil && expectedPayload != nil {
 		payload = expectedPayload
 	}
+	addrBytes, err := extractProtectedAddress(c.Protected)
+	if err != nil {
+		return false, "", err
+	}
+	// Decode the protected address to bech32 for the caller. A failure here is
+	// fatal: a malformed address means the signature cannot be trusted.
+	signerAddr, err := lcommon.NewAddressFromBytes(addrBytes)
+	if err != nil {
+		return false, "", fmt.Errorf("invalid protected address: %w", err)
+	}
+	address = signerAddr.String()
 	if expectedPayload != nil &&
 		c.Payload != nil &&
 		!bytes.Equal(c.Payload, expectedPayload) {
-		return false, nil
+		return false, address, nil
 	}
 	hashed, err := extractPayloadHashed(c.Protected, c.Unprotected)
 	if err != nil {
-		return false, err
+		return false, address, err
 	}
 	pub, err := extractCoseKeyPub(keyBytes)
 	if err != nil {
-		return false, err
+		return false, address, err
 	}
 	if len(pub) != ed25519.PublicKeySize {
-		return false, fmt.Errorf("unexpected public key size %d", len(pub))
+		return false, address, fmt.Errorf("unexpected public key size %d", len(pub))
 	}
-	addr, err := extractProtectedAddress(c.Protected)
-	if err != nil {
-		return false, err
-	}
-	if err := validateAddressForVKey(addr, pub); err != nil {
+	if err := validateAddressForVKey(addrBytes, pub); err != nil {
 		if errors.Is(err, errAddressDoesNotMatchSigningKey) {
-			return false, errors.New("protected address does not match public key")
+			return false, address, errors.New("protected address does not match public key")
 		}
-		return false, err
+		return false, address, err
 	}
 	toBeSigned, err := buildSigStructure(c.Protected, payloadToVerify(payload, hashed))
 	if err != nil {
-		return false, err
+		return false, address, err
 	}
-	return ed25519.Verify(ed25519.PublicKey(pub), toBeSigned, c.Signature), nil
+	return ed25519.Verify(ed25519.PublicKey(pub), toBeSigned, c.Signature), address, nil
 }

--- a/message.go
+++ b/message.go
@@ -409,8 +409,21 @@ func VerifyDataWithAddress(
 	if err != nil {
 		return false, "", err
 	}
-	// Decode the protected address to bech32 for the caller. A failure here is
-	// fatal: a malformed address means the signature cannot be trusted.
+	pub, err := extractCoseKeyPub(keyBytes)
+	if err != nil {
+		return false, "", err
+	}
+	if len(pub) != ed25519.PublicKeySize {
+		return false, "", fmt.Errorf("unexpected public key size %d", len(pub))
+	}
+	if err := validateAddressForVKey(addrBytes, pub); err != nil {
+		if errors.Is(err, errAddressDoesNotMatchSigningKey) {
+			return false, "", errors.New("protected address does not match public key")
+		}
+		return false, "", err
+	}
+	// Decode the protected address to bech32 for the caller only after it is
+	// bound to the supplied public key.
 	signerAddr, err := lcommon.NewAddressFromBytes(addrBytes)
 	if err != nil {
 		return false, "", fmt.Errorf("invalid protected address: %w", err)
@@ -423,19 +436,6 @@ func VerifyDataWithAddress(
 	}
 	hashed, err := extractPayloadHashed(c.Protected, c.Unprotected)
 	if err != nil {
-		return false, address, err
-	}
-	pub, err := extractCoseKeyPub(keyBytes)
-	if err != nil {
-		return false, address, err
-	}
-	if len(pub) != ed25519.PublicKeySize {
-		return false, address, fmt.Errorf("unexpected public key size %d", len(pub))
-	}
-	if err := validateAddressForVKey(addrBytes, pub); err != nil {
-		if errors.Is(err, errAddressDoesNotMatchSigningKey) {
-			return false, address, errors.New("protected address does not match public key")
-		}
 		return false, address, err
 	}
 	toBeSigned, err := buildSigStructure(c.Protected, payloadToVerify(payload, hashed))

--- a/message_test.go
+++ b/message_test.go
@@ -330,6 +330,31 @@ func TestVerifyData_TamperedPayloadFails(t *testing.T) {
 	}
 }
 
+func TestVerifyDataWithAddress_RejectsWrongKeyBeforePayloadMismatch(t *testing.T) {
+	lk1 := testLoadedKey(make([]byte, 32))
+	lk2 := testLoadedKey(append(make([]byte, 31), 1))
+
+	sig, _, err := SignData(testEnterpriseAddress(t, lk1.VKey), []byte("original"), lk1)
+	if err != nil {
+		t.Fatalf("SignData lk1: %v", err)
+	}
+	_, key2, err := SignData(testEnterpriseAddress(t, lk2.VKey), []byte("x"), lk2)
+	if err != nil {
+		t.Fatalf("SignData lk2: %v", err)
+	}
+
+	ok, address, err := VerifyDataWithAddress(sig, key2, []byte("tampered"))
+	if err == nil {
+		t.Fatalf("VerifyDataWithAddress must reject a key mismatch before payload mismatch")
+	}
+	if ok {
+		t.Fatalf("key mismatch must not verify")
+	}
+	if address != "" {
+		t.Fatalf("unverified protected address must not be returned, got %q", address)
+	}
+}
+
 func TestVerifyData_TamperedSignatureFails(t *testing.T) {
 	lk := testLoadedKey(make([]byte, 32))
 	addr := testEnterpriseAddress(t, lk.VKey)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add signer address recovery to CIP-8/CIP-30 signature verification and keep the existing `VerifyData` API intact. Callers can now verify a signature and display the bech32 address that signed it.

- **New Features**
  - Added `VerifyDataWithAddress(signatureHex, keyHex, expectedPayload) (bool, string, error)` to return validity and the signer's bech32 address.
  - Extracts the address from the `COSE_Sign1` protected header and binds it to the supplied public key before returning it.
  - Returns the address on clean signature mismatches; on key/address mismatch or invalid headers returns an error and no address, and rejects this before any payload mismatch.
  - `VerifyData` now delegates to `VerifyDataWithAddress` to preserve existing behavior.

<sup>Written for commit 86560bca5e88dbe3c3efedce657994909a63053a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a verification option that returns both validity and the signer’s address.
  * Improved handling of embedded payloads during signature checks.

* **Bug Fixes**
  * Signature verification now provides clearer errors when the protected address does not match the public key.
  * Payload mismatches are now handled more consistently, with the extracted address still available when verification fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->