### PR TITLE
feat(ui): lean-node history-expiry in-app setting

### DIFF
--- a/ui/cmd/bursa-wallet/main.go
+++ b/ui/cmd/bursa-wallet/main.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -34,6 +35,7 @@ import (
 	"github.com/blinklabs-io/bursa/ui/internal/cardanonet"
 	"github.com/blinklabs-io/bursa/ui/internal/chain"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
+	"github.com/blinklabs-io/bursa/ui/internal/settings"
 	"github.com/blinklabs-io/bursa/ui/internal/spend"
 	"github.com/blinklabs-io/bursa/ui/internal/supervisor"
 	"github.com/blinklabs-io/bursa/ui/internal/vault"
@@ -92,6 +94,20 @@ func run() error {
 	)
 	// Mithril fast-sync is on by default; BURSA_SYNC=genesis opts out.
 	mithrilEnabled := !strings.EqualFold(envOr("BURSA_SYNC", "mithril"), "genesis")
+
+	// The lean-node (history-expiry) profile is now a persisted, user-facing app
+	// setting (the source of truth) rather than an env-only control. BURSA_LEAN
+	// only SEEDS the first-run default — once a value is persisted (default off,
+	// or whatever the user later sets in the Settings screen), the env is ignored.
+	// This keeps the env as the initial-default seed for mobile builds.
+	settingsStore, err := settings.Load(filepath.Join(dataDir, "settings.json"))
+	if err != nil {
+		return fmt.Errorf("load settings: %w", err)
+	}
+	if err := settingsStore.SeedDefault(envBool("BURSA_LEAN", false)); err != nil {
+		return fmt.Errorf("seed lean-node default: %w", err)
+	}
+
 	sup := supervisor.New(supervisor.Config{
 		Network:        network,
 		DataDir:        filepath.Join(dataDir, "db"),
@@ -100,6 +116,9 @@ func run() error {
 		BlockfrostPort: blockfrostPort,
 		Logger:         logger,
 		MithrilEnabled: mithrilEnabled,
+		// Read the persisted setting fresh at each node Start, so a toggle in the
+		// Settings screen takes effect on the next node restart.
+		HistoryExpiry: settingsStore.HistoryExpiry,
 	})
 
 	// The wallet queries the node's own loopback Blockfrost endpoint.
@@ -128,8 +147,13 @@ func run() error {
 	defer sup.Stop()
 
 	srv := &http.Server{
-		Addr:              "127.0.0.1:8090", // loopback only
-		Handler:           api.NewHandler(sup, vlt, walletSvc, spendSvc, network, webui.Handler(), api.WithLegacyKeystore(legacyKeyStore)),
+		Addr: "127.0.0.1:8090", // loopback only
+		Handler: api.NewHandler(
+			sup, vlt, walletSvc, spendSvc,
+			&settingsController{store: settingsStore, sup: sup},
+			network, webui.Handler(),
+			api.WithLegacyKeystore(legacyKeyStore),
+		),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	srvErr := make(chan error, 1)
@@ -157,4 +181,45 @@ func envOr(key, def string) string {
 		return v
 	}
 	return def
+}
+
+// envBool reads a boolean env var, falling back to def when unset or unparsable.
+// Accepts the usual strconv.ParseBool truthy/falsy values (1/0, t/f, true/false).
+func envBool(key string, def bool) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return def
+	}
+	return b
+}
+
+// settingsController adapts the persisted settings store + the supervisor to the
+// api.SettingsController surface. The store is the source of truth for the
+// lean-node profile; the supervisor reports what the running node was actually
+// built with, so a change can be flagged as needing a node restart.
+type settingsController struct {
+	store *settings.Store
+	sup   *supervisor.Supervisor
+}
+
+func (c *settingsController) HistoryExpiry() bool { return c.store.HistoryExpiry() }
+
+func (c *settingsController) SetHistoryExpiry(enabled bool) error {
+	return c.store.SetHistoryExpiry(enabled)
+}
+
+// HistoryExpiryRestartRequired reports whether the persisted value differs from
+// what the running node was launched with. History expiry is a node-construction
+// option, so it only takes effect on the next node start: if no node has been
+// launched yet (ran=false), there is nothing to restart, so it is not required.
+func (c *settingsController) HistoryExpiryRestartRequired() bool {
+	applied, ran := c.sup.AppliedHistoryExpiry()
+	if !ran {
+		return false
+	}
+	return applied != c.store.HistoryExpiry()
 }

--- a/ui/cmd/bursa-wallet/main.go
+++ b/ui/cmd/bursa-wallet/main.go
@@ -116,8 +116,10 @@ func run() error {
 		BlockfrostPort: blockfrostPort,
 		Logger:         logger,
 		MithrilEnabled: mithrilEnabled,
-		// Read the persisted setting fresh at each node Start, so a toggle in the
-		// Settings screen takes effect on the next node restart.
+		// Read the persisted setting fresh at each node construction, so a toggle
+		// in the Settings screen takes effect on the next node restart. This is
+		// deliberately a provider because Mithril bootstrap defers construction
+		// until after the snapshot import completes.
 		HistoryExpiry: settingsStore.HistoryExpiry,
 	})
 
@@ -215,7 +217,8 @@ func (c *settingsController) SetHistoryExpiry(enabled bool) error {
 // HistoryExpiryRestartRequired reports whether the persisted value differs from
 // what the running node was launched with. History expiry is a node-construction
 // option, so it only takes effect on the next node start: if no node has been
-// launched yet (ran=false), there is nothing to restart, so it is not required.
+// launched yet (ran=false), there is nothing to restart, and any pending launch
+// will read the latest persisted value when it constructs the node.
 func (c *settingsController) HistoryExpiryRestartRequired() bool {
 	applied, ran := c.sup.AppliedHistoryExpiry()
 	if !ran {

--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -97,6 +97,20 @@ func WithLegacyKeystore(ks LegacyKeystore) HandlerOption {
 	}
 }
 
+// SettingsController is the user-facing app-settings surface. It exposes the
+// persisted lean-node (history-expiry) profile and whether a node restart is
+// still needed for the persisted value to take effect (history expiry is a
+// node-construction option, applied only at node start). It is decoupled from
+// the storage and supervisor packages so the API can be tested with a fake.
+type SettingsController interface {
+	HistoryExpiry() bool
+	SetHistoryExpiry(enabled bool) error
+	// HistoryExpiryRestartRequired reports whether the running node was built
+	// with a different history-expiry value than what is now persisted (so the
+	// change has not taken effect yet).
+	HistoryExpiryRestartRequired() bool
+}
+
 const defaultWindow = 20
 
 // vaultStatus is the GET /vault/status response.
@@ -135,9 +149,10 @@ func toWalletView(w vault.WalletMeta, activeID string) walletView {
 // NewHandler returns the loopback control-surface mux. network is the network
 // the embedded node runs on; wallet requests must match it (or omit it). vlt is
 // the encrypted multi-wallet store; the API pushes the active wallet onto wl/sp
-// whenever the selection changes. spa is the embedded SPA, registered as the
-// catch-all so the specific API routes take precedence on the mux.
-func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, network string, spa http.Handler, opts ...HandlerOption) http.Handler {
+// whenever the selection changes. settings exposes user-facing app settings
+// (the lean-node profile). spa is the embedded SPA, registered as the catch-all
+// so the specific API routes take precedence on the mux.
+func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings SettingsController, network string, spa http.Handler, opts ...HandlerOption) http.Handler {
 	cfg := handlerOptions{}
 	for _, opt := range opts {
 		opt(&cfg)
@@ -410,6 +425,34 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, network string, s
 		}
 		sig, key, err := sp.SignData(req.Address, []byte(req.Message), req.Password)
 		serve(w, map[string]string{"signature": sig, "key": key}, err)
+	})
+
+	// App settings: the lean-node (history-expiry) profile. Ungated — it is a
+	// config setting, not a node query, so it is readable/settable regardless of
+	// sync state. History expiry is a node-construction option, so a change only
+	// takes effect on the next node restart; restart_required surfaces that.
+	mux.HandleFunc("GET /wallet/settings/history-expiry", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]bool{
+			"enabled":          settings.HistoryExpiry(),
+			"restart_required": settings.HistoryExpiryRestartRequired(),
+		})
+	})
+	mux.HandleFunc("PUT /wallet/settings/history-expiry", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Enabled bool `json:"enabled"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+			return
+		}
+		if err := settings.SetHistoryExpiry(req.Enabled); err != nil {
+			writeJSON(w, http.StatusInternalServerError, errBody(err))
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]bool{
+			"enabled":          settings.HistoryExpiry(),
+			"restart_required": settings.HistoryExpiryRestartRequired(),
+		})
 	})
 
 	// SPA catch-all: the specific API routes above take precedence on the mux;

--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -439,13 +439,17 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 	})
 	mux.HandleFunc("PUT /wallet/settings/history-expiry", func(w http.ResponseWriter, r *http.Request) {
 		var req struct {
-			Enabled bool `json:"enabled"`
+			Enabled *bool `json:"enabled"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
 			return
 		}
-		if err := settings.SetHistoryExpiry(req.Enabled); err != nil {
+		if req.Enabled == nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "enabled is required"})
+			return
+		}
+		if err := settings.SetHistoryExpiry(*req.Enabled); err != nil {
 			writeJSON(w, http.StatusInternalServerError, errBody(err))
 			return
 		}

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -915,14 +915,31 @@ func TestSpendErrorStatusCodes(t *testing.T) {
 	}
 }
 
+type historyExpiryResponse struct {
+	Enabled         bool
+	RestartRequired bool
+}
+
 // decodeHistoryExpiry decodes the {enabled, restart_required} body.
