### PR TITLE
feat(ui): CIP-8 verification + air-gap transaction signing

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -49,10 +49,16 @@ jobs:
       # before the Go module is built/tested.
       - name: Build web bundle
         run: cd ui/web && npm ci && npm run build
+      # Scope to the module's real Go roots (cmd + internal). A repo-wide "./..."
+      # would descend into ui/web/node_modules, where the npm "flatted" package
+      # vendors a stray *.go file; Go's "..." wildcard does not skip node_modules,
+      # so on a clean checkout that package breaks module resolution
+      # ("updates to go.mod needed"). The wallet's Go code lives only under
+      # cmd/ and internal/.
       - name: go vet
-        run: cd ui && go vet ./...
+        run: cd ui && go vet ./cmd/... ./internal/...
       - name: go test
-        run: cd ui && go test ./...
+        run: cd ui && go test ./cmd/... ./internal/...
       - name: go build
         run: cd ui && go build ./cmd/bursa-wallet
 
@@ -75,3 +81,9 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0 https://github.com/golangci/golangci-lint-action/releases/tag/v9.3.0
         with:
           working-directory: ui
+          # Scope to the module's real Go roots. A default "./..." load descends
+          # into ui/web/node_modules, where the npm "flatted" package vendors a
+          # stray *.go file; Go's "..." wildcard does not skip node_modules, so on
+          # a clean checkout golangci-lint fails to load the package graph
+          # ("no go files to analyze: running `go mod tidy` may solve the problem").
+          args: ./cmd/... ./internal/...

--- a/message.go
+++ b/message.go
@@ -342,6 +342,20 @@ type coseSign1 struct {
 	Signature   []byte
 }
 
+// SignaturePayloadHashed returns the CIP-8/CIP-30 COSE "hashed" header value
+// from a hex-encoded COSE_Sign1 signature. It does not verify the signature.
+func SignaturePayloadHashed(signatureHex string) (bool, error) {
+	sigBytes, err := decodeHex(signatureHex)
+	if err != nil {
+		return false, err
+	}
+	var c coseSign1
+	if _, err := cbor.Decode(sigBytes, &c); err != nil {
+		return false, fmt.Errorf("failed to decode COSE_Sign1: %w", err)
+	}
+	return extractPayloadHashed(c.Protected, c.Unprotected)
+}
+
 // extractCoseKeyPub extracts the public key (label -2) from a COSE_Key.
 func extractCoseKeyPub(keyBytes []byte) ([]byte, error) {
 	var m map[any]cbor.RawMessage

--- a/message_test.go
+++ b/message_test.go
@@ -314,6 +314,67 @@ func TestVerifyData_HashedPayload(t *testing.T) {
 	}
 }
 
+func TestSignaturePayloadHashed(t *testing.T) {
+	lk := testLoadedKey(make([]byte, 32))
+	addr := testEnterpriseAddress(t, lk.VKey)
+	payload := []byte("payload signed through CIP-8 hashed mode")
+
+	defaultSig, _, err := SignData(addr, payload, lk)
+	if err != nil {
+		t.Fatalf("SignData: %v", err)
+	}
+
+	protectedSig, _ := testCoseSign1Hex(t, lk, addr, payload, payload, true, true)
+	unprotectedSig, _ := testCoseSign1Hex(t, lk, addr, payload, payload, true, false)
+
+	tests := []struct {
+		name string
+		sig  string
+		want bool
+	}{
+		{name: "default false", sig: defaultSig},
+		{name: "protected true", sig: protectedSig, want: true},
+		{name: "unprotected true", sig: unprotectedSig, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SignaturePayloadHashed(tt.sig)
+			if err != nil {
+				t.Fatalf("SignaturePayloadHashed: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("SignaturePayloadHashed = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSignaturePayloadHashedRejectsDuplicateHeader(t *testing.T) {
+	lk := testLoadedKey(make([]byte, 32))
+	addr := testEnterpriseAddress(t, lk.VKey)
+	protected, err := cbor.Encode(map[any]any{
+		int64(1):  int64(coseAlgEdDSA),
+		"address": addr,
+		"hashed":  true,
+	})
+	if err != nil {
+		t.Fatalf("encode protected headers: %v", err)
+	}
+	coseSign1Bytes, err := cbor.Encode([]any{
+		protected,
+		map[any]any{"hashed": true},
+		[]byte("payload"),
+		[]byte("signature"),
+	})
+	if err != nil {
+		t.Fatalf("encode COSE_Sign1: %v", err)
+	}
+
+	if _, err := SignaturePayloadHashed(hex.EncodeToString(coseSign1Bytes)); err == nil {
+		t.Fatal("SignaturePayloadHashed must reject duplicated hashed headers")
+	}
+}
+
 func TestVerifyData_TamperedPayloadFails(t *testing.T) {
 	lk := testLoadedKey(make([]byte, 32))
 	addr := testEnterpriseAddress(t, lk.VKey)

--- a/ui/go.mod
+++ b/ui/go.mod
@@ -7,12 +7,18 @@ require (
 	github.com/blinklabs-io/bursa v0.16.1-0.20260624233607-e1d8912f7e08
 	github.com/blinklabs-io/dingo v0.58.0
 	github.com/blinklabs-io/go-bip39 v0.2.0
-	github.com/blinklabs-io/gouroboros v0.185.0
+	github.com/blinklabs-io/gouroboros v0.186.0
 	github.com/blinklabs-io/plutigo v0.1.15
 	github.com/utxorpc/go-codegen v0.19.2
 	github.com/webview/webview_go v0.0.0-20240831120633-6173450d4dd6
 	golang.org/x/crypto v0.53.0
 )
+
+// The wallet UI ships together with the bursa keys layer it embeds: CIP-8
+// verification (bursa.VerifyDataWithAddress) and air-gap signing reuse the
+// parent module's COSE/BIP32 code, so build against the local source rather
+// than a published tag.
+replace github.com/blinklabs-io/bursa => ../
 
 require (
 	cel.dev/expr v0.25.1 // indirect

--- a/ui/go.sum
+++ b/ui/go.sum
@@ -131,14 +131,12 @@ github.com/blinklabs-io/apollo/v2 v2.0.0-20260625155554-2c0d64b7d8e9 h1:XFQMZ9Fc
 github.com/blinklabs-io/apollo/v2 v2.0.0-20260625155554-2c0d64b7d8e9/go.mod h1:2V+ozsEcpAYykzUlTBBdMW7+aQTVJSbizRjXli3D92s=
 github.com/blinklabs-io/bark v0.0.2 h1:YcwhDfKu8QuPGjKcaV9/J4Vq+0kYMWMo8C08FW2akeI=
 github.com/blinklabs-io/bark v0.0.2/go.mod h1:+ufcuLfDoj8yXktYHQSffle/gaCJnJWqL/31PnAP3dc=
-github.com/blinklabs-io/bursa v0.16.1-0.20260624233607-e1d8912f7e08 h1:ACWRLp8Rm0TDQy+g3lxHclpESjPBNPNST8NVchyiLJM=
-github.com/blinklabs-io/bursa v0.16.1-0.20260624233607-e1d8912f7e08/go.mod h1:QbCmywpKep03cSZppVPWTvt+zb1ighWTJFXI3DmCNus=
 github.com/blinklabs-io/dingo v0.58.0 h1:8sUWR3n8kq9E5PMht4mCLr7pZKJjOdliqTdJoV2vkhw=
 github.com/blinklabs-io/dingo v0.58.0/go.mod h1:LzAKimQlrjizKI72xMxP6P2ZfEpd3Vat0Lc6D5c9jQw=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
-github.com/blinklabs-io/gouroboros v0.185.0 h1:QQKKDSZa2xz5485xvK8tTZz4TnChwtk7kG4yPy6DmsY=
-github.com/blinklabs-io/gouroboros v0.185.0/go.mod h1:8xBiVJLVon6El0oJ+UwMuPVmbwIyu5xubTnrZmpRBi0=
+github.com/blinklabs-io/gouroboros v0.186.0 h1:YOh+J3ojqAd/Z2ueRkElTbgLl1UwklosldJms5d3aVo=
+github.com/blinklabs-io/gouroboros v0.186.0/go.mod h1:8xBiVJLVon6El0oJ+UwMuPVmbwIyu5xubTnrZmpRBi0=
 github.com/blinklabs-io/ouroboros-mock v0.14.0 h1:tWOjItzHmdcGv1HfH23jJxumOQ0wbeRnayG4mQv5QQg=
 github.com/blinklabs-io/ouroboros-mock v0.14.0/go.mod h1:nvY6cwqImZekjCfuutzTjdMR4/gOkNUO9lZuOGlQGl4=
 github.com/blinklabs-io/plutigo v0.1.15 h1:I2PS/byq30lH3cfq8cNxLb6iF5N7RTpokCtNE4sTLqk=

--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -57,6 +57,10 @@ type Spender interface {
 	Build(ctx context.Context, req spend.SendRequest) (spend.Preview, error)
 	Confirm(ctx context.Context, pendingID, password string) (spend.TxResult, error)
 	SignData(addr string, message []byte, password string) (signatureHex, keyHex string, err error)
+	VerifyData(signatureHex, keyHex string, message []byte, hashed bool, expectedAddress string) (valid bool, address string, err error)
+	ExportUnsigned(pendingID string) (spend.UnsignedTx, error)
+	SignTx(unsignedTxCBOR, password string, requiredSigners []string) (spend.Witness, error)
+	SubmitSigned(ctx context.Context, unsignedTxCBOR, witnessCBOR string) (spend.TxResult, error)
 }
 
 // Vault is the encrypted multi-wallet store the API drives. It owns the wallet
@@ -459,6 +463,64 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 		})
 	})
 
+	// CIP-8 / CIP-30 message verification — the inverse of sign-data. Pure
+	// crypto: ungated, no node, no keystore (a read-only wallet can verify too).
+	mux.HandleFunc("POST /wallet/verify-data", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Signature       string `json:"signature"`
+			Key             string `json:"key"`
+			Message         string `json:"message"`
+			Hashed          bool   `json:"hashed"`
+			ExpectedAddress string `json:"expected_address"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+			return
+		}
+		valid, addr, err := sp.VerifyData(req.Signature, req.Key, []byte(req.Message), req.Hashed, req.ExpectedAddress)
+		serve(w, map[string]any{"valid": valid, "address": addr}, err)
+	})
+
+	// Air-gap step 1 (online instance): export the completed-but-unsigned tx for
+	// a pending send + the key-hashes that must sign it. Built against a synced
+	// node's UTxO view, so it shares the send flow's readyGate.
+	mux.HandleFunc("POST /wallet/send/{id}/export-unsigned", readyGate(st, func(w http.ResponseWriter, r *http.Request) {
+		v, err := sp.ExportUnsigned(r.PathValue("id"))
+		serve(w, v, err)
+	}))
+
+	// Air-gap step 2 (offline instance): sign an unsigned tx with the active
+	// wallet's key. Ungated like sign-data — pure crypto over the keystore, no
+	// node needed; this is what the air-gapped machine runs.
+	mux.HandleFunc("POST /wallet/sign-tx", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			UnsignedTxCBOR  string   `json:"unsigned_tx_cbor"`
+			Password        string   `json:"password"`
+			RequiredSigners []string `json:"required_signers"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+			return
+		}
+		v, err := sp.SignTx(req.UnsignedTxCBOR, req.Password, req.RequiredSigners)
+		serve(w, v, err)
+	})
+
+	// Air-gap step 3 (online instance): attach the offline witness to the
+	// unsigned tx and broadcast. Needs a synced node (readyGate).
+	mux.HandleFunc("POST /wallet/submit-signed", readyGate(st, func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			UnsignedTxCBOR string `json:"unsigned_tx_cbor"`
+			WitnessCBOR    string `json:"witness_cbor"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+			return
+		}
+		v, err := sp.SubmitSigned(r.Context(), req.UnsignedTxCBOR, req.WitnessCBOR)
+		serve(w, v, err)
+	}))
+
 	// SPA catch-all: the specific API routes above take precedence on the mux;
 	// everything else is served by the embedded frontend.
 	mux.Handle("/", spa)
@@ -562,7 +624,9 @@ func serve[T any](w http.ResponseWriter, v T, err error) {
 		writeJSON(w, http.StatusConflict, errBody(err)) // 409: active wallet switched during build
 	case errors.Is(err, vault.ErrWrongPassword), errors.Is(err, spend.ErrWrongPassword):
 		writeJSON(w, http.StatusUnauthorized, errBody(err)) // 401
-	case errors.Is(err, spend.ErrInvalidRequest):
+	case errors.Is(err, spend.ErrInvalidRequest),
+		errors.Is(err, spend.ErrInvalidTx),
+		errors.Is(err, spend.ErrInvalidWitness):
 		writeJSON(w, http.StatusBadRequest, errBody(err)) // 400
 	case errors.Is(err, spend.ErrUnknownPending):
 		writeJSON(w, http.StatusNotFound, errBody(err)) // 404

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -738,6 +738,30 @@ type fakeSpender struct {
 	signKey          string
 	signErr          error
 	signAddr         string
+
+	// verify-data
+	verifyValid   bool
+	verifyAddr    string
+	verifyErr     error
+	gotVerifySig  string
+	gotVerifyKey  string
+	gotVerifyMsg  string
+	gotVerifyExp  string
+	gotVerifyHash bool
+
+	// air-gap
+	unsigned      spend.UnsignedTx
+	exportErr     error
+	gotExportID   string
+	witness       spend.Witness
+	signTxErr     error
+	gotSignTxCBOR string
+	gotSignTxPass string
+	gotSignTxReq  []string
+	submitResult  spend.TxResult
+	submitErr     error
+	gotSubmitTx   string
+	gotSubmitWit  string
 }
 
 func (f *fakeSpender) SetAccount(id string, acct *wallet.Account) {
@@ -769,6 +793,45 @@ func (f *fakeSpender) SignData(addr string, _ []byte, _ string) (string, string,
 	return f.signSig, f.signKey, nil
 }
 
+func (f *fakeSpender) VerifyData(sig, key string, msg []byte, hashed bool, expected string) (bool, string, error) {
+	f.gotVerifySig = sig
+	f.gotVerifyKey = key
+	f.gotVerifyMsg = string(msg)
+	f.gotVerifyExp = expected
+	f.gotVerifyHash = hashed
+	if f.verifyErr != nil {
+		return false, "", f.verifyErr
+	}
+	return f.verifyValid, f.verifyAddr, nil
+}
+
+func (f *fakeSpender) ExportUnsigned(pendingID string) (spend.UnsignedTx, error) {
+	f.gotExportID = pendingID
+	if f.exportErr != nil {
+		return spend.UnsignedTx{}, f.exportErr
+	}
+	return f.unsigned, nil
+}
+
+func (f *fakeSpender) SignTx(unsignedTxCBOR, password string, requiredSigners []string) (spend.Witness, error) {
+	f.gotSignTxCBOR = unsignedTxCBOR
+	f.gotSignTxPass = password
+	f.gotSignTxReq = append([]string(nil), requiredSigners...)
+	if f.signTxErr != nil {
+		return spend.Witness{}, f.signTxErr
+	}
+	return f.witness, nil
+}
+
+func (f *fakeSpender) SubmitSigned(_ context.Context, unsignedTxCBOR, witnessCBOR string) (spend.TxResult, error) {
+	f.gotSubmitTx = unsignedTxCBOR
+	f.gotSubmitWit = witnessCBOR
+	if f.submitErr != nil {
+		return spend.TxResult{}, f.submitErr
+	}
+	return f.submitResult, nil
+}
+
 func TestSignDataReturnsSignature(t *testing.T) {
 	// Ungated: message signing needs no synced node, only the keystore.
 	sp := &fakeSpender{signSig: "84a1deadbeef", signKey: "a4010103"}
@@ -795,6 +858,155 @@ func TestSignDataWrongPasswordReturns401(t *testing.T) {
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-data", body))
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("sign-data with wrong password = %d, want 401", rec.Code)
+	}
+}
+
+func TestVerifyDataReturnsResult(t *testing.T) {
+	// Ungated: verification is pure crypto, needs no node and no keystore.
+	sp := &fakeSpender{verifyValid: true, verifyAddr: "addr_test1signed"}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"signature":"84a1","key":"a401","message":"hi","hashed":true,"expected_address":"addr_test1signed"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/verify-data", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /wallet/verify-data = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"valid":true`) ||
+		!strings.Contains(rec.Body.String(), "addr_test1signed") {
+		t.Fatalf("unexpected body: %s", rec.Body.String())
+	}
+	if sp.gotVerifySig != "84a1" ||
+		sp.gotVerifyKey != "a401" ||
+		sp.gotVerifyMsg != "hi" ||
+		!sp.gotVerifyHash ||
+		sp.gotVerifyExp != "addr_test1signed" {
+		t.Fatalf("args not passed through: %+v", sp)
+	}
+}
+
+func TestVerifyDataInvalidArgsReturns400(t *testing.T) {
+	sp := &fakeSpender{verifyErr: fmt.Errorf("%w: bad hex", spend.ErrInvalidRequest)}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"signature":"zz","key":"a4","message":"hi"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/verify-data", body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("verify-data with bad input = %d, want 400", rec.Code)
+	}
+}
+
+func TestExportUnsignedRequiresReady(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend1/export-unsigned", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("export-unsigned while syncing = %d, want 503", rec.Code)
+	}
+}
+
+func TestExportUnsignedReturnsTx(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	sp := &fakeSpender{unsigned: spend.UnsignedTx{
+		UnsignedTxCBOR:  "84a400",
+		RequiredSigners: []string{"deadbeef"},
+	}}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend1/export-unsigned", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("export-unsigned = %d, want 200", rec.Code)
+	}
+	if sp.gotExportID != "pend1" {
+		t.Fatalf("pending id not passed through: %q", sp.gotExportID)
+	}
+	if !strings.Contains(rec.Body.String(), "84a400") || !strings.Contains(rec.Body.String(), "deadbeef") {
+		t.Fatalf("unexpected body: %s", rec.Body.String())
+	}
+}
+
+func TestSignTxUngated(t *testing.T) {
+	// Offline signing must not need a synced node -- only the keystore.
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
+	sp := &fakeSpender{witness: spend.Witness{WitnessCBOR: "81825820"}}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","password":"pw","required_signers":["deadbeef"]}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-tx", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /wallet/sign-tx = %d, want 200", rec.Code)
+	}
+	if sp.gotSignTxCBOR != "84a400" ||
+		sp.gotSignTxPass != "pw" ||
+		len(sp.gotSignTxReq) != 1 ||
+		sp.gotSignTxReq[0] != "deadbeef" {
+		t.Fatalf("args not passed through: %+v", sp)
+	}
+	if !strings.Contains(rec.Body.String(), "81825820") {
+		t.Fatalf("witness missing from body: %s", rec.Body.String())
+	}
+}
+
+func TestSignTxWrongPasswordReturns401(t *testing.T) {
+	sp := &fakeSpender{signTxErr: fmt.Errorf("%w: bad", spend.ErrWrongPassword)}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","password":"bad","required_signers":["deadbeef"]}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-tx", body))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("sign-tx wrong password = %d, want 401", rec.Code)
+	}
+}
+
+func TestSignTxInvalidTxReturns400(t *testing.T) {
+	sp := &fakeSpender{signTxErr: fmt.Errorf("%w: bad cbor", spend.ErrInvalidTx)}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"zz","password":"pw","required_signers":["deadbeef"]}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-tx", body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("sign-tx invalid tx = %d, want 400", rec.Code)
+	}
+}
+
+func TestSubmitSignedRequiresReady(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witness_cbor":"81"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-signed", body))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("submit-signed while syncing = %d, want 503", rec.Code)
+	}
+}
+
+func TestSubmitSignedReturnsTxHash(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	sp := &fakeSpender{submitResult: spend.TxResult{TxHash: "cafebabe"}}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witness_cbor":"81825820"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-signed", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("submit-signed = %d, want 200", rec.Code)
+	}
+	if sp.gotSubmitTx != "84a400" || sp.gotSubmitWit != "81825820" {
+		t.Fatalf("args not passed through: tx=%q wit=%q", sp.gotSubmitTx, sp.gotSubmitWit)
+	}
+	if !strings.Contains(rec.Body.String(), "cafebabe") {
+		t.Fatalf("tx hash missing: %s", rec.Body.String())
+	}
+}
+
+func TestSubmitSignedInvalidWitnessReturns400(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	sp := &fakeSpender{submitErr: fmt.Errorf("%w: bad cbor", spend.ErrInvalidWitness)}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witness_cbor":"zz"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-signed", body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("submit-signed bad witness = %d, want 400", rec.Code)
 	}
 }
 

