### PR TITLE
fix(ci): use buildx imagetools to build multi-arch manifest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -372,11 +372,16 @@ jobs:
         id: manifest
         shell: bash
         run: |
+          # Use `docker buildx imagetools create` (not `docker manifest create`):
+          # buildx pushes each per-arch tag as an OCI image index (image +
+          # provenance attestation), so `docker manifest create` rejects nesting
+          # it and fails with "<tag>-amd64 is a manifest list". imagetools
+          # composes the per-arch indexes into one multi-arch index and pushes
+          # it in a single step.
           while IFS= read -r tag; do
-            docker manifest create "${tag}" \
+            docker buildx imagetools create -t "${tag}" \
               "${tag}-amd64" \
               "${tag}-arm64"
-            docker manifest push "${tag}"
           done <<< "${{ steps.meta.outputs.tags }}"
           dockerhub_tag=$(echo "${{ steps.meta.outputs.tags }}" | grep -v '^ghcr' | head -1)
           ghcr_tag=$(echo "${{ steps.meta.outputs.tags }}" | grep '^ghcr' | head -1)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -368,6 +368,8 @@ jobs:
             type=ref,event=branch
             # semver
             type=semver,pattern={{version}}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0 https://github.com/docker/setup-buildx-action/releases/tag/v4.1.0
       - name: Create and push image manifests
         id: manifest
         shell: bash


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the publish workflow to `docker buildx imagetools create` and explicitly set up Buildx via `docker/setup-buildx-action` to build and push the multi-arch image index. This fixes CI failures and reliably publishes the combined manifest to Docker Hub and GHCR.

- **Bug Fixes**
  - Fixes "is a manifest list" errors from `docker manifest create` when per-arch tags are OCI image indexes with provenance.
  - Composes `amd64` and `arm64` indexes into one multi-arch index and pushes in a single step.

<sup>Written for commit 694b7945e66afbe40a2be748063475d822915983. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to publish multi-architecture container images using a more compatible build method.
  * Improved image publishing reliability for environments that pull OCI-compliant images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->