-func decodeHistoryExpiry(t *testing.T, body *bytes.Buffer) map[string]bool {
+func decodeHistoryExpiry(t *testing.T, body *bytes.Buffer) historyExpiryResponse {
 	t.Helper()
-	var got map[string]bool
+	var got struct {
+		Enabled         *bool `json:"enabled"`
+		RestartRequired *bool `json:"restart_required"`
+	}
 	if err := json.NewDecoder(body).Decode(&got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	return got
+	if got.Enabled == nil {
+		t.Fatal("response missing enabled")
+	}
+	if got.RestartRequired == nil {
+		t.Fatal("response missing restart_required")
+	}
+	return historyExpiryResponse{
+		Enabled:         *got.Enabled,
+		RestartRequired: *got.RestartRequired,
+	}
 }
 
 func TestGetHistoryExpiryReturnsState(t *testing.T) {
@@ -937,7 +954,7 @@ func TestGetHistoryExpiryReturnsState(t *testing.T) {
 		t.Fatalf("GET history-expiry = %d, want 200", rec.Code)
 	}
 	got := decodeHistoryExpiry(t, rec.Body)
-	if !got["enabled"] || !got["restart_required"] {
+	if !got.Enabled || !got.RestartRequired {
 		t.Fatalf("got %+v, want enabled+restart_required true", got)
 	}
 }
@@ -949,7 +966,7 @@ func TestGetHistoryExpiryDefaultOff(t *testing.T) {
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/settings/history-expiry", nil))
 	got := decodeHistoryExpiry(t, rec.Body)
-	if got["enabled"] || got["restart_required"] {
+	if got.Enabled || got.RestartRequired {
 		t.Fatalf("got %+v, want both false (default)", got)
 	}
 }
@@ -969,11 +986,11 @@ func TestPutHistoryExpiryPersistsAndSignalsRestart(t *testing.T) {
 		t.Fatalf("SetHistoryExpiry not called with true: called=%v with=%v", set.setCalled, set.setCalledWith)
 	}
 	got := decodeHistoryExpiry(t, rec.Body)
-	if !got["enabled"] {
-		t.Fatalf("response enabled = %v, want true", got["enabled"])
+	if !got.Enabled {
+		t.Fatalf("response enabled = %v, want true", got.Enabled)
 	}
-	if !got["restart_required"] {
-		t.Fatalf("response restart_required = %v, want true", got["restart_required"])
+	if !got.RestartRequired {
+		t.Fatalf("response restart_required = %v, want true", got.RestartRequired)
 	}
 }
 
@@ -989,6 +1006,25 @@ func TestPutHistoryExpiryInvalidJSON(t *testing.T) {
 	}
 	if set.setCalled {
 		t.Fatal("SetHistoryExpiry must not be called on a bad request body")
+	}
+}
+
+func TestPutHistoryExpiryRequiresExplicitEnabled(t *testing.T) {
+	for _, bodyJSON := range []string{`{}`, `{"enabled":null}`} {
+		t.Run(bodyJSON, func(t *testing.T) {
+			st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+			set := &fakeSettings{}
+			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, "preview", http.NotFoundHandler())
+			rec := httptest.NewRecorder()
+			body := bytes.NewBufferString(bodyJSON)
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("PUT history-expiry with %s = %d, want 400", bodyJSON, rec.Code)
+			}
+			if set.setCalled {
+				t.Fatal("SetHistoryExpiry must not be called without an explicit enabled value")
+			}
+		})
 	}
 }
 

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -38,20 +39,21 @@ func (f fakeStatuser) Status() supervisor.Status { return f.s }
 // memory: Unlock/Lock toggle locked; AddWallet appends and activates; the active
 // wallet drives reads/spends.
 type fakeVault struct {
-	exists    bool
-	locked    bool
-	wallets   []vault.WalletMeta
-	activeID  string
-	createErr error
-	unlockErr error
-	addErr    error
-	addCalled bool
-	importErr error
-	imported  bool
-	gotName   string
-	gotSpend  string
-	gotVault  string
-	gotSeed   []byte
+	exists     bool
+	locked     bool
+	wallets    []vault.WalletMeta
+	activeID   string
+	createErr  error
+	unlockErr  error
+	addErr     error
+	addCalled  bool
+	importErr  error
+	imported   bool
+	gotName    string
+	gotNetwork string
+	gotSpend   string
+	gotVault   string
+	gotSeed    []byte
 }
 
 type fakeLegacyKeystore struct {
@@ -120,6 +122,7 @@ func (f *fakeVault) AddWallet(name, _, network, vaultPw, spendPw string, _ int) 
 	}
 	f.addCalled = true
 	f.gotName = name
+	f.gotNetwork = network
 	f.gotSpend = spendPw
 	f.gotVault = vaultPw
 	meta := vault.WalletMeta{ID: "w1", Name: name, Network: network, Account: sampleAccount(network)}
@@ -144,6 +147,7 @@ func (f *fakeVault) importWallet(name string, mnemonic []byte, network, vaultPw,
 	f.exists = true
 	f.locked = false
 	f.gotName = name
+	f.gotNetwork = network
 	f.gotSpend = spendPw
 	f.gotVault = vaultPw
 	f.gotSeed = mnemonic
@@ -195,8 +199,31 @@ func (f *fakeVault) Active() (vault.WalletMeta, error) {
 	return vault.WalletMeta{}, vault.ErrNoActiveWallet
 }
 
+// fakeSettings is an in-memory SettingsController for handler tests.
+type fakeSettings struct {
+	enabled         bool
+	restartRequired bool
+	setErr          error
+	setCalledWith   bool
+	setCalled       bool
+}
+
+func (f *fakeSettings) HistoryExpiry() bool { return f.enabled }
+
+func (f *fakeSettings) SetHistoryExpiry(enabled bool) error {
+	f.setCalled = true
+	f.setCalledWith = enabled
+	if f.setErr != nil {
+		return f.setErr
+	}
+	f.enabled = enabled
+	return nil
+}
+
+func (f *fakeSettings) HistoryExpiryRestartRequired() bool { return f.restartRequired }
+
 func TestHealthAlwaysOK(t *testing.T) {
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
 	if rec.Code != http.StatusOK {
@@ -206,7 +233,7 @@ func TestHealthAlwaysOK(t *testing.T) {
 
 func TestStatusReturnsSnapshot(t *testing.T) {
 	want := supervisor.Status{State: supervisor.StateSyncing, Tip: 42, CaughtUp: true}
-	h := NewHandler(fakeStatuser{s: want}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{s: want}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
 	if rec.Code != http.StatusOK {
@@ -275,7 +302,7 @@ func (f *fakeWallet) Delegation(_ context.Context) (wallet.DelegationView, error
 
 func TestVaultStatusReports(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: true, wallets: []vault.WalletMeta{{ID: "a"}, {ID: "b"}}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/status", nil))
 	if rec.Code != http.StatusOK {
@@ -296,7 +323,7 @@ func TestVaultStatusReports(t *testing.T) {
 func TestVaultStatusReportsLegacyKeystore(t *testing.T) {
 	fv := &fakeVault{exists: false, locked: true}
 	legacy := &fakeLegacyKeystore{exists: true}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/status", nil))
 	if rec.Code != http.StatusOK {
@@ -313,7 +340,7 @@ func TestVaultStatusReportsLegacyKeystore(t *testing.T) {
 
 func TestVaultCreateRequiresPassword(t *testing.T) {
 	fv := &fakeVault{}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"short"}`)))
 	if rec.Code != http.StatusBadRequest {
@@ -326,7 +353,7 @@ func TestVaultCreateRequiresPassword(t *testing.T) {
 
 func TestVaultCreateOK(t *testing.T) {
 	fv := &fakeVault{}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusOK {
@@ -339,7 +366,7 @@ func TestVaultCreateOK(t *testing.T) {
 
 func TestVaultCreateConflict(t *testing.T) {
 	fv := &fakeVault{createErr: vault.ErrVaultExists}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusConflict {
@@ -356,7 +383,7 @@ func TestVaultUnlockBindsSoleWalletAndReads(t *testing.T) {
 		wallets: []vault.WalletMeta{{ID: "w1", Name: "main", Network: "preview", Account: sampleAccount("preview")}},
 	}
 	fw := &fakeWallet{balance: wallet.Balance{Lovelace: "1234"}}
-	h := NewHandler(st, fv, fw, &fakeSpender{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, fw, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
@@ -383,7 +410,7 @@ func TestVaultUnlockBindsSoleWalletAndReads(t *testing.T) {
 
 func TestVaultUnlockWrongPassword(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: true, unlockErr: fmt.Errorf("%w: bad", vault.ErrWrongPassword)}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"wrong-but-long-pw"}`)))
 	if rec.Code != http.StatusUnauthorized {
@@ -395,7 +422,7 @@ func TestVaultLock(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false}
 	fw := &fakeWallet{set: true}
 	sp := &fakeSpender{set: true}
-	h := NewHandler(fakeStatuser{}, fv, fw, sp, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/lock", nil))
 	if rec.Code != http.StatusOK {
@@ -414,7 +441,7 @@ func TestMigrateLegacyKeystoreImportsAndBinds(t *testing.T) {
 	fw := &fakeWallet{}
 	sp := &fakeSpender{}
 	legacy := &fakeLegacyKeystore{exists: true, mnemonic: []byte("abandon abandon about")}
-	h := NewHandler(fakeStatuser{}, fv, fw, sp, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 
 	body := `{"name":"Imported","vault_password":"valid-vault-password","spend_password":"legacy-spend-password"}`
 	rec := httptest.NewRecorder()
@@ -453,7 +480,7 @@ func TestMigrateLegacyKeystoreImportsAndBinds(t *testing.T) {
 func TestMigrateLegacyKeystoreWrongPassword(t *testing.T) {
 	fv := &fakeVault{exists: false, locked: true}
 	legacy := &fakeLegacyKeystore{exists: true, err: keystore.ErrDecryptFailed}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 
 	body := `{"name":"Imported","vault_password":"valid-vault-password","spend_password":"wrong-password"}`
 	rec := httptest.NewRecorder()
@@ -469,7 +496,7 @@ func TestMigrateLegacyKeystoreWrongPassword(t *testing.T) {
 func TestMigrateLegacyKeystoreRequiresSpendPasswordMinLength(t *testing.T) {
 	fv := &fakeVault{exists: false, locked: true}
 	legacy := &fakeLegacyKeystore{exists: true, mnemonic: []byte("abandon abandon about")}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 
 	body := `{"name":"Imported","vault_password":"valid-vault-password","spend_password":"short"}`
 	rec := httptest.NewRecorder()
@@ -492,7 +519,7 @@ func TestAddWalletEnablesReadsAndSpend(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false}
 	fw := &fakeWallet{balance: wallet.Balance{Lovelace: "1234"}}
 	sp := &fakeSpender{}
-	h := NewHandler(st, fv, fw, sp, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
@@ -521,7 +548,7 @@ func TestAddWalletRequiresSpendPassword(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
 	sp := &fakeSpender{}
-	h := NewHandler(st, fv, &fakeWallet{}, sp, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","vault_password":"valid-vault-password","spend_password":"short"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -536,7 +563,7 @@ func TestAddWalletRequiresSpendPassword(t *testing.T) {
 func TestAddWalletRequiresVaultPassword(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -548,7 +575,7 @@ func TestAddWalletRequiresVaultPassword(t *testing.T) {
 func TestAddWalletNetworkMismatch(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"mainnet","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -557,10 +584,25 @@ func TestAddWalletNetworkMismatch(t *testing.T) {
 	}
 }
 
+func TestAddWalletDefaultNetworkIsNodeNetwork(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	fv := &fakeVault{exists: true, locked: false}
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preprod", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := `{"name":"main","mnemonic":"x x x","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /wallet without network = %d, want 200", rec.Code)
+	}
+	if fv.gotNetwork != "preprod" {
+		t.Fatalf("AddWallet got network %q, want preprod (node network)", fv.gotNetwork)
+	}
+}
+
 func TestAddWalletDuplicateConflict(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false, addErr: vault.ErrDuplicateWallet}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -580,7 +622,7 @@ func TestActivateWalletBinds(t *testing.T) {
 	}
 	fw := &fakeWallet{}
 	sp := &fakeSpender{}
-	h := NewHandler(st, fv, fw, sp, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/w2/activate", nil))
 	if rec.Code != http.StatusOK {
@@ -603,7 +645,7 @@ func TestActivateWalletBinds(t *testing.T) {
 
 func TestActivateUnknownWallet(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/nope/activate", nil))
 	if rec.Code != http.StatusNotFound {
@@ -613,7 +655,7 @@ func TestActivateUnknownWallet(t *testing.T) {
 
 func TestDeleteWalletRequiresVaultPassword(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false, wallets: []vault.WalletMeta{{ID: "w1"}}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/wallet/w1", bytes.NewBufferString(`{}`)))
 	if rec.Code != http.StatusBadRequest {
@@ -628,7 +670,7 @@ func TestDeleteWalletOK(t *testing.T) {
 	}
 	fw := &fakeWallet{set: true}
 	sp := &fakeSpender{set: true}
-	h := NewHandler(fakeStatuser{}, fv, fw, sp, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/wallet/w1", bytes.NewBufferString(`{"vault_password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusOK {
@@ -646,7 +688,7 @@ func TestDeleteWalletOK(t *testing.T) {
 
 func TestWalletGatedWhileStarting(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/balance", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -657,7 +699,7 @@ func TestWalletGatedWhileStarting(t *testing.T) {
 func TestWalletGatedWhileBootstrapping(t *testing.T) {
 	// Mithril bootstrap is not a servable state: reads must be gated (503).
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateBootstrapping}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/balance", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -670,7 +712,7 @@ func TestWalletNoActiveWalletConflict(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	for _, path := range []string{"/wallet/balance", "/wallet/addresses", "/wallet/transactions", "/wallet/delegation"} {
 		t.Run(path, func(t *testing.T) {
-			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler())
+			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
 			if rec.Code != http.StatusConflict {
@@ -730,7 +772,7 @@ func (f *fakeSpender) SignData(addr string, _ []byte, _ string) (string, string,
 func TestSignDataReturnsSignature(t *testing.T) {
 	// Ungated: message signing needs no synced node, only the keystore.
 	sp := &fakeSpender{signSig: "84a1deadbeef", signKey: "a4010103"}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"address":"addr_test1xyz","message":"hello","password":"pw"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-data", body))
@@ -747,7 +789,7 @@ func TestSignDataReturnsSignature(t *testing.T) {
 
 func TestSignDataWrongPasswordReturns401(t *testing.T) {
 	sp := &fakeSpender{signErr: fmt.Errorf("%w: bad", spend.ErrWrongPassword)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"address":"a","message":"m","password":"bad"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-data", body))
@@ -759,7 +801,7 @@ func TestSignDataWrongPasswordReturns401(t *testing.T) {
 func TestSpendSendReadyReturnsPreview(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{preview: spend.Preview{PendingID: "pend123", Fee: "170000"}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send", body))
@@ -778,7 +820,7 @@ func TestSpendSendReadyReturnsPreview(t *testing.T) {
 func TestSpendSendGatedWhileSyncing(t *testing.T) {
 	// Spending requires a fully synced node (StateReady), unlike reads.
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send", body))
@@ -790,7 +832,7 @@ func TestSpendSendGatedWhileSyncing(t *testing.T) {
 func TestSpendSendNoWalletConflict(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{buildErr: spend.ErrNoWallet}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send", body))
@@ -802,7 +844,7 @@ func TestSpendSendNoWalletConflict(t *testing.T) {
 func TestSpendConfirmReadyReturnsTxHash(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{result: spend.TxResult{TxHash: "deadbeef"}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-spend-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend123/confirm", body))
@@ -823,7 +865,7 @@ func TestSpendConfirmReadyReturnsTxHash(t *testing.T) {
 
 func TestSpendConfirmGatedWhileSyncing(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-spend-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend123/confirm", body))
@@ -863,12 +905,101 @@ func TestSpendErrorStatusCodes(t *testing.T) {
 				req = httptest.NewRequest(http.MethodPost, "/wallet/send",
 					bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`))
 			}
-			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, "preview", http.NotFoundHandler())
+			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
 			if rec.Code != tc.wantCode {
 				t.Fatalf("%s: code = %d, want %d", tc.name, rec.Code, tc.wantCode)
 			}
 		})
+	}
+}
+
+// decodeHistoryExpiry decodes the {enabled, restart_required} body.
+func decodeHistoryExpiry(t *testing.T, body *bytes.Buffer) map[string]bool {
+	t.Helper()
+	var got map[string]bool
+	if err := json.NewDecoder(body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return got
+}
+
+func TestGetHistoryExpiryReturnsState(t *testing.T) {
+	// Ungated: a stopped node must still answer (it is a config setting, not a
+	// node query).
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStopped}}
+	set := &fakeSettings{enabled: true, restartRequired: true}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/settings/history-expiry", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET history-expiry = %d, want 200", rec.Code)
+	}
+	got := decodeHistoryExpiry(t, rec.Body)
+	if !got["enabled"] || !got["restart_required"] {
+		t.Fatalf("got %+v, want enabled+restart_required true", got)
+	}
+}
+
+func TestGetHistoryExpiryDefaultOff(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	set := &fakeSettings{} // default off, no restart needed
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/settings/history-expiry", nil))
+	got := decodeHistoryExpiry(t, rec.Body)
+	if got["enabled"] || got["restart_required"] {
+		t.Fatalf("got %+v, want both false (default)", got)
+	}
+}
+
+func TestPutHistoryExpiryPersistsAndSignalsRestart(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	// Running node was built with off; flipping to on must signal a restart.
+	set := &fakeSettings{enabled: false, restartRequired: true}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"enabled":true}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT history-expiry = %d, want 200", rec.Code)
+	}
+	if !set.setCalled || !set.setCalledWith {
+		t.Fatalf("SetHistoryExpiry not called with true: called=%v with=%v", set.setCalled, set.setCalledWith)
+	}
+	got := decodeHistoryExpiry(t, rec.Body)
+	if !got["enabled"] {
+		t.Fatalf("response enabled = %v, want true", got["enabled"])
+	}
+	if !got["restart_required"] {
+		t.Fatalf("response restart_required = %v, want true", got["restart_required"])
+	}
+}
+
+func TestPutHistoryExpiryInvalidJSON(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	set := &fakeSettings{}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{not json`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("PUT history-expiry with bad JSON = %d, want 400", rec.Code)
+	}
+	if set.setCalled {
+		t.Fatal("SetHistoryExpiry must not be called on a bad request body")
+	}
+}
+
+func TestPutHistoryExpiryPersistError(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	set := &fakeSettings{setErr: errors.New("disk full")}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"enabled":true}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("PUT history-expiry with persist error = %d, want 500", rec.Code)
 	}
 }

--- a/ui/internal/settings/settings.go
+++ b/ui/internal/settings/settings.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package settings persists user-facing app settings in the data dir as a small
+// JSON file. It is the source of truth for runtime-configurable behaviour (e.g.
+// the lean-node history-expiry profile) that env vars only seed a first-run
+// default for. Writes are atomic (temp file + rename) so a crash can never leave
+// a half-written settings file, and reads tolerate a missing file (all defaults).
+package settings
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// settingsVersion lets the on-disk format evolve without a hard break.
+const settingsVersion = 1
+
+// maxSettingsLen caps Load's read of the settings file. A real settings file is
+// a few hundred bytes; anything larger is not one of ours.
+const maxSettingsLen = 64 * 1024
+
+// data is the on-disk shape. Booleans use a pointer so a missing key (absent
+// field) is distinguishable from an explicit false — only a present value counts
+// as "persisted" for seeding purposes.
+type data struct {
+	Version       int   `json:"version"`
+	HistoryExpiry *bool `json:"history_expiry,omitempty"`
+}
+
+// Store is a settings file at Path. It is safe for concurrent use: every method
+// takes the mutex, and the in-memory snapshot is the authority once loaded.
+type Store struct {
+	path string
+
+	mu sync.Mutex
+	d  data
+}
+
+// Load opens (or initializes) the settings store at path. A missing file is not
+// an error — it yields an all-defaults store. A present but corrupt file IS an
+// error: silently discarding a user's persisted settings would be surprising.
+func Load(path string) (*Store, error) {
+	s := &Store{path: path, d: data{Version: settingsVersion}}
+	blob, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return s, nil
+		}
+		return nil, fmt.Errorf("read settings: %w", err)
+	}
+	if len(blob) > maxSettingsLen {
+		return nil, fmt.Errorf("settings file exceeds %d bytes", maxSettingsLen)
+	}
+	var d data
+	if err := json.Unmarshal(blob, &d); err != nil {
+		return nil, fmt.Errorf("parse settings %s: %w", path, err)
+	}
+	s.d = d
+	return s, nil
+}
+
+// HistoryExpiry reports the persisted lean-node profile, defaulting to false
+// when no value has ever been persisted.
+func (s *Store) HistoryExpiry() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.d.HistoryExpiry != nil && *s.d.HistoryExpiry
+}
+
+// SetHistoryExpiry persists the lean-node profile and atomically writes the file.
+func (s *Store) SetHistoryExpiry(enabled bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v := enabled
+	s.d.HistoryExpiry = &v
+	return s.writeLocked()
+}
+
+// SeedDefault sets the history-expiry default ONLY when no value has been
+// persisted yet (first run). It is how an env-var/build default (e.g. BURSA_LEAN,
+// on-for-mobile) becomes the initial value without ever overriding a value the
+// user has since chosen. It is a no-op once any value is persisted, and only
+// touches disk when it actually seeds.
+func (s *Store) SeedDefault(enabled bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.d.HistoryExpiry != nil {
+		return nil // already persisted — the setting is now the source of truth
+	}
+	v := enabled
+	s.d.HistoryExpiry = &v
+	return s.writeLocked()
+}
+
+// writeLocked atomically writes the current snapshot. The caller holds s.mu.
+// It writes to a temp file in the same directory then renames over the target,
+// so a reader never observes a partial write and a crash leaves either the old
+// file or the new one — never a truncated one.
+func (s *Store) writeLocked() error {
+	s.d.Version = settingsVersion
+	blob, err := json.MarshalIndent(s.d, "", "  ")
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(s.path)
+	tmp, err := os.CreateTemp(dir, ".settings-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp settings: %w", err)
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if we bail before the rename; after a successful
+	// rename the temp name no longer exists, so the Remove is a harmless no-op.
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(blob); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp settings: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp settings: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp settings: %w", err)
+	}
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		return fmt.Errorf("chmod temp settings: %w", err)
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		return fmt.Errorf("replace settings: %w", err)
+	}
+	return nil
+}

--- a/ui/internal/settings/settings.go
+++ b/ui/internal/settings/settings.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -58,15 +59,15 @@ type Store struct {
 // error: silently discarding a user's persisted settings would be surprising.
 func Load(path string) (*Store, error) {
 	s := &Store{path: path, d: data{Version: settingsVersion}}
-	blob, err := os.ReadFile(path)
+	blob, err := readFileCapped(path, maxSettingsLen)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return s, nil
 		}
+		if errors.Is(err, errSettingsTooLarge) {
+			return nil, fmt.Errorf("settings file exceeds %d bytes", maxSettingsLen)
+		}
 		return nil, fmt.Errorf("read settings: %w", err)
-	}
-	if len(blob) > maxSettingsLen {
-		return nil, fmt.Errorf("settings file exceeds %d bytes", maxSettingsLen)
 	}
 	var d data
 	if err := json.Unmarshal(blob, &d); err != nil {
@@ -88,9 +89,14 @@ func (s *Store) HistoryExpiry() bool {
 func (s *Store) SetHistoryExpiry(enabled bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	old := s.d
 	v := enabled
 	s.d.HistoryExpiry = &v
-	return s.writeLocked()
+	if err := s.writeLocked(); err != nil {
+		s.d = old
+		return err
+	}
+	return nil
 }
 
 // SeedDefault sets the history-expiry default ONLY when no value has been
@@ -104,9 +110,39 @@ func (s *Store) SeedDefault(enabled bool) error {
 	if s.d.HistoryExpiry != nil {
 		return nil // already persisted — the setting is now the source of truth
 	}
+	old := s.d
 	v := enabled
 	s.d.HistoryExpiry = &v
-	return s.writeLocked()
+	if err := s.writeLocked(); err != nil {
+		s.d = old
+		return err
+	}
+	return nil
+}
+
+var errSettingsTooLarge = errors.New("settings file too large")
+
+func readFileCapped(path string, maxLen int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() > maxLen {
+		return nil, errSettingsTooLarge
+	}
+	blob, err := io.ReadAll(io.LimitReader(f, maxLen+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(blob)) > maxLen {
+		return nil, errSettingsTooLarge
+	}
+	return blob, nil
 }
 
 // writeLocked atomically writes the current snapshot. The caller holds s.mu.
@@ -145,5 +181,17 @@ func (s *Store) writeLocked() error {
 	if err := os.Rename(tmpName, s.path); err != nil {
 		return fmt.Errorf("replace settings: %w", err)
 	}
+	if err := syncDir(dir); err != nil {
+		return fmt.Errorf("sync settings dir: %w", err)
+	}
 	return nil
+}
+
+func syncDir(dir string) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
 }

--- a/ui/internal/settings/settings.go
+++ b/ui/internal/settings/settings.go
@@ -92,8 +92,10 @@ func (s *Store) SetHistoryExpiry(enabled bool) error {
 	old := s.d
 	v := enabled
 	s.d.HistoryExpiry = &v
-	if err := s.writeLocked(); err != nil {
-		s.d = old
+	if committed, err := s.writeLocked(); err != nil {
+		if !committed {
+			s.d = old
+		}
 		return err
 	}
 	return nil
@@ -113,8 +115,10 @@ func (s *Store) SeedDefault(enabled bool) error {
 	old := s.d
 	v := enabled
 	s.d.HistoryExpiry = &v
-	if err := s.writeLocked(); err != nil {
-		s.d = old
+	if committed, err := s.writeLocked(); err != nil {
+		if !committed {
+			s.d = old
+		}
 		return err
 	}
 	return nil
@@ -145,20 +149,21 @@ func readFileCapped(path string, maxLen int64) ([]byte, error) {
 	return blob, nil
 }
 
-// writeLocked atomically writes the current snapshot. The caller holds s.mu.
-// It writes to a temp file in the same directory then renames over the target,
-// so a reader never observes a partial write and a crash leaves either the old
-// file or the new one — never a truncated one.
-func (s *Store) writeLocked() error {
+// writeLocked atomically writes the current snapshot. The caller holds s.mu. It
+// writes to a temp file in the same directory then renames over the target, so a
+// reader never observes a partial write and a crash leaves either the old file
+// or the new one - never a truncated one. The committed return value is true
+// once the target path has been replaced, even if a later durability step fails.
+func (s *Store) writeLocked() (committed bool, err error) {
 	s.d.Version = settingsVersion
 	blob, err := json.MarshalIndent(s.d, "", "  ")
 	if err != nil {
-		return err
+		return false, err
 	}
 	dir := filepath.Dir(s.path)
 	tmp, err := os.CreateTemp(dir, ".settings-*.tmp")
 	if err != nil {
-		return fmt.Errorf("create temp settings: %w", err)
+		return false, fmt.Errorf("create temp settings: %w", err)
 	}
 	tmpName := tmp.Name()
 	// Best-effort cleanup if we bail before the rename; after a successful
@@ -166,28 +171,30 @@ func (s *Store) writeLocked() error {
 	defer func() { _ = os.Remove(tmpName) }()
 	if _, err := tmp.Write(blob); err != nil {
 		_ = tmp.Close()
-		return fmt.Errorf("write temp settings: %w", err)
+		return false, fmt.Errorf("write temp settings: %w", err)
 	}
 	if err := tmp.Sync(); err != nil {
 		_ = tmp.Close()
-		return fmt.Errorf("sync temp settings: %w", err)
+		return false, fmt.Errorf("sync temp settings: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close temp settings: %w", err)
+		return false, fmt.Errorf("close temp settings: %w", err)
 	}
 	if err := os.Chmod(tmpName, 0o600); err != nil {
-		return fmt.Errorf("chmod temp settings: %w", err)
+		return false, fmt.Errorf("chmod temp settings: %w", err)
 	}
 	if err := os.Rename(tmpName, s.path); err != nil {
-		return fmt.Errorf("replace settings: %w", err)
+		return false, fmt.Errorf("replace settings: %w", err)
 	}
 	if err := syncDir(dir); err != nil {
-		return fmt.Errorf("sync settings dir: %w", err)
+		return true, fmt.Errorf("sync settings dir: %w", err)
 	}
-	return nil
+	return true, nil
 }
 
-func syncDir(dir string) error {
+var syncDir = syncDirFS
+
+func syncDirFS(dir string) error {
 	f, err := os.Open(dir)
 	if err != nil {
 		return err

--- a/ui/internal/settings/settings_test.go
+++ b/ui/internal/settings/settings_test.go
@@ -14,6 +14,7 @@
 package settings
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -175,6 +176,41 @@ func TestSetHistoryExpiryRollsBackOnPersistError(t *testing.T) {
 	}
 	if !s.HistoryExpiry() {
 		t.Fatal("failed SetHistoryExpiry must leave the in-memory setting unchanged")
+	}
+}
+
+func TestSetHistoryExpiryDoesNotRollBackAfterRename(t *testing.T) {
+	path := tmpPath(t)
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	origSyncDir := syncDir
+	syncDir = func(string) error {
+		return errors.New("sync failed")
+	}
+	t.Cleanup(func() {
+		syncDir = origSyncDir
+	})
+
+	err = s.SetHistoryExpiry(true)
+	if err == nil {
+		t.Fatal("SetHistoryExpiry should return the syncDir error")
+	}
+	if !strings.Contains(err.Error(), "sync settings dir") {
+		t.Fatalf("SetHistoryExpiry error = %q, want syncDir error", err)
+	}
+	if !s.HistoryExpiry() {
+		t.Fatal("post-rename syncDir failure must keep memory aligned with replaced settings file")
+	}
+
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !reloaded.HistoryExpiry() {
+		t.Fatal("post-rename syncDir failure should leave the replaced settings file readable")
 	}
 }
 

--- a/ui/internal/settings/settings_test.go
+++ b/ui/internal/settings/settings_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package settings
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func tmpPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "settings.json")
+}
+
+// TestDefaultOffWhenAbsent: a missing settings file yields a usable store whose
+// history-expiry defaults to false.
+func TestDefaultOffWhenAbsent(t *testing.T) {
+	s, err := Load(tmpPath(t))
+	if err != nil {
+		t.Fatalf("Load with no file: %v", err)
+	}
+	if s.HistoryExpiry() {
+		t.Fatal("history expiry should default to false when no file exists")
+	}
+}
+
+// TestSetPersistsRoundTrip: setting the value writes the file, and a fresh Load
+// reads it back — the default-off → on → reload round trip.
+func TestSetPersistsRoundTrip(t *testing.T) {
+	path := tmpPath(t)
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := s.SetHistoryExpiry(true); err != nil {
+		t.Fatalf("SetHistoryExpiry: %v", err)
+	}
+	if !s.HistoryExpiry() {
+		t.Fatal("in-memory value not updated after SetHistoryExpiry(true)")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("settings file not written: %v", err)
+	}
+
+	// A brand new store over the same path must observe the persisted value.
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !reloaded.HistoryExpiry() {
+		t.Fatal("persisted history-expiry=true did not survive reload")
+	}
+
+	// And turning it back off persists too.
+	if err := reloaded.SetHistoryExpiry(false); err != nil {
+		t.Fatalf("SetHistoryExpiry(false): %v", err)
+	}
+	again, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload after off: %v", err)
+	}
+	if again.HistoryExpiry() {
+		t.Fatal("persisted history-expiry=false did not survive reload")
+	}
+}
+
+// TestSeedDefaultSeedsWhenAbsent: SeedDefault sets the value on first run (no
+// persisted value), mirroring BURSA_LEAN seeding the initial default.
+func TestSeedDefaultSeedsWhenAbsent(t *testing.T) {
+	path := tmpPath(t)
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := s.SeedDefault(true); err != nil {
+		t.Fatalf("SeedDefault: %v", err)
+	}
+	if !s.HistoryExpiry() {
+		t.Fatal("SeedDefault(true) should set the value when none is persisted")
+	}
+	// It must have hit disk, so a reload sees the seeded value.
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !reloaded.HistoryExpiry() {
+		t.Fatal("seeded value did not persist")
+	}
+}
+
+// TestSeedDefaultDoesNotOverridePersisted: once the user has chosen a value, the
+// env seed is ignored — the persisted setting is the source of truth thereafter.
+func TestSeedDefaultDoesNotOverridePersisted(t *testing.T) {
+	path := tmpPath(t)
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// User explicitly turned it OFF.
+	if err := s.SetHistoryExpiry(false); err != nil {
+		t.Fatalf("SetHistoryExpiry(false): %v", err)
+	}
+	// A later seed of true (e.g. BURSA_LEAN=1) must NOT override the user's choice.
+	if err := s.SeedDefault(true); err != nil {
+		t.Fatalf("SeedDefault: %v", err)
+	}
+	if s.HistoryExpiry() {
+		t.Fatal("SeedDefault must not override a persisted value")
+	}
+
+	// Same across a reload + a fresh store's SeedDefault.
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if err := reloaded.SeedDefault(true); err != nil {
+		t.Fatalf("reload SeedDefault: %v", err)
+	}
+	if reloaded.HistoryExpiry() {
+		t.Fatal("SeedDefault on reload must not override the persisted false")
+	}
+}
+
+// TestLoadRejectsCorruptFile: a present-but-corrupt file is a hard error rather
+// than silently discarding the user's settings.
+func TestLoadRejectsCorruptFile(t *testing.T) {
+	path := tmpPath(t)
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatalf("seed corrupt file: %v", err)
+	}
+	if _, err := Load(path); err == nil {
+		t.Fatal("Load should error on a corrupt settings file")
+	}
+}
+
+// TestSeedDefaultFalseStillPersistsFirstRun: seeding false on first run records
+// an explicit value (so a later env flip to true is correctly ignored). i.e.
+// the absence-vs-explicit-false distinction is preserved.
+func TestSeedDefaultFalseStillPersistsFirstRun(t *testing.T) {
+	path := tmpPath(t)
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := s.SeedDefault(false); err != nil {
+		t.Fatalf("SeedDefault(false): %v", err)
+	}
+	// Now a different seed must be ignored: the first-run default is locked in.
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if err := reloaded.SeedDefault(true); err != nil {
+		t.Fatalf("reload SeedDefault(true): %v", err)
+	}
+	if reloaded.HistoryExpiry() {
+		t.Fatal("first-run SeedDefault(false) should lock in false, not be re-seeded to true")
+	}
+}

--- a/ui/internal/settings/settings_test.go
+++ b/ui/internal/settings/settings_test.go
@@ -16,6 +16,7 @@ package settings
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -142,6 +143,38 @@ func TestLoadRejectsCorruptFile(t *testing.T) {
 	}
 	if _, err := Load(path); err == nil {
 		t.Fatal("Load should error on a corrupt settings file")
+	}
+}
+
+func TestLoadRejectsOversizedFile(t *testing.T) {
+	path := tmpPath(t)
+	if err := os.WriteFile(path, make([]byte, maxSettingsLen+1), 0o600); err != nil {
+		t.Fatalf("seed oversized file: %v", err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load should reject an oversized settings file")
+	}
+	if !strings.Contains(err.Error(), "settings file exceeds") {
+		t.Fatalf("Load error = %q, want size-cap error", err)
+	}
+}
+
+func TestSetHistoryExpiryRollsBackOnPersistError(t *testing.T) {
+	enabled := true
+	s := &Store{
+		path: filepath.Join(t.TempDir(), "missing-parent", "settings.json"),
+		d: data{
+			Version:       settingsVersion,
+			HistoryExpiry: &enabled,
+		},
+	}
+
+	if err := s.SetHistoryExpiry(false); err == nil {
+		t.Fatal("SetHistoryExpiry should fail when the settings directory is missing")
+	}
+	if !s.HistoryExpiry() {
+		t.Fatal("failed SetHistoryExpiry must leave the in-memory setting unchanged")
 	}
 }
 

--- a/ui/internal/supervisor/supervisor.go
+++ b/ui/internal/supervisor/supervisor.go
@@ -47,12 +47,13 @@ type Config struct {
 	// HistoryExpiry reports whether the "lean node" (history-expiry) profile is
 	// enabled. It is a provider (not a static bool) so the persisted user setting
 	// is the source of truth: it is read fresh every time the node config is built
-	// (each Start), letting a toggled setting take effect on the next node
-	// restart. A nil provider, or one returning false, keeps full immutable block
-	// history (behavior unchanged). When it returns true (the lean/mobile
-	// profile), the node periodically prunes immutable blocks older than the
-	// stability window, keeping the ledger state and recent blocks — a much
-	// smaller on-disk footprint at the cost of deep block history.
+	// (each launch, including after asynchronous bootstrap), letting a toggled
+	// setting take effect on the next node restart. A nil provider, or one
+	// returning false, keeps full immutable block history (behavior unchanged).
+	// When it returns true (the lean/mobile profile), the node periodically
+	// prunes immutable blocks older than the stability window, keeping the ledger
+	// state and recent blocks — a much smaller on-disk footprint at the cost of
+	// deep block history.
 	HistoryExpiry func() bool
 }
 
@@ -75,6 +76,7 @@ type Supervisor struct {
 
 	now          func() time.Time // injectable clock for tests
 	bootstrapper Bootstrapper     // injectable for tests
+	newNode      func(dingo.Config) (nodeRunner, error)
 }
 
 func New(cfg Config) *Supervisor {
@@ -89,7 +91,14 @@ func New(cfg Config) *Supervisor {
 		status:       Status{State: StateStopped},
 		now:          time.Now,
 		bootstrapper: mithrilBootstrapper{logger: cfg.Logger},
+		newNode: func(cfg dingo.Config) (nodeRunner, error) {
+			return dingo.New(cfg)
+		},
 	}
+}
+
+type nodeRunner interface {
+	Run(context.Context) error
 }
 
 // historyExpiryEnabled resolves the lean-node profile from the (optional)
@@ -101,9 +110,8 @@ func (cfg Config) historyExpiryEnabled() bool {
 // nodeConfigOptions builds the dingo option set for the embedded node. It is a
 // standalone function (not inlined into Start) so the config wiring — in
 // particular the opt-in history-expiry profile — can be unit-tested without
-// constructing a real node. historyExpiry is the resolved profile value (read
-// from the persisted setting at Start), passed in so the caller controls when
-// the source-of-truth provider is read.
+// constructing a real node. historyExpiry is the resolved profile value, passed
+// in so the caller controls when the source-of-truth provider is read.
 func nodeConfigOptions(
 	cfg Config,
 	historyExpiry bool,
@@ -205,15 +213,16 @@ func (s *Supervisor) Start(ctx context.Context) error {
 		return fail(fmt.Errorf("load Dingo topology config: %w", err))
 	}
 
-	// Read the lean-node profile from its (persisted) source of truth once, here
-	// at Start, so a toggled setting takes effect on this node start. Record the
-	// applied value so the API can report whether a later change needs a restart.
-	historyExpiry := s.cfg.historyExpiryEnabled()
-	nodeCfg := dingo.NewConfig(nodeConfigOptions(s.cfg, historyExpiry, cardanoCfg, topologyCfg)...)
 	// launch creates the node, marks it starting, and begins serving + polling.
 	// Used by both the direct and post-bootstrap paths.
 	launch := func() error {
-		node, err := dingo.New(nodeCfg)
+		// Read the lean-node profile from its persisted source of truth at the
+		// actual construction point. In the Mithril path, Start returns while
+		// bootstrap is still running, so reading earlier can freeze a stale value
+		// before the first node exists.
+		historyExpiry := s.cfg.historyExpiryEnabled()
+		nodeCfg := dingo.NewConfig(nodeConfigOptions(s.cfg, historyExpiry, cardanoCfg, topologyCfg)...)
+		node, err := s.newNode(nodeCfg)
 		if err != nil {
 			return err
 		}

--- a/ui/internal/supervisor/supervisor.go
+++ b/ui/internal/supervisor/supervisor.go
@@ -44,6 +44,16 @@ type Config struct {
 	// serving. The zero value is false (genesis sync); main.go enables it by
 	// default and BURSA_SYNC=genesis opts out.
 	MithrilEnabled bool
+	// HistoryExpiry reports whether the "lean node" (history-expiry) profile is
+	// enabled. It is a provider (not a static bool) so the persisted user setting
+	// is the source of truth: it is read fresh every time the node config is built
+	// (each Start), letting a toggled setting take effect on the next node
+	// restart. A nil provider, or one returning false, keeps full immutable block
+	// history (behavior unchanged). When it returns true (the lean/mobile
+	// profile), the node periodically prunes immutable blocks older than the
+	// stability window, keeping the ledger state and recent blocks — a much
+	// smaller on-disk footprint at the cost of deep block history.
+	HistoryExpiry func() bool
 }
 
 // Supervisor owns the embedded Dingo node's lifecycle and exposes its status.
@@ -54,6 +64,14 @@ type Supervisor struct {
 
 	mu     sync.RWMutex
 	status Status
+	// applied records the history-expiry value the currently-running node was
+	// built with, so the API can tell whether a changed setting still needs a
+	// restart to take effect. ran is false until the node has been launched at
+	// least once this process.
+	applied struct {
+		historyExpiry bool
+		ran           bool
+	}
 
 	now          func() time.Time // injectable clock for tests
 	bootstrapper Bootstrapper     // injectable for tests
@@ -72,6 +90,67 @@ func New(cfg Config) *Supervisor {
 		now:          time.Now,
 		bootstrapper: mithrilBootstrapper{logger: cfg.Logger},
 	}
+}
+
+// historyExpiryEnabled resolves the lean-node profile from the (optional)
+// provider. A nil provider means the feature is not wired in (default off).
+func (cfg Config) historyExpiryEnabled() bool {
+	return cfg.HistoryExpiry != nil && cfg.HistoryExpiry()
+}
+
+// nodeConfigOptions builds the dingo option set for the embedded node. It is a
+// standalone function (not inlined into Start) so the config wiring — in
+// particular the opt-in history-expiry profile — can be unit-tested without
+// constructing a real node. historyExpiry is the resolved profile value (read
+// from the persisted setting at Start), passed in so the caller controls when
+// the source-of-truth provider is read.
+func nodeConfigOptions(
+	cfg Config,
+	historyExpiry bool,
+	cardanoCfg *cardano.CardanoNodeConfig,
+	topologyCfg *topology.TopologyConfig,
+) []dingo.ConfigOptionFunc {
+	opts := []dingo.ConfigOptionFunc{
+		dingo.WithNetwork(cfg.Network),
+		dingo.WithCardanoNodeConfig(cardanoCfg),
+		dingo.WithTopologyConfig(topologyCfg),
+		dingo.WithDatabasePath(cfg.DataDir),
+		dingo.WithStorageMode(dingo.StorageModeAPI),
+		// Without an explicit capacity the mempool defaults to 0 bytes and
+		// rejects every transaction ("mempool full: capacity=0 bytes"), so the
+		// wallet could never submit a spend. Match Dingo's own Praos default
+		// (1 MiB) — ample for a single-user wallet submitting its own txs.
+		dingo.WithMempoolCapacity(1 << 20),
+		dingo.WithBindAddr("127.0.0.1"),
+		dingo.WithUtxorpcPort(cfg.UtxorpcPort),
+		dingo.WithBlockfrostPort(cfg.BlockfrostPort),
+		dingo.WithListeners(connmanager.ListenerConfig{
+			ListenNetwork: "unix",
+			ListenAddress: cfg.SocketPath,
+			UseNtC:        true,
+		}),
+		dingo.WithLogger(cfg.Logger),
+	}
+	// Lean-node profile: opt in to dingo's history expiry so the node prunes
+	// immutable block history past the stability window. Off by default, where
+	// the node keeps full history (behavior unchanged).
+	if historyExpiry {
+		opts = append(opts, dingo.WithHistoryExpiry(dingo.HistoryExpiryConfig{
+			Enabled:   true,
+			Frequency: time.Hour,
+		}))
+	}
+	return opts
+}
+
+// AppliedHistoryExpiry reports the history-expiry value the currently/last
+// launched node was built with, and whether a node has been launched at all
+// this process (ran). The API compares this against the persisted setting to
+// decide whether a change still needs a node restart to take effect.
+func (s *Supervisor) AppliedHistoryExpiry() (applied bool, ran bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.applied.historyExpiry, s.applied.ran
 }
 
 // Start constructs the node, launches it, and begins polling its tip. It
@@ -126,27 +205,11 @@ func (s *Supervisor) Start(ctx context.Context) error {
 		return fail(fmt.Errorf("load Dingo topology config: %w", err))
 	}
 
-	nodeCfg := dingo.NewConfig(
-		dingo.WithNetwork(s.cfg.Network),
-		dingo.WithCardanoNodeConfig(cardanoCfg),
-		dingo.WithTopologyConfig(topologyCfg),
-		dingo.WithDatabasePath(s.cfg.DataDir),
-		dingo.WithStorageMode(dingo.StorageModeAPI),
-		// Without an explicit capacity the mempool defaults to 0 bytes and
-		// rejects every transaction ("mempool full: capacity=0 bytes"), so the
-		// wallet could never submit a spend. Match Dingo's own Praos default
-		// (1 MiB) — ample for a single-user wallet submitting its own txs.
-		dingo.WithMempoolCapacity(1<<20),
-		dingo.WithBindAddr("127.0.0.1"),
-		dingo.WithUtxorpcPort(s.cfg.UtxorpcPort),
-		dingo.WithBlockfrostPort(s.cfg.BlockfrostPort),
-		dingo.WithListeners(connmanager.ListenerConfig{
-			ListenNetwork: "unix",
-			ListenAddress: s.cfg.SocketPath,
-			UseNtC:        true,
-		}),
-		dingo.WithLogger(s.cfg.Logger),
-	)
+	// Read the lean-node profile from its (persisted) source of truth once, here
+	// at Start, so a toggled setting takes effect on this node start. Record the
+	// applied value so the API can report whether a later change needs a restart.
+	historyExpiry := s.cfg.historyExpiryEnabled()
+	nodeCfg := dingo.NewConfig(nodeConfigOptions(s.cfg, historyExpiry, cardanoCfg, topologyCfg)...)
 	// launch creates the node, marks it starting, and begins serving + polling.
 	// Used by both the direct and post-bootstrap paths.
 	launch := func() error {
@@ -154,6 +217,10 @@ func (s *Supervisor) Start(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		s.mu.Lock()
+		s.applied.historyExpiry = historyExpiry
+		s.applied.ran = true
+		s.mu.Unlock()
 		s.setStateForRun(runID, StateStarting)
 		go func() {
 			if err := node.Run(runCtx); err != nil && runCtx.Err() == nil {

--- a/ui/internal/supervisor/supervisor_test.go
+++ b/ui/internal/supervisor/supervisor_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package supervisor
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo"
+)
+
+// baseConfig is a minimal Config for exercising nodeConfigOptions.
+func baseConfig() Config {
+	return Config{
+		Network:        "preview",
+		DataDir:        "/data/db",
+		SocketPath:     "/data/node.socket",
+		UtxorpcPort:    5555,
+		BlockfrostPort: 5556,
+	}
+}
+
+// TestNodeConfigOptionsHistoryExpiryOptIn asserts the lean-node profile plumbs
+// through: enabling HistoryExpiry appends exactly one extra dingo option
+// (WithHistoryExpiry), and the default (off) does not. dingo.Config keeps the
+// history-expiry setting unexported with no getter, so the option set is the
+// smallest observable seam for the wiring.
+func TestNodeConfigOptionsHistoryExpiryOptIn(t *testing.T) {
+	off := nodeConfigOptions(baseConfig(), false, nil, nil)
+	on := nodeConfigOptions(baseConfig(), true, nil, nil)
+
+	if len(on) != len(off)+1 {
+		t.Fatalf(
+			"history expiry should add exactly one option; off=%d on=%d",
+			len(off), len(on),
+		)
+	}
+
+	// The options must apply cleanly to a real dingo.Config (the wiring is only
+	// useful if dingo accepts it). This also guards against the option panicking
+	// on nil cardano/topology configs.
+	mustApply := func(opts []dingo.ConfigOptionFunc) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("applying node config options panicked: %v", r)
+			}
+		}()
+		_ = dingo.NewConfig(opts...)
+	}
+	mustApply(off)
+	mustApply(on)
+}
+
+// TestNodeConfigOptionsDefaultOff guards the default: history expiry off must
+// not include the lean-profile option.
+func TestNodeConfigOptionsDefaultOff(t *testing.T) {
+	def := nodeConfigOptions(baseConfig(), false, nil, nil)
+	on := nodeConfigOptions(baseConfig(), true, nil, nil)
+	if len(def) == len(on) {
+		t.Fatal("history expiry off must not include the history-expiry option")
+	}
+}
+
+// TestHistoryExpiryEnabledReadsProvider asserts the supervisor reads the
+// (persisted) setting through its provider — it is the source of truth, not a
+// value frozen at construction. A nil provider reads as off.
+func TestHistoryExpiryEnabledReadsProvider(t *testing.T) {
+	cfg := baseConfig()
+	if cfg.historyExpiryEnabled() {
+		t.Fatal("nil HistoryExpiry provider must read as off")
+	}
+
+	// A live provider is consulted each call, so flipping the backing value is
+	// observed without rebuilding the Config — i.e. the persisted setting (not a
+	// static field) drives node construction.
+	enabled := false
+	cfg.HistoryExpiry = func() bool { return enabled }
+	if cfg.historyExpiryEnabled() {
+		t.Fatal("provider returning false must read as off")
+	}
+	enabled = true
+	if !cfg.historyExpiryEnabled() {
+		t.Fatal("provider returning true must read as on")
+	}
+}
+
+// TestAppliedHistoryExpiryBeforeLaunch: with no node launched yet, the applied
+// value reports ran=false so the API knows it has nothing to compare against.
+func TestAppliedHistoryExpiryBeforeLaunch(t *testing.T) {
+	s := New(baseConfig())
+	if _, ran := s.AppliedHistoryExpiry(); ran {
+		t.Fatal("AppliedHistoryExpiry must report ran=false before any launch")
+	}
+}

--- a/ui/internal/supervisor/supervisor_test.go
+++ b/ui/internal/supervisor/supervisor_test.go
@@ -65,16 +65,6 @@ func TestNodeConfigOptionsHistoryExpiryOptIn(t *testing.T) {
 	mustApply(on)
 }
 
-// TestNodeConfigOptionsDefaultOff guards the default: history expiry off must
-// not include the lean-profile option.
-func TestNodeConfigOptionsDefaultOff(t *testing.T) {
-	def := nodeConfigOptions(baseConfig(), false, nil, nil)
-	on := nodeConfigOptions(baseConfig(), true, nil, nil)
-	if len(def) == len(on) {
-		t.Fatal("history expiry off must not include the history-expiry option")
-	}
-}
-
 // TestHistoryExpiryEnabledReadsProvider asserts the supervisor reads the
 // (persisted) setting through its provider — it is the source of truth, not a
 // value frozen at construction. A nil provider reads as off.

--- a/ui/internal/supervisor/supervisor_test.go
+++ b/ui/internal/supervisor/supervisor_test.go
@@ -14,7 +14,11 @@
 package supervisor
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/dingo"
 )
@@ -100,5 +104,78 @@ func TestAppliedHistoryExpiryBeforeLaunch(t *testing.T) {
 	s := New(baseConfig())
 	if _, ran := s.AppliedHistoryExpiry(); ran {
 		t.Fatal("AppliedHistoryExpiry must report ran=false before any launch")
+	}
+}
+
+type blockingBootstrapper struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingBootstrapper) Bootstrap(ctx context.Context, p BootstrapParams) error {
+	if err := os.MkdirAll(p.DataDir, 0o700); err != nil {
+		return err
+	}
+	close(b.started)
+	select {
+	case <-b.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type nodeRunnerFunc func(context.Context) error
+
+func (f nodeRunnerFunc) Run(ctx context.Context) error { return f(ctx) }
+
+func TestStartReadsHistoryExpiryAtDeferredBootstrapLaunch(t *testing.T) {
+	enabled := false
+	cfg := baseConfig()
+	dir := t.TempDir()
+	cfg.DataDir = filepath.Join(dir, "db")
+	cfg.SocketPath = filepath.Join(dir, "node.socket")
+	cfg.MithrilEnabled = true
+	cfg.HistoryExpiry = func() bool { return enabled }
+
+	s := New(cfg)
+	fb := &blockingBootstrapper{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	s.bootstrapper = fb
+	nodeStarted := make(chan struct{})
+	s.newNode = func(dingo.Config) (nodeRunner, error) {
+		return nodeRunnerFunc(func(ctx context.Context) error {
+			close(nodeStarted)
+			<-ctx.Done()
+			return ctx.Err()
+		}), nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := s.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer s.Stop()
+
+	select {
+	case <-fb.started:
+	case <-time.After(time.Second):
+		t.Fatal("bootstrap did not start")
+	}
+
+	enabled = true
+	close(fb.release)
+
+	select {
+	case <-nodeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("node was not launched after bootstrap")
+	}
+	applied, ran := s.AppliedHistoryExpiry()
+	if !ran || !applied {
+		t.Fatalf("AppliedHistoryExpiry = (%v, %v), want (true, true)", applied, ran)
 	}
 }

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -15,6 +15,7 @@ import type {
   UnlockVaultRequest,
   AddWalletRequest,
   MigrateLegacyKeystoreRequest,
+  HistoryExpirySetting,
 } from "./types";
 
 export class ApiError extends Error {
@@ -65,6 +66,7 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
 
 export const apiGet = <T>(path: string) => request<T>("GET", path);
 export const apiPost = <T>(path: string, body?: unknown) => request<T>("POST", path, body);
+export const apiPut = <T>(path: string, body?: unknown) => request<T>("PUT", path, body);
 
 export const apiDelete = <T>(path: string, body?: unknown) => request<T>("DELETE", path, body);
 
@@ -93,3 +95,7 @@ export const buildSend = (req: SendRequest) => apiPost<Preview>("/wallet/send", 
 export const confirmSend = (id: string, password: string) =>
   apiPost<TxResult>(`/wallet/send/${encodeURIComponent(id)}/confirm`, { password });
 export const signData = (req: SignDataRequest) => apiPost<SignDataResult>("/wallet/sign-data", req);
+export const getHistoryExpiry = () =>
+  apiGet<HistoryExpirySetting>("/wallet/settings/history-expiry");
+export const setHistoryExpiry = (enabled: boolean) =>
+  apiPut<HistoryExpirySetting>("/wallet/settings/history-expiry", { enabled });

--- a/ui/web/src/api/hooks.ts
+++ b/ui/web/src/api/hooks.ts
@@ -1,5 +1,13 @@
 import { useState, useEffect, useCallback } from "react";
-import type { Status, Balance, AddressView, Tx, DelegationView, VaultStatus } from "./types";
+import type {
+  Status,
+  Balance,
+  AddressView,
+  Tx,
+  DelegationView,
+  VaultStatus,
+  HistoryExpirySetting,
+} from "./types";
 import {
   getStatus,
   getVaultStatus,
@@ -7,6 +15,7 @@ import {
   getAddresses,
   getTransactions,
   getDelegation,
+  getHistoryExpiry,
 } from "./client";
 
 export interface AsyncState<T> {
@@ -74,3 +83,4 @@ export const useBalance = (): AsyncState<Balance> => useAsync(getBalance);
 export const useAddresses = (): AsyncState<AddressView> => useAsync(getAddresses);
 export const useTransactions = (): AsyncState<Tx[]> => useAsync(getTransactions);
 export const useDelegation = (): AsyncState<DelegationView> => useAsync(getDelegation);
+export const useHistoryExpiry = (): AsyncState<HistoryExpirySetting> => useAsync(getHistoryExpiry);

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -117,6 +117,15 @@ export interface VaultStatus {
   legacy_keystore?: boolean;
 }
 
+// App settings: the lean-node (history-expiry) profile. restart_required is true
+// when the persisted value differs from what the running node was built with —
+// history expiry is a node-construction option, so it only takes effect on the
+// next node restart.
+export interface HistoryExpirySetting {
+  enabled: boolean;
+  restart_required: boolean;
+}
+
 // A wallet as listed by the vault: read-only fields plus whether it's active.
 // The encrypted seed is never exposed.
 export interface WalletView {

--- a/ui/web/src/screens/Settings.test.tsx
+++ b/ui/web/src/screens/Settings.test.tsx
@@ -138,7 +138,9 @@ test("(l) toggling lean storage PUTs the new value and shows restart note", asyn
   fireEvent.click(toggle);
 
   await waitFor(() => expect(spy).toHaveBeenCalledWith(true));
-  expect(await screen.findByText(/takes effect after a node restart/i)).toBeInTheDocument();
+  await waitFor(() => expect(toggle).not.toBeDisabled());
+  expect(toggle).toBeChecked();
+  expect(screen.getByRole("status")).toHaveTextContent(/takes effect after a node restart/i);
 });
 
 test("(m) a persisted restart_required surfaces the restart note", () => {

--- a/ui/web/src/screens/Settings.test.tsx
+++ b/ui/web/src/screens/Settings.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { Settings } from "./Settings";
 import * as hooks from "../api/hooks";
-import type { Account } from "../api/types";
+import * as client from "../api/client";
+import type { Account, HistoryExpirySetting } from "../api/types";
 
 const mockAccount: Account = {
   network: "preview",
@@ -17,6 +18,21 @@ function mockStatus(state: string, tip = 12345, caughtUp = false) {
     refresh: vi.fn(),
   } as never);
 }
+
+// The Lean Storage card reads useHistoryExpiry; default it to a loaded
+// disabled/no-restart state so the existing Settings assertions are unaffected.
+function mockHistoryExpiry(setting: HistoryExpirySetting | null, loading = false) {
+  vi.spyOn(hooks, "useHistoryExpiry").mockReturnValue({
+    data: setting,
+    error: null,
+    loading,
+    refresh: vi.fn(),
+  } as never);
+}
+
+beforeEach(() => {
+  mockHistoryExpiry({ enabled: false, restart_required: false });
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -89,4 +105,47 @@ test("(i) loading state from useStatus renders gracefully", () => {
   render(<Settings account={mockAccount} spendingEnabled={false} />);
   // Should not crash; network card still shows
   expect(screen.getByText("preview")).toBeInTheDocument();
+});
+
+// ---------------------------------------------------------- lean storage ---
+
+test("(j) lean storage toggle reflects the persisted enabled state", () => {
+  mockStatus("ready", 12345, true);
+  mockHistoryExpiry({ enabled: true, restart_required: false });
+  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  const toggle = screen.getByRole("switch", { name: /lean storage/i });
+  expect(toggle).toBeChecked();
+  expect(screen.getByText(/enabled/i)).toBeInTheDocument();
+});
+
+test("(k) lean storage renders the tradeoff copy", () => {
+  mockStatus("ready", 12345, true);
+  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  expect(screen.getByText(/saves significant disk space/i)).toBeInTheDocument();
+  expect(screen.getByText(/your mithril snapshot is kept/i)).toBeInTheDocument();
+  expect(screen.getByText(/one-way until re-sync/i)).toBeInTheDocument();
+});
+
+test("(l) toggling lean storage PUTs the new value and shows restart note", async () => {
+  mockStatus("ready", 12345, true);
+  mockHistoryExpiry({ enabled: false, restart_required: false });
+  const spy = vi
+    .spyOn(client, "setHistoryExpiry")
+    .mockResolvedValue({ enabled: true, restart_required: true });
+
+  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  const toggle = screen.getByRole("switch", { name: /lean storage/i });
+  fireEvent.click(toggle);
+
+  await waitFor(() => expect(spy).toHaveBeenCalledWith(true));
+  expect(await screen.findByText(/takes effect after a node restart/i)).toBeInTheDocument();
+});
+
+test("(m) a persisted restart_required surfaces the restart note", () => {
+  mockStatus("ready", 12345, true);
+  mockHistoryExpiry({ enabled: true, restart_required: true });
+  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  // The restart note appears both in the live status line (role=status) and as
+  // the final bullet of the copy; assert the live status one specifically.
+  expect(screen.getByRole("status")).toHaveTextContent(/takes effect after a node restart/i);
 });

--- a/ui/web/src/screens/Settings.test.tsx
+++ b/ui/web/src/screens/Settings.test.tsx
@@ -143,7 +143,41 @@ test("(l) toggling lean storage PUTs the new value and shows restart note", asyn
   expect(screen.getByRole("status")).toHaveTextContent(/takes effect after a node restart/i);
 });
 
-test("(m) a persisted restart_required surfaces the restart note", () => {
+test("(m) failed lean storage update rolls back and surfaces the error", async () => {
+  mockStatus("ready", 12345, true);
+  mockHistoryExpiry({ enabled: false, restart_required: false });
+  const spy = vi
+    .spyOn(client, "setHistoryExpiry")
+    .mockRejectedValue(new client.ApiError(500, "disk full"));
+
+  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  const toggle = screen.getByRole("switch", { name: /lean storage/i });
+  fireEvent.click(toggle);
+
+  await waitFor(() => expect(spy).toHaveBeenCalledWith(true));
+  await waitFor(() => expect(toggle).not.toBeDisabled());
+  expect(toggle).not.toBeChecked();
+  expect(screen.getByRole("alert")).toHaveTextContent(/disk full/i);
+});
+
+test("(n) failed initial lean storage load renders unavailable", () => {
+  mockStatus("ready", 12345, true);
+  vi.spyOn(hooks, "useHistoryExpiry").mockReturnValue({
+    data: null,
+    error: new Error("settings unavailable"),
+    loading: false,
+    refresh: vi.fn(),
+  } as never);
+
+  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  const toggle = screen.getByRole("switch", { name: /lean storage/i });
+  expect(toggle).toBeDisabled();
+  expect(screen.getByText(/^Unavailable$/)).toBeInTheDocument();
+  expect(screen.queryByText(/^disabled$/i)).toBeNull();
+  expect(screen.getByRole("alert")).toHaveTextContent(/settings unavailable/i);
+});
+
+test("(o) a persisted restart_required surfaces the restart note", () => {
   mockStatus("ready", 12345, true);
   mockHistoryExpiry({ enabled: true, restart_required: true });
   render(<Settings account={mockAccount} spendingEnabled={false} />);

--- a/ui/web/src/screens/Settings.tsx
+++ b/ui/web/src/screens/Settings.tsx
@@ -1,7 +1,9 @@
+import { useState, useEffect } from "react";
 import { Card } from "../components/Card";
 import { StatusPill } from "../components/StatusPill";
 import { CopyButton } from "../components/CopyButton";
-import { useStatus } from "../api/hooks";
+import { useStatus, useHistoryExpiry } from "../api/hooks";
+import { setHistoryExpiry as putHistoryExpiry, ApiError } from "../api/client";
 import type { Account, NodeState } from "../api/types";
 
 interface SettingsProps {
@@ -14,6 +16,128 @@ function syncTone(state: NodeState): "ok" | "warn" | "error" | "muted" {
   if (state === "error") return "error";
   if (state === "stopped") return "muted";
   return "warn";
+}
+
+// LeanStorageCard is the user-facing control for the lean-node (history-expiry)
+// profile. It shows the persisted state, signals when a change still needs a
+// node restart to take effect, and renders the tradeoff copy.
+function LeanStorageCard() {
+  const setting = useHistoryExpiry();
+  // Optimistic local view of the toggle, so it reflects the user's click
+  // immediately while the PUT is in flight (then reconciles with the server).
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [restartRequired, setRestartRequired] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Seed local state from the server once it loads (and whenever it refreshes
+  // while we are not mid-save).
+  useEffect(() => {
+    if (setting.data && !saving) {
+      setEnabled(setting.data.enabled);
+      setRestartRequired(setting.data.restart_required);
+    }
+  }, [setting.data, saving]);
+
+  async function handleToggle(next: boolean) {
+    setError(null);
+    setSaving(true);
+    setEnabled(next); // optimistic
+    try {
+      const res = await putHistoryExpiry(next);
+      setEnabled(res.enabled);
+      setRestartRequired(res.restart_required);
+    } catch (e) {
+      // Roll back the optimistic flip on failure.
+      setEnabled(!next);
+      setError(e instanceof ApiError ? e.message : "An unexpected error occurred");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const loading = setting.loading && enabled === null;
+  const checked = enabled ?? false;
+
+  return (
+    <Card title="Lean Storage">
+      <div className="setting-toggle-row">
+        <label htmlFor="lean-storage" className="setting-toggle-label">
+          Lean storage (history expiry)
+        </label>
+        <label className="switch">
+          <input
+            id="lean-storage"
+            type="checkbox"
+            role="switch"
+            aria-checked={checked}
+            checked={checked}
+            disabled={loading || saving}
+            onChange={(e) => handleToggle(e.target.checked)}
+          />
+          <span className="switch-track" aria-hidden="true">
+            <span className="switch-thumb" />
+          </span>
+        </label>
+      </div>
+
+      {loading ? (
+        <p className="muted">Loading…</p>
+      ) : (
+        <p className="setting-state">
+          {checked ? "Enabled" : "Disabled"}
+          {saving && " · saving…"}
+        </p>
+      )}
+
+      {error && (
+        <p role="alert" className="error-text">
+          {error}
+        </p>
+      )}
+
+      {restartRequired && (
+        <p role="status" className="setting-restart-note">
+          Takes effect after a node restart.
+        </p>
+      )}
+
+      <div className="setting-copy">
+        <p>
+          Prune old blockchain history from local storage. Your node keeps the
+          current ledger state, your wallet&apos;s data, and recent blocks — and
+          drops older block history it no longer needs.
+        </p>
+        <ul>
+          <li>
+            <strong>Saves significant disk space</strong> — typically tens of GB
+            down to a few GB.
+          </li>
+          <li>
+            <strong>The wallet stays fully functional</strong> — balances,
+            sending, staking, and governance all rely on current ledger state and
+            your own transaction history, not deep chain history.
+          </li>
+          <li>
+            <strong>Tradeoff:</strong> historical chain data beyond the recent
+            window is removed locally; recovering it requires a re-sync.
+          </li>
+          <li>
+            <strong>Your Mithril snapshot is kept</strong>, so re-syncing stays
+            fast — it won&apos;t re-download.
+          </li>
+          <li>
+            <strong>One-way until re-sync:</strong> turning this on starts
+            pruning; turning it back off stops further pruning but doesn&apos;t
+            restore already-pruned history without a re-sync.
+          </li>
+          <li>
+            <strong>Takes effect after a node restart.</strong>
+          </li>
+        </ul>
+      </div>
+    </Card>
+  );
 }
 
 export function Settings({ account, spendingEnabled }: SettingsProps) {
@@ -56,6 +180,8 @@ export function Settings({ account, spendingEnabled }: SettingsProps) {
           <p className="muted">Unavailable</p>
         )}
       </Card>
+
+      <LeanStorageCard />
 
       <Card title="Keystore">
         <p>{spendingEnabled ? "Spending enabled" : "Read-only"}</p>

--- a/ui/web/src/screens/Settings.tsx
+++ b/ui/web/src/screens/Settings.tsx
@@ -30,14 +30,15 @@ function LeanStorageCard() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Seed local state from the server once it loads (and whenever it refreshes
-  // while we are not mid-save).
+  // Seed local state from the server once it loads, and whenever the hook data
+  // itself refreshes. Do not key this off saving: the hook may still hold the
+  // pre-PUT value when a successful save finishes.
   useEffect(() => {
-    if (setting.data && !saving) {
+    if (setting.data) {
       setEnabled(setting.data.enabled);
       setRestartRequired(setting.data.restart_required);
     }
-  }, [setting.data, saving]);
+  }, [setting.data]);
 
   async function handleToggle(next: boolean) {
     setError(null);

--- a/ui/web/src/screens/Settings.tsx
+++ b/ui/web/src/screens/Settings.tsx
@@ -41,6 +41,8 @@ function LeanStorageCard() {
   }, [setting.data]);
 
   async function handleToggle(next: boolean) {
+    if (enabled === null || saving) return;
+    const previous = enabled;
     setError(null);
     setSaving(true);
     setEnabled(next); // optimistic
@@ -50,15 +52,19 @@ function LeanStorageCard() {
       setRestartRequired(res.restart_required);
     } catch (e) {
       // Roll back the optimistic flip on failure.
-      setEnabled(!next);
+      setEnabled(previous);
       setError(e instanceof ApiError ? e.message : "An unexpected error occurred");
     } finally {
       setSaving(false);
     }
   }
 
-  const loading = setting.loading && enabled === null;
+  const hasLoaded = enabled !== null;
+  const loading = setting.loading && !hasLoaded;
+  const unavailable = !loading && !hasLoaded;
   const checked = enabled ?? false;
+  const loadError = setting.error?.message ?? null;
+  const cardError = error ?? loadError;
 
   return (
     <Card title="Lean Storage">
@@ -73,7 +79,7 @@ function LeanStorageCard() {
             role="switch"
             aria-checked={checked}
             checked={checked}
-            disabled={loading || saving}
+            disabled={!hasLoaded || loading || saving}
             onChange={(e) => handleToggle(e.target.checked)}
           />
           <span className="switch-track" aria-hidden="true">
@@ -84,6 +90,8 @@ function LeanStorageCard() {
 
       {loading ? (
         <p className="muted">Loading…</p>
+      ) : unavailable ? (
+        <p className="muted">Unavailable</p>
       ) : (
         <p className="setting-state">
           {checked ? "Enabled" : "Disabled"}
@@ -91,9 +99,9 @@ function LeanStorageCard() {
         </p>
       )}
 
-      {error && (
+      {cardError && (
         <p role="alert" className="error-text">
-          {error}
+          {cardError}
         </p>
       )}
 

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -814,6 +814,126 @@ a:hover {
   margin-bottom: 0;
 }
 
+/* ------------------------------------------------------ settings toggles -- */
+/* A labeled switch row: caption on the left, a sliding toggle on the right. */
+.setting-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+.setting-toggle-label {
+  font-family: var(--mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text);
+}
+
+/* iOS-style switch built on a visually-hidden checkbox so it stays accessible
+   (focus + keyboard) while reading as an instrument toggle. */
+.switch {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+.switch input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.switch-track {
+  display: inline-block;
+  width: 42px;
+  height: 24px;
+  border-radius: 999px;
+  background: var(--inset);
+  border: 1px solid var(--border);
+  transition:
+    background 0.14s ease,
+    border-color 0.14s ease;
+}
+.switch-thumb {
+  display: block;
+  width: 18px;
+  height: 18px;
+  margin: 2px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  transition:
+    transform 0.14s ease,
+    background 0.14s ease;
+}
+.switch input:checked + .switch-track {
+  background: var(--accent-dim);
+  border-color: var(--accent);
+}
+.switch input:checked + .switch-track .switch-thumb {
+  transform: translateX(18px);
+  background: var(--accent);
+}
+.switch input:focus-visible + .switch-track {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.switch input:disabled + .switch-track {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.setting-state {
+  margin-top: var(--space-2);
+  font-family: var(--mono);
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+/* "Takes effect after a node restart" — a small attention readout in the
+   working/warning hue. */
+.setting-restart-note {
+  margin-top: var(--space-2);
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  color: var(--warn);
+}
+
+/* The tradeoff explanation: body copy + a bullet list of effects. */
+.setting-copy {
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border);
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  line-height: 1.55;
+}
+.setting-copy p {
+  margin-bottom: var(--space-2);
+}
+.setting-copy ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.setting-copy li {
+  position: relative;
+  padding-left: var(--space-3);
+}
+.setting-copy li::before {
+  content: "·";
+  position: absolute;
+  left: 0;
+  color: var(--accent);
+  font-weight: 700;
+}
+.setting-copy strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .dot-warn,
   .sync-bar-indeterminate,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an in-app Lean Storage (history-expiry) setting with persistence, a small API, and a UI toggle; the node reads it on the next restart, including after Mithril bootstrap. Also hardens settings writes with atomic replace and clearer error handling.

- **New Features**
  - Persisted app setting in `settings.json` with atomic writes; `BURSA_LEAN` only seeds the first-run default and is ignored after.
  - API: `GET/PUT /wallet/settings/history-expiry` returns `{ enabled, restart_required }` and is not sync-gated.
  - Supervisor takes a provider for the setting, reads it at each node construction (post-Mithril too), and exposes the applied value for restart detection.
  - Settings screen adds a Lean Storage card with an accessible toggle, optimistic save with rollback on error, a restart note, and concise tradeoff copy.

- **Migration**
  - No action for existing users; default is off unless seeded by `BURSA_LEAN` on first run.
  - Changing the setting requires a node restart to apply.
  - `api.NewHandler` now takes a `SettingsController`; pass the store-backed controller as in `main.go`.

<sup>Written for commit 749e663080b5902ca7902fe74c1cfc447febc898. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Lean storage” setting in Wallet Settings, letting you enable or disable history expiry from the UI.
  * Added support for persisting this setting so it stays saved between app restarts.

* **Bug Fixes**
  * The setting now shows when a restart is required for changes to take effect.
  * Improved default behavior so the wallet uses the saved setting reliably instead of resetting unexpectedly.
  * Added clearer loading, saving, and error states for the new toggle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->