--- a/ui/internal/boundary/boundary_test.go
+++ b/ui/internal/boundary/boundary_test.go
@@ -36,8 +36,17 @@ var denylist = []string{
 
 // TestNoExternalServiceImports walks the bursa-wallet module's full transitive
 // import set and fails if any denylisted package is present.
+//
+// The scan is scoped to the module's real Go package roots (cmd + internal)
+// rather than "../../..." on purpose: the SPA under ../../web ships an npm
+// dependency tree, and at least one package (flatted) vendors a stray *.go
+// file under node_modules. Go's "..." wildcard does NOT skip node_modules, so a
+// repo-wide list would pull that package into the module graph and, on a clean
+// CI checkout, fail module resolution ("updates to go.mod needed"). The wallet's
+// outbound surface lives entirely under cmd/ and internal/, so those roots are
+// the correct and complete scope for this boundary check.
 func TestNoExternalServiceImports(t *testing.T) {
-	out, err := exec.Command("go", "list", "-deps", "../../...").Output()
+	out, err := exec.Command("go", "list", "-deps", "../../cmd/...", "../../internal/...").Output()
 	if err != nil {
 		t.Fatalf("go list -deps: %v", err)
 	}

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -944,9 +944,14 @@ func (s *Service) SignTx(unsignedTxCBOR, password string, requiredSigners []stri
 	if tx == nil {
 		return Witness{}, fmt.Errorf("%w: no transaction body", ErrInvalidTx)
 	}
-	bodyCbor, err := cbor.Encode(&tx.Body)
-	if err != nil {
-		return Witness{}, fmt.Errorf("encode tx body: %w", err)
+	// Witnesses sign the hash of the body bytes exactly as carried by the
+	// unsigned transaction. Re-encoding can drift while preserving semantics.
+	bodyCbor := tx.Body.Cbor()
+	if bodyCbor == nil {
+		bodyCbor, err = cbor.Encode(&tx.Body)
+		if err != nil {
+			return Witness{}, fmt.Errorf("encode tx body: %w", err)
+		}
 	}
 	bodyHash := lcommon.Blake2b256Hash(bodyCbor)
 

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -335,7 +335,6 @@ func (s *Service) Build(ctx context.Context, req SendRequest) (Preview, error) {
 		}
 		if sameKeyHashSet(required, actual) {
 			a = next
-			required = actual
 			break
 		}
 		required = actual
@@ -830,6 +829,64 @@ func cloneAccount(acct *wallet.Account) *wallet.Account {
 	return &cp
 }
 
+type coseSign1Headers struct {
+	cbor.StructAsArray
+	Protected   []byte
+	Unprotected cbor.RawMessage
+	Payload     []byte
+	Signature   []byte
+}
+
+func coseSignatureHashed(signatureHex string) (bool, error) {
+	sigBytes, err := hex.DecodeString(signatureHex)
+	if err != nil {
+		return false, fmt.Errorf("invalid signature hex: %w", err)
+	}
+	var c coseSign1Headers
+	if _, err := cbor.Decode(sigBytes, &c); err != nil {
+		return false, fmt.Errorf("failed to decode COSE_Sign1: %w", err)
+	}
+	protectedHashed, hasProtected, err := coseHeaderHashed(c.Protected, "protected")
+	if err != nil {
+		return false, err
+	}
+	unprotectedHashed, hasUnprotected, err := coseHeaderHashed(c.Unprotected, "unprotected")
+	if err != nil {
+		return false, err
+	}
+	if hasProtected && hasUnprotected {
+		return false, errors.New("COSE hashed header duplicated")
+	}
+	if hasProtected {
+		return protectedHashed, nil
+	}
+	if hasUnprotected {
+		return unprotectedHashed, nil
+	}
+	return false, nil
+}
+
+func coseHeaderHashed(raw cbor.RawMessage, location string) (bool, bool, error) {
+	if len(raw) == 0 {
+		return false, false, nil
+	}
+	var headers map[any]cbor.RawMessage
+	if _, err := cbor.Decode(raw, &headers); err != nil {
+		return false, false, fmt.Errorf("failed to decode COSE %s headers: %w", location, err)
+	}
+	for label, value := range headers {
+		if got, ok := label.(string); !ok || got != "hashed" {
+			continue
+		}
+		var hashed bool
+		if _, err := cbor.Decode(value, &hashed); err != nil {
+			return false, false, fmt.Errorf("failed to decode COSE hashed header: %w", err)
+		}
+		return hashed, true, nil
+	}
+	return false, false, nil
+}
+
 // VerifyData verifies a CIP-8/CIP-30 signData signature (hex COSE_Sign1) against
 // the supplied COSE_Key (hex) and message, returning whether it is valid and the
 // bech32 address that signed it (carried in the COSE_Sign1 protected header).
@@ -843,9 +900,19 @@ func (s *Service) VerifyData(
 	hashed bool,
 	expectedAddress string,
 ) (valid bool, address string, err error) {
-	// bursa.VerifyDataWithAddress reads the COSE "hashed" header and applies the
-	// CIP-8 payload hash when rebuilding the Sig_structure. The UI's hashed flag
-	// says the caller supplied the preimage, so pass it through unchanged here.
+	signatureHashed, err := coseSignatureHashed(signatureHex)
+	if err != nil {
+		return false, "", fmt.Errorf("%w: %w", ErrInvalidRequest, err)
+	}
+	if signatureHashed != hashed {
+		return false, "", fmt.Errorf(
+			"%w: hashed flag %t does not match COSE hashed header %t",
+			ErrInvalidRequest, hashed, signatureHashed,
+		)
+	}
+	// bursa.VerifyDataWithAddress treats the COSE "hashed" header as the source
+	// of truth when rebuilding the Sig_structure. The UI flag is validated above
+	// so request shape mistakes do not silently verify.
 	valid, address, err = bursa.VerifyDataWithAddress(signatureHex, keyHex, message)
 	if err != nil {
 		return false, "", fmt.Errorf("%w: %w", ErrInvalidRequest, err)

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -22,6 +22,7 @@ import (
 	"github.com/blinklabs-io/bursa/bip32"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/wallet"
+	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
@@ -47,6 +48,12 @@ var (
 	// ErrWalletChanged: the active wallet changed while a transaction was being
 	// built, so the preview is discarded instead of storing a stale pending send.
 	ErrWalletChanged = errors.New("wallet changed while building transaction")
+	// ErrInvalidTx: a supplied transaction CBOR is malformed or could not be
+	// loaded (→ 400). Used by the air-gap sign/submit endpoints.
+	ErrInvalidTx = errors.New("invalid transaction")
+	// ErrInvalidWitness: a supplied witness CBOR is malformed, or none of its
+	// witnesses match the transaction's required signers (→ 400).
+	ErrInvalidWitness = errors.New("invalid witness")
 )
 
 // pendingTTL bounds how long a built-but-unconfirmed transaction is held. After
@@ -91,6 +98,26 @@ type TxResult struct {
 	TxHash string `json:"tx_hash"`
 }
 
+// UnsignedTx is returned from ExportUnsigned: the completed-but-unsigned
+// transaction CBOR (hex) plus the key-hashes that must witness it. It is the
+// hand-off artifact carried (file or copy/paste) to an offline, keyed instance
+// for signing.
+type UnsignedTx struct {
+	// UnsignedTxCBOR is the hex-encoded CBOR of the completed Conway tx with an
+	// empty witness set.
+	UnsignedTxCBOR string `json:"unsigned_tx_cbor"`
+	// RequiredSigners are the hex-encoded payment key-hashes (Blake2b-224) of the
+	// distinct input addresses — the witnesses the offline instance must produce.
+	RequiredSigners []string `json:"required_signers"`
+}
+
+// Witness is returned from SignTx: the vkey witness(es) produced offline for an
+// unsigned tx. WitnessCBOR is a hex-encoded CBOR array of common.VkeyWitness
+// (one per distinct signing key) ready to be attached by SubmitSigned.
+type Witness struct {
+	WitnessCBOR string `json:"witness_cbor"`
+}
+
 // Keystore is the minimal interface satisfied by *keystore.Keystore. It is
 // accepted as an interface so the service can be constructed with a nil keystore
 // when only Build is needed, and faked in tests.
@@ -109,9 +136,9 @@ type walletSeedStore interface {
 // derived addresses (and their indices) line up for signing.
 const addressWindow = 20
 
-// feePaddingLovelace is added to Apollo's estimated fee to cover the witness
-// bytes attached after Complete() (see Build). The observed shortfall is a few
-// hundred lovelace; 1000 leaves comfortable headroom while staying negligible.
+// feePaddingLovelace is a small safety margin on Apollo's estimated fee. The
+// air-gap path embeds required signers before fee estimation; this padding is
+// only a conservative buffer for serialization/provider variance.
 const feePaddingLovelace = 1000
 
 // pending holds a completed but unsigned tx while awaiting Confirm.
@@ -238,25 +265,11 @@ func (s *Service) Build(ctx context.Context, req SendRequest) (Preview, error) {
 		return Preview{}, fmt.Errorf("change address: %w", err)
 	}
 
-	// Construct a watch-only Apollo builder with an ExternalWallet.
-	// ExternalWallet implements the Wallet interface; Complete() accepts it
-	// because it only needs Address() for the change output — it does not call Sign().
-	//
-	// SetFeePadding: Complete() estimates the fee before the vkey witness is
-	// attached at Confirm() time, so the estimate runs a few bytes (and thus a
-	// couple hundred lovelace) under the node's calculated minimum — the node
-	// then rejects the tx ("fee X is less than the calculated minimum fee Y").
-	// A small fixed padding reserves the shortfall during coin selection; it is
-	// taken from change, costing the sender a negligible (<0.001 ADA) amount.
-	a := apollo.New(s.chain).
-		SetWallet(apollo.NewExternalWallet(changeAddr)).
-		SetChangeAddress(changeAddr).
-		SetFeePadding(feePaddingLovelace)
-
 	// Load spendable UTxOs from every receive address; record txref→address for
 	// later signing. We pre-load them so Apollo's coin selection can see them
 	// without needing a live chain query inside Complete().
 	utxoAddr := make(map[string]string)
+	var loaded []lcommon.Utxo
 	for _, addrStr := range acct.ReceiveAddresses {
 		addr, err := lcommon.NewAddress(addrStr)
 		if err != nil {
@@ -267,7 +280,7 @@ func (s *Service) Build(ctx context.Context, req SendRequest) (Preview, error) {
 			return Preview{}, fmt.Errorf("utxos for %s: %w", addrStr, err)
 		}
 		if len(utxos) > 0 {
-			a = a.AddLoadedUTxOs(utxos...)
+			loaded = append(loaded, utxos...)
 			for _, u := range utxos {
 				utxoAddr[makeUtxoRef(u)] = addrStr
 			}
@@ -287,15 +300,48 @@ func (s *Service) Build(ctx context.Context, req SendRequest) (Preview, error) {
 	if err != nil {
 		return Preview{}, fmt.Errorf("%w: lovelace: %w", ErrInvalidRequest, err)
 	}
-	a = a.PayToAddress(recvAddr, int64(lovelace), units...) //nolint:gosec // validated by parseAmount
-
-	// Complete: coin selection + fee estimation.
-	a, err = a.CompleteContext(ctx)
-	if err != nil {
-		if isInsufficientFundsError(err) {
-			return Preview{}, fmt.Errorf("%w: %w", ErrInsufficientFunds, err)
+	// Complete with the selected input payment key hashes embedded as Conway
+	// required signers. The first pass discovers selected inputs; later passes
+	// rebuild the tx with that signer set so fee estimation covers the bound body.
+	var a *apollo.Apollo
+	var required []lcommon.Blake2b224
+	maxAttempts := len(acct.ReceiveAddresses) + 2
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		next := apollo.New(s.chain).
+			SetWallet(apollo.NewExternalWallet(changeAddr)).
+			SetChangeAddress(changeAddr).
+			SetFeePadding(feePaddingLovelace).
+			AddLoadedUTxOs(loaded...)
+		for _, kh := range required {
+			next = next.AddRequiredSigner(kh)
 		}
-		return Preview{}, fmt.Errorf("complete transaction: %w", err)
+		next = next.PayToAddress(recvAddr, int64(lovelace), units...) //nolint:gosec // validated by parseAmount
+
+		next, err = next.CompleteContext(ctx)
+		if err != nil {
+			if isInsufficientFundsError(err) {
+				return Preview{}, fmt.Errorf("%w: %w", ErrInsufficientFunds, err)
+			}
+			return Preview{}, fmt.Errorf("complete transaction: %w", err)
+		}
+
+		tx := next.GetTx()
+		if tx == nil {
+			return Preview{}, errors.New("completed tx is nil")
+		}
+		actual, err := requiredPaymentKeyHashesForInputs(tx.Body.Inputs(), utxoAddr)
+		if err != nil {
+			return Preview{}, err
+		}
+		if sameKeyHashSet(required, actual) {
+			a = next
+			required = actual
+			break
+		}
+		required = actual
+	}
+	if a == nil {
+		return Preview{}, errors.New("required signer set did not converge")
 	}
 
 	// Store the pending entry (sweeping any that have outlived their TTL first).
@@ -421,6 +467,87 @@ func (s *Service) sweepExpiredLocked() {
 // This mirrors apollo's private utxoRef function.
 func makeUtxoRef(u lcommon.Utxo) string {
 	return hex.EncodeToString(u.Id.Id().Bytes()) + "#" + strconv.Itoa(int(u.Id.Index()))
+}
+
+func inputRef(inp lcommon.TransactionInput) string {
+	return hex.EncodeToString(inp.Id().Bytes()) + "#" + strconv.Itoa(int(inp.Index()))
+}
+
+func requiredPaymentKeyHashesForInputs(
+	inputs []lcommon.TransactionInput,
+	utxoAddr map[string]string,
+) ([]lcommon.Blake2b224, error) {
+	seen := make(map[lcommon.Blake2b224]bool)
+	signers := make([]lcommon.Blake2b224, 0, len(inputs))
+	for _, inp := range inputs {
+		ref := inputRef(inp)
+		addrStr, found := utxoAddr[ref]
+		if !found {
+			return nil, fmt.Errorf("input %s not in utxoAddr map", ref)
+		}
+		addr, err := lcommon.NewAddress(addrStr)
+		if err != nil {
+			return nil, fmt.Errorf("parse address %s: %w", addrStr, err)
+		}
+		kh := addr.PaymentKeyHash()
+		if !seen[kh] {
+			seen[kh] = true
+			signers = append(signers, kh)
+		}
+	}
+	return signers, nil
+}
+
+func parseRequiredSignerHashes(requiredSigners []string) ([]lcommon.Blake2b224, error) {
+	seen := make(map[lcommon.Blake2b224]bool, len(requiredSigners))
+	signers := make([]lcommon.Blake2b224, 0, len(requiredSigners))
+	for _, signer := range requiredSigners {
+		signer = strings.ToLower(strings.TrimSpace(signer))
+		if signer == "" {
+			continue
+		}
+		b, err := hex.DecodeString(signer)
+		if err != nil || len(b) != lcommon.Blake2b224Size {
+			return nil, fmt.Errorf(
+				"%w: required signer %q is not a 28-byte key hash hex",
+				ErrInvalidRequest, signer,
+			)
+		}
+		var kh lcommon.Blake2b224
+		copy(kh[:], b)
+		if !seen[kh] {
+			seen[kh] = true
+			signers = append(signers, kh)
+		}
+	}
+	return signers, nil
+}
+
+func sameKeyHashSet(a, b []lcommon.Blake2b224) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[lcommon.Blake2b224]bool, len(a))
+	for _, kh := range a {
+		seen[kh] = true
+	}
+	if len(seen) != len(a) {
+		return false
+	}
+	for _, kh := range b {
+		if !seen[kh] {
+			return false
+		}
+	}
+	return true
+}
+
+func keyHashesHex(signers []lcommon.Blake2b224) []string {
+	ret := make([]string, 0, len(signers))
+	for _, kh := range signers {
+		ret = append(ret, hex.EncodeToString(kh.Bytes()))
+	}
+	return ret
 }
 
 // assetsToUnits converts the service's Asset slice to Apollo Unit values.
@@ -701,6 +828,316 @@ func cloneAccount(acct *wallet.Account) *wallet.Account {
 	cp := *acct
 	cp.ReceiveAddresses = append([]string(nil), acct.ReceiveAddresses...)
 	return &cp
+}
+
+// VerifyData verifies a CIP-8/CIP-30 signData signature (hex COSE_Sign1) against
+// the supplied COSE_Key (hex) and message, returning whether it is valid and the
+// bech32 address that signed it (carried in the COSE_Sign1 protected header).
+// It is the inverse of SignData and, like it, is fully offline (pure crypto - no
+// keystore, no node). When hashed is true the message is the Blake2b-224 preimage
+// the signer hashed before signing (CIP-8 "hashed" payload). When expectedAddress
+// is non-empty, a signature whose protected address differs is reported invalid.
+func (s *Service) VerifyData(
+	signatureHex, keyHex string,
+	message []byte,
+	hashed bool,
+	expectedAddress string,
+) (valid bool, address string, err error) {
+	// bursa.VerifyDataWithAddress reads the COSE "hashed" header and applies the
+	// CIP-8 payload hash when rebuilding the Sig_structure. The UI's hashed flag
+	// says the caller supplied the preimage, so pass it through unchanged here.
+	valid, address, err = bursa.VerifyDataWithAddress(signatureHex, keyHex, message)
+	if err != nil {
+		return false, "", fmt.Errorf("%w: %w", ErrInvalidRequest, err)
+	}
+	if expectedAddress != "" && address != expectedAddress {
+		// The signature may itself be cryptographically valid, but it does not
+		// attest the address the caller expected: report it as not valid.
+		return false, address, nil
+	}
+	return valid, address, nil
+}
+
+// ExportUnsigned returns the completed-but-UNSIGNED transaction CBOR for a
+// pending send plus the payment key-hashes that must witness it. It is the first
+// step of the air-gap flow: the returned artifact is carried to an offline, keyed
+// instance (file download or copy/paste) which produces the witness via SignTx.
+//
+// Unlike Confirm it does NOT consume the pending entry — the user may still
+// Confirm online instead, or re-export — but it is subject to the same TTL.
+func (s *Service) ExportUnsigned(pendingID string) (UnsignedTx, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.pending[pendingID]
+	expired := ok && s.now().Sub(p.created) > pendingTTL
+	if !ok {
+		return UnsignedTx{}, fmt.Errorf("%w: %q", ErrUnknownPending, pendingID)
+	}
+	if expired {
+		return UnsignedTx{}, fmt.Errorf("%w: %q", ErrExpiredPending, pendingID)
+	}
+
+	tx := p.tx.GetTx()
+	if tx == nil {
+		return UnsignedTx{}, errors.New("pending tx is nil")
+	}
+	// The required signers are the distinct input addresses' payment key-hashes.
+	// They are derived from the same utxoAddr map Confirm uses, so the offline
+	// instance is told exactly which keys it must produce witnesses for.
+	signerHashes, err := requiredPaymentKeyHashesForInputs(tx.Body.Inputs(), p.utxoAddr)
+	if err != nil {
+		return UnsignedTx{}, err
+	}
+	if !sameKeyHashSet(tx.Body.RequiredSigners(), signerHashes) {
+		return UnsignedTx{}, fmt.Errorf(
+			"%w: unsigned tx required signers do not match selected input signers",
+			ErrInvalidTx,
+		)
+	}
+	cborBytes, err := p.tx.GetTxCbor()
+	if err != nil {
+		return UnsignedTx{}, fmt.Errorf("encode unsigned tx: %w", err)
+	}
+
+	return UnsignedTx{
+		UnsignedTxCBOR:  hex.EncodeToString(cborBytes),
+		RequiredSigners: keyHashesHex(signerHashes),
+	}, nil
+}
+
+// SignTx is the air-gapped step: it decrypts the seed with the spending password,
+// derives the wallet's signing keys, and produces vkey witness(es) over the
+// supplied unsigned transaction's body. The result is a CBOR array of
+// common.VkeyWitness (one per derived key) which SubmitSigned attaches to the
+// same unsigned tx on the online instance.
+//
+// It needs only the unsigned tx CBOR, the required signer key hashes exported
+// with that tx, and the password - no node, no UTxO set. The signer list is
+// accepted only as redundancy for the hand-off artifact: it must exactly match
+// the required signer set embedded in the transaction body before any key is
+// unlocked. SignTx then derives the wallet's address window but emits only
+// witnesses whose vkey hash is in the body-bound signer set.
+func (s *Service) SignTx(unsignedTxCBOR, password string, requiredSigners []string) (Witness, error) {
+	if s.keys == nil {
+		return Witness{}, errors.New("no keystore configured")
+	}
+	walletID, acct, _ := s.currentBinding()
+	if acct == nil {
+		return Witness{}, ErrNoWallet
+	}
+
+	// Load the unsigned tx and hash its body — this is what each witness signs.
+	loader, err := apollo.New(s.chain).LoadTxCbor(unsignedTxCBOR)
+	if err != nil {
+		return Witness{}, fmt.Errorf("%w: %w", ErrInvalidTx, err)
+	}
+	tx := loader.GetTx()
+	if tx == nil {
+		return Witness{}, fmt.Errorf("%w: no transaction body", ErrInvalidTx)
+	}
+	bodyCbor, err := cbor.Encode(&tx.Body)
+	if err != nil {
+		return Witness{}, fmt.Errorf("encode tx body: %w", err)
+	}
+	bodyHash := lcommon.Blake2b256Hash(bodyCbor)
+
+	bodyRequired := tx.Body.RequiredSigners()
+	if len(bodyRequired) == 0 {
+		return Witness{}, fmt.Errorf("%w: unsigned tx does not declare required signers", ErrInvalidTx)
+	}
+	requested, err := parseRequiredSignerHashes(requiredSigners)
+	if err != nil {
+		return Witness{}, err
+	}
+	if len(requested) == 0 {
+		return Witness{}, fmt.Errorf("%w: required_signers is required", ErrInvalidRequest)
+	}
+	if !sameKeyHashSet(requested, bodyRequired) {
+		return Witness{}, fmt.Errorf(
+			"%w: required_signers does not match the unsigned transaction body",
+			ErrInvalidRequest,
+		)
+	}
+
+	needed := make(map[string]bool, len(bodyRequired))
+	for _, signer := range bodyRequired {
+		needed[hex.EncodeToString(signer.Bytes())] = true
+	}
+
+	mnemonicBytes, err := s.unlockSeed(walletID, password)
+	if err != nil {
+		if errors.Is(err, keystore.ErrDecryptFailed) {
+			return Witness{}, fmt.Errorf("%w: %w", ErrWrongPassword, err)
+		}
+		return Witness{}, fmt.Errorf("unlock keystore: %w", err)
+	}
+	var rootKey, acctKey bip32.XPrv
+	defer func() {
+		for _, k := range []bip32.XPrv{rootKey, acctKey} {
+			for i := range k {
+				k[i] = 0
+			}
+		}
+		for i := range mnemonicBytes {
+			mnemonicBytes[i] = 0
+		}
+	}()
+
+	rootKey, err = bursa.GetRootKeyFromMnemonic(string(mnemonicBytes), "")
+	if err != nil {
+		return Witness{}, fmt.Errorf("root key: %w", err)
+	}
+	acctKey, err = bursa.GetAccountKey(rootKey, 0)
+	if err != nil {
+		return Witness{}, fmt.Errorf("account key: %w", err)
+	}
+
+	// Walk the same derived keys as the former candidate loop, but only sign and
+	// emit keys whose vkey hash is required by the exported tx.
+	seenKeyHash := make(map[string]bool)
+	var witnesses []lcommon.VkeyWitness
+	addCandidate := func(signKey bip32.XPrv) error {
+		defer func() {
+			for i := range signKey {
+				signKey[i] = 0
+			}
+		}()
+		kh := hex.EncodeToString(lcommon.Blake2b224Hash(signKey.PublicKey()).Bytes())
+		if !needed[kh] || seenKeyHash[kh] {
+			return nil
+		}
+		w, err := apollo.NewVkeyWitnessFromSkey(bodyHash, []byte(signKey))
+		if err != nil {
+			return err
+		}
+		seenKeyHash[kh] = true
+		witnesses = append(witnesses, w)
+		return nil
+	}
+	for i := range acct.ReceiveAddresses {
+		payKey, err := bursa.GetPaymentKey(acctKey, uint32(i)) //nolint:gosec // bounded by window size
+		if err != nil {
+			return Witness{}, fmt.Errorf("payment key idx %d: %w", i, err)
+		}
+		if err := addCandidate(payKey); err != nil {
+			return Witness{}, fmt.Errorf("witness payment idx %d: %w", i, err)
+		}
+	}
+	if stakeKey, err := bursa.GetStakeKey(acctKey, 0); err == nil {
+		if err := addCandidate(stakeKey); err != nil {
+			return Witness{}, fmt.Errorf("witness stake key: %w", err)
+		}
+	}
+	if len(witnesses) == 0 {
+		return Witness{}, fmt.Errorf(
+			"%w: none of this wallet's keys match the transaction's required signers",
+			ErrInvalidWitness,
+		)
+	}
+	if len(witnesses) < len(needed) {
+		return Witness{}, fmt.Errorf(
+			"%w: transaction needs %d distinct signers but this wallet produced %d",
+			ErrInvalidWitness, len(needed), len(witnesses),
+		)
+	}
+
+	encoded, err := cbor.Encode(witnesses)
+	if err != nil {
+		return Witness{}, fmt.Errorf("encode witnesses: %w", err)
+	}
+	return Witness{WitnessCBOR: hex.EncodeToString(encoded)}, nil
+}
+
+// SubmitSigned is the final air-gap step, run on the online instance: it loads
+// the unsigned tx, decodes the witness array produced offline by SignTx, attaches
+// only the witnesses the transaction's inputs actually require (resolved against
+// the chain), and submits. The tx body is never mutated, so the body hash the
+// witnesses signed still matches the submitted transaction.
+func (s *Service) SubmitSigned(ctx context.Context, unsignedTxCBOR, witnessCBOR string) (TxResult, error) {
+	a, err := apollo.New(s.chain).LoadTxCbor(unsignedTxCBOR)
+	if err != nil {
+		return TxResult{}, fmt.Errorf("%w: %w", ErrInvalidTx, err)
+	}
+	tx := a.GetTx()
+	if tx == nil {
+		return TxResult{}, fmt.Errorf("%w: no transaction body", ErrInvalidTx)
+	}
+
+	witBytes, err := hex.DecodeString(witnessCBOR)
+	if err != nil {
+		return TxResult{}, fmt.Errorf("%w: witness hex: %w", ErrInvalidWitness, err)
+	}
+	var witnesses []lcommon.VkeyWitness
+	if _, err := cbor.Decode(witBytes, &witnesses); err != nil {
+		return TxResult{}, fmt.Errorf("%w: %w", ErrInvalidWitness, err)
+	}
+	if len(witnesses) == 0 {
+		return TxResult{}, fmt.Errorf("%w: no witnesses supplied", ErrInvalidWitness)
+	}
+
+	// Determine which key-hashes the transaction requires: input payment hashes
+	// resolved against the chain plus any hashes explicitly required by the body.
+	needed := make(map[string]bool)
+	for _, signer := range tx.Body.RequiredSigners() {
+		needed[hex.EncodeToString(signer.Bytes())] = true
+	}
+	for _, inp := range tx.Body.Inputs() {
+		u, err := s.chain.UtxoByRef(ctx, inp.Id(), inp.Index())
+		if err != nil {
+			return TxResult{}, fmt.Errorf("resolve input %s#%d: %w",
+				hex.EncodeToString(inp.Id().Bytes()), inp.Index(), err)
+		}
+		if u == nil || u.Output == nil {
+			return TxResult{}, fmt.Errorf("%w: input %s#%d not found on chain (already spent?)",
+				ErrInvalidTx, hex.EncodeToString(inp.Id().Bytes()), inp.Index())
+		}
+		inAddr := u.Output.Address() // addressable copy: PaymentKeyHash has a pointer receiver
+		needed[hex.EncodeToString(inAddr.PaymentKeyHash().Bytes())] = true
+	}
+
+	// Attach only the witnesses whose vkey hashes a required signer, deduped.
+	attached := make(map[string]bool)
+	count := 0
+	for _, w := range witnesses {
+		kh := hex.EncodeToString(lcommon.Blake2b224Hash(w.Vkey).Bytes())
+		if !needed[kh] || attached[kh] {
+			continue
+		}
+		attached[kh] = true
+		if a, err = a.AddVerificationKeyWitness(w); err != nil {
+			return TxResult{}, fmt.Errorf("attach witness: %w", err)
+		}
+		count++
+	}
+	if count == 0 {
+		return TxResult{}, fmt.Errorf(
+			"%w: none of the supplied witnesses match the transaction's required signers",
+			ErrInvalidWitness,
+		)
+	}
+	if count < len(needed) {
+		return TxResult{}, fmt.Errorf(
+			"%w: transaction needs %d distinct signers but only %d were supplied",
+			ErrInvalidWitness, len(needed), count,
+		)
+	}
+
+	// LoadTxCbor cached the decoded transaction's raw CBOR; ConwayTransaction
+	// (and its witness set) re-emit that cache on encode, which would drop the
+	// witnesses we just attached. Clear the transaction-level and witness-set
+	// caches so SubmitContext re-serializes from the mutated struct. The BODY
+	// cache is deliberately left intact: the witnesses signed over the original
+	// body bytes, so re-encoding the body must reproduce them exactly.
+	tx.SetCbor(nil)
+	tx.WitnessSet.SetCbor(nil)
+
+	// Detach from the request context: once submitted the inputs are consumed, so
+	// a client disconnect must not strand a broadcast (mirrors Confirm).
+	txHash, err := a.SubmitContext(context.WithoutCancel(ctx))
+	if err != nil {
+		return TxResult{}, fmt.Errorf("%w: %w", ErrSubmitRejected, err)
+	}
+	return TxResult{TxHash: hex.EncodeToString(txHash.Bytes())}, nil
 }
 
 // randID generates a 16-byte random hex string for pending IDs.

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -829,64 +829,6 @@ func cloneAccount(acct *wallet.Account) *wallet.Account {
 	return &cp
 }
 
-type coseSign1Headers struct {
-	cbor.StructAsArray
-	Protected   []byte
-	Unprotected cbor.RawMessage
-	Payload     []byte
-	Signature   []byte
-}
-
-func coseSignatureHashed(signatureHex string) (bool, error) {
-	sigBytes, err := hex.DecodeString(signatureHex)
-	if err != nil {
-		return false, fmt.Errorf("invalid signature hex: %w", err)
-	}
-	var c coseSign1Headers
-	if _, err := cbor.Decode(sigBytes, &c); err != nil {
-		return false, fmt.Errorf("failed to decode COSE_Sign1: %w", err)
-	}
-	protectedHashed, hasProtected, err := coseHeaderHashed(c.Protected, "protected")
-	if err != nil {
-		return false, err
-	}
-	unprotectedHashed, hasUnprotected, err := coseHeaderHashed(c.Unprotected, "unprotected")
-	if err != nil {
-		return false, err
-	}
-	if hasProtected && hasUnprotected {
-		return false, errors.New("COSE hashed header duplicated")
-	}
-	if hasProtected {
-		return protectedHashed, nil
-	}
-	if hasUnprotected {
-		return unprotectedHashed, nil
-	}
-	return false, nil
-}
-
-func coseHeaderHashed(raw cbor.RawMessage, location string) (bool, bool, error) {
-	if len(raw) == 0 {
-		return false, false, nil
-	}
-	var headers map[any]cbor.RawMessage
-	if _, err := cbor.Decode(raw, &headers); err != nil {
-		return false, false, fmt.Errorf("failed to decode COSE %s headers: %w", location, err)
-	}
-	for label, value := range headers {
-		if got, ok := label.(string); !ok || got != "hashed" {
-			continue
-		}
-		var hashed bool
-		if _, err := cbor.Decode(value, &hashed); err != nil {
-			return false, false, fmt.Errorf("failed to decode COSE hashed header: %w", err)
-		}
-		return hashed, true, nil
-	}
-	return false, false, nil
-}
-
 // VerifyData verifies a CIP-8/CIP-30 signData signature (hex COSE_Sign1) against
 // the supplied COSE_Key (hex) and message, returning whether it is valid and the
 // bech32 address that signed it (carried in the COSE_Sign1 protected header).
@@ -900,7 +842,7 @@ func (s *Service) VerifyData(
 	hashed bool,
 	expectedAddress string,
 ) (valid bool, address string, err error) {
-	signatureHashed, err := coseSignatureHashed(signatureHex)
+	signatureHashed, err := bursa.SignaturePayloadHashed(signatureHex)
 	if err != nil {
 		return false, "", fmt.Errorf("%w: %w", ErrInvalidRequest, err)
 	}

--- a/ui/internal/spend/spend_test.go
+++ b/ui/internal/spend/spend_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/wallet"
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
@@ -435,6 +436,137 @@ func mustDeriveConfirmAccount(t *testing.T) *wallet.Account {
 	return acct
 }
 
+func paymentKeyHashForAddress(t *testing.T, addrStr string) string {
+	t.Helper()
+	addr, err := lcommon.NewAddress(addrStr)
+	if err != nil {
+		t.Fatalf("NewAddress(%q): %v", addrStr, err)
+	}
+	return hex.EncodeToString(addr.PaymentKeyHash().Bytes())
+}
+
+func hashedSignDataFixture(t *testing.T, acct *wallet.Account) (string, string, []byte, string) {
+	t.Helper()
+	addrStr := acct.ReceiveAddresses[0]
+	addr, err := lcommon.NewAddress(addrStr)
+	if err != nil {
+		t.Fatalf("NewAddress: %v", err)
+	}
+	addrBytes, err := addr.Bytes()
+	if err != nil {
+		t.Fatalf("Address.Bytes: %v", err)
+	}
+	rootKey, err := bursa.GetRootKeyFromMnemonic(testMnemonic, "")
+	if err != nil {
+		t.Fatalf("root key: %v", err)
+	}
+	acctKey, err := bursa.GetAccountKey(rootKey, 0)
+	if err != nil {
+		t.Fatalf("account key: %v", err)
+	}
+	payKey, err := bursa.GetPaymentKey(acctKey, 0)
+	if err != nil {
+		t.Fatalf("payment key: %v", err)
+	}
+
+	payload := []byte("payload signed through CIP-8 hashed mode")
+	protected, err := cbor.Encode(map[any]any{
+		int64(1):  int64(-8),
+		"address": addrBytes,
+	})
+	if err != nil {
+		t.Fatalf("encode protected headers: %v", err)
+	}
+	hash := lcommon.Blake2b224Hash(payload)
+	toBeSigned, err := cbor.Encode([]any{"Signature1", protected, []byte{}, hash[:]})
+	if err != nil {
+		t.Fatalf("encode Sig_structure: %v", err)
+	}
+	signature := payKey.Sign(toBeSigned)
+	coseSign1Bytes, err := cbor.Encode([]any{
+		protected,
+		map[any]any{"hashed": true},
+		payload,
+		signature,
+	})
+	if err != nil {
+		t.Fatalf("encode COSE_Sign1: %v", err)
+	}
+	coseKey, err := cbor.Encode(map[any]any{
+		int64(1):  int64(1),
+		int64(3):  int64(-8),
+		int64(-1): int64(6),
+		int64(-2): payKey.PublicKey(),
+	})
+	if err != nil {
+		t.Fatalf("encode COSE_Key: %v", err)
+	}
+	return hex.EncodeToString(coseSign1Bytes), hex.EncodeToString(coseKey), payload, addrStr
+}
+
+func witnessCount(t *testing.T, wit Witness) int {
+	t.Helper()
+	witBytes, err := hex.DecodeString(wit.WitnessCBOR)
+	if err != nil {
+		t.Fatalf("decode witness hex: %v", err)
+	}
+	var witnesses []lcommon.VkeyWitness
+	if _, err := cbor.Decode(witBytes, &witnesses); err != nil {
+		t.Fatalf("decode witnesses: %v", err)
+	}
+	return len(witnesses)
+}
+
+func bodyRequiredSigners(t *testing.T, unsignedTxCBOR string) []lcommon.Blake2b224 {
+	t.Helper()
+	txBytes, err := hex.DecodeString(unsignedTxCBOR)
+	if err != nil {
+		t.Fatalf("decode unsigned tx hex: %v", err)
+	}
+	tx, err := ledger.NewConwayTransactionFromCbor(txBytes)
+	if err != nil {
+		t.Fatalf("decode unsigned tx: %v", err)
+	}
+	return tx.Body.RequiredSigners()
+}
+
+func stakeKeyHashForAddress(t *testing.T, addrStr string) string {
+	t.Helper()
+	addr, err := lcommon.NewAddress(addrStr)
+	if err != nil {
+		t.Fatalf("NewAddress(%q): %v", addrStr, err)
+	}
+	kh := addr.StakeKeyHash()
+	if kh == (lcommon.Blake2b224{}) {
+		t.Fatalf("address %q has no stake key hash", addrStr)
+	}
+	return hex.EncodeToString(kh.Bytes())
+}
+
+func unsignedWithRequiredSigners(
+	t *testing.T,
+	unsignedTxCBOR string,
+	required []lcommon.Blake2b224,
+) string {
+	t.Helper()
+	txBytes, err := hex.DecodeString(unsignedTxCBOR)
+	if err != nil {
+		t.Fatalf("decode unsigned tx hex: %v", err)
+	}
+	tx, err := ledger.NewConwayTransactionFromCbor(txBytes)
+	if err != nil {
+		t.Fatalf("decode unsigned tx: %v", err)
+	}
+	tx.Body.TxRequiredSigners = cbor.NewSetType(required, true)
+	tx.SetCbor(nil)
+	tx.Body.SetCbor(nil)
+	encoded, err := cbor.Encode(tx)
+	if err != nil {
+		t.Fatalf("encode unsigned tx: %v", err)
+	}
+	return hex.EncodeToString(encoded)
+}
+
 func TestConfirmSignsAndSubmits(t *testing.T) {
 	acct := mustDeriveConfirmAccount(t)
 	addr0 := acct.ReceiveAddresses[0]
@@ -549,6 +681,53 @@ func TestConfirmUsesPendingWalletAfterAccountSwitch(t *testing.T) {
 	}
 }
 
+func TestSignTxUsesActiveWalletBindingAfterAccountSwitch(t *testing.T) {
+	acctA := mustDeriveConfirmAccount(t)
+	acctB, err := wallet.Derive(differentMnemonic, "preview", 5)
+	if err != nil {
+		t.Fatalf("derive account B: %v", err)
+	}
+	fc := newFakeChain(5_000_000, acctA.ReceiveAddresses[0])
+	ks := &blockingSeedStore{
+		mnemonicByID: map[string]string{"a": testMnemonic, "b": differentMnemonic},
+		unlockForID:  make(chan string, 1),
+		release:      make(chan struct{}),
+	}
+	s := NewService(fc, ks, nil)
+	s.SetAccount("a", acctA)
+
+	pv, err := s.Build(context.Background(), SendRequest{To: acctA.ReceiveAddresses[2], Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	unsigned, err := s.ExportUnsigned(pv.PendingID)
+	if err != nil {
+		t.Fatalf("ExportUnsigned: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.SignTx(unsigned.UnsignedTxCBOR, "pw", unsigned.RequiredSigners)
+		done <- err
+	}()
+
+	var unlockID string
+	select {
+	case unlockID = <-ks.unlockForID:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SignTx did not request seed unlock")
+	}
+	if unlockID != "a" {
+		t.Fatalf("SignTx unlocked wallet %q, want active wallet a", unlockID)
+	}
+
+	s.SetAccount("b", acctB)
+	close(ks.release)
+	if err := <-done; err != nil {
+		t.Fatalf("SignTx after account switch: %v", err)
+	}
+}
+
 func TestWalletBoundUnlockRequiresUnlockFor(t *testing.T) {
 	ks := &trackingKeystore{mnemonic: testMnemonic}
 	s := NewService(nil, ks, nil)
@@ -599,6 +778,377 @@ func TestSignDataRoundTrip(t *testing.T) {
 	// A different payload must NOT verify against the same signature.
 	if tampered, _ := bursa.VerifyData(sig, key, []byte("tampered")); tampered {
 		t.Fatal("signature verified against the wrong payload")
+	}
+}
+
+func TestVerifyDataRoundTrip(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	addr0 := acct.ReceiveAddresses[0]
+	ks := fakeKeystore{mnemonic: testMnemonic}
+	s := NewService(newFakeChain(0, addr0), ks, acct)
+
+	msg := []byte("prove I control this address")
+	sig, key, err := s.SignData(addr0, msg, "pw")
+	if err != nil {
+		t.Fatalf("SignData: %v", err)
+	}
+
+	// Verifies, and reports the signer address from the COSE protected header.
+	valid, gotAddr, err := s.VerifyData(sig, key, msg, false, "")
+	if err != nil {
+		t.Fatalf("VerifyData: %v", err)
+	}
+	if !valid {
+		t.Fatal("expected signature to verify")
+	}
+	if gotAddr != addr0 {
+		t.Fatalf("reported signer %q, want %q", gotAddr, addr0)
+	}
+
+	// expected_address matching the signer keeps it valid.
+	if v, _, _ := s.VerifyData(sig, key, msg, false, addr0); !v {
+		t.Fatal("expected valid when expected_address matches signer")
+	}
+	// A different expected_address makes it invalid (not an error).
+	if v, _, err := s.VerifyData(sig, key, msg, false, acct.ReceiveAddresses[1]); err != nil || v {
+		t.Fatalf("expected invalid for mismatched expected_address, got valid=%v err=%v", v, err)
+	}
+	// A tampered message must not verify.
+	if v, _, _ := s.VerifyData(sig, key, []byte("tampered"), false, ""); v {
+		t.Fatal("tampered message verified")
+	}
+}
+
+func TestVerifyDataHashedPayload(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	sig, key, msg, addr := hashedSignDataFixture(t, acct)
+	s := NewService(newFakeChain(0, addr), fakeKeystore{mnemonic: testMnemonic}, acct)
+
+	valid, gotAddr, err := s.VerifyData(sig, key, msg, true, addr)
+	if err != nil {
+		t.Fatalf("VerifyData: %v", err)
+	}
+	if !valid {
+		t.Fatal("expected hashed payload signature to verify")
+	}
+	if gotAddr != addr {
+		t.Fatalf("reported signer %q, want %q", gotAddr, addr)
+	}
+}
+
+func TestVerifyDataMalformedReturnsInvalidRequest(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	s := NewService(newFakeChain(0, acct.ReceiveAddresses[0]), fakeKeystore{mnemonic: testMnemonic}, acct)
+	if _, _, err := s.VerifyData("zz", "a4", []byte("x"), false, ""); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("expected ErrInvalidRequest for bad hex, got %v", err)
+	}
+}
+
+// TestAirGapRoundTrip exercises the split flow: Build → ExportUnsigned (online)
+// → SignTx (offline) → SubmitSigned (online). The submitted tx must carry the
+// exact witnesses the inputs require and submit once.
+func TestAirGapRoundTrip(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	addr0 := acct.ReceiveAddresses[0]
+	recvAddr := acct.ReceiveAddresses[2]
+
+	fc := newFakeChain(5_000_000, addr0)
+	ks := fakeKeystore{mnemonic: testMnemonic}
+	s := NewService(fc, ks, acct)
+
+	ctx := context.Background()
+	pv, err := s.Build(ctx, SendRequest{To: recvAddr, Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	// Export the unsigned tx + required signers (online instance).
+	unsigned, err := s.ExportUnsigned(pv.PendingID)
+	if err != nil {
+		t.Fatalf("ExportUnsigned: %v", err)
+	}
+	if unsigned.UnsignedTxCBOR == "" {
+		t.Fatal("expected non-empty unsigned tx cbor")
+	}
+	if len(unsigned.RequiredSigners) != 1 {
+		t.Fatalf("required signers = %d (%v), want 1", len(unsigned.RequiredSigners), unsigned.RequiredSigners)
+	}
+
+	// Sign offline (keystore + password, no chain access used).
+	wit, err := s.SignTx(unsigned.UnsignedTxCBOR, "pw", unsigned.RequiredSigners)
+	if err != nil {
+		t.Fatalf("SignTx: %v", err)
+	}
+	if wit.WitnessCBOR == "" {
+		t.Fatal("expected non-empty witness cbor")
+	}
+	if got := witnessCount(t, wit); got != len(unsigned.RequiredSigners) {
+		t.Fatalf("offline witnesses = %d, want %d", got, len(unsigned.RequiredSigners))
+	}
+
+	// Submit on the online instance: attaches only the needed witness.
+	res, err := s.SubmitSigned(ctx, unsigned.UnsignedTxCBOR, wit.WitnessCBOR)
+	if err != nil {
+		t.Fatalf("SubmitSigned: %v", err)
+	}
+	if res.TxHash == "" {
+		t.Fatal("expected non-empty tx hash")
+	}
+	if fc.submitCalls != 1 {
+		t.Fatalf("SubmitTx calls = %d, want 1", fc.submitCalls)
+	}
+
+	// The broadcast tx must carry exactly one vkey witness (the single input
+	// address).
+	submitted, err := ledger.NewConwayTransactionFromCbor(fc.submittedTxCbor())
+	if err != nil {
+		t.Fatalf("decode submitted tx: %v", err)
+	}
+	if got := len(submitted.WitnessSet.VkeyWitnesses.Items()); got != 1 {
+		t.Fatalf("submitted vkey witnesses = %d, want 1", got)
+	}
+}
+
+func TestExportUnsignedBindsRequiredSignersInBody(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	fc := newFakeChain(5_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, fakeKeystore{mnemonic: testMnemonic}, acct)
+
+	pv, err := s.Build(context.Background(), SendRequest{
+		To:       acct.ReceiveAddresses[2],
+		Lovelace: "1000000",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	unsigned, err := s.ExportUnsigned(pv.PendingID)
+	if err != nil {
+		t.Fatalf("ExportUnsigned: %v", err)
+	}
+
+	sidecar, err := parseRequiredSignerHashes(unsigned.RequiredSigners)
+	if err != nil {
+		t.Fatalf("parse exported required signers: %v", err)
+	}
+	body := bodyRequiredSigners(t, unsigned.UnsignedTxCBOR)
+	if !sameKeyHashSet(sidecar, body) {
+		t.Fatalf("body required signers %v do not match sidecar %v", keyHashesHex(body), unsigned.RequiredSigners)
+	}
+}
+
+func TestSignTxRejectsSidecarMismatchBeforeUnlock(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	fc := newFakeChain(5_000_000, acct.ReceiveAddresses[0])
+	ks := &trackingKeystore{mnemonic: testMnemonic}
+	s := NewService(fc, ks, acct)
+
+	pv, err := s.Build(context.Background(), SendRequest{
+		To:       acct.ReceiveAddresses[2],
+		Lovelace: "1000000",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	unsigned, err := s.ExportUnsigned(pv.PendingID)
+	if err != nil {
+		t.Fatalf("ExportUnsigned: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		signers []string
+	}{
+		{
+			name: "extra wallet payment key",
+			signers: append(
+				append([]string(nil), unsigned.RequiredSigners...),
+				paymentKeyHashForAddress(t, acct.ReceiveAddresses[1]),
+			),
+		},
+		{
+			name:    "stake key only",
+			signers: []string{stakeKeyHashForAddress(t, acct.ReceiveAddresses[0])},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := s.SignTx(unsigned.UnsignedTxCBOR, "pw", tt.signers); !errors.Is(err, ErrInvalidRequest) {
+				t.Fatalf("expected ErrInvalidRequest, got %v", err)
+			}
+		})
+	}
+	if ks.unlockCalls != 0 {
+		t.Fatalf("SignTx unlocked keystore %d times for mismatched sidecar", ks.unlockCalls)
+	}
+}
+
+func TestSubmitSignedAttachesBodyRequiredSigner(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	fc := newFakeChain(5_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, fakeKeystore{mnemonic: testMnemonic}, acct)
+
+	ctx := context.Background()
+	pv, err := s.Build(ctx, SendRequest{To: acct.ReceiveAddresses[2], Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	unsigned, err := s.ExportUnsigned(pv.PendingID)
+	if err != nil {
+		t.Fatalf("ExportUnsigned: %v", err)
+	}
+
+	required := bodyRequiredSigners(t, unsigned.UnsignedTxCBOR)
+	stakeRequired, err := parseRequiredSignerHashes([]string{stakeKeyHashForAddress(t, acct.ReceiveAddresses[0])})
+	if err != nil {
+		t.Fatalf("parse stake signer: %v", err)
+	}
+	required = append(required, stakeRequired...)
+	mutatedTx := unsignedWithRequiredSigners(t, unsigned.UnsignedTxCBOR, required)
+	wit, err := s.SignTx(mutatedTx, "pw", keyHashesHex(required))
+	if err != nil {
+		t.Fatalf("SignTx: %v", err)
+	}
+	if got := witnessCount(t, wit); got != 2 {
+		t.Fatalf("offline witnesses = %d, want 2", got)
+	}
+	if _, err := s.SubmitSigned(ctx, mutatedTx, wit.WitnessCBOR); err != nil {
+		t.Fatalf("SubmitSigned: %v", err)
+	}
+	submitted, err := ledger.NewConwayTransactionFromCbor(fc.submittedTxCbor())
+	if err != nil {
+		t.Fatalf("decode submitted tx: %v", err)
+	}
+	if got := len(submitted.WitnessSet.VkeyWitnesses.Items()); got != 2 {
+		t.Fatalf("submitted vkey witnesses = %d, want 2", got)
+	}
+}
+
+// TestAirGapMultiInput checks the split flow attaches one witness per distinct
+// input address when coin selection spans two addresses.
+func TestAirGapMultiInput(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	addr0 := acct.ReceiveAddresses[0]
+	addr1 := acct.ReceiveAddresses[1]
+	recvAddr := acct.ReceiveAddresses[2]
+
+	fc := newFakeChain(3_000_000, addr0)
+	fc.addUTxO(3_000_000, addr1, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0", 0)
+	s := NewService(fc, fakeKeystore{mnemonic: testMnemonic}, acct)
+
+	ctx := context.Background()
+	pv, err := s.Build(ctx, SendRequest{To: recvAddr, Lovelace: "4000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	unsigned, err := s.ExportUnsigned(pv.PendingID)
+	if err != nil {
+		t.Fatalf("ExportUnsigned: %v", err)
+	}
+	if len(unsigned.RequiredSigners) != 2 {
+		t.Fatalf("required signers = %d, want 2", len(unsigned.RequiredSigners))
+	}
+	wit, err := s.SignTx(unsigned.UnsignedTxCBOR, "pw", unsigned.RequiredSigners)
+	if err != nil {
+		t.Fatalf("SignTx: %v", err)
+	}
+	if got := witnessCount(t, wit); got != len(unsigned.RequiredSigners) {
+		t.Fatalf("offline witnesses = %d, want %d", got, len(unsigned.RequiredSigners))
+	}
+	if _, err := s.SubmitSigned(ctx, unsigned.UnsignedTxCBOR, wit.WitnessCBOR); err != nil {
+		t.Fatalf("SubmitSigned: %v", err)
+	}
+	submitted, err := ledger.NewConwayTransactionFromCbor(fc.submittedTxCbor())
+	if err != nil {
+		t.Fatalf("decode submitted tx: %v", err)
+	}
+	if got := len(submitted.WitnessSet.VkeyWitnesses.Items()); got != 2 {
+		t.Fatalf("submitted vkey witnesses = %d, want 2", got)
+	}
+}
+
+func TestExportUnsignedUnknownPending(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	s := NewService(newFakeChain(5_000_000, acct.ReceiveAddresses[0]), fakeKeystore{mnemonic: testMnemonic}, acct)
+	if _, err := s.ExportUnsigned("nope"); !errors.Is(err, ErrUnknownPending) {
+		t.Fatalf("expected ErrUnknownPending, got %v", err)
+	}
+}
+
+func TestSignTxWrongPassword(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	addr0 := acct.ReceiveAddresses[0]
+	fc := newFakeChain(5_000_000, addr0)
+	s := NewService(fc, fakeKeystore{mnemonic: testMnemonic}, acct)
+
+	ctx := context.Background()
+	pv, err := s.Build(ctx, SendRequest{To: acct.ReceiveAddresses[2], Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	unsigned, err := s.ExportUnsigned(pv.PendingID)
+	if err != nil {
+		t.Fatalf("ExportUnsigned: %v", err)
+	}
+	// A service whose keystore rejects the password.
+	bad := NewService(fc, fakeKeystore{err: keystore.ErrDecryptFailed}, acct)
+	if _, err := bad.SignTx(unsigned.UnsignedTxCBOR, "wrong", unsigned.RequiredSigners); !errors.Is(err, ErrWrongPassword) {
+		t.Fatalf("expected ErrWrongPassword, got %v", err)
+	}
+}
+
+func TestSignTxInvalidCbor(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	s := NewService(newFakeChain(0, acct.ReceiveAddresses[0]), fakeKeystore{mnemonic: testMnemonic}, acct)
+	if _, err := s.SignTx("zzzz", "pw", nil); !errors.Is(err, ErrInvalidTx) {
+		t.Fatalf("expected ErrInvalidTx, got %v", err)
+	}
+}
+
+func TestSubmitSignedRejectsMismatchedWitness(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	addr0 := acct.ReceiveAddresses[0]
+	fc := newFakeChain(5_000_000, addr0)
+	s := NewService(fc, fakeKeystore{mnemonic: testMnemonic}, acct)
+
+	ctx := context.Background()
+	pv, err := s.Build(ctx, SendRequest{To: acct.ReceiveAddresses[2], Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	unsigned, err := s.ExportUnsigned(pv.PendingID)
+	if err != nil {
+		t.Fatalf("ExportUnsigned: %v", err)
+	}
+
+	// Sign with a DIFFERENT wallet's keys: the witnesses won't match the inputs'
+	// required signers, so SubmitSigned must reject and never broadcast. The
+	// foreign service uses a different wallet and emits that wallet's witness,
+	// so SubmitSigned must reject it against acct's input signer set.
+	foreignAcct, err := wallet.Derive(differentMnemonic, "preview", 5)
+	if err != nil {
+		t.Fatalf("derive foreign account: %v", err)
+	}
+	foreign := NewService(fc, fakeKeystore{mnemonic: differentMnemonic}, foreignAcct)
+	foreignRequired, err := parseRequiredSignerHashes([]string{
+		paymentKeyHashForAddress(t, foreignAcct.ReceiveAddresses[0]),
+	})
+	if err != nil {
+		t.Fatalf("parse foreign required signer: %v", err)
+	}
+	foreignTx := unsignedWithRequiredSigners(t, unsigned.UnsignedTxCBOR, foreignRequired)
+	wit, err := foreign.SignTx(
+		foreignTx,
+		"pw",
+		keyHashesHex(foreignRequired),
+	)
+	if err != nil {
+		t.Fatalf("foreign SignTx: %v", err)
+	}
+	if _, err := s.SubmitSigned(ctx, unsigned.UnsignedTxCBOR, wit.WitnessCBOR); !errors.Is(err, ErrInvalidWitness) {
+		t.Fatalf("expected ErrInvalidWitness for foreign witness, got %v", err)
+	}
+	if fc.submitCalls != 0 {
+		t.Fatalf("foreign witness reached SubmitTx (%d calls)", fc.submitCalls)
 	}
 }
 

--- a/ui/internal/spend/spend_test.go
+++ b/ui/internal/spend/spend_test.go
@@ -836,6 +836,26 @@ func TestVerifyDataHashedPayload(t *testing.T) {
 	}
 }
 
+func TestVerifyDataRejectsHashedFlagMismatch(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	addr := acct.ReceiveAddresses[0]
+	s := NewService(newFakeChain(0, addr), fakeKeystore{mnemonic: testMnemonic}, acct)
+
+	msg := []byte("prove I control this address")
+	sig, key, err := s.SignData(addr, msg, "pw")
+	if err != nil {
+		t.Fatalf("SignData: %v", err)
+	}
+	if _, _, err := s.VerifyData(sig, key, msg, true, ""); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("expected ErrInvalidRequest for unhashed signature with hashed=true, got %v", err)
+	}
+
+	hashedSig, hashedKey, hashedMsg, _ := hashedSignDataFixture(t, acct)
+	if _, _, err := s.VerifyData(hashedSig, hashedKey, hashedMsg, false, ""); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("expected ErrInvalidRequest for hashed signature with hashed=false, got %v", err)
+	}
+}
+
 func TestVerifyDataMalformedReturnsInvalidRequest(t *testing.T) {
 	acct := mustDeriveConfirmAccount(t)
 	s := NewService(newFakeChain(0, acct.ReceiveAddresses[0]), fakeKeystore{mnemonic: testMnemonic}, acct)

--- a/ui/internal/spend/spend_test.go
+++ b/ui/internal/spend/spend_test.go
@@ -506,6 +506,11 @@ func hashedSignDataFixture(t *testing.T, acct *wallet.Account) (string, string, 
 
 func witnessCount(t *testing.T, wit Witness) int {
 	t.Helper()
+	return len(decodeWitnesses(t, wit))
+}
+
+func decodeWitnesses(t *testing.T, wit Witness) []lcommon.VkeyWitness {
+	t.Helper()
 	witBytes, err := hex.DecodeString(wit.WitnessCBOR)
 	if err != nil {
 		t.Fatalf("decode witness hex: %v", err)
@@ -514,7 +519,7 @@ func witnessCount(t *testing.T, wit Witness) int {
 	if _, err := cbor.Decode(witBytes, &witnesses); err != nil {
 		t.Fatalf("decode witnesses: %v", err)
 	}
-	return len(witnesses)
+	return witnesses
 }
 
 func bodyRequiredSigners(t *testing.T, unsignedTxCBOR string) []lcommon.Blake2b224 {
@@ -563,6 +568,35 @@ func unsignedWithRequiredSigners(
 	encoded, err := cbor.Encode(tx)
 	if err != nil {
 		t.Fatalf("encode unsigned tx: %v", err)
+	}
+	return hex.EncodeToString(encoded)
+}
+
+func unsignedWithIndefiniteBodyMap(t *testing.T, unsignedTxCBOR string) string {
+	t.Helper()
+	txBytes, err := hex.DecodeString(unsignedTxCBOR)
+	if err != nil {
+		t.Fatalf("decode unsigned tx hex: %v", err)
+	}
+	var arr []cbor.RawMessage
+	if _, err := cbor.Decode(txBytes, &arr); err != nil {
+		t.Fatalf("decode unsigned tx array: %v", err)
+	}
+	if len(arr) != 4 {
+		t.Fatalf("unsigned tx array length = %d, want 4", len(arr))
+	}
+	body := []byte(arr[0])
+	if len(body) == 0 || body[0] < 0xa0 || body[0] > 0xb7 {
+		t.Fatalf("body CBOR does not start with a definite map header: %x", body[:min(len(body), 8)])
+	}
+	driftedBody := make([]byte, 0, len(body)+1)
+	driftedBody = append(driftedBody, 0xbf)
+	driftedBody = append(driftedBody, body[1:]...)
+	driftedBody = append(driftedBody, 0xff)
+	arr[0] = cbor.RawMessage(driftedBody)
+	encoded, err := cbor.Encode(arr)
+	if err != nil {
+		t.Fatalf("encode drifted unsigned tx: %v", err)
 	}
 	return hex.EncodeToString(encoded)
 }
@@ -999,6 +1033,58 @@ func TestSignTxRejectsSidecarMismatchBeforeUnlock(t *testing.T) {
 	}
 	if ks.unlockCalls != 0 {
 		t.Fatalf("SignTx unlocked keystore %d times for mismatched sidecar", ks.unlockCalls)
+	}
+}
+
+func TestSignTxHashesOriginalBodyCbor(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	fc := newFakeChain(5_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, fakeKeystore{mnemonic: testMnemonic}, acct)
+
+	pv, err := s.Build(context.Background(), SendRequest{
+		To:       acct.ReceiveAddresses[2],
+		Lovelace: "1000000",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	unsigned, err := s.ExportUnsigned(pv.PendingID)
+	if err != nil {
+		t.Fatalf("ExportUnsigned: %v", err)
+	}
+
+	driftedTx := unsignedWithIndefiniteBodyMap(t, unsigned.UnsignedTxCBOR)
+	txBytes, err := hex.DecodeString(driftedTx)
+	if err != nil {
+		t.Fatalf("decode drifted tx hex: %v", err)
+	}
+	tx, err := ledger.NewConwayTransactionFromCbor(txBytes)
+	if err != nil {
+		t.Fatalf("decode drifted tx: %v", err)
+	}
+	originalBodyHash := lcommon.Blake2b256Hash(tx.Body.Cbor())
+	reencodedBody, err := cbor.Encode(&tx.Body)
+	if err != nil {
+		t.Fatalf("re-encode drifted body: %v", err)
+	}
+	reencodedBodyHash := lcommon.Blake2b256Hash(reencodedBody)
+	if originalBodyHash == reencodedBodyHash {
+		t.Fatal("test fixture did not create a body CBOR hash drift")
+	}
+
+	wit, err := s.SignTx(driftedTx, "pw", unsigned.RequiredSigners)
+	if err != nil {
+		t.Fatalf("SignTx: %v", err)
+	}
+	witnesses := decodeWitnesses(t, wit)
+	if len(witnesses) != 1 {
+		t.Fatalf("offline witnesses = %d, want 1", len(witnesses))
+	}
+	if err := lcommon.VerifyVKeySignature(witnesses[0].Vkey, witnesses[0].Signature, originalBodyHash.Bytes()); err != nil {
+		t.Fatalf("witness does not verify against original body hash: %v", err)
+	}
+	if err := lcommon.VerifyVKeySignature(witnesses[0].Vkey, witnesses[0].Signature, reencodedBodyHash.Bytes()); err == nil {
+		t.Fatal("witness unexpectedly verifies against re-encoded body hash")
 	}
 }
 

--- a/ui/internal/webui/dist/index.html
+++ b/ui/internal/webui/dist/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
-  <head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Bursa Wallet</title>  <script type="module" crossorigin src="/assets/index-CJ_qgKZL.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-C0I2Wlpq.css">
+  <head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Bursa Wallet</title>  <script type="module" crossorigin src="/assets/index-B_Wl8VO8.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-C2kL1fv_.css">
 </head>
   <body><div id="root"></div></body>
 </html>

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -16,6 +16,12 @@ import type {
   AddWalletRequest,
   MigrateLegacyKeystoreRequest,
   HistoryExpirySetting,
+  VerifyDataRequest,
+  VerifyDataResult,
+  UnsignedTx,
+  WitnessResult,
+  SignTxRequest,
+  SubmitSignedRequest,
 } from "./types";
 
 export class ApiError extends Error {
@@ -99,3 +105,10 @@ export const getHistoryExpiry = () =>
   apiGet<HistoryExpirySetting>("/wallet/settings/history-expiry");
 export const setHistoryExpiry = (enabled: boolean) =>
   apiPut<HistoryExpirySetting>("/wallet/settings/history-expiry", { enabled });
+export const verifyData = (req: VerifyDataRequest) =>
+  apiPost<VerifyDataResult>("/wallet/verify-data", req);
+export const exportUnsigned = (id: string) =>
+  apiPost<UnsignedTx>(`/wallet/send/${encodeURIComponent(id)}/export-unsigned`);
+export const signTx = (req: SignTxRequest) => apiPost<WitnessResult>("/wallet/sign-tx", req);
+export const submitSigned = (req: SubmitSignedRequest) =>
+  apiPost<TxResult>("/wallet/submit-signed", req);

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -126,6 +126,44 @@ export interface HistoryExpirySetting {
   restart_required: boolean;
 }
 
+// CIP-8/CIP-30 verification: the inverse of signData. expected_address is
+// optional; when set, a signature whose signer differs is reported invalid.
+export interface VerifyDataRequest {
+  signature: string; // COSE_Sign1, hex
+  key: string; // COSE_Key, hex
+  message: string;
+  hashed?: boolean;
+  expected_address?: string;
+}
+
+export interface VerifyDataResult {
+  valid: boolean;
+  address: string; // the bech32 address carried in the COSE protected header
+}
+
+// Air-gap signing. CBOR fields are hex strings carried (file/copy-paste)
+// between an online instance (export + submit) and an offline keyed instance
+// (sign).
+export interface UnsignedTx {
+  unsigned_tx_cbor: string;
+  required_signers: string[]; // payment key-hashes (hex) that must witness the tx
+}
+
+export interface WitnessResult {
+  witness_cbor: string;
+}
+
+export interface SignTxRequest {
+  unsigned_tx_cbor: string;
+  password: string;
+  required_signers: string[];
+}
+
+export interface SubmitSignedRequest {
+  unsigned_tx_cbor: string;
+  witness_cbor: string;
+}
+
 // A wallet as listed by the vault: read-only fields plus whether it's active.
 // The encrypted seed is never exposed.
 export interface WalletView {

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -17,6 +17,8 @@ import { Receive } from "./screens/Receive";
 import { Activity } from "./screens/Activity";
 import { Send } from "./screens/Send";
 import { SignMessage } from "./screens/SignMessage";
+import { VerifyMessage } from "./screens/VerifyMessage";
+import { Offline } from "./screens/Offline";
 import { Settings } from "./screens/Settings";
 
 // A Map (not a plain object) so a crafted hash like "#/constructor" or
@@ -35,6 +37,8 @@ const NAV: { key: string; label: string }[] = [
   { key: "activity", label: "Activity" },
   { key: "send", label: "Send" },
   { key: "sign", label: "Sign" },
+  { key: "verify", label: "Verify" },
+  { key: "offline", label: "Offline" },
   { key: "settings", label: "Settings" },
 ];
 
@@ -193,6 +197,8 @@ export function App() {
     if (route === "settings") activeRoute = "settings";
     else if (route === "send" && canSend) activeRoute = "send";
     else if (route === "sign" && canSign) activeRoute = "sign";
+    else if (route === "verify") activeRoute = "verify";
+    else if (route === "offline" && canSign) activeRoute = "offline";
     else if (ROUTES.has(route) && route !== "send") activeRoute = route;
     else activeRoute = "portfolio";
   }
@@ -220,6 +226,14 @@ export function App() {
     content = <Portfolio />;
   } else if (route === "sign") {
     content = canSign ? <SignMessage account={toAccount(activeWallet)} /> : <Portfolio />;
+  } else if (route === "verify") {
+    // Verification is pure crypto — available to any active wallet, even
+    // read-only, since it neither needs a node nor the keystore.
+    content = <VerifyMessage />;
+  } else if (route === "offline") {
+    // Air-gap signing needs the active wallet's seed (to sign) but no node for
+    // the sign step; falls back to Portfolio without an active wallet.
+    content = canSign ? <Offline /> : <Portfolio />;
   } else {
     const Screen = ROUTES.get(route) ?? Portfolio;
     content = <Screen />;
@@ -251,7 +265,8 @@ export function App() {
               activeWallet === null ||
               addingWallet ||
               (key === "send" && !canSend) ||
-              (key === "sign" && !canSign);
+              (key === "sign" && !canSign) ||
+              (key === "offline" && !canSign);
             const active = key === activeRoute;
             return (
               <button

--- a/ui/web/src/components/DownloadButton.tsx
+++ b/ui/web/src/components/DownloadButton.tsx
@@ -1,0 +1,30 @@
+interface DownloadButtonProps {
+  // The text content to download (e.g. CBOR hex).
+  value: string;
+  // Suggested file name for the download.
+  filename: string;
+  label?: string;
+}
+
+// DownloadButton offers a string payload as a downloadable text file. It is used
+// to carry air-gap artifacts (unsigned tx / witness CBOR) to a separate machine
+// where copy/paste across an air gap is impractical.
+export function DownloadButton({ value, filename, label = "Download" }: DownloadButtonProps) {
+  function handleClick() {
+    const blob = new Blob([value], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 100);
+  }
+
+  return (
+    <button type="button" className="btn ghost" onClick={handleClick} disabled={!value}>
+      {label}
+    </button>
+  );
+}

--- a/ui/web/src/screens/Offline.test.tsx
+++ b/ui/web/src/screens/Offline.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Offline } from "./Offline";
+import * as client from "../api/client";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("Sign offline: signTx is called and the witness is shown", async () => {
+  const signTx = vi
+    .spyOn(client, "signTx")
+    .mockResolvedValue({ witness_cbor: "81825820cafe" });
+
+  render(<Offline />);
+
+  fireEvent.change(screen.getByRole("textbox", { name: /unsigned transaction/i }), {
+    target: { value: "84a400" },
+  });
+  fireEvent.change(screen.getByRole("textbox", { name: /required signers/i }), {
+    target: { value: "aabbccdd" },
+  });
+  fireEvent.change(screen.getByLabelText(/spending password/i), {
+    target: { value: "pw" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /sign transaction/i }));
+
+  await waitFor(() =>
+    expect(signTx).toHaveBeenCalledWith({
+      unsigned_tx_cbor: "84a400",
+      password: "pw",
+      required_signers: ["aabbccdd"],
+    }),
+  );
+  expect(await screen.findByText("81825820cafe")).toBeInTheDocument();
+});
+
+test("Submit signed: submitSigned is called and the tx hash is shown", async () => {
+  const submitSigned = vi
+    .spyOn(client, "submitSigned")
+    .mockResolvedValue({ tx_hash: "deadbeef" });
+
+  render(<Offline />);
+
+  // Switch to the submit tab.
+  fireEvent.click(screen.getByRole("button", { name: /submit signed/i }));
+
+  fireEvent.change(screen.getByRole("textbox", { name: /unsigned transaction/i }), {
+    target: { value: "84a400" },
+  });
+  fireEvent.change(screen.getByRole("textbox", { name: /^witness$/i }), {
+    target: { value: "81825820cafe" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /attach witness & submit/i }));
+
+  await waitFor(() =>
+    expect(submitSigned).toHaveBeenCalledWith({
+      unsigned_tx_cbor: "84a400",
+      witness_cbor: "81825820cafe",
+    }),
+  );
+  expect(await screen.findByText("deadbeef")).toBeInTheDocument();
+});
+
+test("Submit signed: shows the API error on a rejected witness", async () => {
+  vi.spyOn(client, "submitSigned").mockRejectedValue(
+    new client.ApiError(400, "invalid witness"),
+  );
+
+  render(<Offline />);
+  fireEvent.click(screen.getByRole("button", { name: /submit signed/i }));
+  fireEvent.change(screen.getByRole("textbox", { name: /unsigned transaction/i }), {
+    target: { value: "84a400" },
+  });
+  fireEvent.change(screen.getByRole("textbox", { name: /^witness$/i }), {
+    target: { value: "zz" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /attach witness & submit/i }));
+
+  await waitFor(() =>
+    expect(screen.getByText(/invalid witness/i)).toBeInTheDocument(),
+  );
+});
+
+test("the Sign button is disabled until all fields are entered", () => {
+  render(<Offline />);
+  expect(screen.getByRole("button", { name: /sign transaction/i })).toBeDisabled();
+});

--- a/ui/web/src/screens/Offline.tsx
+++ b/ui/web/src/screens/Offline.tsx
@@ -1,0 +1,273 @@
+import { useState } from "react";
+import { Card } from "../components/Card";
+import { Input } from "../components/Input";
+import { Button } from "../components/Button";
+import { CopyButton } from "../components/CopyButton";
+import { DownloadButton } from "../components/DownloadButton";
+import { signTx, submitSigned, ApiError } from "../api/client";
+import type { WitnessResult, TxResult } from "../api/types";
+
+function errorMessage(err: unknown): string {
+  if (err instanceof ApiError) return err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+type Tab = "sign" | "submit";
+
+interface ActionTabProps {
+  setBusy: (busy: boolean) => void;
+}
+
+function parseRequiredSigners(value: string): string[] {
+  return value
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+// SignTab is the air-gapped step: paste the unsigned transaction CBOR exported
+// from an online instance and the spending password to derive the key and
+// produce a vkey witness. No node is contacted — this is what the offline,
+// keyed instance runs.
+function SignTab({ setBusy }: ActionTabProps) {
+  const [unsignedCbor, setUnsignedCbor] = useState("");
+  const [requiredSigners, setRequiredSigners] = useState("");
+  const [password, setPassword] = useState("");
+  const [result, setResult] = useState<WitnessResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  function clearResult() {
+    setResult(null);
+    setError(null);
+  }
+
+  async function handleSign() {
+    setError(null);
+    setResult(null);
+    setLoading(true);
+    setBusy(true);
+    try {
+      const res = await signTx({
+        unsigned_tx_cbor: unsignedCbor.trim(),
+        password,
+        required_signers: parseRequiredSigners(requiredSigners),
+      });
+      setResult(res);
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setLoading(false);
+      setBusy(false);
+    }
+  }
+
+  const parsedRequiredSigners = parseRequiredSigners(requiredSigners);
+
+  return (
+    <div className="sign-form">
+      <p className="helper-text">
+        Sign an unsigned transaction offline. Paste the CBOR exported from your
+        online instance and your spending password; the resulting witness can be
+        carried back to that instance to submit. Nothing is broadcast here.
+      </p>
+
+      <label htmlFor="offline-unsigned">Unsigned transaction (CBOR)</label>
+      <textarea
+        id="offline-unsigned"
+        className="field"
+        rows={4}
+        value={unsignedCbor}
+        onChange={(e) => {
+          setUnsignedCbor(e.target.value);
+          clearResult();
+        }}
+        placeholder="hex…"
+        aria-label="Unsigned transaction"
+        disabled={loading}
+      />
+
+      <label htmlFor="offline-required-signers">Required signers</label>
+      <textarea
+        id="offline-required-signers"
+        className="field"
+        rows={2}
+        value={requiredSigners}
+        onChange={(e) => {
+          setRequiredSigners(e.target.value);
+          clearResult();
+        }}
+        placeholder="hex key hashes…"
+        aria-label="Required signers"
+        disabled={loading}
+      />
+
+      <label htmlFor="offline-password">Spending password</label>
+      <Input
+        id="offline-password"
+        type="password"
+        value={password}
+        onChange={(e) => {
+          setPassword(e.target.value);
+          clearResult();
+        }}
+        placeholder="Spending password"
+        aria-label="Spending password"
+        disabled={loading}
+      />
+
+      {error && (
+        <p role="alert" className="error-text">
+          {error}
+        </p>
+      )}
+
+      <Button
+        onClick={handleSign}
+        disabled={loading || !unsignedCbor.trim() || parsedRequiredSigners.length === 0 || !password}
+      >
+        {loading ? "Signing…" : "Sign transaction"}
+      </Button>
+
+      {result && (
+        <div className="sign-result">
+          <p className="field-label">Witness (CBOR)</p>
+          <div className="tx-hash-row">
+            <code className="tx-hash">{result.witness_cbor}</code>
+            <CopyButton value={result.witness_cbor} />
+            <DownloadButton value={result.witness_cbor} filename="witness.cbor" label="Download" />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// SubmitTab is the final online step: paste the original unsigned transaction
+// CBOR plus the witness produced offline. The instance attaches the witness and
+// broadcasts. It needs a synced node.
+function SubmitTab({ setBusy }: ActionTabProps) {
+  const [unsignedCbor, setUnsignedCbor] = useState("");
+  const [witnessCbor, setWitnessCbor] = useState("");
+  const [result, setResult] = useState<TxResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  function clearResult() {
+    setResult(null);
+    setError(null);
+  }
+
+  async function handleSubmit() {
+    setError(null);
+    setResult(null);
+    setLoading(true);
+    setBusy(true);
+    try {
+      const res = await submitSigned({
+        unsigned_tx_cbor: unsignedCbor.trim(),
+        witness_cbor: witnessCbor.trim(),
+      });
+      setResult(res);
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setLoading(false);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="sign-form">
+      <p className="helper-text">
+        Submit a transaction signed offline. Paste the original unsigned CBOR and
+        the witness from your offline instance; this instance attaches the witness
+        and broadcasts it to the network.
+      </p>
+
+      <label htmlFor="submit-unsigned">Unsigned transaction (CBOR)</label>
+      <textarea
+        id="submit-unsigned"
+        className="field"
+        rows={4}
+        value={unsignedCbor}
+        onChange={(e) => {
+          setUnsignedCbor(e.target.value);
+          clearResult();
+        }}
+        placeholder="hex…"
+        aria-label="Unsigned transaction"
+        disabled={loading}
+      />
+
+      <label htmlFor="submit-witness">Witness (CBOR)</label>
+      <textarea
+        id="submit-witness"
+        className="field"
+        rows={3}
+        value={witnessCbor}
+        onChange={(e) => {
+          setWitnessCbor(e.target.value);
+          clearResult();
+        }}
+        placeholder="hex…"
+        aria-label="Witness"
+        disabled={loading}
+      />
+
+      {error && (
+        <p role="alert" className="error-text">
+          {error}
+        </p>
+      )}
+
+      <Button
+        onClick={handleSubmit}
+        disabled={loading || !unsignedCbor.trim() || !witnessCbor.trim()}
+      >
+        {loading ? "Submitting…" : "Attach witness & submit"}
+      </Button>
+
+      {result && (
+        <div className="sign-result">
+          <p>Your transaction has been submitted successfully.</p>
+          <p className="field-label">Transaction hash</p>
+          <div className="tx-hash-row">
+            <code className="tx-hash">{result.tx_hash}</code>
+            <CopyButton value={result.tx_hash} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Offline groups the air-gap signing primitives: sign an exported unsigned tx
+// (offline instance) and submit a tx signed elsewhere (online instance).
+export function Offline() {
+  const [tab, setTab] = useState<Tab>("sign");
+  const [busy, setBusy] = useState(false);
+
+  return (
+    <Card title="Offline Signing">
+      <div className="tab-bar">
+        <button
+          className={tab === "sign" ? "tab active" : "tab"}
+          disabled={busy}
+          onClick={() => setTab("sign")}
+        >
+          Sign offline
+        </button>
+        <button
+          className={tab === "submit" ? "tab active" : "tab"}
+          disabled={busy}
+          onClick={() => setTab("submit")}
+        >
+          Submit signed
+        </button>
+      </div>
+      {tab === "sign" ? <SignTab setBusy={setBusy} /> : <SubmitTab setBusy={setBusy} />}
+    </Card>
+  );
+}

--- a/ui/web/src/screens/Send.test.tsx
+++ b/ui/web/src/screens/Send.test.tsx
@@ -251,6 +251,63 @@ test("(i) compose inputs are disabled while the preview build is in flight", asy
   });
 });
 
+// --- export for offline signing ---
+
+test("(j) Export for offline signing shows the unsigned tx CBOR and required signers", async () => {
+  vi.spyOn(client, "buildSend").mockResolvedValue(MOCK_PREVIEW);
+  const exportUnsigned = vi.spyOn(client, "exportUnsigned").mockResolvedValue({
+    unsigned_tx_cbor: "84a400deadbeef",
+    required_signers: ["aabbccdd"],
+  });
+
+  render(<Send />);
+
+  const inputs = screen.getAllByRole("textbox");
+  fireEvent.change(inputs[0], { target: { value: "addr_test1recipient" } });
+  fireEvent.change(inputs[1], { target: { value: "5" } });
+  fireEvent.click(screen.getByRole("button", { name: /review/i }));
+
+  await waitFor(() => {
+    expect(screen.getByText(/2 inputs/i)).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByRole("button", { name: /export for offline signing/i }));
+
+  await waitFor(() => {
+    expect(exportUnsigned).toHaveBeenCalledWith("pending-abc-123");
+  });
+  expect(await screen.findByText("84a400deadbeef")).toBeInTheDocument();
+  expect(screen.getByText("aabbccdd")).toBeInTheDocument();
+});
+
+test("(j2) failed export retry clears a previous unsigned tx", async () => {
+  vi.spyOn(client, "buildSend").mockResolvedValue(MOCK_PREVIEW);
+  vi.spyOn(client, "exportUnsigned")
+    .mockResolvedValueOnce({
+      unsigned_tx_cbor: "84a400deadbeef",
+      required_signers: ["aabbccdd"],
+    })
+    .mockRejectedValueOnce(new client.ApiError(400, "invalid transaction"));
+
+  render(<Send />);
+
+  const inputs = screen.getAllByRole("textbox");
+  fireEvent.change(inputs[0], { target: { value: "addr_test1recipient" } });
+  fireEvent.change(inputs[1], { target: { value: "5" } });
+  fireEvent.click(screen.getByRole("button", { name: /review/i }));
+
+  await waitFor(() => {
+    expect(screen.getByText(/2 inputs/i)).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByRole("button", { name: /export for offline signing/i }));
+  expect(await screen.findByText("84a400deadbeef")).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("button", { name: /export for offline signing/i }));
+  expect(await screen.findByRole("alert")).toHaveTextContent(/invalid transaction/i);
+  expect(screen.queryByText("84a400deadbeef")).not.toBeInTheDocument();
+});
+
 // --- invalid ADA shows error, buildSend NOT called ---
 
 test("(f) invalid ADA amount shows error without calling buildSend", async () => {

--- a/ui/web/src/screens/Send.tsx
+++ b/ui/web/src/screens/Send.tsx
@@ -1,12 +1,13 @@
 import { useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
-import type { Preview, TxResult, SendAsset } from "../api/types";
-import { buildSend, confirmSend, ApiError } from "../api/client";
+import type { Preview, TxResult, SendAsset, UnsignedTx } from "../api/types";
+import { buildSend, confirmSend, exportUnsigned, ApiError } from "../api/client";
 import { Card } from "../components/Card";
 import { Input } from "../components/Input";
 import { Button } from "../components/Button";
 import { Table } from "../components/Table";
 import { CopyButton } from "../components/CopyButton";
+import { DownloadButton } from "../components/DownloadButton";
 import { formatAda, parseAda } from "../format";
 
 type Phase = "compose" | "preview" | "done";
@@ -186,6 +187,8 @@ function PreviewPhase({ preview, onBack, onDone }: PreviewPhaseProps) {
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [exported, setExported] = useState<UnsignedTx | null>(null);
 
   const outputRows = preview.outputs.map((o) => ({
     address: o.address,
@@ -206,6 +209,23 @@ function PreviewPhase({ preview, onBack, onDone }: PreviewPhaseProps) {
       setError(errorMessage(e));
     } finally {
       setLoading(false);
+    }
+  }
+
+  // Export the unsigned tx for offline signing. The result is shown for
+  // copy/download so it can be carried to an air-gapped, keyed instance; the
+  // pending send is not consumed, so the user may still confirm online instead.
+  async function handleExport() {
+    setError(null);
+    setExported(null);
+    setExporting(true);
+    try {
+      const res = await exportUnsigned(preview.pending_id);
+      setExported(res);
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setExporting(false);
     }
   }
 
@@ -246,12 +266,48 @@ function PreviewPhase({ preview, onBack, onDone }: PreviewPhaseProps) {
         )}
 
         <div className="preview-actions">
-          <Button variant="ghost" onClick={onBack} disabled={loading}>
+          <Button variant="ghost" onClick={onBack} disabled={loading || exporting}>
             Back
           </Button>
-          <Button onClick={handleConfirm} disabled={loading || !password}>
+          <Button onClick={handleConfirm} disabled={loading || exporting || !password}>
             {loading ? "Submitting…" : "Confirm & send"}
           </Button>
+        </div>
+
+        <div className="offline-export">
+          <Button variant="ghost" onClick={handleExport} disabled={loading || exporting}>
+            {exporting ? "Exporting…" : "Export for offline signing"}
+          </Button>
+          {exported && (
+            <div className="sign-result">
+              <p className="helper-text">
+                Carry this unsigned transaction to your offline instance, sign it
+                there, then bring the witness back to Submit signed.
+              </p>
+              <p className="field-label">Unsigned transaction (CBOR)</p>
+              <div className="tx-hash-row">
+                <code className="tx-hash">{exported.unsigned_tx_cbor}</code>
+                <CopyButton value={exported.unsigned_tx_cbor} />
+                <DownloadButton
+                  value={exported.unsigned_tx_cbor}
+                  filename="unsigned-tx.cbor"
+                  label="Download"
+                />
+              </div>
+              {exported.required_signers.length > 0 && (
+                <>
+                  <p className="field-label">Required signers</p>
+                  <ul className="signer-list">
+                    {exported.required_signers.map((s) => (
+                      <li key={s}>
+                        <code className="tx-hash">{s}</code>
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </Card>

--- a/ui/web/src/screens/VerifyMessage.test.tsx
+++ b/ui/web/src/screens/VerifyMessage.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { VerifyMessage } from "./VerifyMessage";
+import * as client from "../api/client";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("verifies a signature and shows the signer address", async () => {
+  const verifyData = vi
+    .spyOn(client, "verifyData")
+    .mockResolvedValue({ valid: true, address: "addr_test1signer" });
+
+  render(<VerifyMessage />);
+
+  fireEvent.change(screen.getByRole("textbox", { name: /signature/i }), {
+    target: { value: "84a1cose" },
+  });
+  fireEvent.change(screen.getByRole("textbox", { name: /key/i }), {
+    target: { value: "a401key" },
+  });
+  fireEvent.change(screen.getByRole("textbox", { name: /message/i }), {
+    target: { value: "prove it" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /verify signature/i }));
+
+  await waitFor(() =>
+    expect(verifyData).toHaveBeenCalledWith({
+      signature: "84a1cose",
+      key: "a401key",
+      message: "prove it",
+    }),
+  );
+  expect(await screen.findByText(/valid signature/i)).toBeInTheDocument();
+  expect(screen.getByText("addr_test1signer")).toBeInTheDocument();
+});
+
+test("passes expected_address when provided", async () => {
+  const verifyData = vi
+    .spyOn(client, "verifyData")
+    .mockResolvedValue({ valid: false, address: "addr_test1other" });
+
+  render(<VerifyMessage />);
+
+  fireEvent.change(screen.getByRole("textbox", { name: /signature/i }), {
+    target: { value: "84a1" },
+  });
+  fireEvent.change(screen.getByRole("textbox", { name: /key/i }), {
+    target: { value: "a4" },
+  });
+  fireEvent.change(screen.getByRole("textbox", { name: /^message$/i }), {
+    target: { value: "m" },
+  });
+  fireEvent.change(screen.getByRole("textbox", { name: /expected address/i }), {
+    target: { value: "addr_test1expected" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /verify signature/i }));
+
+  await waitFor(() =>
+    expect(verifyData).toHaveBeenCalledWith({
+      signature: "84a1",
+      key: "a4",
+      message: "m",
+      expected_address: "addr_test1expected",
+    }),
+  );
+  expect(await screen.findByText(/invalid signature/i)).toBeInTheDocument();
+});
+
+test("shows the API error message when verification errors", async () => {
+  vi.spyOn(client, "verifyData").mockRejectedValue(
+    new client.ApiError(400, "invalid hex"),
+  );
+
+  render(<VerifyMessage />);
+  fireEvent.change(screen.getByRole("textbox", { name: /signature/i }), {
+    target: { value: "zz" },
+  });
+  fireEvent.change(screen.getByRole("textbox", { name: /key/i }), {
+    target: { value: "a4" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /verify signature/i }));
+
+  await waitFor(() =>
+    expect(screen.getByText(/invalid hex/i)).toBeInTheDocument(),
+  );
+});
+
+test("the Verify button starts disabled", () => {
+  render(<VerifyMessage />);
+  expect(screen.getByRole("button", { name: /verify signature/i })).toBeDisabled();
+});

--- a/ui/web/src/screens/VerifyMessage.tsx
+++ b/ui/web/src/screens/VerifyMessage.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import { Card } from "../components/Card";
+import { Input } from "../components/Input";
+import { Button } from "../components/Button";
+import { verifyData, ApiError } from "../api/client";
+import type { VerifyDataResult } from "../api/types";
+
+// VerifyMessage verifies a CIP-8 / CIP-30 signData result: a COSE_Sign1
+// signature + COSE_Key (the Sign screen's output) over a message. It is fully
+// offline (pure crypto — no node, no keystore) and reports whether the
+// signature is valid and which address signed it. An optional expected address
+// pins the verification to a specific signer.
+export function VerifyMessage() {
+  const [signature, setSignature] = useState("");
+  const [key, setKey] = useState("");
+  const [message, setMessage] = useState("");
+  const [expectedAddress, setExpectedAddress] = useState("");
+  const [result, setResult] = useState<VerifyDataResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Editing any field invalidates a previous result/error so the verdict shown
+  // always matches the current inputs.
+  function clearResult() {
+    setResult(null);
+    setError(null);
+  }
+
+  async function handleVerify() {
+    setError(null);
+    setResult(null);
+    setLoading(true);
+    try {
+      const res = await verifyData({
+        signature: signature.trim(),
+        key: key.trim(),
+        message,
+        ...(expectedAddress.trim() ? { expected_address: expectedAddress.trim() } : {}),
+      });
+      setResult(res);
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "An unexpected error occurred");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card title="Verify Message">
+      <div className="sign-form">
+        <p className="helper-text">
+          Check a CIP-8 / CIP-30 signature. Paste the COSE_Sign1 signature and
+          COSE_Key from a Sign result, along with the original message, to confirm
+          it is valid and see which address signed it.
+        </p>
+
+        <label htmlFor="verify-signature">Signature (COSE_Sign1)</label>
+        <textarea
+          id="verify-signature"
+          className="field"
+          rows={3}
+          value={signature}
+          onChange={(e) => {
+            setSignature(e.target.value);
+            clearResult();
+          }}
+          placeholder="hex…"
+          disabled={loading}
+        />
+
+        <label htmlFor="verify-key">Key (COSE_Key)</label>
+        <textarea
+          id="verify-key"
+          className="field"
+          rows={2}
+          value={key}
+          onChange={(e) => {
+            setKey(e.target.value);
+            clearResult();
+          }}
+          placeholder="hex…"
+          disabled={loading}
+        />
+
+        <label htmlFor="verify-message">Message</label>
+        <textarea
+          id="verify-message"
+          className="field"
+          rows={4}
+          value={message}
+          onChange={(e) => {
+            setMessage(e.target.value);
+            clearResult();
+          }}
+          placeholder="The message that was signed…"
+          aria-label="Message"
+          disabled={loading}
+        />
+
+        <label htmlFor="verify-expected">Expected address (optional)</label>
+        <Input
+          id="verify-expected"
+          type="text"
+          value={expectedAddress}
+          onChange={(e) => {
+            setExpectedAddress(e.target.value);
+            clearResult();
+          }}
+          placeholder="addr1… — leave blank to accept any signer"
+          aria-label="Expected address"
+          disabled={loading}
+        />
+
+        {error && (
+          <p role="alert" className="error-text">
+            {error}
+          </p>
+        )}
+
+        <Button
+          onClick={handleVerify}
+          disabled={loading || !signature.trim() || !key.trim()}
+        >
+          {loading ? "Verifying…" : "Verify signature"}
+        </Button>
+
+        {result && (
+          <div className="sign-result">
+            {result.valid ? (
+              <p role="status" className="success-text">
+                Valid signature
+              </p>
+            ) : (
+              <p role="status" className="error-text">
+                Invalid signature
+              </p>
+            )}
+            {result.address && (
+              <>
+                <p className="field-label">Signed by</p>
+                <div className="tx-hash-row">
+                  <code className="tx-hash">{result.address}</code>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -358,6 +358,14 @@ a:hover {
   font-size: 0.875rem;
   margin: var(--space-1) 0;
 }
+/* Affirmative verdict (verification valid). Mirrors .error-text but positive. */
+.success-text {
+  color: var(--ok);
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: 0.875rem;
+  margin: var(--space-1) 0;
+}
 .muted {
   color: var(--text-muted);
 }
@@ -932,6 +940,52 @@ a:hover {
 .setting-copy strong {
   color: var(--text);
   font-weight: 600;
+}
+
+/* Offline export block on the send preview, set off from the main actions. */
+.offline-export {
+  margin-top: var(--space-4);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.signer-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+/* Tab bar (offline screen: sign / submit). */
+.tab-bar {
+  display: flex;
+  gap: var(--space-1);
+  margin-bottom: var(--space-3);
+  border-bottom: 1px solid var(--border);
+}
+.tab {
+  appearance: none;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  cursor: pointer;
+  margin-bottom: -1px;
+}
+.tab:hover {
+  color: var(--text);
+}
+.tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CIP‑8/CIP‑30 message verification and a full offline (air‑gap) transaction signing flow. Signs the exact CBOR bytes to prevent re‑encode drift so required signers and witnesses are preserved.

- **New Features**
  - API
    - POST `/wallet/verify-data`: verifies COSE_Sign1 + COSE_Key (supports hashed payloads; validates the `hashed` flag against the COSE header; optional `expected_address`); returns `{ valid, address }`; ungated.
    - POST `/wallet/send/{id}/export-unsigned`: returns `{ unsigned_tx_cbor, required_signers[] }` with the signer set embedded in the tx body; requires a synced node.
    - POST `/wallet/sign-tx`: signs the exact `unsigned_tx_cbor` bytes; returns `{ witness_cbor }`; rejects if the provided `required_signers[]` doesn’t match the tx body; ungated.
    - POST `/wallet/submit-signed`: attaches only needed vkey witnesses (deduped) to the unsigned tx and broadcasts; returns `{ tx_hash }`; requires a synced node.
    - Errors: invalid input/tx/witness → 400; wrong password → 401; wallet switched → 409; unknown/expired pending → 404/410; syncing → 503.
  - UI
    - New Verify screen (shows valid/invalid, signer address, optional expected address).
    - New Offline screen with “Sign offline” and “Submit signed” tabs, plus copy/download of CBOR artifacts.
    - Send review adds “Export for offline signing” showing unsigned CBOR and required signers.
  - Lib
    - `SignaturePayloadHashed(signatureHex)`: reads the CIP‑8/CIP‑30 COSE “hashed” header without verifying.
- **Dependencies**
  - `ui/go.mod`: `replace github.com/blinklabs-io/bursa => ../` to use `VerifyDataWithAddress` and `SignaturePayloadHashed`; bump `github.com/blinklabs-io/gouroboros` to `v0.186.0`.
  - CI and boundary tests scope `go vet/test/lint` to `ui/cmd/...` and `ui/internal/...` to avoid `ui/web/node_modules` vendored Go files.

<sup>Written for commit 1d8e854b7b350cb9ee63c15ad3ab6e476f86a90e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an offline signing workflow to verify signatures, export unsigned transactions, produce witnesses, and submit signed transactions.
  * Added new wallet screens for signature verification and offline transaction handling.
  * Added export/download support for unsigned transactions and generated witness data.

* **Bug Fixes**
  * Improved validation and error handling for malformed transaction and witness data.
  * Updated request handling so invalid input returns clearer client-facing errors.

* **UI**
  * Added navigation and screen states for the new verification and offline signing flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->