### PR TITLE
ci(publish): use .Manifest.Digest in manifest attest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -387,8 +387,8 @@ jobs:
           done <<< "${{ steps.meta.outputs.tags }}"
           dockerhub_tag=$(echo "${{ steps.meta.outputs.tags }}" | grep -v '^ghcr' | head -1)
           ghcr_tag=$(echo "${{ steps.meta.outputs.tags }}" | grep '^ghcr' | head -1)
-          echo "dockerhub-digest=$(docker buildx imagetools inspect --format '{{.Digest}}' ${dockerhub_tag})" >> $GITHUB_OUTPUT
-          echo "ghcr-digest=$(docker buildx imagetools inspect --format '{{.Digest}}' ${ghcr_tag})" >> $GITHUB_OUTPUT
+          echo "dockerhub-digest=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' ${dockerhub_tag})" >> $GITHUB_OUTPUT
+          echo "ghcr-digest=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' ${ghcr_tag})" >> $GITHUB_OUTPUT
       - name: Attest Docker Hub manifest
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
         with:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix manifest attestation in the publish workflow by using the manifest digest from `docker buildx imagetools inspect`. Ensures Docker Hub and GHCR attestations target the multi-arch manifest rather than an image-specific digest.

- **Bug Fixes**
  - Replace `--format '{{.Digest}}'` with `--format '{{.Manifest.Digest}}'` for both Docker Hub and GHCR tags.
  - Prevents incorrect or missing attestations for multi-arch images.

<sup>Written for commit 37346e0f7219dd38de719d5b40f44499041a3ea4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

