### PR TITLE
feat(ui): staking & governance delegation

### DIFF
--- a/ui/cmd/bursa-wallet/main.go
+++ b/ui/cmd/bursa-wallet/main.go
@@ -108,9 +108,10 @@ func run() error {
 		return fmt.Errorf("seed lean-node default: %w", err)
 	}
 
+	nodeDataDir := filepath.Join(dataDir, "db")
 	sup := supervisor.New(supervisor.Config{
 		Network:        network,
-		DataDir:        filepath.Join(dataDir, "db"),
+		DataDir:        nodeDataDir,
 		SocketPath:     filepath.Join(dataDir, "node.socket"),
 		UtxorpcPort:    utxorpcPort,
 		BlockfrostPort: blockfrostPort,
@@ -123,8 +124,11 @@ func run() error {
 		HistoryExpiry: settingsStore.HistoryExpiry,
 	})
 
-	// The wallet queries the node's own loopback Blockfrost endpoint.
-	walletSvc := wallet.NewService(chain.NewClient(blockfrostPort))
+	// The wallet queries the node's own loopback Blockfrost endpoint. The same
+	// client also verifies pasted pool/DRep IDs and reads protocol params for the
+	// staking flow (consent law: the embedded node is the only network contact).
+	chainClient := chain.NewClient(blockfrostPort, chain.WithDingoDataDir(nodeDataDir))
+	walletSvc := wallet.NewService(chainClient)
 
 	// The vault is the encrypted multi-wallet store: a single file under the data
 	// dir holding the wallet index (encrypted under the vault password) and each
@@ -135,10 +139,13 @@ func run() error {
 
 	// Spending builds/signs/submits through the node's loopback UTxO-RPC
 	// endpoint; the active wallet's seed is decrypted from the vault on demand.
+	// Delegation txs additionally query pool/DRep/account state + protocol params
+	// through the Blockfrost client.
 	chainCtx := utxorpc.NewUtxoRpcChainContext(
 		fmt.Sprintf("http://127.0.0.1:%d", utxorpcPort), netID, nil,
 	)
 	spendSvc := spend.NewService(chainCtx, vaultKeystore{v: vlt}, nil)
+	spendSvc.SetChainQuerier(chainClient)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -153,6 +160,7 @@ func run() error {
 		Handler: api.NewHandler(
 			sup, vlt, walletSvc, spendSvc,
 			&settingsController{store: settingsStore, sup: sup},
+			chainClient,
 			network, webui.Handler(),
 			api.WithLegacyKeystore(legacyKeyStore),
 		),

--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/blinklabs-io/bursa/ui/internal/chain"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/spend"
 	"github.com/blinklabs-io/bursa/ui/internal/supervisor"
@@ -47,10 +48,12 @@ type Wallet interface {
 }
 
 // Spender is the spending surface the API exposes for the active wallet:
-// building a send for preview, confirming it (decrypt seed → sign → submit), and
-// CIP-8/CIP-30 message signing. SetAccount binds the active wallet (pushed by
-// the vault); the seed is decrypted via the vault under the wallet's spending
-// password at confirm/sign time.
+// building a send for preview, confirming it (decrypt seed → sign → submit),
+// CIP-8/CIP-30 message signing, and building staking/governance delegation
+// transactions (which Confirm signs + submits through the same path as a send).
+// SetAccount binds the active wallet (pushed by the vault); the seed is
+// decrypted via the vault under the wallet's spending password at confirm/sign
+// time.
 type Spender interface {
 	// SetAccount("", nil) clears the active wallet binding and pending sends.
 	SetAccount(id string, acct *wallet.Account)
@@ -61,6 +64,15 @@ type Spender interface {
 	ExportUnsigned(pendingID string) (spend.UnsignedTx, error)
 	SignTx(unsignedTxCBOR, password string, requiredSigners []string) (spend.Witness, error)
 	SubmitSigned(ctx context.Context, unsignedTxCBOR, witnessCBOR string) (spend.TxResult, error)
+	BuildDelegation(ctx context.Context, req spend.DelegationRequest) (spend.DelegationPreview, error)
+}
+
+// PoolDRepLookup is the node-backed verification surface the staking screen uses
+// to confirm a pasted pool or DRep ID exists (consent law: the embedded node is
+// the only thing that touches the network). *chain.Client satisfies it.
+type PoolDRepLookup interface {
+	Pool(ctx context.Context, poolID string) (chain.PoolInfo, error)
+	DRep(ctx context.Context, drepID string) (chain.DRepInfo, error)
 }
 
 // Vault is the encrypted multi-wallet store the API drives. It owns the wallet
@@ -154,9 +166,11 @@ func toWalletView(w vault.WalletMeta, activeID string) walletView {
 // the embedded node runs on; wallet requests must match it (or omit it). vlt is
 // the encrypted multi-wallet store; the API pushes the active wallet onto wl/sp
 // whenever the selection changes. settings exposes user-facing app settings
-// (the lean-node profile). spa is the embedded SPA, registered as the catch-all
-// so the specific API routes take precedence on the mux.
-func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings SettingsController, network string, spa http.Handler, opts ...HandlerOption) http.Handler {
+// (the lean-node profile). lookup verifies pasted pool/DRep IDs through the
+// node (may be nil, in which case those endpoints report unavailable). spa is
+// the embedded SPA, registered as the catch-all so the specific API routes
+// take precedence on the mux.
+func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings SettingsController, lookup PoolDRepLookup, network string, spa http.Handler, opts ...HandlerOption) http.Handler {
 	cfg := handlerOptions{}
 	for _, opt := range opts {
 		opt(&cfg)
@@ -521,6 +535,49 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 		serve(w, v, err)
 	}))
 
+	// Staking & governance. Pool/DRep lookups verify a pasted ID through the node
+	// (gated like reads — they only need the node serving queries). Building a
+	// delegation tx and confirming it are gated like sends (a fully synced node),
+	// since they select UTxOs and submit.
+	mux.HandleFunc("GET /wallet/pool/{id}", gated(st, func(w http.ResponseWriter, r *http.Request) {
+		if lookup == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "pool lookup unavailable"})
+			return
+		}
+		info, err := lookup.Pool(r.Context(), r.PathValue("id"))
+		serveLookup(w, info, err)
+	}))
+	mux.HandleFunc("GET /wallet/drep/{id}", gated(st, func(w http.ResponseWriter, r *http.Request) {
+		if lookup == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "drep lookup unavailable"})
+			return
+		}
+		info, err := lookup.DRep(r.Context(), r.PathValue("id"))
+		serveLookup(w, info, err)
+	}))
+
+	mux.HandleFunc("POST /wallet/delegation", readyGate(st, func(w http.ResponseWriter, r *http.Request) {
+		var req spend.DelegationRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+			return
+		}
+		pv, err := sp.BuildDelegation(r.Context(), req)
+		serve(w, pv, err)
+	}))
+
+	mux.HandleFunc("POST /wallet/delegation/{id}/confirm", readyGate(st, func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Password string `json:"password"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+			return
+		}
+		res, err := sp.Confirm(r.Context(), r.PathValue("id"), req.Password)
+		serve(w, res, err)
+	}))
+
 	// SPA catch-all: the specific API routes above take precedence on the mux;
 	// everything else is served by the embedded frontend.
 	mux.Handle("/", spa)
@@ -553,6 +610,20 @@ func requirePassword(w http.ResponseWriter, password string) bool {
 		return false
 	}
 	return true
+}
+
+// serveLookup writes a pool/DRep lookup result, mapping the node's not-found to
+// 404 (so the screen can show "not found by your node" inline) and other errors
+// to 502 (the node query failed).
+func serveLookup[T any](w http.ResponseWriter, v T, err error) {
+	switch {
+	case err == nil:
+		writeJSON(w, http.StatusOK, v)
+	case errors.Is(err, chain.ErrNotFound):
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found by your node"})
+	default:
+		writeJSON(w, http.StatusBadGateway, errBody(err))
+	}
 }
 
 // resolveNetwork returns the effective network for a wallet request, defaulting
@@ -632,9 +703,11 @@ func serve[T any](w http.ResponseWriter, v T, err error) {
 		writeJSON(w, http.StatusNotFound, errBody(err)) // 404
 	case errors.Is(err, spend.ErrExpiredPending):
 		writeJSON(w, http.StatusGone, errBody(err)) // 410
-	case errors.Is(err, spend.ErrInsufficientFunds), errors.Is(err, spend.ErrSubmitRejected):
+	case errors.Is(err, spend.ErrInsufficientFunds), errors.Is(err, spend.ErrSubmitRejected),
+		errors.Is(err, spend.ErrNoChange):
 		// 422: the request was understood but cannot be fulfilled; the node's
-		// structured rejection reason (for submit) rides along in the message.
+		// structured rejection reason (for submit), the funding shortfall, or the
+		// "already in the requested state" note rides along in the message.
 		writeJSON(w, http.StatusUnprocessableEntity, errBody(err))
 	default:
 		writeJSON(w, http.StatusInternalServerError, errBody(err))

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -223,7 +223,7 @@ func (f *fakeSettings) SetHistoryExpiry(enabled bool) error {
 func (f *fakeSettings) HistoryExpiryRestartRequired() bool { return f.restartRequired }
 
 func TestHealthAlwaysOK(t *testing.T) {
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
 	if rec.Code != http.StatusOK {
@@ -233,7 +233,7 @@ func TestHealthAlwaysOK(t *testing.T) {
 
 func TestStatusReturnsSnapshot(t *testing.T) {
 	want := supervisor.Status{State: supervisor.StateSyncing, Tip: 42, CaughtUp: true}
-	h := NewHandler(fakeStatuser{s: want}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{s: want}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
 	if rec.Code != http.StatusOK {
@@ -302,7 +302,7 @@ func (f *fakeWallet) Delegation(_ context.Context) (wallet.DelegationView, error
 
 func TestVaultStatusReports(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: true, wallets: []vault.WalletMeta{{ID: "a"}, {ID: "b"}}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/status", nil))
 	if rec.Code != http.StatusOK {
@@ -323,7 +323,7 @@ func TestVaultStatusReports(t *testing.T) {
 func TestVaultStatusReportsLegacyKeystore(t *testing.T) {
 	fv := &fakeVault{exists: false, locked: true}
 	legacy := &fakeLegacyKeystore{exists: true}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/status", nil))
 	if rec.Code != http.StatusOK {
@@ -340,7 +340,7 @@ func TestVaultStatusReportsLegacyKeystore(t *testing.T) {
 
 func TestVaultCreateRequiresPassword(t *testing.T) {
 	fv := &fakeVault{}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"short"}`)))
 	if rec.Code != http.StatusBadRequest {
@@ -353,7 +353,7 @@ func TestVaultCreateRequiresPassword(t *testing.T) {
 
 func TestVaultCreateOK(t *testing.T) {
 	fv := &fakeVault{}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusOK {
@@ -366,7 +366,7 @@ func TestVaultCreateOK(t *testing.T) {
 
 func TestVaultCreateConflict(t *testing.T) {
 	fv := &fakeVault{createErr: vault.ErrVaultExists}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusConflict {
@@ -383,7 +383,7 @@ func TestVaultUnlockBindsSoleWalletAndReads(t *testing.T) {
 		wallets: []vault.WalletMeta{{ID: "w1", Name: "main", Network: "preview", Account: sampleAccount("preview")}},
 	}
 	fw := &fakeWallet{balance: wallet.Balance{Lovelace: "1234"}}
-	h := NewHandler(st, fv, fw, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, fw, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
@@ -410,7 +410,7 @@ func TestVaultUnlockBindsSoleWalletAndReads(t *testing.T) {
 
 func TestVaultUnlockWrongPassword(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: true, unlockErr: fmt.Errorf("%w: bad", vault.ErrWrongPassword)}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"wrong-but-long-pw"}`)))
 	if rec.Code != http.StatusUnauthorized {
@@ -422,7 +422,7 @@ func TestVaultLock(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false}
 	fw := &fakeWallet{set: true}
 	sp := &fakeSpender{set: true}
-	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/lock", nil))
 	if rec.Code != http.StatusOK {
@@ -441,7 +441,7 @@ func TestMigrateLegacyKeystoreImportsAndBinds(t *testing.T) {
 	fw := &fakeWallet{}
 	sp := &fakeSpender{}
 	legacy := &fakeLegacyKeystore{exists: true, mnemonic: []byte("abandon abandon about")}
-	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 
 	body := `{"name":"Imported","vault_password":"valid-vault-password","spend_password":"legacy-spend-password"}`
 	rec := httptest.NewRecorder()
@@ -480,7 +480,7 @@ func TestMigrateLegacyKeystoreImportsAndBinds(t *testing.T) {
 func TestMigrateLegacyKeystoreWrongPassword(t *testing.T) {
 	fv := &fakeVault{exists: false, locked: true}
 	legacy := &fakeLegacyKeystore{exists: true, err: keystore.ErrDecryptFailed}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 
 	body := `{"name":"Imported","vault_password":"valid-vault-password","spend_password":"wrong-password"}`
 	rec := httptest.NewRecorder()
@@ -496,7 +496,7 @@ func TestMigrateLegacyKeystoreWrongPassword(t *testing.T) {
 func TestMigrateLegacyKeystoreRequiresSpendPasswordMinLength(t *testing.T) {
 	fv := &fakeVault{exists: false, locked: true}
 	legacy := &fakeLegacyKeystore{exists: true, mnemonic: []byte("abandon abandon about")}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 
 	body := `{"name":"Imported","vault_password":"valid-vault-password","spend_password":"short"}`
 	rec := httptest.NewRecorder()
@@ -519,7 +519,7 @@ func TestAddWalletEnablesReadsAndSpend(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false}
 	fw := &fakeWallet{balance: wallet.Balance{Lovelace: "1234"}}
 	sp := &fakeSpender{}
-	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
@@ -548,7 +548,7 @@ func TestAddWalletRequiresSpendPassword(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
 	sp := &fakeSpender{}
-	h := NewHandler(st, fv, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","vault_password":"valid-vault-password","spend_password":"short"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -563,7 +563,7 @@ func TestAddWalletRequiresSpendPassword(t *testing.T) {
 func TestAddWalletRequiresVaultPassword(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -575,7 +575,7 @@ func TestAddWalletRequiresVaultPassword(t *testing.T) {
 func TestAddWalletNetworkMismatch(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"mainnet","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -587,7 +587,7 @@ func TestAddWalletNetworkMismatch(t *testing.T) {
 func TestAddWalletDefaultNetworkIsNodeNetwork(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preprod", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preprod", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -602,7 +602,7 @@ func TestAddWalletDefaultNetworkIsNodeNetwork(t *testing.T) {
 func TestAddWalletDuplicateConflict(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false, addErr: vault.ErrDuplicateWallet}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -622,7 +622,7 @@ func TestActivateWalletBinds(t *testing.T) {
 	}
 	fw := &fakeWallet{}
 	sp := &fakeSpender{}
-	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/w2/activate", nil))
 	if rec.Code != http.StatusOK {
@@ -645,7 +645,7 @@ func TestActivateWalletBinds(t *testing.T) {
 
 func TestActivateUnknownWallet(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/nope/activate", nil))
 	if rec.Code != http.StatusNotFound {
@@ -655,7 +655,7 @@ func TestActivateUnknownWallet(t *testing.T) {
 
 func TestDeleteWalletRequiresVaultPassword(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false, wallets: []vault.WalletMeta{{ID: "w1"}}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/wallet/w1", bytes.NewBufferString(`{}`)))
 	if rec.Code != http.StatusBadRequest {
@@ -670,7 +670,7 @@ func TestDeleteWalletOK(t *testing.T) {
 	}
 	fw := &fakeWallet{set: true}
 	sp := &fakeSpender{set: true}
-	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/wallet/w1", bytes.NewBufferString(`{"vault_password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusOK {
@@ -688,7 +688,7 @@ func TestDeleteWalletOK(t *testing.T) {
 
 func TestWalletGatedWhileStarting(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/balance", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -699,7 +699,7 @@ func TestWalletGatedWhileStarting(t *testing.T) {
 func TestWalletGatedWhileBootstrapping(t *testing.T) {
 	// Mithril bootstrap is not a servable state: reads must be gated (503).
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateBootstrapping}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/balance", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -712,7 +712,7 @@ func TestWalletNoActiveWalletConflict(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	for _, path := range []string{"/wallet/balance", "/wallet/addresses", "/wallet/transactions", "/wallet/delegation"} {
 		t.Run(path, func(t *testing.T) {
-			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
 			if rec.Code != http.StatusConflict {
@@ -832,10 +832,17 @@ func (f *fakeSpender) SubmitSigned(_ context.Context, unsignedTxCBOR, witnessCBO
 	return f.submitResult, nil
 }
 
+func (f *fakeSpender) BuildDelegation(_ context.Context, _ spend.DelegationRequest) (spend.DelegationPreview, error) {
+	if f.buildErr != nil {
+		return spend.DelegationPreview{}, f.buildErr
+	}
+	return spend.DelegationPreview{}, nil
+}
+
 func TestSignDataReturnsSignature(t *testing.T) {
 	// Ungated: message signing needs no synced node, only the keystore.
 	sp := &fakeSpender{signSig: "84a1deadbeef", signKey: "a4010103"}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"address":"addr_test1xyz","message":"hello","password":"pw"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-data", body))
@@ -852,7 +859,7 @@ func TestSignDataReturnsSignature(t *testing.T) {
 
 func TestSignDataWrongPasswordReturns401(t *testing.T) {
 	sp := &fakeSpender{signErr: fmt.Errorf("%w: bad", spend.ErrWrongPassword)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"address":"a","message":"m","password":"bad"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-data", body))
@@ -864,7 +871,7 @@ func TestSignDataWrongPasswordReturns401(t *testing.T) {
 func TestVerifyDataReturnsResult(t *testing.T) {
 	// Ungated: verification is pure crypto, needs no node and no keystore.
 	sp := &fakeSpender{verifyValid: true, verifyAddr: "addr_test1signed"}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"signature":"84a1","key":"a401","message":"hi","hashed":true,"expected_address":"addr_test1signed"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/verify-data", body))
@@ -886,7 +893,7 @@ func TestVerifyDataReturnsResult(t *testing.T) {
 
 func TestVerifyDataInvalidArgsReturns400(t *testing.T) {
 	sp := &fakeSpender{verifyErr: fmt.Errorf("%w: bad hex", spend.ErrInvalidRequest)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"signature":"zz","key":"a4","message":"hi"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/verify-data", body))
@@ -897,7 +904,7 @@ func TestVerifyDataInvalidArgsReturns400(t *testing.T) {
 
 func TestExportUnsignedRequiresReady(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend1/export-unsigned", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -911,7 +918,7 @@ func TestExportUnsignedReturnsTx(t *testing.T) {
 		UnsignedTxCBOR:  "84a400",
 		RequiredSigners: []string{"deadbeef"},
 	}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend1/export-unsigned", nil))
 	if rec.Code != http.StatusOK {
@@ -929,7 +936,7 @@ func TestSignTxUngated(t *testing.T) {
 	// Offline signing must not need a synced node -- only the keystore.
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
 	sp := &fakeSpender{witness: spend.Witness{WitnessCBOR: "81825820"}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","password":"pw","required_signers":["deadbeef"]}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-tx", body))
@@ -949,7 +956,7 @@ func TestSignTxUngated(t *testing.T) {
 
 func TestSignTxWrongPasswordReturns401(t *testing.T) {
 	sp := &fakeSpender{signTxErr: fmt.Errorf("%w: bad", spend.ErrWrongPassword)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","password":"bad","required_signers":["deadbeef"]}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-tx", body))
@@ -960,7 +967,7 @@ func TestSignTxWrongPasswordReturns401(t *testing.T) {
 
 func TestSignTxInvalidTxReturns400(t *testing.T) {
 	sp := &fakeSpender{signTxErr: fmt.Errorf("%w: bad cbor", spend.ErrInvalidTx)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"zz","password":"pw","required_signers":["deadbeef"]}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-tx", body))
@@ -971,7 +978,7 @@ func TestSignTxInvalidTxReturns400(t *testing.T) {
 
 func TestSubmitSignedRequiresReady(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witness_cbor":"81"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-signed", body))
@@ -983,7 +990,7 @@ func TestSubmitSignedRequiresReady(t *testing.T) {
 func TestSubmitSignedReturnsTxHash(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{submitResult: spend.TxResult{TxHash: "cafebabe"}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witness_cbor":"81825820"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-signed", body))
@@ -1001,7 +1008,7 @@ func TestSubmitSignedReturnsTxHash(t *testing.T) {
 func TestSubmitSignedInvalidWitnessReturns400(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{submitErr: fmt.Errorf("%w: bad cbor", spend.ErrInvalidWitness)}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witness_cbor":"zz"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-signed", body))
@@ -1013,7 +1020,7 @@ func TestSubmitSignedInvalidWitnessReturns400(t *testing.T) {
 func TestSpendSendReadyReturnsPreview(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{preview: spend.Preview{PendingID: "pend123", Fee: "170000"}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send", body))
@@ -1032,7 +1039,7 @@ func TestSpendSendReadyReturnsPreview(t *testing.T) {
 func TestSpendSendGatedWhileSyncing(t *testing.T) {
 	// Spending requires a fully synced node (StateReady), unlike reads.
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send", body))
@@ -1044,7 +1051,7 @@ func TestSpendSendGatedWhileSyncing(t *testing.T) {
 func TestSpendSendNoWalletConflict(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{buildErr: spend.ErrNoWallet}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send", body))
@@ -1056,7 +1063,7 @@ func TestSpendSendNoWalletConflict(t *testing.T) {
 func TestSpendConfirmReadyReturnsTxHash(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{result: spend.TxResult{TxHash: "deadbeef"}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-spend-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend123/confirm", body))
@@ -1077,7 +1084,7 @@ func TestSpendConfirmReadyReturnsTxHash(t *testing.T) {
 
 func TestSpendConfirmGatedWhileSyncing(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-spend-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend123/confirm", body))
@@ -1117,7 +1124,7 @@ func TestSpendErrorStatusCodes(t *testing.T) {
 				req = httptest.NewRequest(http.MethodPost, "/wallet/send",
 					bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`))
 			}
-			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, "preview", http.NotFoundHandler())
+			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
 			if rec.Code != tc.wantCode {
@@ -1159,7 +1166,7 @@ func TestGetHistoryExpiryReturnsState(t *testing.T) {
 	// node query).
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStopped}}
 	set := &fakeSettings{enabled: true, restartRequired: true}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/settings/history-expiry", nil))
 	if rec.Code != http.StatusOK {
@@ -1174,7 +1181,7 @@ func TestGetHistoryExpiryReturnsState(t *testing.T) {
 func TestGetHistoryExpiryDefaultOff(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{} // default off, no restart needed
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/settings/history-expiry", nil))
 	got := decodeHistoryExpiry(t, rec.Body)
@@ -1187,7 +1194,7 @@ func TestPutHistoryExpiryPersistsAndSignalsRestart(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	// Running node was built with off; flipping to on must signal a restart.
 	set := &fakeSettings{enabled: false, restartRequired: true}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"enabled":true}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
@@ -1209,7 +1216,7 @@ func TestPutHistoryExpiryPersistsAndSignalsRestart(t *testing.T) {
 func TestPutHistoryExpiryInvalidJSON(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{not json`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
@@ -1226,7 +1233,7 @@ func TestPutHistoryExpiryRequiresExplicitEnabled(t *testing.T) {
 		t.Run(bodyJSON, func(t *testing.T) {
 			st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 			set := &fakeSettings{}
-			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, "preview", http.NotFoundHandler())
+			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, "preview", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
 			body := bytes.NewBufferString(bodyJSON)
 			h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
@@ -1243,7 +1250,7 @@ func TestPutHistoryExpiryRequiresExplicitEnabled(t *testing.T) {
 func TestPutHistoryExpiryPersistError(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{setErr: errors.New("disk full")}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"enabled":true}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))

--- a/ui/internal/chain/blockfrost.go
+++ b/ui/internal/chain/blockfrost.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -34,6 +35,11 @@ type Client struct {
 	BaseURL      string
 	http         *http.Client
 	dingoDataDir string
+
+	poolMu            sync.Mutex
+	poolCache         map[string]PoolInfo
+	poolCacheComplete bool
+	poolCacheUntil    time.Time
 }
 
 type ClientOption func(*Client)
@@ -187,6 +193,8 @@ func (c *Client) get(ctx context.Context, path string, out any) error {
 const pageSize = 100
 
 const maxPages = 1000
+
+const poolCacheTTL = time.Minute
 
 // getAllPages fetches every page of a list endpoint. The node caps pages at
 // pageSize rows; a page with fewer rows is the last one.
@@ -398,20 +406,69 @@ func (c *Client) ProtocolParams(ctx context.Context) (ProtocolParams, error) {
 
 // Pool returns the on-chain parameters for poolID. dingo has no per-pool lookup
 // endpoint; it exposes pools only via the paginated GET /api/v0/pools/extended
-// list, so Pool walks that list and returns the matching entry. A pool the node
-// has not seen yields ErrNotFound — the wallet treats that as "not found by your
-// node" and refuses to delegate.
+// list, so Pool scans pages until it finds the requested entry and keeps a
+// short-lived index for repeated UI/build verification. A pool the node has not
+// seen yields ErrNotFound — the wallet treats that as "not found by your node"
+// and refuses to delegate.
 func (c *Client) Pool(ctx context.Context, poolID string) (PoolInfo, error) {
-	pools, err := getAllPages[PoolInfo](ctx, c, "/api/v0/pools/extended")
-	if err != nil {
-		return PoolInfo{}, err
+	if pool, found, complete := c.cachedPool(poolID); found || complete {
+		if found {
+			return pool, nil
+		}
+		return PoolInfo{}, ErrNotFound
 	}
-	for _, p := range pools {
-		if p.PoolID == poolID {
-			return p, nil
+
+	for page := 1; page <= maxPages; page++ {
+		var rows []PoolInfo
+		paged := fmt.Sprintf("/api/v0/pools/extended?count=%d&page=%d", pageSize, page)
+		if err := c.get(ctx, paged, &rows); err != nil {
+			return PoolInfo{}, err
+		}
+		complete := len(rows) < pageSize
+		c.cachePools(rows, complete)
+		for _, p := range rows {
+			if p.PoolID == poolID {
+				return p, nil
+			}
+		}
+		if complete {
+			return PoolInfo{}, ErrNotFound
 		}
 	}
-	return PoolInfo{}, ErrNotFound
+	return PoolInfo{}, fmt.Errorf("%w: /api/v0/pools/extended exceeded %d pages", errPageLimitExceeded, maxPages)
+}
+
+func (c *Client) cachedPool(poolID string) (PoolInfo, bool, bool) {
+	c.poolMu.Lock()
+	defer c.poolMu.Unlock()
+	if c.poolCache == nil || time.Now().After(c.poolCacheUntil) {
+		c.poolCache = nil
+		c.poolCacheComplete = false
+		c.poolCacheUntil = time.Time{}
+		return PoolInfo{}, false, false
+	}
+	pool, found := c.poolCache[poolID]
+	return pool, found, c.poolCacheComplete
+}
+
+func (c *Client) cachePools(pools []PoolInfo, complete bool) {
+	now := time.Now()
+	c.poolMu.Lock()
+	defer c.poolMu.Unlock()
+	if c.poolCache == nil || now.After(c.poolCacheUntil) {
+		c.poolCache = make(map[string]PoolInfo)
+		c.poolCacheComplete = false
+		c.poolCacheUntil = now.Add(poolCacheTTL)
+	}
+	for _, p := range pools {
+		if p.PoolID == "" {
+			continue
+		}
+		c.poolCache[p.PoolID] = p
+	}
+	if complete {
+		c.poolCacheComplete = true
+	}
 }
 
 // DRep confirms a delegated representative exists on chain and returns its

--- a/ui/internal/chain/blockfrost.go
+++ b/ui/internal/chain/blockfrost.go
@@ -1,16 +1,25 @@
-// Package chain is a typed client for the embedded Dingo node's loopback
-// Blockfrost REST API. It is the wallet's only data source and never contacts
-// any external service — only http://127.0.0.1:<port>.
+// Package chain reads state from the embedded Dingo node. It primarily uses
+// the node's loopback Blockfrost REST API and may enrich fields from Dingo's
+// local metadata DB when the compatibility API omits them. It never contacts
+// any external service.
 package chain
 
 import (
 	"context"
+	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
 	"time"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	_ "github.com/glebarez/go-sqlite"
 )
 
 // ErrNotFound is returned when the node reports the queried resource does not
@@ -22,29 +31,46 @@ var errPageLimitExceeded = errors.New("chain: pagination limit exceeded")
 
 // Client talks to a Blockfrost-compatible API at BaseURL (the local node).
 type Client struct {
-	BaseURL string
-	http    *http.Client
+	BaseURL      string
+	http         *http.Client
+	dingoDataDir string
+}
+
+type ClientOption func(*Client)
+
+// WithDingoDataDir enables read-only local metadata lookups for chain state
+// that the embedded Blockfrost compatibility API does not expose.
+func WithDingoDataDir(dir string) ClientOption {
+	return func(c *Client) {
+		c.dingoDataDir = dir
+	}
 }
 
 // NewClient builds a client for the node's loopback Blockfrost port.
-func NewClient(port uint) *Client {
-	return NewClientURL(fmt.Sprintf("http://127.0.0.1:%d", port))
+func NewClient(port uint, opts ...ClientOption) *Client {
+	return NewClientURL(fmt.Sprintf("http://127.0.0.1:%d", port), opts...)
 }
 
 // NewClientURL builds a client for an explicit base URL (used in tests).
-func NewClientURL(baseURL string) *Client {
-	return &Client{BaseURL: baseURL, http: &http.Client{Timeout: 10 * time.Second}}
+func NewClientURL(baseURL string, opts ...ClientOption) *Client {
+	c := &Client{BaseURL: baseURL, http: &http.Client{Timeout: 10 * time.Second}}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 // AccountInfo mirrors GET /api/v0/accounts/{stake_address}.
 type AccountInfo struct {
 	StakeAddress       string  `json:"stake_address"`
 	Active             bool    `json:"active"`
+	Registered         bool    `json:"registered"`
 	ActiveEpoch        *int64  `json:"active_epoch"`
 	ControlledAmount   string  `json:"controlled_amount"`
 	RewardsSum         string  `json:"rewards_sum"`
 	WithdrawableAmount string  `json:"withdrawable_amount"`
 	PoolID             *string `json:"pool_id"`
+	DRepID             *string `json:"drep_id"`
 }
 
 // Amount is one asset entry in a UTxO (unit "lovelace" or policy+hexname).
@@ -83,6 +109,48 @@ type Reward struct {
 	Epoch  int32  `json:"epoch"`
 	Amount string `json:"amount"`
 	PoolID string `json:"pool_id"`
+}
+
+// PoolInfo describes a stake pool's on-chain parameters, as the wallet needs
+// them to present a verified pool readout before delegation. dingo exposes pools
+// only through the paginated GET /api/v0/pools/extended list (there is no
+// per-pool lookup), so Pool fetches that list and filters by ID; the fields
+// mirror one PoolExtendedResponse entry (margin_cost, declared_pledge,
+// fixed_cost, live_stake, active_stake).
+type PoolInfo struct {
+	PoolID         string  `json:"pool_id"`
+	Hex            string  `json:"hex"`
+	VrfKey         string  `json:"vrf_key"`
+	ActiveStake    string  `json:"active_stake"`
+	LiveStake      string  `json:"live_stake"`
+	DeclaredPledge string  `json:"declared_pledge"`
+	FixedCost      string  `json:"fixed_cost"`
+	MarginCost     float64 `json:"margin_cost"`
+}
+
+// ProtocolParams holds the protocol parameters the wallet needs for delegation:
+// the refundable deposits for stake-key registration (key_deposit) and DRep
+// registration (drep_deposit). It mirrors the subset of dingo's
+// GET /api/v0/epochs/latest/parameters that this feature uses; key_deposit and
+// pool_deposit are always present, drep_deposit is null in pre-Conway eras.
+type ProtocolParams struct {
+	KeyDeposit  string  `json:"key_deposit"`
+	PoolDeposit string  `json:"pool_deposit"`
+	DRepDeposit *string `json:"drep_deposit"`
+}
+
+// DRepInfo describes a delegated representative as returned by
+// GET /api/v0/governance/dreps/{drep_id}. It confirms the DRep exists on chain
+// (the node 404s an unknown DRep, surfaced as ErrNotFound) and reports whether
+// it is currently registered/active.
+type DRepInfo struct {
+	DRepID     string `json:"drep_id"`
+	Hex        string `json:"hex"`
+	HasScript  bool   `json:"has_script"`
+	Registered bool   `json:"registered"`
+	Amount     string `json:"amount"`
+	Active     bool   `json:"active"`
+	LiveStake  string `json:"live_stake"`
 }
 
 type accountAddress struct {
@@ -151,6 +219,146 @@ func (c *Client) Account(ctx context.Context, stakeAddr string) (AccountInfo, er
 	return out, err
 }
 
+const (
+	dingoDRepTypeAddrKeyHash      = 0
+	dingoDRepTypeScriptHash       = 1
+	dingoDRepTypeAlwaysAbstain    = 2
+	dingoDRepTypeNoConfidence     = 3
+	dingoAccountCredentialKeyHash = 0
+	dingoAccountCredentialScript  = 1
+)
+
+// AccountDRepID reads the account's current vote delegation from Dingo's local
+// metadata DB. Dingo v0.58 does not include drep_id in its Blockfrost-compatible
+// account response, but it persists the value in account.drep/account.drep_type.
+func (c *Client) AccountDRepID(ctx context.Context, stakeAddr string) (*string, error) {
+	if c.dingoDataDir == "" {
+		return nil, nil
+	}
+	metadataPath := filepath.Join(c.dingoDataDir, "metadata.sqlite")
+	if _, err := os.Stat(metadataPath); errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("account drep metadata: %w", err)
+	}
+	credentialTag, stakingKey, err := stakeCredential(stakeAddr)
+	if err != nil {
+		return nil, err
+	}
+	db, err := sql.Open("sqlite", sqliteReadOnlyDSN(metadataPath))
+	if err != nil {
+		return nil, fmt.Errorf("open account drep metadata: %w", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	var drep nullableBytes
+	var drepType sql.NullInt64
+	err = db.QueryRowContext(
+		ctx,
+		`SELECT drep, drep_type FROM account WHERE credential_tag = ? AND staking_key = ? AND active = 1`,
+		credentialTag,
+		stakingKey,
+	).Scan(&drep, &drepType)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query account drep metadata: %w", err)
+	}
+	if !drepType.Valid {
+		return nil, nil
+	}
+	if drepType.Int64 < 0 {
+		return nil, fmt.Errorf("account drep metadata: unknown drep_type %d", drepType.Int64)
+	}
+	id, ok, err := dingoDRepID(drep.Bytes, uint64(drepType.Int64))
+	if err != nil || !ok {
+		return nil, err
+	}
+	return &id, nil
+}
+
+func sqliteReadOnlyDSN(path string) string {
+	u := url.URL{Scheme: "file", Path: path}
+	q := u.Query()
+	q.Set("mode", "ro")
+	q.Add("_pragma", "busy_timeout(30000)")
+	q.Add("_pragma", "foreign_keys(1)")
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func stakeCredential(stakeAddr string) (uint8, []byte, error) {
+	addr, err := lcommon.NewAddress(stakeAddr)
+	if err != nil {
+		return 0, nil, fmt.Errorf("parse stake address: %w", err)
+	}
+	hash := addr.StakeKeyHash()
+	if hash == lcommon.NewBlake2b224(nil) {
+		return 0, nil, errors.New("parse stake address: no stake credential")
+	}
+	var credentialTag uint8
+	switch addr.StakingPayload().(type) {
+	case lcommon.AddressPayloadKeyHash:
+		credentialTag = dingoAccountCredentialKeyHash
+	case lcommon.AddressPayloadScriptHash:
+		credentialTag = dingoAccountCredentialScript
+	default:
+		return 0, nil, errors.New("parse stake address: unsupported stake credential")
+	}
+	return credentialTag, hash.Bytes(), nil
+}
+
+func dingoDRepID(drep []byte, drepType uint64) (string, bool, error) {
+	switch drepType {
+	case dingoDRepTypeAddrKeyHash:
+		if len(drep) == 0 {
+			return "", false, nil
+		}
+		if len(drep) != lcommon.AddressHashSize {
+			return "", false, fmt.Errorf("account drep metadata: key hash has %d bytes", len(drep))
+		}
+		return "drep-keyHash-" + hex.EncodeToString(drep), true, nil
+	case dingoDRepTypeScriptHash:
+		if len(drep) == 0 {
+			return "", false, nil
+		}
+		if len(drep) != lcommon.AddressHashSize {
+			return "", false, fmt.Errorf("account drep metadata: script hash has %d bytes", len(drep))
+		}
+		return "drep-scriptHash-" + hex.EncodeToString(drep), true, nil
+	case dingoDRepTypeAlwaysAbstain:
+		return "drep_abstain", true, nil
+	case dingoDRepTypeNoConfidence:
+		return "drep_no_confidence", true, nil
+	default:
+		return "", false, fmt.Errorf("account drep metadata: unknown drep_type %d", drepType)
+	}
+}
+
+type nullableBytes struct {
+	Bytes []byte
+}
+
+func (n *nullableBytes) Scan(value any) error {
+	if value == nil {
+		n.Bytes = nil
+		return nil
+	}
+	switch v := value.(type) {
+	case []byte:
+		n.Bytes = append(n.Bytes[:0], v...)
+		return nil
+	case string:
+		n.Bytes = append(n.Bytes[:0], v...)
+		return nil
+	default:
+		return fmt.Errorf("cannot scan %T into nullableBytes", value)
+	}
+}
+
 func (c *Client) AccountAddresses(ctx context.Context, stakeAddr string) ([]string, error) {
 	rows, err := getAllPages[accountAddress](ctx, c, "/api/v0/accounts/"+stakeAddr+"/addresses")
 	if err != nil {
@@ -177,4 +385,43 @@ func (c *Client) AccountDelegations(ctx context.Context, stakeAddr string) ([]De
 
 func (c *Client) AccountRewards(ctx context.Context, stakeAddr string) ([]Reward, error) {
 	return getAllPages[Reward](ctx, c, "/api/v0/accounts/"+stakeAddr+"/rewards")
+}
+
+// ProtocolParams returns the current protocol parameters subset the wallet needs
+// for delegation (the refundable deposits). Backed by
+// GET /api/v0/epochs/latest/parameters.
+func (c *Client) ProtocolParams(ctx context.Context) (ProtocolParams, error) {
+	var out ProtocolParams
+	err := c.get(ctx, "/api/v0/epochs/latest/parameters", &out)
+	return out, err
+}
+
+// Pool returns the on-chain parameters for poolID. dingo has no per-pool lookup
+// endpoint; it exposes pools only via the paginated GET /api/v0/pools/extended
+// list, so Pool walks that list and returns the matching entry. A pool the node
+// has not seen yields ErrNotFound — the wallet treats that as "not found by your
+// node" and refuses to delegate.
+func (c *Client) Pool(ctx context.Context, poolID string) (PoolInfo, error) {
+	pools, err := getAllPages[PoolInfo](ctx, c, "/api/v0/pools/extended")
+	if err != nil {
+		return PoolInfo{}, err
+	}
+	for _, p := range pools {
+		if p.PoolID == poolID {
+			return p, nil
+		}
+	}
+	return PoolInfo{}, ErrNotFound
+}
+
+// DRep confirms a delegated representative exists on chain and returns its
+// registration state. Backed by GET /api/v0/governance/dreps/{drep_id}; an
+// unknown DRep yields ErrNotFound. drepID is the bech32 drep1… identifier (the
+// node also accepts the predefined "drep_always_abstain" /
+// "drep_always_no_confidence" forms, but those are never queried — they have no
+// on-chain registration).
+func (c *Client) DRep(ctx context.Context, drepID string) (DRepInfo, error) {
+	var out DRepInfo
+	err := c.get(ctx, "/api/v0/governance/dreps/"+url.PathEscape(drepID), &out)
+	return out, err
 }

--- a/ui/internal/chain/blockfrost_test.go
+++ b/ui/internal/chain/blockfrost_test.go
@@ -2,12 +2,16 @@ package chain
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
 const blockfrostNotFoundJSON = `{"status_code":404,"error":"Not Found","message":"The requested component has not been found."}`
@@ -28,14 +32,86 @@ func TestAccount(t *testing.T) {
 			t.Errorf("path = %q", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"stake_address":"stake_test1xyz","active":true,"active_epoch":42,"controlled_amount":"1500000","rewards_sum":"2000","withdrawals_sum":"0","reserves_sum":"0","treasury_sum":"0","withdrawable_amount":"2000","pool_id":"pool1abc"}`))
+		_, _ = w.Write([]byte(`{"stake_address":"stake_test1xyz","active":true,"registered":true,"active_epoch":42,"controlled_amount":"1500000","rewards_sum":"2000","withdrawals_sum":"0","reserves_sum":"0","treasury_sum":"0","withdrawable_amount":"2000","pool_id":"pool1abc"}`))
 	})
 	got, err := c.Account(context.Background(), "stake_test1xyz")
 	if err != nil {
 		t.Fatalf("Account: %v", err)
 	}
-	if got.ControlledAmount != "1500000" || got.PoolID == nil || *got.PoolID != "pool1abc" || !got.Active {
+	if got.ControlledAmount != "1500000" || got.PoolID == nil || *got.PoolID != "pool1abc" || got.DRepID != nil || !got.Active || !got.Registered {
 		t.Fatalf("unexpected account: %+v", got)
+	}
+}
+
+func TestAccountDRepIDFromDingoMetadata(t *testing.T) {
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite", filepath.Join(dir, "metadata.sqlite"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	_, err = db.Exec(`CREATE TABLE account (
+		credential_tag integer NOT NULL,
+		staking_key blob NOT NULL,
+		drep blob,
+		drep_type integer,
+		active boolean NOT NULL
+	)`)
+	if err != nil {
+		t.Fatalf("create account table: %v", err)
+	}
+	stakingKey := make([]byte, lcommon.AddressHashSize)
+	for i := range stakingKey {
+		stakingKey[i] = byte(i + 1)
+	}
+	stakeAddr, err := lcommon.NewAddressFromParts(lcommon.AddressTypeNoneKey, lcommon.AddressNetworkTestnet, nil, stakingKey)
+	if err != nil {
+		t.Fatalf("stake address: %v", err)
+	}
+	_, err = db.Exec(
+		`INSERT INTO account (credential_tag, staking_key, drep, drep_type, active) VALUES (?, ?, NULL, ?, 1)`,
+		dingoAccountCredentialKeyHash,
+		stakingKey,
+		dingoDRepTypeAlwaysAbstain,
+	)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+
+	c := NewClientURL("http://127.0.0.1:1", WithDingoDataDir(dir))
+	got, err := c.AccountDRepID(context.Background(), stakeAddr.String())
+	if err != nil {
+		t.Fatalf("AccountDRepID: %v", err)
+	}
+	if got == nil || *got != "drep_abstain" {
+		t.Fatalf("AccountDRepID = %v, want drep_abstain", got)
+	}
+}
+
+func TestDingoDRepID(t *testing.T) {
+	hash := make([]byte, lcommon.AddressHashSize)
+	for i := range hash {
+		hash[i] = 0xaa
+	}
+	got, ok, err := dingoDRepID(hash, dingoDRepTypeAddrKeyHash)
+	if err != nil || !ok || !strings.HasPrefix(got, "drep-keyHash-") {
+		t.Fatalf("key hash drep = %q, ok=%v, err=%v", got, ok, err)
+	}
+	got, ok, err = dingoDRepID(hash, dingoDRepTypeScriptHash)
+	if err != nil || !ok || !strings.HasPrefix(got, "drep-scriptHash-") {
+		t.Fatalf("script hash drep = %q, ok=%v, err=%v", got, ok, err)
+	}
+	got, ok, err = dingoDRepID(nil, dingoDRepTypeAlwaysAbstain)
+	if err != nil || !ok || got != "drep_abstain" {
+		t.Fatalf("abstain drep = %q, ok=%v, err=%v", got, ok, err)
+	}
+	got, ok, err = dingoDRepID(nil, dingoDRepTypeNoConfidence)
+	if err != nil || !ok || got != "drep_no_confidence" {
+		t.Fatalf("no-confidence drep = %q, ok=%v, err=%v", got, ok, err)
+	}
+	got, ok, err = dingoDRepID(nil, dingoDRepTypeAddrKeyHash)
+	if err != nil || ok || got != "" {
+		t.Fatalf("nil key drep = %q, ok=%v, err=%v", got, ok, err)
 	}
 }
 
@@ -235,6 +311,111 @@ func TestAccountRewardsNotFound(t *testing.T) {
 		_, _ = w.Write([]byte(blockfrostNotFoundJSON))
 	})
 	_, err := c.AccountRewards(context.Background(), "stake_test1missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("404 should map to ErrNotFound, got %v", err)
+	}
+}
+
+func TestProtocolParams(t *testing.T) {
+	drepDeposit := "500000000"
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/epochs/latest/parameters" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"key_deposit":"2000000","pool_deposit":"500000000","drep_deposit":"500000000"}`))
+	})
+	got, err := c.ProtocolParams(context.Background())
+	if err != nil {
+		t.Fatalf("ProtocolParams: %v", err)
+	}
+	if got.KeyDeposit != "2000000" || got.PoolDeposit != "500000000" {
+		t.Fatalf("unexpected params: %+v", got)
+	}
+	if got.DRepDeposit == nil || *got.DRepDeposit != drepDeposit {
+		t.Fatalf("drep_deposit = %v, want %q", got.DRepDeposit, drepDeposit)
+	}
+}
+
+func TestProtocolParamsPreConwayDRepDepositNull(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"key_deposit":"2000000","pool_deposit":"500000000","drep_deposit":null}`))
+	})
+	got, err := c.ProtocolParams(context.Background())
+	if err != nil {
+		t.Fatalf("ProtocolParams: %v", err)
+	}
+	if got.DRepDeposit != nil {
+		t.Fatalf("drep_deposit = %v, want nil", got.DRepDeposit)
+	}
+}
+
+func TestPoolFiltersExtendedList(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/pools/extended" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"pool_id":"pool1aaa","hex":"aa","margin_cost":0.05,"declared_pledge":"100000000","fixed_cost":"340000000","live_stake":"5000000000","active_stake":"4800000000"},
+			{"pool_id":"pool1bbb","hex":"bb","margin_cost":0.02,"declared_pledge":"200000000","fixed_cost":"170000000","live_stake":"9000000000","active_stake":"8800000000"}
+		]`))
+	})
+	got, err := c.Pool(context.Background(), "pool1bbb")
+	if err != nil {
+		t.Fatalf("Pool: %v", err)
+	}
+	if got.PoolID != "pool1bbb" || got.MarginCost != 0.02 || got.FixedCost != "170000000" || got.DeclaredPledge != "200000000" {
+		t.Fatalf("unexpected pool: %+v", got)
+	}
+}
+
+func TestPoolNotInList(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[{"pool_id":"pool1aaa"}]`))
+	})
+	_, err := c.Pool(context.Background(), "pool1missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("a pool not in the list should map to ErrNotFound, got %v", err)
+	}
+}
+
+func TestDRep(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/governance/dreps/drep1abc" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"drep_id":"drep1abc","hex":"abc","has_script":false,"registered":true,"amount":"123","active":true,"live_stake":"123"}`))
+	})
+	got, err := c.DRep(context.Background(), "drep1abc")
+	if err != nil {
+		t.Fatalf("DRep: %v", err)
+	}
+	if got.DRepID != "drep1abc" || !got.Registered || !got.Active {
+		t.Fatalf("unexpected drep: %+v", got)
+	}
+}
+
+func TestDRepNotFound(t *testing.T) {
+	t.Parallel()
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v0/governance/dreps/drep1missing" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(blockfrostNotFoundJSON))
+	})
+	_, err := c.DRep(context.Background(), "drep1missing")
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("404 should map to ErrNotFound, got %v", err)
 	}

--- a/ui/internal/chain/blockfrost_test.go
+++ b/ui/internal/chain/blockfrost_test.go
@@ -3,6 +3,7 @@ package chain
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -373,6 +374,63 @@ func TestPoolFiltersExtendedList(t *testing.T) {
 	}
 	if got.PoolID != "pool1bbb" || got.MarginCost != 0.02 || got.FixedCost != "170000000" || got.DeclaredPledge != "200000000" {
 		t.Fatalf("unexpected pool: %+v", got)
+	}
+}
+
+func TestPoolStopsWhenMatchFoundBeforeLastPage(t *testing.T) {
+	calls := 0
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.URL.Path != "/api/v0/pools/extended" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if page := r.URL.Query().Get("page"); page != "1" {
+			t.Fatalf("requested page %q after match was on page 1", page)
+		}
+		rows := make([]PoolInfo, pageSize)
+		for i := range rows {
+			rows[i] = PoolInfo{PoolID: fmt.Sprintf("pool1%03d", i)}
+		}
+		rows[7] = PoolInfo{PoolID: "pool1target", FixedCost: "340000000"}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(rows); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	})
+	got, err := c.Pool(context.Background(), "pool1target")
+	if err != nil {
+		t.Fatalf("Pool: %v", err)
+	}
+	if got.PoolID != "pool1target" || got.FixedCost != "340000000" {
+		t.Fatalf("unexpected pool: %+v", got)
+	}
+	if calls != 1 {
+		t.Fatalf("requests = %d, want 1", calls)
+	}
+}
+
+func TestPoolUsesCachedCompleteList(t *testing.T) {
+	calls := 0
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"pool_id":"pool1aaa","fixed_cost":"340000000"},
+			{"pool_id":"pool1bbb","fixed_cost":"170000000"}
+		]`))
+	})
+	if _, err := c.Pool(context.Background(), "pool1bbb"); err != nil {
+		t.Fatalf("Pool first lookup: %v", err)
+	}
+	got, err := c.Pool(context.Background(), "pool1aaa")
+	if err != nil {
+		t.Fatalf("Pool cached lookup: %v", err)
+	}
+	if got.FixedCost != "340000000" {
+		t.Fatalf("unexpected cached pool: %+v", got)
+	}
+	if calls != 1 {
+		t.Fatalf("requests = %d, want 1", calls)
 	}
 }
 

--- a/ui/internal/spend/delegation.go
+++ b/ui/internal/spend/delegation.go
@@ -1,0 +1,861 @@
+package spend
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+
+	apollo "github.com/blinklabs-io/apollo/v2"
+	"github.com/blinklabs-io/bursa/ui/internal/chain"
+	"github.com/blinklabs-io/bursa/ui/internal/wallet"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/btcsuite/btcd/btcutil/bech32"
+)
+
+// VoteTarget is one of the four governance voting-power destinations a wallet
+// can delegate to (CIP-1694). RegisterSelf additionally registers the wallet's
+// own DRep credential and delegates its vote to itself.
+type VoteTarget string
+
+const (
+	VoteAbstain      VoteTarget = "abstain"
+	VoteNoConfidence VoteTarget = "no_confidence"
+	VoteDRep         VoteTarget = "drep"
+	VoteRegisterSelf VoteTarget = "register_self"
+)
+
+// Anchor is an optional governance metadata anchor (a URL plus the 32-byte
+// blake2b-256 hash of the document it points to), attached to a self-DRep
+// registration.
+type Anchor struct {
+	URL  string `json:"url"`
+	Hash string `json:"hash"` // hex-encoded 32-byte blake2b-256 digest
+}
+
+// Vote selects a governance voting-power target for a delegation request.
+type Vote struct {
+	Type   VoteTarget `json:"type"`
+	DRepID string     `json:"drep_id,omitempty"` // bech32 drep1…, when Type == VoteDRep
+	Anchor *Anchor    `json:"anchor,omitempty"`  // optional, when Type == VoteRegisterSelf
+}
+
+// DelegationRequest is the caller-supplied parameters for a single
+// staking/governance action. Any combination of fields may be set; the minimal
+// certificate set is computed from the wallet's current on-chain state. A
+// withdrawal-only request sets just Withdraw.
+type DelegationRequest struct {
+	PoolID   string `json:"pool_id,omitempty"` // omitted = leave stake delegation unchanged
+	Vote     *Vote  `json:"vote,omitempty"`
+	Withdraw bool   `json:"withdraw,omitempty"` // sweep withdrawable rewards
+}
+
+// CertKind tags an itemized certificate (or withdrawal) in the preview so the
+// confirm screen can distinguish, e.g., the 2 ₳ stake deposit from the ~500 ₳
+// DRep deposit.
+type CertKind string
+
+const (
+	CertStakeRegistration CertKind = "stake_registration"
+	CertStakeDelegation   CertKind = "stake_delegation"
+	CertVoteDelegation    CertKind = "vote_delegation"
+	CertDRepRegistration  CertKind = "drep_registration"
+	CertWithdrawal        CertKind = "withdrawal"
+)
+
+// Cert is one itemized line in a DelegationPreview: a human-readable summary of
+// a certificate (or withdrawal) plus, where applicable, the refundable deposit
+// it locks (DepositLovelace) or the amount it moves (e.g. a withdrawal).
+type Cert struct {
+	Kind            CertKind `json:"kind"`
+	Summary         string   `json:"summary"`
+	DepositLovelace string   `json:"deposit_lovelace,omitempty"` // refundable deposit, decimal lovelace
+	AmountLovelace  string   `json:"amount_lovelace,omitempty"`  // moved amount (withdrawal), decimal lovelace
+}
+
+// DelegationPreview is returned from BuildDelegation: the itemized certificate
+// set plus the fee, total refundable deposit, withdrawal amount, and net total,
+// all keyed by an opaque PendingID to pass to Confirm (the same Confirm the Send
+// flow uses).
+type DelegationPreview struct {
+	PendingID  string `json:"pending_id"`
+	Certs      []Cert `json:"certs"`
+	Fee        string `json:"fee"`                  // decimal lovelace
+	Deposit    string `json:"deposit"`              // total refundable deposit, decimal lovelace
+	Withdrawal string `json:"withdrawal,omitempty"` // total withdrawn, decimal lovelace
+	Total      string `json:"total"`                // net cost to the wallet (fee + deposits − withdrawals), decimal lovelace
+}
+
+// AccountState is the wallet's current on-chain staking/governance state, as
+// needed to compute the minimal certificate set. It is populated from the node;
+// a never-registered wallet has Registered == false.
+type AccountState struct {
+	Registered        bool          // stake key registered on chain
+	CurrentPool       *string       // pool currently delegated to, nil if none
+	CurrentDRep       *lcommon.Drep // governance vote target currently delegated to, nil if none
+	OwnDRep           *lcommon.Drep // wallet's own DRep credential, for register_self planning
+	OwnDRepRegistered bool          // wallet's own DRep credential is already registered on chain
+}
+
+// ProtocolParams holds the refundable deposit amounts the plan needs, parsed
+// from the node's protocol parameters.
+type ProtocolParams struct {
+	KeyDeposit  uint64
+	DRepDeposit uint64
+}
+
+// ErrNoChange is returned when the request asks for the wallet's current state:
+// no certificates would be produced. The UI disables submit in this case.
+var ErrNoChange = errors.New("requested state matches current state; nothing to do")
+
+// chainQuerier is the slice of the Blockfrost chain client the delegation flow
+// needs to verify pools/DReps and read account state + protocol params. It is an
+// interface so tests can supply a fake. *chain.Client satisfies it.
+type chainQuerier interface {
+	Account(ctx context.Context, stakeAddr string) (chain.AccountInfo, error)
+	AccountDRepID(ctx context.Context, stakeAddr string) (*string, error)
+	Pool(ctx context.Context, poolID string) (chain.PoolInfo, error)
+	DRep(ctx context.Context, drepID string) (chain.DRepInfo, error)
+	ProtocolParams(ctx context.Context) (chain.ProtocolParams, error)
+}
+
+// SetChainQuerier attaches the node-backed query client used by the delegation
+// flow (pool/DRep verification, account state, protocol params). It is separate
+// from the apollo ChainContext (which builds/submits txs): pool, DRep, and
+// protocol-parameter lookups go through the node's Blockfrost API. Passing nil
+// disables delegation (BuildDelegation returns an error).
+func (s *Service) SetChainQuerier(q chainQuerier) {
+	s.mu.Lock()
+	s.chainQ = q
+	s.mu.Unlock()
+}
+
+func (s *Service) chainQuerierLocked() chainQuerier {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.chainQ
+}
+
+// plan computes the minimal certificate set for req given the wallet's current
+// on-chain state and the protocol deposits. It is pure (no I/O) and is the
+// unit-tested heart of the delegation feature.
+//
+// Rules (per the design spec):
+//   - stake key not registered and (pool or vote requested) → prepend stake
+//     registration (+key deposit);
+//   - pool_id set and differs from the current pool → stake-delegation cert;
+//   - vote set and differs from the current vote target → vote-delegation cert;
+//     register_self additionally registers the wallet's own DRep credential
+//     (+drep deposit) only when it is not already registered;
+//   - withdraw → a withdrawal line of the full withdrawable amount.
+//
+// Requesting exactly the current state yields no certs and ErrNoChange.
+//
+// withdrawable is the wallet's withdrawable rewards (decimal lovelace as the
+// node reports it); it is only consulted when req.Withdraw is set.
+func plan(current AccountState, req DelegationRequest, params ProtocolParams, withdrawable string) ([]Cert, error) {
+	var certs []Cert
+
+	wantPool := req.PoolID != ""
+	wantVote := req.Vote != nil
+	registerSelf := wantVote && req.Vote.Type == VoteRegisterSelf
+
+	// A fresh wallet must register its stake key before it can delegate stake or
+	// vote. (Withdrawal of rewards also implicitly requires registration, but a
+	// never-registered wallet has no rewards, so we don't force it here.)
+	if !current.Registered && (wantPool || wantVote) {
+		certs = append(certs, Cert{
+			Kind:            CertStakeRegistration,
+			Summary:         "Register stake key",
+			DepositLovelace: strconv.FormatUint(params.KeyDeposit, 10),
+		})
+	}
+
+	// Stake delegation: only when a pool is requested AND it differs from the
+	// current delegation (idempotent — re-delegating to the same pool is a no-op).
+	if wantPool {
+		changed := current.CurrentPool == nil || *current.CurrentPool != req.PoolID
+		if changed {
+			certs = append(certs, Cert{
+				Kind:    CertStakeDelegation,
+				Summary: "Delegate stake to " + req.PoolID,
+			})
+		}
+	}
+
+	// Vote delegation. register_self also registers the wallet's own DRep first,
+	// but only when that DRep is not already registered. Re-selecting the current
+	// vote target is a no-op, just like re-selecting the current pool.
+	if wantVote {
+		requestedDRep, err := requestedVoteDrep(current.OwnDRep, *req.Vote)
+		if err != nil {
+			return nil, err
+		}
+		voteChanged := current.CurrentDRep == nil || !drepEqual(*current.CurrentDRep, requestedDRep)
+		if registerSelf {
+			if err := validateAnchor(req.Vote.Anchor); err != nil {
+				return nil, err
+			}
+			if !current.OwnDRepRegistered {
+				cert := Cert{
+					Kind:            CertDRepRegistration,
+					Summary:         "Register self as a DRep",
+					DepositLovelace: strconv.FormatUint(params.DRepDeposit, 10),
+				}
+				if completeAnchor(req.Vote.Anchor) {
+					cert.Summary = "Register self as a DRep (with metadata anchor)"
+				}
+				certs = append(certs, cert)
+			}
+			if voteChanged {
+				certs = append(certs, Cert{
+					Kind:    CertVoteDelegation,
+					Summary: "Delegate voting power to self",
+				})
+			}
+		} else if voteChanged {
+			summary, err := voteSummary(*req.Vote)
+			if err != nil {
+				return nil, err
+			}
+			certs = append(certs, Cert{Kind: CertVoteDelegation, Summary: summary})
+		}
+	}
+
+	// Withdrawal of the full withdrawable amount.
+	if req.Withdraw {
+		amt, err := parseAmount(withdrawable)
+		if err != nil || amt == 0 {
+			return nil, fmt.Errorf("%w: no withdrawable rewards", ErrInvalidRequest)
+		}
+		certs = append(certs, Cert{
+			Kind:           CertWithdrawal,
+			Summary:        "Withdraw staking rewards",
+			AmountLovelace: strconv.FormatUint(amt, 10),
+		})
+	}
+
+	if len(certs) == 0 {
+		return nil, ErrNoChange
+	}
+	return certs, nil
+}
+
+// voteSummary describes a non-register-self vote target for the preview, and
+// validates that a specific DRep request carries a DRep ID.
+func voteSummary(v Vote) (string, error) {
+	switch v.Type {
+	case VoteAbstain:
+		return "Delegate voting power to Always Abstain", nil
+	case VoteNoConfidence:
+		return "Delegate voting power to Always No Confidence", nil
+	case VoteDRep:
+		if v.DRepID == "" {
+			return "", fmt.Errorf("%w: drep_id required for a specific-DRep vote", ErrInvalidRequest)
+		}
+		return "Delegate voting power to " + v.DRepID, nil
+	case VoteRegisterSelf:
+		// voteSummary is only called for non-register-self targets; this path is
+		// unreachable in normal flow but must be handled for exhaustive coverage.
+		return "", fmt.Errorf("%w: use register_self path, not voteSummary", ErrInvalidRequest)
+	default:
+		return "", fmt.Errorf("%w: unknown vote target %q", ErrInvalidRequest, v.Type)
+	}
+}
+
+func requestedVoteDrep(own *lcommon.Drep, v Vote) (lcommon.Drep, error) {
+	switch v.Type {
+	case VoteAbstain:
+		return lcommon.Drep{Type: lcommon.DrepTypeAbstain}, nil
+	case VoteNoConfidence:
+		return lcommon.Drep{Type: lcommon.DrepTypeNoConfidence}, nil
+	case VoteDRep:
+		if v.DRepID == "" {
+			return lcommon.Drep{}, fmt.Errorf("%w: drep_id required for a specific-DRep vote", ErrInvalidRequest)
+		}
+		return parseDRepTarget(v.DRepID)
+	case VoteRegisterSelf:
+		if own == nil {
+			return lcommon.Drep{}, errors.New("wallet has no DRep credential derived")
+		}
+		return cloneDrep(*own), nil
+	default:
+		return lcommon.Drep{}, fmt.Errorf("%w: unknown vote target %q", ErrInvalidRequest, v.Type)
+	}
+}
+
+func drepEqual(a, b lcommon.Drep) bool {
+	return a.Type == b.Type && bytes.Equal(a.Credential, b.Credential)
+}
+
+func cloneDrep(d lcommon.Drep) lcommon.Drep {
+	if d.Credential == nil {
+		return d
+	}
+	out := d
+	out.Credential = append([]byte(nil), d.Credential...)
+	return out
+}
+
+func parseDRepTarget(id string) (lcommon.Drep, error) {
+	trimmed := strings.TrimSpace(id)
+	normalized := strings.ToLower(trimmed)
+	switch normalized {
+	case "drep_abstain", "drep_always_abstain", "drep-alwaysabstain":
+		return lcommon.Drep{Type: lcommon.DrepTypeAbstain}, nil
+	case "drep_no_confidence", "drep_always_no_confidence", "drep-alwaysnoconfidence":
+		return lcommon.Drep{Type: lcommon.DrepTypeNoConfidence}, nil
+	}
+	if h, ok, err := prefixedDRepHash(trimmed, "drep-keyHash-"); ok || err != nil {
+		if err != nil {
+			return lcommon.Drep{}, err
+		}
+		return lcommon.Drep{Type: lcommon.DrepTypeAddrKeyHash, Credential: h}, nil
+	}
+	if h, ok, err := prefixedDRepHash(trimmed, "drep-scriptHash-"); ok || err != nil {
+		if err != nil {
+			return lcommon.Drep{}, err
+		}
+		return lcommon.Drep{Type: lcommon.DrepTypeScriptHash, Credential: h}, nil
+	}
+	if raw, err := hex.DecodeString(trimmed); err == nil && len(raw) == 28 {
+		return lcommon.Drep{Type: lcommon.DrepTypeAddrKeyHash, Credential: raw}, nil
+	}
+	typ, hash, err := decodeDRepID(trimmed)
+	if err != nil {
+		return lcommon.Drep{}, err
+	}
+	return lcommon.Drep{Type: typ, Credential: hash}, nil
+}
+
+func prefixedDRepHash(id, prefix string) ([]byte, bool, error) {
+	if !strings.HasPrefix(strings.ToLower(id), strings.ToLower(prefix)) {
+		return nil, false, nil
+	}
+	h, err := hex.DecodeString(id[len(prefix):])
+	if err != nil {
+		return nil, true, fmt.Errorf("%w: invalid drep hash %q: %w", ErrInvalidRequest, id, err)
+	}
+	if len(h) != 28 {
+		return nil, true, fmt.Errorf("%w: invalid drep hash %q: expected 28 bytes, got %d", ErrInvalidRequest, id, len(h))
+	}
+	return h, true, nil
+}
+
+// BuildDelegation queries the wallet's current on-chain state and protocol
+// params, verifies any requested pool / DRep through the node, computes the
+// minimal certificate set via plan(), builds the transaction with apollo
+// (attaching certs + the withdrawal), stores it under a new pending id, and
+// returns an itemized DelegationPreview. Confirm signs + submits it through the
+// same path the Send flow uses.
+func (s *Service) BuildDelegation(ctx context.Context, req DelegationRequest) (DelegationPreview, error) {
+	walletID, acct, gen := s.currentBinding()
+	if acct == nil {
+		return DelegationPreview{}, ErrNoWallet
+	}
+	if len(acct.ReceiveAddresses) == 0 {
+		return DelegationPreview{}, errors.New("account has no receive addresses")
+	}
+	q := s.chainQuerierLocked()
+	if q == nil {
+		return DelegationPreview{}, errors.New("no chain querier configured")
+	}
+
+	// --- gather current state + protocol params ---
+	state, withdrawable, err := s.accountState(ctx, q, acct.StakeAddress)
+	if err != nil {
+		return DelegationPreview{}, err
+	}
+	pp, err := q.ProtocolParams(ctx)
+	if err != nil {
+		return DelegationPreview{}, fmt.Errorf("protocol params: %w", err)
+	}
+	params, err := toPlanParams(pp)
+	if err != nil {
+		return DelegationPreview{}, err
+	}
+	if registerSelf := req.Vote != nil && req.Vote.Type == VoteRegisterSelf; registerSelf {
+		own, err := drepFromHex(acct.DRepKeyHash)
+		if err != nil {
+			return DelegationPreview{}, err
+		}
+		state.OwnDRep = own
+		registered, err := s.ownDRepRegistered(ctx, q, *own)
+		if err != nil {
+			return DelegationPreview{}, err
+		}
+		state.OwnDRepRegistered = registered
+	}
+
+	// --- verify any requested pool / DRep through the node (consent law: no
+	// external call — the embedded node confirms existence) ---
+	if req.PoolID != "" {
+		if _, err := q.Pool(ctx, req.PoolID); err != nil {
+			if errors.Is(err, chain.ErrNotFound) {
+				return DelegationPreview{}, fmt.Errorf("%w: pool %q not found by your node", ErrInvalidRequest, req.PoolID)
+			}
+			return DelegationPreview{}, fmt.Errorf("verify pool: %w", err)
+		}
+	}
+	if req.Vote != nil && req.Vote.Type == VoteDRep {
+		if req.Vote.DRepID == "" {
+			return DelegationPreview{}, fmt.Errorf("%w: drep_id required for a specific-DRep vote", ErrInvalidRequest)
+		}
+		if _, err := q.DRep(ctx, req.Vote.DRepID); err != nil {
+			if errors.Is(err, chain.ErrNotFound) {
+				return DelegationPreview{}, fmt.Errorf("%w: DRep %q not found by your node", ErrInvalidRequest, req.Vote.DRepID)
+			}
+			return DelegationPreview{}, fmt.Errorf("verify drep: %w", err)
+		}
+	}
+
+	// --- compute the minimal certificate set (pure) ---
+	certs, err := plan(state, req, params, withdrawable)
+	if err != nil {
+		return DelegationPreview{}, err
+	}
+
+	// --- build the transaction with apollo ---
+	a, utxoAddr, err := s.buildDelegationTx(ctx, acct, req, certs, params)
+	if err != nil {
+		return DelegationPreview{}, err
+	}
+
+	id := s.mkID()
+	s.mu.Lock()
+	if s.gen != gen || s.walletID != walletID {
+		s.mu.Unlock()
+		return DelegationPreview{}, ErrWalletChanged
+	}
+	s.sweepExpiredLocked()
+	// Bind the pending delegation tx to the active wallet so Confirm decrypts the
+	// correct seed (vault model) and has the account for address-index lookup.
+	s.pending[id] = &pending{
+		tx:        a,
+		utxoAddr:  utxoAddr,
+		created:   s.now(),
+		walletID:  walletID,
+		account:   acct,
+		certKinds: certKindsFrom(certs),
+	}
+	s.mu.Unlock()
+
+	return toDelegationPreview(id, a, certs), nil
+}
+
+// certKindsFrom extracts the set of CertKind values from the computed cert list.
+func certKindsFrom(certs []Cert) []CertKind {
+	kinds := make([]CertKind, len(certs))
+	for i, c := range certs {
+		kinds[i] = c.Kind
+	}
+	return kinds
+}
+
+// accountState reads the wallet's stake registration + current pool, plus its
+// withdrawable rewards, from the node. A never-seen account (ErrNotFound) is an
+// unregistered wallet with no rewards.
+func (s *Service) accountState(ctx context.Context, q chainQuerier, stakeAddr string) (AccountState, string, error) {
+	info, err := q.Account(ctx, stakeAddr)
+	if errors.Is(err, chain.ErrNotFound) {
+		return AccountState{Registered: false}, "0", nil
+	}
+	if err != nil {
+		return AccountState{}, "", fmt.Errorf("account state: %w", err)
+	}
+	withdrawable := info.WithdrawableAmount
+	if withdrawable == "" {
+		withdrawable = "0"
+	}
+	state := AccountState{Registered: info.Registered || info.Active, CurrentPool: info.PoolID}
+	drepID := info.DRepID
+	if drepID == nil || *drepID == "" {
+		drepID, err = q.AccountDRepID(ctx, stakeAddr)
+		if err != nil {
+			return AccountState{}, "", fmt.Errorf("account drep_id: %w", err)
+		}
+	}
+	if drepID != nil && *drepID != "" {
+		drep, err := parseDRepTarget(*drepID)
+		if err != nil {
+			return AccountState{}, "", fmt.Errorf("account drep_id: %w", err)
+		}
+		state.CurrentDRep = &drep
+	}
+	return state, withdrawable, nil
+}
+
+func drepFromHex(hashHex string) (*lcommon.Drep, error) {
+	if hashHex == "" {
+		return nil, errors.New("wallet has no DRep credential derived")
+	}
+	b, err := hex.DecodeString(hashHex)
+	if err != nil {
+		return nil, fmt.Errorf("drep key hash: %w", err)
+	}
+	if len(b) != 28 {
+		return nil, fmt.Errorf("drep key hash: expected 28 bytes, got %d", len(b))
+	}
+	return &lcommon.Drep{Type: lcommon.DrepTypeAddrKeyHash, Credential: b}, nil
+}
+
+func (s *Service) ownDRepRegistered(ctx context.Context, q chainQuerier, own lcommon.Drep) (bool, error) {
+	ids := []string{own.String()}
+	if len(own.Credential) == 28 {
+		ids = append(ids, hex.EncodeToString(own.Credential))
+	}
+	var firstErr error
+	for _, id := range ids {
+		info, err := q.DRep(ctx, id)
+		if errors.Is(err, chain.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		return info.Registered, nil
+	}
+	if firstErr != nil {
+		return false, fmt.Errorf("verify own DRep: %w", firstErr)
+	}
+	return false, nil
+}
+
+// toPlanParams parses the node's deposit strings into the uint64 amounts plan()
+// needs. drep_deposit is null in pre-Conway eras; it defaults to 0 (a self-DRep
+// registration would then fail at the node, which is the correct behavior).
+func toPlanParams(pp chain.ProtocolParams) (ProtocolParams, error) {
+	key, err := parseAmount(pp.KeyDeposit)
+	if err != nil {
+		return ProtocolParams{}, fmt.Errorf("%w: key_deposit %q", ErrInvalidRequest, pp.KeyDeposit)
+	}
+	var drep uint64
+	if pp.DRepDeposit != nil && *pp.DRepDeposit != "" {
+		drep, err = parseAmount(*pp.DRepDeposit)
+		if err != nil {
+			return ProtocolParams{}, fmt.Errorf("%w: drep_deposit %q", ErrInvalidRequest, *pp.DRepDeposit)
+		}
+	}
+	return ProtocolParams{KeyDeposit: key, DRepDeposit: drep}, nil
+}
+
+// buildDelegationTx constructs and completes the apollo transaction for the
+// computed certificate set. It loads the wallet's UTxOs (so coin selection can
+// fund the deposits + fee), attaches each certificate keyed by the wallet's
+// stake credential, attaches the withdrawal to the stake address, and runs
+// Complete (which auto-accounts the deposits). It returns the completed builder
+// and the txref→address map Confirm uses to sign.
+func (s *Service) buildDelegationTx(
+	ctx context.Context,
+	acct *wallet.Account,
+	req DelegationRequest,
+	certs []Cert,
+	params ProtocolParams,
+) (*apollo.Apollo, map[string]string, error) {
+	changeAddr, err := lcommon.NewAddress(acct.ReceiveAddresses[0])
+	if err != nil {
+		return nil, nil, fmt.Errorf("change address: %w", err)
+	}
+	stakeAddr, err := lcommon.NewAddress(acct.StakeAddress)
+	if err != nil {
+		return nil, nil, fmt.Errorf("stake address: %w", err)
+	}
+	stakeCred, err := lcommon.NewAddress(acct.ReceiveAddresses[0])
+	if err != nil {
+		return nil, nil, fmt.Errorf("base address: %w", err)
+	}
+	// The wallet's stake credential, derived from any base (receive) address: all
+	// receive addresses share the canonical stake key, so the stake key hash is
+	// the credential for every certificate.
+	stakeKeyHash := stakeCred.StakeKeyHash()
+	cred := lcommon.Credential{
+		CredType:   lcommon.CredentialTypeAddrKeyHash,
+		Credential: stakeKeyHash,
+	}
+
+	a := apollo.New(s.chain).
+		SetWallet(apollo.NewExternalWallet(changeAddr)).
+		SetChangeAddress(changeAddr).
+		SetFeePadding(feePaddingLovelace)
+
+	utxoAddr := make(map[string]string)
+	for _, addrStr := range acct.ReceiveAddresses {
+		addr, err := lcommon.NewAddress(addrStr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("address %q: %w", addrStr, err)
+		}
+		utxos, err := s.chain.Utxos(ctx, addr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("utxos for %s: %w", addrStr, err)
+		}
+		if len(utxos) > 0 {
+			a = a.AddLoadedUTxOs(utxos...)
+			for _, u := range utxos {
+				utxoAddr[makeUtxoRef(u)] = addrStr
+			}
+		}
+	}
+
+	// Apply each computed certificate. We build the discrete certs (the combined
+	// register+delegate cert is equivalent and the discrete set keeps the apollo
+	// calls one-to-one with the itemized preview).
+	for _, c := range certs {
+		switch c.Kind {
+		case CertStakeRegistration:
+			a, err = a.RegisterStake(&cred)
+			if err != nil {
+				return nil, nil, fmt.Errorf("register stake: %w", err)
+			}
+		case CertStakeDelegation:
+			poolHash, err := poolKeyHash(req.PoolID)
+			if err != nil {
+				return nil, nil, err
+			}
+			a, err = a.DelegateStake(&cred, poolHash)
+			if err != nil {
+				return nil, nil, fmt.Errorf("delegate stake: %w", err)
+			}
+		case CertDRepRegistration:
+			drepCred, anchor, err := s.selfDRepCredential(req)
+			if err != nil {
+				return nil, nil, err
+			}
+			a = a.RegisterDRep(drepCred, int64(params.DRepDeposit), anchor) //nolint:gosec // deposit from node params
+		case CertVoteDelegation:
+			drep, err := s.voteDrep(req)
+			if err != nil {
+				return nil, nil, err
+			}
+			a, err = a.DelegateVote(&cred, drep)
+			if err != nil {
+				return nil, nil, fmt.Errorf("delegate vote: %w", err)
+			}
+		case CertWithdrawal:
+			amt, err := parseAmount(c.AmountLovelace)
+			if err != nil {
+				return nil, nil, fmt.Errorf("%w: withdrawal amount", ErrInvalidRequest)
+			}
+			a = a.AddWithdrawal(stakeAddr, amt, nil, nil)
+		}
+	}
+
+	a, err = a.CompleteContext(ctx)
+	if err != nil {
+		if isInsufficientFundsError(err) {
+			return nil, nil, fmt.Errorf("%w: %w", ErrInsufficientFunds, err)
+		}
+		return nil, nil, fmt.Errorf("complete transaction: %w", err)
+	}
+	return a, utxoAddr, nil
+}
+
+// poolKeyHash decodes a bech32 pool1… ID into the 28-byte pool key hash apollo's
+// DelegateStake expects.
+func poolKeyHash(poolID string) (lcommon.Blake2b224, error) {
+	pid, err := lcommon.NewPoolIdFromBech32(poolID)
+	if err != nil {
+		return lcommon.Blake2b224{}, fmt.Errorf("%w: invalid pool id %q: %w", ErrInvalidRequest, poolID, err)
+	}
+	return lcommon.Blake2b224(pid), nil
+}
+
+// voteDrep maps a vote request to apollo's Drep argument: the predefined Always
+// Abstain / Always No Confidence variants, a specific DRep by its decoded key/
+// script hash, or — for register_self — the wallet's own DRep key-hash
+// credential.
+func (s *Service) voteDrep(req DelegationRequest) (lcommon.Drep, error) {
+	if req.Vote == nil {
+		return lcommon.Drep{}, fmt.Errorf("%w: no vote target", ErrInvalidRequest)
+	}
+	switch req.Vote.Type {
+	case VoteAbstain:
+		return lcommon.Drep{Type: lcommon.DrepTypeAbstain}, nil
+	case VoteNoConfidence:
+		return lcommon.Drep{Type: lcommon.DrepTypeNoConfidence}, nil
+	case VoteDRep:
+		typ, hash, err := decodeDRepID(req.Vote.DRepID)
+		if err != nil {
+			return lcommon.Drep{}, err
+		}
+		return lcommon.Drep{Type: typ, Credential: hash}, nil
+	case VoteRegisterSelf:
+		hash, err := s.selfDRepKeyHash()
+		if err != nil {
+			return lcommon.Drep{}, err
+		}
+		return lcommon.Drep{Type: lcommon.DrepTypeAddrKeyHash, Credential: hash}, nil
+	default:
+		return lcommon.Drep{}, fmt.Errorf("%w: unknown vote target %q", ErrInvalidRequest, req.Vote.Type)
+	}
+}
+
+// selfDRepCredential returns the wallet's own DRep credential (key hash) and the
+// optional metadata anchor for a self-DRep registration.
+func (s *Service) selfDRepCredential(req DelegationRequest) (lcommon.Credential, *lcommon.GovAnchor, error) {
+	hash, err := s.selfDRepKeyHash()
+	if err != nil {
+		return lcommon.Credential{}, nil, err
+	}
+	cred := lcommon.Credential{
+		CredType:   lcommon.CredentialTypeAddrKeyHash,
+		Credential: lcommon.NewBlake2b224(hash),
+	}
+	var anchor *lcommon.GovAnchor
+	if req.Vote != nil {
+		if err := validateAnchor(req.Vote.Anchor); err != nil {
+			return lcommon.Credential{}, nil, err
+		}
+	}
+	if req.Vote != nil && completeAnchor(req.Vote.Anchor) {
+		ga, err := buildAnchor(*req.Vote.Anchor)
+		if err != nil {
+			return lcommon.Credential{}, nil, err
+		}
+		anchor = &ga
+	}
+	return cred, anchor, nil
+}
+
+func completeAnchor(a *Anchor) bool {
+	return a != nil && a.URL != "" && a.Hash != ""
+}
+
+func validateAnchor(a *Anchor) error {
+	if a == nil {
+		return nil
+	}
+	if (a.URL == "") != (a.Hash == "") {
+		return fmt.Errorf("%w: anchor url and hash must both be provided", ErrInvalidRequest)
+	}
+	return nil
+}
+
+// selfDRepKeyHash returns the wallet's own DRep verification-key hash (CIP-0105,
+// derivation role 3). It is the public credential carried on the derived
+// account (wallet.Derive populates DRepKeyHash), so it needs no password at
+// build time — building a self-DRep registration only requires the public key
+// hash; the actual signing key is derived from the mnemonic at Confirm time.
+func (s *Service) selfDRepKeyHash() ([]byte, error) {
+	acct := s.currentAccount()
+	if acct == nil {
+		return nil, ErrNoWallet
+	}
+	drep, err := drepFromHex(acct.DRepKeyHash)
+	if err != nil {
+		return nil, err
+	}
+	return cloneDrep(*drep).Credential, nil
+}
+
+// buildAnchor converts a request Anchor into a gouroboros GovAnchor, validating
+// the 32-byte hex hash.
+func buildAnchor(a Anchor) (lcommon.GovAnchor, error) {
+	hashBytes, err := hexDecode32(a.Hash)
+	if err != nil {
+		return lcommon.GovAnchor{}, fmt.Errorf("%w: anchor hash: %w", ErrInvalidRequest, err)
+	}
+	ga, err := lcommon.NewGovAnchor(a.URL, hashBytes)
+	if err != nil {
+		return lcommon.GovAnchor{}, fmt.Errorf("%w: anchor: %w", ErrInvalidRequest, err)
+	}
+	return ga, nil
+}
+
+// toDelegationPreview assembles the itemized preview from the computed certs and
+// the completed apollo tx (for the fee). Deposit is the sum of every cert's
+// refundable deposit; Withdrawal is the sum of withdrawal lines; Total is the
+// net cost to the wallet (fee + deposits − withdrawals).
+func toDelegationPreview(id string, a *apollo.Apollo, certs []Cert) DelegationPreview {
+	var fee uint64
+	if tx := a.GetTx(); tx != nil {
+		fee = tx.Body.TxFee
+	}
+	deposit := new(big.Int)
+	withdrawal := new(big.Int)
+	for _, c := range certs {
+		if c.DepositLovelace != "" {
+			if v, ok := new(big.Int).SetString(c.DepositLovelace, 10); ok {
+				deposit.Add(deposit, v)
+			}
+		}
+		if c.AmountLovelace != "" && c.Kind == CertWithdrawal {
+			if v, ok := new(big.Int).SetString(c.AmountLovelace, 10); ok {
+				withdrawal.Add(withdrawal, v)
+			}
+		}
+	}
+	// total = fee + deposit − withdrawal
+	total := new(big.Int).SetUint64(fee)
+	total.Add(total, deposit)
+	total.Sub(total, withdrawal)
+
+	pv := DelegationPreview{
+		PendingID: id,
+		Certs:     certs,
+		Fee:       strconv.FormatUint(fee, 10),
+		Deposit:   deposit.String(),
+		Total:     total.String(),
+	}
+	if withdrawal.Sign() > 0 {
+		pv.Withdrawal = withdrawal.String()
+	}
+	return pv
+}
+
+// hexDecode32 decodes a 32-byte hex string (a blake2b-256 digest).
+func hexDecode32(s string) ([]byte, error) {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) != 32 {
+		return nil, fmt.Errorf("expected 32 bytes, got %d", len(b))
+	}
+	return b, nil
+}
+
+// decodeDRepID decodes a bech32 drep1… identifier into apollo's Drep type tag
+// (key-hash vs script-hash) and the 28-byte credential hash. It accepts both the
+// legacy CIP-0105 form (28-byte payload, key hash) and the CIP-0129 form (a
+// 1-byte header followed by the 28-byte hash, where the header's low nibble is
+// 2 for a key hash or 3 for a script hash). This is purely client-side bech32
+// validation + decoding — no node call — so it works even if the node cannot
+// resolve the DRep; the node's separate existence check (DRep()) provides the
+// "not found by your node" signal.
+func decodeDRepID(drepID string) (typ int, hash []byte, err error) {
+	hrp, data5, derr := bech32.DecodeNoLimit(drepID)
+	if derr != nil {
+		return 0, nil, fmt.Errorf("%w: invalid drep id %q: %w", ErrInvalidRequest, drepID, derr)
+	}
+	if hrp != "drep" {
+		return 0, nil, fmt.Errorf("%w: drep id %q has prefix %q, want drep", ErrInvalidRequest, drepID, hrp)
+	}
+	raw, derr := bech32.ConvertBits(data5, 5, 8, false)
+	if derr != nil {
+		return 0, nil, fmt.Errorf("%w: drep id %q: %w", ErrInvalidRequest, drepID, derr)
+	}
+	switch len(raw) {
+	case 28:
+		// Legacy CIP-0105: bare 28-byte key hash.
+		return lcommon.DrepTypeAddrKeyHash, raw, nil
+	case 29:
+		// CIP-0129: 1-byte header + 28-byte hash. Low nibble: 2 = key, 3 = script.
+		switch raw[0] & 0x0f {
+		case 0x02:
+			return lcommon.DrepTypeAddrKeyHash, raw[1:], nil
+		case 0x03:
+			return lcommon.DrepTypeScriptHash, raw[1:], nil
+		default:
+			return 0, nil, fmt.Errorf("%w: drep id %q has unrecognized header 0x%02x", ErrInvalidRequest, drepID, raw[0])
+		}
+	default:
+		return 0, nil, fmt.Errorf("%w: drep id %q decodes to %d bytes, want 28 or 29", ErrInvalidRequest, drepID, len(raw))
+	}
+}

--- a/ui/internal/spend/delegation.go
+++ b/ui/internal/spend/delegation.go
@@ -580,11 +580,7 @@ func (s *Service) buildDelegationTx(
 		Credential: stakeKeyHash,
 	}
 
-	a := apollo.New(s.chain).
-		SetWallet(apollo.NewExternalWallet(changeAddr)).
-		SetChangeAddress(changeAddr).
-		SetFeePadding(feePaddingLovelace)
-
+	var loaded []lcommon.Utxo
 	utxoAddr := make(map[string]string)
 	for _, addrStr := range acct.ReceiveAddresses {
 		addr, err := lcommon.NewAddress(addrStr)
@@ -596,64 +592,156 @@ func (s *Service) buildDelegationTx(
 			return nil, nil, fmt.Errorf("utxos for %s: %w", addrStr, err)
 		}
 		if len(utxos) > 0 {
-			a = a.AddLoadedUTxOs(utxos...)
+			loaded = append(loaded, utxos...)
 			for _, u := range utxos {
 				utxoAddr[makeUtxoRef(u)] = addrStr
 			}
 		}
 	}
 
-	// Apply each computed certificate. We build the discrete certs (the combined
-	// register+delegate cert is equivalent and the discrete set keeps the apollo
-	// calls one-to-one with the itemized preview).
+	certSigners, err := delegationCertRequiredSigners(certs, stakeKeyHash, acct)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var a *apollo.Apollo
+	var paymentSigners []lcommon.Blake2b224
+	maxAttempts := len(acct.ReceiveAddresses) + 2
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		next := apollo.New(s.chain).
+			SetWallet(apollo.NewExternalWallet(changeAddr)).
+			SetChangeAddress(changeAddr).
+			SetFeePadding(feePaddingLovelace).
+			AddLoadedUTxOs(loaded...)
+		for _, kh := range appendKeyHashes(nil, certSigners, paymentSigners) {
+			next = next.AddRequiredSigner(kh)
+		}
+		next, err = s.applyDelegationTx(next, req, certs, params, stakeAddr, cred)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		next, err = next.CompleteContext(ctx)
+		if err != nil {
+			if isInsufficientFundsError(err) {
+				return nil, nil, fmt.Errorf("%w: %w", ErrInsufficientFunds, err)
+			}
+			return nil, nil, fmt.Errorf("complete transaction: %w", err)
+		}
+
+		tx := next.GetTx()
+		if tx == nil {
+			return nil, nil, errors.New("completed tx is nil")
+		}
+		actualPaymentSigners, err := requiredPaymentKeyHashesForInputs(tx.Body.Inputs(), utxoAddr)
+		if err != nil {
+			return nil, nil, err
+		}
+		if sameKeyHashSet(paymentSigners, actualPaymentSigners) {
+			a = next
+			break
+		}
+		paymentSigners = actualPaymentSigners
+	}
+	if a == nil {
+		return nil, nil, errors.New("delegation required signer set did not converge")
+	}
+	return a, utxoAddr, nil
+}
+
+// applyDelegationTx applies each computed certificate/withdrawal to a fresh
+// Apollo builder. The discrete certs keep the apollo calls one-to-one with the
+// itemized preview.
+func (s *Service) applyDelegationTx(
+	a *apollo.Apollo,
+	req DelegationRequest,
+	certs []Cert,
+	params ProtocolParams,
+	stakeAddr lcommon.Address,
+	cred lcommon.Credential,
+) (*apollo.Apollo, error) {
+	var err error
 	for _, c := range certs {
 		switch c.Kind {
 		case CertStakeRegistration:
 			a, err = a.RegisterStake(&cred)
 			if err != nil {
-				return nil, nil, fmt.Errorf("register stake: %w", err)
+				return nil, fmt.Errorf("register stake: %w", err)
 			}
 		case CertStakeDelegation:
 			poolHash, err := poolKeyHash(req.PoolID)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 			a, err = a.DelegateStake(&cred, poolHash)
 			if err != nil {
-				return nil, nil, fmt.Errorf("delegate stake: %w", err)
+				return nil, fmt.Errorf("delegate stake: %w", err)
 			}
 		case CertDRepRegistration:
 			drepCred, anchor, err := s.selfDRepCredential(req)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 			a = a.RegisterDRep(drepCred, int64(params.DRepDeposit), anchor) //nolint:gosec // deposit from node params
 		case CertVoteDelegation:
 			drep, err := s.voteDrep(req)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 			a, err = a.DelegateVote(&cred, drep)
 			if err != nil {
-				return nil, nil, fmt.Errorf("delegate vote: %w", err)
+				return nil, fmt.Errorf("delegate vote: %w", err)
 			}
 		case CertWithdrawal:
 			amt, err := parseAmount(c.AmountLovelace)
 			if err != nil {
-				return nil, nil, fmt.Errorf("%w: withdrawal amount", ErrInvalidRequest)
+				return nil, fmt.Errorf("%w: withdrawal amount", ErrInvalidRequest)
 			}
 			a = a.AddWithdrawal(stakeAddr, amt, nil, nil)
 		}
 	}
+	return a, nil
+}
 
-	a, err = a.CompleteContext(ctx)
-	if err != nil {
-		if isInsufficientFundsError(err) {
-			return nil, nil, fmt.Errorf("%w: %w", ErrInsufficientFunds, err)
+func delegationCertRequiredSigners(
+	certs []Cert,
+	stakeKeyHash lcommon.Blake2b224,
+	acct *wallet.Account,
+) ([]lcommon.Blake2b224, error) {
+	var signers []lcommon.Blake2b224
+	for _, c := range certs {
+		switch c.Kind {
+		case CertStakeRegistration, CertStakeDelegation, CertVoteDelegation, CertWithdrawal:
+			if stakeKeyHash == (lcommon.Blake2b224{}) {
+				return nil, errors.New("stake credential is missing")
+			}
+			signers = appendKeyHashes(signers, []lcommon.Blake2b224{stakeKeyHash})
+		case CertDRepRegistration:
+			drep, err := drepFromHex(acct.DRepKeyHash)
+			if err != nil {
+				return nil, err
+			}
+			signers = appendKeyHashes(signers, []lcommon.Blake2b224{lcommon.NewBlake2b224(drep.Credential)})
 		}
-		return nil, nil, fmt.Errorf("complete transaction: %w", err)
 	}
-	return a, utxoAddr, nil
+	return signers, nil
+}
+
+func appendKeyHashes(dst []lcommon.Blake2b224, sets ...[]lcommon.Blake2b224) []lcommon.Blake2b224 {
+	seen := make(map[lcommon.Blake2b224]bool, len(dst))
+	for _, kh := range dst {
+		seen[kh] = true
+	}
+	for _, set := range sets {
+		for _, kh := range set {
+			if seen[kh] {
+				continue
+			}
+			seen[kh] = true
+			dst = append(dst, kh)
+		}
+	}
+	return dst
 }
 
 // poolKeyHash decodes a bech32 pool1… ID into the 28-byte pool key hash apollo's

--- a/ui/internal/spend/delegation_test.go
+++ b/ui/internal/spend/delegation_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/bursa/ui/internal/chain"
+	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
@@ -340,6 +341,58 @@ func newFakeQuerier() *fakeQuerier {
 	}
 }
 
+func drepKeyHashForAccount(t *testing.T, acct *wallet.Account) string {
+	t.Helper()
+	drep, err := drepFromHex(acct.DRepKeyHash)
+	if err != nil {
+		t.Fatalf("drepFromHex: %v", err)
+	}
+	return hex.EncodeToString(drep.Credential)
+}
+
+func exportedRequiredSignerSet(t *testing.T, s *Service, pendingID string) map[string]bool {
+	t.Helper()
+	unsigned, err := s.ExportUnsigned(pendingID)
+	if err != nil {
+		t.Fatalf("ExportUnsigned: %v", err)
+	}
+	s.mu.Lock()
+	p := s.pending[pendingID]
+	if p == nil || p.tx == nil || p.tx.GetTx() == nil {
+		s.mu.Unlock()
+		t.Fatalf("pending tx %q is missing", pendingID)
+	}
+	body := keyHashesHex(p.tx.GetTx().Body.RequiredSigners())
+	s.mu.Unlock()
+	if !equalStringSets(body, unsigned.RequiredSigners) {
+		t.Fatalf("body required signers %v do not match sidecar %v", body, unsigned.RequiredSigners)
+	}
+	ret := make(map[string]bool, len(body))
+	for _, signer := range body {
+		ret[signer] = true
+	}
+	return ret
+}
+
+func equalStringSets(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[string]bool, len(a))
+	for _, s := range a {
+		seen[s] = true
+	}
+	if len(seen) != len(a) {
+		return false
+	}
+	for _, s := range b {
+		if !seen[s] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestBuildDelegationNoWallet(t *testing.T) {
 	fc := newFakeChain(5_000_000, mustDeriveTestAccount(t).ReceiveAddresses[0])
 	s := NewService(fc, nil, nil)
@@ -496,6 +549,12 @@ func TestBuildDelegationFreshWalletPreview(t *testing.T) {
 	if pv.Fee == "" || pv.Fee == "0" {
 		t.Fatalf("expected non-zero fee, got %q", pv.Fee)
 	}
+	signers := exportedRequiredSignerSet(t, s, pv.PendingID)
+	payment := paymentKeyHashForAddress(t, acct.ReceiveAddresses[0])
+	stake := stakeKeyHashForAddress(t, acct.ReceiveAddresses[0])
+	if !signers[payment] || !signers[stake] || len(signers) != 2 {
+		t.Fatalf("required signers = %v, want payment %s and stake %s", signers, payment, stake)
+	}
 }
 
 // TestBuildDelegationConfirmSignsAndSubmits proves a delegation tx flows through
@@ -569,6 +628,48 @@ func TestBuildDelegationRegisterSelfPreview(t *testing.T) {
 	}
 	if pv.Deposit != "500000000" {
 		t.Fatalf("total deposit = %q, want 500000000", pv.Deposit)
+	}
+	signers := exportedRequiredSignerSet(t, s, pv.PendingID)
+	payment := paymentKeyHashForAddress(t, acct.ReceiveAddresses[0])
+	stake := stakeKeyHashForAddress(t, acct.ReceiveAddresses[0])
+	drep := drepKeyHashForAccount(t, acct)
+	if !signers[payment] || !signers[stake] || !signers[drep] || len(signers) != 3 {
+		t.Fatalf("required signers = %v, want payment %s, stake %s, drep %s", signers, payment, stake, drep)
+	}
+}
+
+func TestBuildDelegationRegisterSelfOnlyDoesNotRequireStakeSigner(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	fc := newFakeChain(600_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, nil, acct)
+	q := newFakeQuerier()
+	ownDRepID := "drep-keyHash-" + acct.DRepKeyHash
+	q.account = chain.AccountInfo{
+		Registered:         true,
+		Active:             true,
+		PoolID:             strptr("pool1abc"),
+		DRepID:             &ownDRepID,
+		WithdrawableAmount: "0",
+	}
+	q.drepErr = chain.ErrNotFound
+	s.SetChainQuerier(q)
+
+	pv, err := s.BuildDelegation(context.Background(), DelegationRequest{
+		Vote: &Vote{Type: VoteRegisterSelf},
+	})
+	if err != nil {
+		t.Fatalf("BuildDelegation register-self only: %v", err)
+	}
+	if len(pv.Certs) != 1 || pv.Certs[0].Kind != CertDRepRegistration {
+		t.Fatalf("unexpected certs: %+v", pv.Certs)
+	}
+
+	signers := exportedRequiredSignerSet(t, s, pv.PendingID)
+	payment := paymentKeyHashForAddress(t, acct.ReceiveAddresses[0])
+	stake := stakeKeyHashForAddress(t, acct.ReceiveAddresses[0])
+	drep := drepKeyHashForAccount(t, acct)
+	if !signers[payment] || !signers[drep] || signers[stake] || len(signers) != 2 {
+		t.Fatalf("required signers = %v, want payment %s and drep %s only", signers, payment, drep)
 	}
 }
 

--- a/ui/internal/spend/delegation_test.go
+++ b/ui/internal/spend/delegation_test.go
@@ -1,0 +1,627 @@
+package spend
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/bursa/ui/internal/chain"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// strptr is a helper for the *string fields in test fixtures.
+func strptr(s string) *string { return &s }
+
+// validPoolID is a syntactically valid bech32 pool1… id (28 bytes 0x01..0x1c);
+// BuildDelegation decodes the pool id, so the build tests must use a real one.
+const validPoolID = "pool1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5z5tpwxqergd3c6vr4kr"
+
+// validDRepID is the matching bech32 drep1… id (legacy CIP-0105, 28 bytes).
+const validDRepID = "drep1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5z5tpwxqergd3cpvc53e"
+
+// defaultParams is the deposit set used across plan() tests: 2 ₳ key deposit,
+// 500 ₳ DRep deposit (matching mainnet/preview Conway values).
+var defaultParams = ProtocolParams{KeyDeposit: 2_000_000, DRepDeposit: 500_000_000}
+
+// kinds extracts the cert kinds from a plan result for concise assertions.
+func kinds(certs []Cert) []CertKind {
+	out := make([]CertKind, len(certs))
+	for i, c := range certs {
+		out[i] = c.Kind
+	}
+	return out
+}
+
+func equalKinds(a, b []CertKind) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func drepPtr(t *testing.T, id string) *lcommon.Drep {
+	t.Helper()
+	drep, err := parseDRepTarget(id)
+	if err != nil {
+		t.Fatalf("parseDRepTarget(%q): %v", id, err)
+	}
+	return &drep
+}
+
+func withOwnDRep(s AccountState) AccountState {
+	drep, err := parseDRepTarget(validDRepID)
+	if err != nil {
+		panic(err)
+	}
+	s.OwnDRep = &drep
+	return s
+}
+
+func TestPlanStateMatrix(t *testing.T) {
+	const pool = "pool1abc"
+	const otherPool = "pool1xyz"
+
+	cases := []struct {
+		name         string
+		current      AccountState
+		req          DelegationRequest
+		withdrawable string
+		want         []CertKind
+		wantErr      error
+	}{
+		{
+			name:    "fresh wallet, pool only → register + delegate",
+			current: AccountState{Registered: false},
+			req:     DelegationRequest{PoolID: pool},
+			want:    []CertKind{CertStakeRegistration, CertStakeDelegation},
+		},
+		{
+			name:    "fresh wallet, pool + abstain → register + delegate + vote",
+			current: AccountState{Registered: false},
+			req:     DelegationRequest{PoolID: pool, Vote: &Vote{Type: VoteAbstain}},
+			want:    []CertKind{CertStakeRegistration, CertStakeDelegation, CertVoteDelegation},
+		},
+		{
+			name:    "fresh wallet, register self → register + drep-reg + vote",
+			current: withOwnDRep(AccountState{Registered: false}),
+			req:     DelegationRequest{PoolID: pool, Vote: &Vote{Type: VoteRegisterSelf}},
+			want:    []CertKind{CertStakeRegistration, CertStakeDelegation, CertDRepRegistration, CertVoteDelegation},
+		},
+		{
+			name:    "already registered, pool change → delegate only",
+			current: AccountState{Registered: true, CurrentPool: strptr(otherPool)},
+			req:     DelegationRequest{PoolID: pool},
+			want:    []CertKind{CertStakeDelegation},
+		},
+		{
+			name:    "already registered, same pool → no-op",
+			current: AccountState{Registered: true, CurrentPool: strptr(pool)},
+			req:     DelegationRequest{PoolID: pool},
+			wantErr: ErrNoChange,
+		},
+		{
+			name:    "registered, no delegation yet, set pool → delegate only",
+			current: AccountState{Registered: true, CurrentPool: nil},
+			req:     DelegationRequest{PoolID: pool},
+			want:    []CertKind{CertStakeDelegation},
+		},
+		{
+			name:    "registered, abstain vote only → vote only",
+			current: AccountState{Registered: true, CurrentPool: strptr(pool)},
+			req:     DelegationRequest{Vote: &Vote{Type: VoteAbstain}},
+			want:    []CertKind{CertVoteDelegation},
+		},
+		{
+			name:    "registered, no-confidence vote only → vote only",
+			current: AccountState{Registered: true},
+			req:     DelegationRequest{Vote: &Vote{Type: VoteNoConfidence}},
+			want:    []CertKind{CertVoteDelegation},
+		},
+		{
+			name:    "registered, specific drep vote → vote only",
+			current: AccountState{Registered: true},
+			req:     DelegationRequest{Vote: &Vote{Type: VoteDRep, DRepID: validDRepID}},
+			want:    []CertKind{CertVoteDelegation},
+		},
+		{
+			name:    "registered, register self → drep-reg + vote",
+			current: withOwnDRep(AccountState{Registered: true, CurrentPool: strptr(pool)}),
+			req:     DelegationRequest{Vote: &Vote{Type: VoteRegisterSelf}},
+			want:    []CertKind{CertDRepRegistration, CertVoteDelegation},
+		},
+		{
+			name:    "registered, same abstain vote → no-op",
+			current: AccountState{Registered: true, CurrentDRep: &lcommon.Drep{Type: lcommon.DrepTypeAbstain}},
+			req:     DelegationRequest{Vote: &Vote{Type: VoteAbstain}},
+			wantErr: ErrNoChange,
+		},
+		{
+			name:    "registered, same no-confidence vote → no-op",
+			current: AccountState{Registered: true, CurrentDRep: &lcommon.Drep{Type: lcommon.DrepTypeNoConfidence}},
+			req:     DelegationRequest{Vote: &Vote{Type: VoteNoConfidence}},
+			wantErr: ErrNoChange,
+		},
+		{
+			name:    "registered, same specific drep vote → no-op",
+			current: AccountState{Registered: true, CurrentDRep: drepPtr(t, validDRepID)},
+			req:     DelegationRequest{Vote: &Vote{Type: VoteDRep, DRepID: validDRepID}},
+			wantErr: ErrNoChange,
+		},
+		{
+			name: "registered, self DRep already registered and delegated → no-op",
+			current: withOwnDRep(AccountState{
+				Registered:        true,
+				CurrentDRep:       drepPtr(t, validDRepID),
+				OwnDRepRegistered: true,
+			}),
+			req:     DelegationRequest{Vote: &Vote{Type: VoteRegisterSelf}},
+			wantErr: ErrNoChange,
+		},
+		{
+			name: "registered, self DRep already registered but vote differs → vote only",
+			current: withOwnDRep(AccountState{
+				Registered:        true,
+				CurrentDRep:       &lcommon.Drep{Type: lcommon.DrepTypeAbstain},
+				OwnDRepRegistered: true,
+			}),
+			req:  DelegationRequest{Vote: &Vote{Type: VoteRegisterSelf}},
+			want: []CertKind{CertVoteDelegation},
+		},
+		{
+			name:    "register self with anchor url only → error",
+			current: withOwnDRep(AccountState{Registered: true}),
+			req:     DelegationRequest{Vote: &Vote{Type: VoteRegisterSelf, Anchor: &Anchor{URL: "https://example.com/drep.jsonld"}}},
+			wantErr: ErrInvalidRequest,
+		},
+		{
+			name:    "register self with anchor hash only → error",
+			current: withOwnDRep(AccountState{Registered: true}),
+			req:     DelegationRequest{Vote: &Vote{Type: VoteRegisterSelf, Anchor: &Anchor{Hash: strings.Repeat("ab", 32)}}},
+			wantErr: ErrInvalidRequest,
+		},
+		{
+			name:         "registered, withdraw only → withdrawal",
+			current:      AccountState{Registered: true, CurrentPool: strptr(pool)},
+			req:          DelegationRequest{Withdraw: true},
+			withdrawable: "5000000",
+			want:         []CertKind{CertWithdrawal},
+		},
+		{
+			name:         "pool change + withdraw → delegate + withdrawal",
+			current:      AccountState{Registered: true, CurrentPool: strptr(otherPool)},
+			req:          DelegationRequest{PoolID: pool, Withdraw: true},
+			withdrawable: "5000000",
+			want:         []CertKind{CertStakeDelegation, CertWithdrawal},
+		},
+		{
+			name:         "withdraw with zero rewards → error",
+			current:      AccountState{Registered: true, CurrentPool: strptr(pool)},
+			req:          DelegationRequest{Withdraw: true},
+			withdrawable: "0",
+			wantErr:      ErrInvalidRequest,
+		},
+		{
+			name:    "empty request → no-op",
+			current: AccountState{Registered: true},
+			req:     DelegationRequest{},
+			wantErr: ErrNoChange,
+		},
+		{
+			name:    "specific drep without id → error",
+			current: AccountState{Registered: true},
+			req:     DelegationRequest{Vote: &Vote{Type: VoteDRep}},
+			wantErr: ErrInvalidRequest,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			certs, err := plan(tc.current, tc.req, defaultParams, tc.withdrawable)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("plan err = %v, want %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("plan: %v", err)
+			}
+			if !equalKinds(kinds(certs), tc.want) {
+				t.Fatalf("plan kinds = %v, want %v", kinds(certs), tc.want)
+			}
+		})
+	}
+}
+
+func TestPlanDepositMath(t *testing.T) {
+	// A fresh wallet registering self carries both the key deposit (on the stake
+	// registration cert) and the DRep deposit (on the DRep registration cert),
+	// each distinctly itemized.
+	certs, err := plan(
+		withOwnDRep(AccountState{Registered: false}),
+		DelegationRequest{PoolID: "pool1abc", Vote: &Vote{Type: VoteRegisterSelf}},
+		defaultParams, "0",
+	)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	var keyDep, drepDep string
+	for _, c := range certs {
+		switch c.Kind {
+		case CertStakeRegistration:
+			keyDep = c.DepositLovelace
+		case CertDRepRegistration:
+			drepDep = c.DepositLovelace
+		}
+	}
+	if keyDep != "2000000" {
+		t.Fatalf("stake registration deposit = %q, want 2000000", keyDep)
+	}
+	if drepDep != "500000000" {
+		t.Fatalf("drep registration deposit = %q, want 500000000", drepDep)
+	}
+}
+
+func TestPlanWithdrawalAmount(t *testing.T) {
+	certs, err := plan(
+		AccountState{Registered: true, CurrentPool: strptr("pool1abc")},
+		DelegationRequest{Withdraw: true},
+		defaultParams, "7500000",
+	)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	if len(certs) != 1 || certs[0].Kind != CertWithdrawal {
+		t.Fatalf("unexpected certs: %+v", certs)
+	}
+	if certs[0].AmountLovelace != "7500000" {
+		t.Fatalf("withdrawal amount = %q, want 7500000", certs[0].AmountLovelace)
+	}
+}
+
+// fakeQuerier implements chainQuerier for BuildDelegation tests.
+type fakeQuerier struct {
+	account           chain.AccountInfo
+	accountErr        error
+	accountDRepID     *string
+	accountDRepIDErr  error
+	accountDRepIDUsed bool
+	pool              chain.PoolInfo
+	poolErr           error
+	drep              chain.DRepInfo
+	drepErr           error
+	params            chain.ProtocolParams
+	paramsErr         error
+	poolCalled        bool
+	drepCalled        bool
+	gotPoolID         string
+	gotDRepID         string
+}
+
+func (f *fakeQuerier) Account(_ context.Context, _ string) (chain.AccountInfo, error) {
+	return f.account, f.accountErr
+}
+
+func (f *fakeQuerier) AccountDRepID(_ context.Context, _ string) (*string, error) {
+	f.accountDRepIDUsed = true
+	return f.accountDRepID, f.accountDRepIDErr
+}
+
+func (f *fakeQuerier) Pool(_ context.Context, id string) (chain.PoolInfo, error) {
+	f.poolCalled = true
+	f.gotPoolID = id
+	return f.pool, f.poolErr
+}
+
+func (f *fakeQuerier) DRep(_ context.Context, id string) (chain.DRepInfo, error) {
+	f.drepCalled = true
+	f.gotDRepID = id
+	return f.drep, f.drepErr
+}
+
+func (f *fakeQuerier) ProtocolParams(_ context.Context) (chain.ProtocolParams, error) {
+	return f.params, f.paramsErr
+}
+
+func newFakeQuerier() *fakeQuerier {
+	dd := "500000000"
+	return &fakeQuerier{
+		account: chain.AccountInfo{Active: false, WithdrawableAmount: "0"},
+		pool:    chain.PoolInfo{PoolID: "pool1abc"},
+		drep:    chain.DRepInfo{DRepID: "drep1abc", Registered: true},
+		params:  chain.ProtocolParams{KeyDeposit: "2000000", PoolDeposit: "500000000", DRepDeposit: &dd},
+	}
+}
+
+func TestBuildDelegationNoWallet(t *testing.T) {
+	fc := newFakeChain(5_000_000, mustDeriveTestAccount(t).ReceiveAddresses[0])
+	s := NewService(fc, nil, nil)
+	s.SetChainQuerier(newFakeQuerier())
+	_, err := s.BuildDelegation(context.Background(), DelegationRequest{PoolID: "pool1abc"})
+	if !errors.Is(err, ErrNoWallet) {
+		t.Fatalf("BuildDelegation without wallet = %v, want ErrNoWallet", err)
+	}
+}
+
+func TestBuildDelegationPoolNotFound(t *testing.T) {
+	acct := mustDeriveTestAccount(t)
+	fc := newFakeChain(5_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, nil, acct)
+	q := newFakeQuerier()
+	q.poolErr = chain.ErrNotFound
+	s.SetChainQuerier(q)
+
+	_, err := s.BuildDelegation(context.Background(), DelegationRequest{PoolID: "pool1missing"})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("BuildDelegation unknown pool = %v, want ErrInvalidRequest", err)
+	}
+	if !strings.Contains(err.Error(), "not found by your node") {
+		t.Fatalf("error should mention node not-found: %v", err)
+	}
+}
+
+func TestBuildDelegationDRepNotFound(t *testing.T) {
+	acct := mustDeriveTestAccount(t)
+	fc := newFakeChain(5_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, nil, acct)
+	q := newFakeQuerier()
+	q.account = chain.AccountInfo{Active: true, WithdrawableAmount: "0"}
+	q.drepErr = chain.ErrNotFound
+	s.SetChainQuerier(q)
+
+	_, err := s.BuildDelegation(context.Background(), DelegationRequest{Vote: &Vote{Type: VoteDRep, DRepID: "drep1missing"}})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("BuildDelegation unknown drep = %v, want ErrInvalidRequest", err)
+	}
+	if !strings.Contains(err.Error(), "not found by your node") {
+		t.Fatalf("error should mention node not-found: %v", err)
+	}
+}
+
+func TestBuildDelegationNoChange(t *testing.T) {
+	acct := mustDeriveTestAccount(t)
+	fc := newFakeChain(5_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, nil, acct)
+	q := newFakeQuerier()
+	// Already delegated to the requested pool → no certs.
+	q.account = chain.AccountInfo{Registered: true, Active: true, PoolID: strptr("pool1abc"), WithdrawableAmount: "0"}
+	s.SetChainQuerier(q)
+
+	_, err := s.BuildDelegation(context.Background(), DelegationRequest{PoolID: "pool1abc"})
+	if !errors.Is(err, ErrNoChange) {
+		t.Fatalf("BuildDelegation no change = %v, want ErrNoChange", err)
+	}
+}
+
+func TestBuildDelegationVoteNoChange(t *testing.T) {
+	acct := mustDeriveTestAccount(t)
+	fc := newFakeChain(5_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, nil, acct)
+	q := newFakeQuerier()
+	q.account = chain.AccountInfo{Registered: true, Active: true, WithdrawableAmount: "0"}
+	q.accountDRepID = strptr("drep_abstain")
+	s.SetChainQuerier(q)
+
+	_, err := s.BuildDelegation(context.Background(), DelegationRequest{Vote: &Vote{Type: VoteAbstain}})
+	if !errors.Is(err, ErrNoChange) {
+		t.Fatalf("BuildDelegation same vote = %v, want ErrNoChange", err)
+	}
+	if !q.accountDRepIDUsed {
+		t.Fatal("AccountDRepID was not used for account response without drep_id")
+	}
+}
+
+func TestBuildDelegationRegisterSelfNoChange(t *testing.T) {
+	acct := mustDeriveTestAccount(t)
+	own, err := drepFromHex(acct.DRepKeyHash)
+	if err != nil {
+		t.Fatalf("own drep: %v", err)
+	}
+	fc := newFakeChain(5_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, nil, acct)
+	q := newFakeQuerier()
+	q.account = chain.AccountInfo{Registered: true, Active: true, WithdrawableAmount: "0"}
+	q.accountDRepID = strptr(own.String())
+	q.drep = chain.DRepInfo{DRepID: own.String(), Registered: true}
+	s.SetChainQuerier(q)
+
+	_, err = s.BuildDelegation(context.Background(), DelegationRequest{Vote: &Vote{Type: VoteRegisterSelf}})
+	if !errors.Is(err, ErrNoChange) {
+		t.Fatalf("BuildDelegation same self vote = %v, want ErrNoChange", err)
+	}
+	if !q.drepCalled || q.gotDRepID != own.String() {
+		t.Fatalf("own drep registration not checked: called=%v id=%q", q.drepCalled, q.gotDRepID)
+	}
+}
+
+func TestBuildDelegationRegisterSelfAlreadyRegisteredVoteOnly(t *testing.T) {
+	acct := mustDeriveTestAccount(t)
+	own, err := drepFromHex(acct.DRepKeyHash)
+	if err != nil {
+		t.Fatalf("own drep: %v", err)
+	}
+	fc := newFakeChain(5_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, nil, acct)
+	q := newFakeQuerier()
+	q.account = chain.AccountInfo{Registered: true, Active: true, WithdrawableAmount: "0"}
+	q.accountDRepID = strptr("drep_abstain")
+	q.drep = chain.DRepInfo{DRepID: own.String(), Registered: true}
+	s.SetChainQuerier(q)
+
+	pv, err := s.BuildDelegation(context.Background(), DelegationRequest{Vote: &Vote{Type: VoteRegisterSelf}})
+	if err != nil {
+		t.Fatalf("BuildDelegation register self already registered: %v", err)
+	}
+	if got, want := kinds(pv.Certs), []CertKind{CertVoteDelegation}; !equalKinds(got, want) {
+		t.Fatalf("cert kinds = %v, want %v", got, want)
+	}
+	if pv.Deposit != "0" {
+		t.Fatalf("deposit = %q, want 0", pv.Deposit)
+	}
+}
+
+// TestBuildDelegationFreshWalletPreview drives the full build of a fresh wallet
+// registering + delegating to a pool, asserting the itemized preview surfaces
+// the stake deposit and a non-zero fee, and that the pool was verified.
+func TestBuildDelegationFreshWalletPreview(t *testing.T) {
+	acct := mustDeriveTestAccount(t)
+	fc := newFakeChain(10_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, nil, acct)
+	q := newFakeQuerier()
+	s.SetChainQuerier(q)
+
+	pv, err := s.BuildDelegation(context.Background(), DelegationRequest{PoolID: validPoolID})
+	if err != nil {
+		t.Fatalf("BuildDelegation: %v", err)
+	}
+	if !q.poolCalled || q.gotPoolID != validPoolID {
+		t.Fatalf("pool not verified: called=%v id=%q", q.poolCalled, q.gotPoolID)
+	}
+	if pv.PendingID == "" {
+		t.Fatal("expected non-empty pending id")
+	}
+	if len(pv.Certs) != 2 || pv.Certs[0].Kind != CertStakeRegistration || pv.Certs[1].Kind != CertStakeDelegation {
+		t.Fatalf("unexpected certs: %+v", pv.Certs)
+	}
+	if pv.Deposit != "2000000" {
+		t.Fatalf("deposit = %q, want 2000000", pv.Deposit)
+	}
+	if pv.Fee == "" || pv.Fee == "0" {
+		t.Fatalf("expected non-zero fee, got %q", pv.Fee)
+	}
+}
+
+// TestBuildDelegationConfirmSignsAndSubmits proves a delegation tx flows through
+// the SAME Confirm (sign+submit) path the Send flow uses, unchanged.
+func TestBuildDelegationConfirmSignsAndSubmits(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	fc := newFakeChain(10_000_000, acct.ReceiveAddresses[0])
+	ks := fakeKeystore{mnemonic: testMnemonic}
+	s := NewService(fc, ks, acct)
+	q := newFakeQuerier()
+	s.SetChainQuerier(q)
+
+	ctx := context.Background()
+	pv, err := s.BuildDelegation(ctx, DelegationRequest{PoolID: validPoolID, Vote: &Vote{Type: VoteAbstain}})
+	if err != nil {
+		t.Fatalf("BuildDelegation: %v", err)
+	}
+	if len(pv.Certs) != 3 {
+		t.Fatalf("expected 3 certs (register, delegate, vote), got %+v", pv.Certs)
+	}
+
+	res, err := s.Confirm(ctx, pv.PendingID, "pw")
+	if err != nil {
+		t.Fatalf("Confirm delegation: %v", err)
+	}
+	if res.TxHash == "" {
+		t.Fatal("expected non-empty tx hash")
+	}
+	if fc.submitCalls != 1 {
+		t.Fatalf("SubmitTx calls = %d, want 1", fc.submitCalls)
+	}
+}
+
+// TestBuildDelegationRegisterSelfPreview drives a self-DRep registration,
+// asserting the DRep deposit is itemized distinctly from the stake deposit.
+func TestBuildDelegationRegisterSelfPreview(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	if acct.DRepKeyHash == "" {
+		t.Fatal("derived account is missing its DRep key hash")
+	}
+	fc := newFakeChain(600_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, nil, acct)
+	q := newFakeQuerier()
+	q.account = chain.AccountInfo{Registered: true, Active: true, PoolID: strptr("pool1abc"), WithdrawableAmount: "0"}
+	q.drepErr = chain.ErrNotFound
+	s.SetChainQuerier(q)
+
+	pv, err := s.BuildDelegation(context.Background(), DelegationRequest{
+		Vote: &Vote{Type: VoteRegisterSelf, Anchor: &Anchor{
+			URL:  "https://example.com/drep.jsonld",
+			Hash: strings.Repeat("ab", 32),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("BuildDelegation register self: %v", err)
+	}
+	var keyDep, drepDep string
+	for _, c := range pv.Certs {
+		switch c.Kind {
+		case CertStakeRegistration:
+			keyDep = c.DepositLovelace
+		case CertDRepRegistration:
+			drepDep = c.DepositLovelace
+		}
+	}
+	if keyDep != "" {
+		t.Fatalf("already-registered wallet should not re-register stake (deposit %q)", keyDep)
+	}
+	if drepDep != "500000000" {
+		t.Fatalf("drep deposit = %q, want 500000000", drepDep)
+	}
+	if pv.Deposit != "500000000" {
+		t.Fatalf("total deposit = %q, want 500000000", pv.Deposit)
+	}
+}
+
+func TestDecodeDRepID(t *testing.T) {
+	// A valid legacy CIP-0105 (28-byte) drep1 id decodes to a key-hash credential.
+	typ, hash, err := decodeDRepID(validDRepID)
+	if err != nil {
+		t.Fatalf("decodeDRepID(%q): %v", validDRepID, err)
+	}
+	if typ != 0 { // DrepTypeAddrKeyHash
+		t.Fatalf("type = %d, want 0 (key hash)", typ)
+	}
+	if len(hash) != 28 {
+		t.Fatalf("hash len = %d, want 28", len(hash))
+	}
+	if _, _, err := decodeDRepID("notbech32"); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("invalid bech32 should error, got %v", err)
+	}
+	if _, _, err := decodeDRepID(validPoolID); err == nil {
+		t.Fatal("a non-drep prefix should error")
+	}
+}
+
+func TestParseDRepTargetNormalizesCurrentAccountFormats(t *testing.T) {
+	keyHash := strings.Repeat("01", 28)
+	cases := []struct {
+		name     string
+		id       string
+		wantType int
+		wantHash string
+	}{
+		{name: "abstain", id: "drep_abstain", wantType: lcommon.DrepTypeAbstain},
+		{name: "legacy always abstain", id: "drep_always_abstain", wantType: lcommon.DrepTypeAbstain},
+		{name: "no confidence", id: "drep_no_confidence", wantType: lcommon.DrepTypeNoConfidence},
+		{name: "legacy always no confidence", id: "drep_always_no_confidence", wantType: lcommon.DrepTypeNoConfidence},
+		{name: "legacy drep bech32", id: validDRepID, wantType: lcommon.DrepTypeAddrKeyHash},
+		{name: "cip129 drep bech32", id: drepPtr(t, validDRepID).String(), wantType: lcommon.DrepTypeAddrKeyHash},
+		{name: "internal key hash", id: "drep-keyHash-" + keyHash, wantType: lcommon.DrepTypeAddrKeyHash, wantHash: keyHash},
+		{name: "raw key hash", id: keyHash, wantType: lcommon.DrepTypeAddrKeyHash, wantHash: keyHash},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseDRepTarget(tc.id)
+			if err != nil {
+				t.Fatalf("parseDRepTarget: %v", err)
+			}
+			if got.Type != tc.wantType {
+				t.Fatalf("type = %d, want %d", got.Type, tc.wantType)
+			}
+			if tc.wantHash != "" && hex.EncodeToString(got.Credential) != tc.wantHash {
+				t.Fatalf("hash = %x, want %s", got.Credential, tc.wantHash)
+			}
+		})
+	}
+}

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -106,8 +106,8 @@ type UnsignedTx struct {
 	// UnsignedTxCBOR is the hex-encoded CBOR of the completed Conway tx with an
 	// empty witness set.
 	UnsignedTxCBOR string `json:"unsigned_tx_cbor"`
-	// RequiredSigners are the hex-encoded payment key-hashes (Blake2b-224) of the
-	// distinct input addresses — the witnesses the offline instance must produce.
+	// RequiredSigners are the hex-encoded key-hashes (Blake2b-224) that must
+	// witness the transaction.
 	RequiredSigners []string `json:"required_signers"`
 }
 
@@ -551,6 +551,19 @@ func sameKeyHashSet(a, b []lcommon.Blake2b224) bool {
 	return true
 }
 
+func keyHashSetContainsAll(set, subset []lcommon.Blake2b224) bool {
+	seen := make(map[lcommon.Blake2b224]bool, len(set))
+	for _, kh := range set {
+		seen[kh] = true
+	}
+	for _, kh := range subset {
+		if !seen[kh] {
+			return false
+		}
+	}
+	return true
+}
+
 func keyHashesHex(signers []lcommon.Blake2b224) []string {
 	ret := make([]string, 0, len(signers))
 	for _, kh := range signers {
@@ -933,16 +946,18 @@ func (s *Service) ExportUnsigned(pendingID string) (UnsignedTx, error) {
 	if tx == nil {
 		return UnsignedTx{}, errors.New("pending tx is nil")
 	}
-	// The required signers are the distinct input addresses' payment key-hashes.
-	// They are derived from the same utxoAddr map Confirm uses, so the offline
-	// instance is told exactly which keys it must produce witnesses for.
-	signerHashes, err := requiredPaymentKeyHashesForInputs(tx.Body.Inputs(), p.utxoAddr)
+	// Payment signer hashes are derived from the same utxoAddr map Confirm uses.
+	// Delegation transactions may also bind stake/DRep certificate signers in the
+	// body; export the full body-bound signer set after confirming the selected
+	// payment keys are represented.
+	paymentSignerHashes, err := requiredPaymentKeyHashesForInputs(tx.Body.Inputs(), p.utxoAddr)
 	if err != nil {
 		return UnsignedTx{}, err
 	}
-	if !sameKeyHashSet(tx.Body.RequiredSigners(), signerHashes) {
+	bodySignerHashes := tx.Body.RequiredSigners()
+	if !keyHashSetContainsAll(bodySignerHashes, paymentSignerHashes) {
 		return UnsignedTx{}, fmt.Errorf(
-			"%w: unsigned tx required signers do not match selected input signers",
+			"%w: unsigned tx required signers do not include selected input signers",
 			ErrInvalidTx,
 		)
 	}
@@ -953,7 +968,7 @@ func (s *Service) ExportUnsigned(pendingID string) (UnsignedTx, error) {
 
 	return UnsignedTx{
 		UnsignedTxCBOR:  hex.EncodeToString(cborBytes),
-		RequiredSigners: keyHashesHex(signerHashes),
+		RequiredSigners: keyHashesHex(bodySignerHashes),
 	}, nil
 }
 
@@ -1085,6 +1100,11 @@ func (s *Service) SignTx(unsignedTxCBOR, password string, requiredSigners []stri
 			return Witness{}, fmt.Errorf("witness stake key: %w", err)
 		}
 	}
+	if drepKey, err := bursa.GetDRepKey(acctKey, 0); err == nil {
+		if err := addCandidate(drepKey); err != nil {
+			return Witness{}, fmt.Errorf("witness drep key: %w", err)
+		}
+	}
 	if len(witnesses) == 0 {
 		return Witness{}, fmt.Errorf(
 			"%w: none of this wallet's keys match the transaction's required signers",
@@ -1200,14 +1220,13 @@ func (s *Service) SubmitSigned(ctx context.Context, unsignedTxCBOR, witnessCBOR 
 // certKindsRequireWitnesses returns which additional witnesses a delegation tx
 // needs beyond the payment-input witnesses. Stake-touching certs (registration,
 // stake delegation, vote delegation, withdrawal) each require the stake key to
-// be a witness; DRep registration additionally requires the DRep key.
+// be a witness; DRep registration requires the DRep key.
 func certKindsRequireWitnesses(kinds []CertKind) (needsStake, needsDRep bool) {
 	for _, k := range kinds {
 		switch k {
 		case CertStakeRegistration, CertStakeDelegation, CertVoteDelegation, CertWithdrawal:
 			needsStake = true
 		case CertDRepRegistration:
-			needsStake = true
 			needsDRep = true
 		}
 	}

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -143,11 +143,12 @@ const feePaddingLovelace = 1000
 
 // pending holds a completed but unsigned tx while awaiting Confirm.
 type pending struct {
-	tx       *apollo.Apollo
-	utxoAddr map[string]string // "txhash#index" → bech32 address (for signing)
-	created  time.Time
-	walletID string
-	account  *wallet.Account
+	tx        *apollo.Apollo
+	utxoAddr  map[string]string // "txhash#index" → bech32 address (for signing)
+	created   time.Time
+	walletID  string
+	account   *wallet.Account
+	certKinds []CertKind // non-nil for delegation txs; drives stake/DRep witness addition at Confirm
 }
 
 // Service builds and holds pending send transactions.
@@ -157,6 +158,7 @@ type Service struct {
 	account  *wallet.Account
 	walletID string
 	gen      uint64
+	chainQ   chainQuerier     // node-backed pool/DRep/account/params queries (delegation); may be nil
 	mkID     func() string    // pending id generator; injectable for tests
 	now      func() time.Time // injectable for tests
 
@@ -246,6 +248,14 @@ func (s *Service) currentBinding() (string, *wallet.Account, uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.walletID, cloneAccount(s.account), s.gen
+}
+
+// currentAccount returns a snapshot of the active account under lock (nil if
+// none is set). Used by the delegation flow.
+func (s *Service) currentAccount() *wallet.Account {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return cloneAccount(s.account)
 }
 
 // Build runs coin selection and fee estimation for req using Apollo, stores the
@@ -794,6 +804,39 @@ func (s *Service) Confirm(ctx context.Context, pendingID, password string) (TxRe
 		}
 	}
 
+	// --- step 6b: add stake / DRep key witnesses for delegation certificates ---
+	// Cardano requires a vkey witness from the stake key for any cert that touches
+	// the stake credential (stake registration, stake delegation, vote delegation,
+	// and reward withdrawal). It also requires a witness from the DRep key for a
+	// DRep registration. These are in addition to the payment-key witnesses above.
+	needsStakeWitness, needsDRepWitness := certKindsRequireWitnesses(p.certKinds)
+	if needsStakeWitness {
+		stakeKey, err := bursa.GetStakeKey(acctKey, 0)
+		if err != nil {
+			return TxResult{}, fmt.Errorf("stake key: %w", err)
+		}
+		a, err = a.SignWithSkey([]byte(stakeKey))
+		for i := range stakeKey {
+			stakeKey[i] = 0
+		}
+		if err != nil {
+			return TxResult{}, fmt.Errorf("sign stake key: %w", err)
+		}
+	}
+	if needsDRepWitness {
+		drepKey, err := bursa.GetDRepKey(acctKey, 0)
+		if err != nil {
+			return TxResult{}, fmt.Errorf("drep key: %w", err)
+		}
+		a, err = a.SignWithSkey([]byte(drepKey))
+		for i := range drepKey {
+			drepKey[i] = 0
+		}
+		if err != nil {
+			return TxResult{}, fmt.Errorf("sign drep key: %w", err)
+		}
+	}
+
 	// --- step 7: submit ---
 	// The node's structured rejection reason (the failing ledger rule, via the
 	// utxorpc backend) rides along in the wrapped message.
@@ -1152,6 +1195,23 @@ func (s *Service) SubmitSigned(ctx context.Context, unsignedTxCBOR, witnessCBOR 
 		return TxResult{}, fmt.Errorf("%w: %w", ErrSubmitRejected, err)
 	}
 	return TxResult{TxHash: hex.EncodeToString(txHash.Bytes())}, nil
+}
+
+// certKindsRequireWitnesses returns which additional witnesses a delegation tx
+// needs beyond the payment-input witnesses. Stake-touching certs (registration,
+// stake delegation, vote delegation, withdrawal) each require the stake key to
+// be a witness; DRep registration additionally requires the DRep key.
+func certKindsRequireWitnesses(kinds []CertKind) (needsStake, needsDRep bool) {
+	for _, k := range kinds {
+		switch k {
+		case CertStakeRegistration, CertStakeDelegation, CertVoteDelegation, CertWithdrawal:
+			needsStake = true
+		case CertDRepRegistration:
+			needsStake = true
+			needsDRep = true
+		}
+	}
+	return
 }
 
 // randID generates a 16-byte random hex string for pending IDs.

--- a/ui/internal/wallet/account.go
+++ b/ui/internal/wallet/account.go
@@ -5,6 +5,7 @@
 package wallet
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	"github.com/blinklabs-io/bursa"
@@ -16,10 +17,17 @@ import (
 // Account is a derived, read-only view of a wallet: its stake address (the
 // query key) and a window of external (receive) payment addresses, all sharing
 // the canonical stake key at index 0.
+//
+// DRepKeyHash is the wallet's own DRep verification-key hash (CIP-0105,
+// derivation role 3), derived at the same time as the addresses. It carries the
+// public credential (a 28-byte blake2b-224 digest, hex-encoded over JSON) for
+// self-DRep registration and self vote delegation, so those operations need no
+// password to learn the wallet's DRep identity. It is public material, not a key.
 type Account struct {
 	Network          string   `json:"network"`
 	StakeAddress     string   `json:"stake_address"`
 	ReceiveAddresses []string `json:"receive_addresses"`
+	DRepKeyHash      string   `json:"drep_key_hash,omitempty"`
 }
 
 // AccountXpub returns the Bech32-encoded extended public key for the CIP-1852
@@ -106,6 +114,15 @@ func deriveFromRoot(root bip32.XPrv, network string, netID uint8, windowN int) (
 	defer zeroXPrv(stakeKey)
 	stakeHash := stakeKey.Public().PublicKey().Hash()
 
+	// The wallet's own DRep credential (CIP-0105, role 3): a public key hash used
+	// for self-DRep registration and self vote delegation.
+	drepKey, err := bursa.GetDRepKey(acctKey, 0)
+	if err != nil {
+		return nil, fmt.Errorf("drep key: %w", err)
+	}
+	defer zeroXPrv(drepKey)
+	drepHash := hex.EncodeToString(drepKey.Public().PublicKey().Hash())
+
 	stakeAddr, err := lcommon.NewAddressFromParts(lcommon.AddressTypeNoneKey, netID, nil, stakeHash)
 	if err != nil {
 		return nil, fmt.Errorf("stake address: %w", err)
@@ -130,6 +147,7 @@ func deriveFromRoot(root bip32.XPrv, network string, netID uint8, windowN int) (
 		Network:          network,
 		StakeAddress:     stakeAddr.String(),
 		ReceiveAddresses: receive,
+		DRepKeyHash:      drepHash,
 	}, nil
 }
 

--- a/ui/internal/wallet/service.go
+++ b/ui/internal/wallet/service.go
@@ -62,6 +62,7 @@ func cloneAccount(acct *Account) *Account {
 		Network:          acct.Network,
 		StakeAddress:     acct.StakeAddress,
 		ReceiveAddresses: cloneStringSlice(acct.ReceiveAddresses),
+		DRepKeyHash:      acct.DRepKeyHash,
 	}
 }
 

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -22,6 +22,10 @@ import type {
   WitnessResult,
   SignTxRequest,
   SubmitSignedRequest,
+  PoolInfo,
+  DRepInfo,
+  DelegationRequest,
+  DelegationPreview,
 } from "./types";
 
 export class ApiError extends Error {
@@ -112,3 +116,13 @@ export const exportUnsigned = (id: string) =>
 export const signTx = (req: SignTxRequest) => apiPost<WitnessResult>("/wallet/sign-tx", req);
 export const submitSigned = (req: SubmitSignedRequest) =>
   apiPost<TxResult>("/wallet/submit-signed", req);
+
+// Staking & governance. Pool/DRep lookups verify a pasted ID through the node;
+// buildDelegation returns an itemized preview; confirmDelegation signs + submits
+// through the same Confirm path the send flow uses.
+export const getPool = (id: string) => apiGet<PoolInfo>(`/wallet/pool/${encodeURIComponent(id)}`);
+export const getDRep = (id: string) => apiGet<DRepInfo>(`/wallet/drep/${encodeURIComponent(id)}`);
+export const buildDelegation = (req: DelegationRequest) =>
+  apiPost<DelegationPreview>("/wallet/delegation", req);
+export const confirmDelegation = (id: string, password: string) =>
+  apiPost<TxResult>(`/wallet/delegation/${encodeURIComponent(id)}/confirm`, { password });

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -164,6 +164,76 @@ export interface SubmitSignedRequest {
   witness_cbor: string;
 }
 
+// --- staking & governance ---
+
+// PoolInfo mirrors GET /wallet/pool/{id}: a node-verified stake pool readout.
+// margin_cost is a fraction (0.02 = 2%); the lovelace fields are decimal strings.
+export interface PoolInfo {
+  pool_id: string;
+  hex: string;
+  vrf_key: string;
+  active_stake: string;
+  live_stake: string;
+  declared_pledge: string;
+  fixed_cost: string;
+  margin_cost: number;
+}
+
+// DRepInfo mirrors GET /wallet/drep/{id}: confirms a DRep exists on chain.
+export interface DRepInfo {
+  drep_id: string;
+  hex: string;
+  has_script: boolean;
+  registered: boolean;
+  amount: string;
+  active: boolean;
+  live_stake: string;
+}
+
+export type VoteType = "abstain" | "no_confidence" | "drep" | "register_self";
+
+export interface VoteAnchor {
+  url: string;
+  hash: string; // hex-encoded 32-byte blake2b-256 digest
+}
+
+export type DelegationVote =
+  | { type: "abstain"; drep_id?: never; anchor?: never }
+  | { type: "no_confidence"; drep_id?: never; anchor?: never }
+  | { type: "drep"; drep_id: string; anchor?: never }
+  | { type: "register_self"; drep_id?: never; anchor?: VoteAnchor };
+
+export interface DelegationRequest {
+  pool_id?: string; // omitted = leave stake delegation unchanged
+  vote?: DelegationVote;
+  withdraw?: boolean; // sweep withdrawable rewards
+}
+
+export type CertKind =
+  | "stake_registration"
+  | "stake_delegation"
+  | "vote_delegation"
+  | "drep_registration"
+  | "withdrawal";
+
+// Cert is one itemized line in a delegation preview: a summary plus, where
+// applicable, the refundable deposit it locks or the amount it moves.
+export interface Cert {
+  kind: CertKind;
+  summary: string;
+  deposit_lovelace?: string;
+  amount_lovelace?: string;
+}
+
+export interface DelegationPreview {
+  pending_id: string;
+  certs: Cert[];
+  fee: string;
+  deposit: string; // total refundable deposit, decimal lovelace
+  withdrawal?: string; // total withdrawn, decimal lovelace
+  total: string; // net cost (fee + deposits − withdrawals), decimal lovelace
+}
+
 // A wallet as listed by the vault: read-only fields plus whether it's active.
 // The encrypted seed is never exposed.
 export interface WalletView {

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -16,6 +16,7 @@ import { Portfolio } from "./screens/Portfolio";
 import { Receive } from "./screens/Receive";
 import { Activity } from "./screens/Activity";
 import { Send } from "./screens/Send";
+import { Staking } from "./screens/Staking";
 import { SignMessage } from "./screens/SignMessage";
 import { VerifyMessage } from "./screens/VerifyMessage";
 import { Offline } from "./screens/Offline";
@@ -36,6 +37,7 @@ const NAV: { key: string; label: string }[] = [
   { key: "receive", label: "Receive" },
   { key: "activity", label: "Activity" },
   { key: "send", label: "Send" },
+  { key: "staking", label: "Staking" },
   { key: "sign", label: "Sign" },
   { key: "verify", label: "Verify" },
   { key: "offline", label: "Offline" },
@@ -188,6 +190,11 @@ export function App() {
     );
   }
 
+  // Staking/governance is gated identically to send: a fully synced node AND an
+  // active (spending-capable) wallet. A read-only or unsynced wallet falls back
+  // to Portfolio.
+  const canStake = isReady && activeWallet !== null;
+
   // --- Unlocked: the normal wallet UI bound to the active wallet ----------
 
   // Which nav entry maps to the screen currently shown (mirrors the content
@@ -196,6 +203,7 @@ export function App() {
   if (!addingWallet && activeWallet !== null) {
     if (route === "settings") activeRoute = "settings";
     else if (route === "send" && canSend) activeRoute = "send";
+    else if (route === "staking" && canStake) activeRoute = "staking";
     else if (route === "sign" && canSign) activeRoute = "sign";
     else if (route === "verify") activeRoute = "verify";
     else if (route === "offline" && canSign) activeRoute = "offline";
@@ -224,6 +232,11 @@ export function App() {
     content = <Settings account={toAccount(activeWallet)} spendingEnabled />;
   } else if (route === "send" && !canSend) {
     content = <Portfolio />;
+  } else if (route === "staking") {
+    // Staking/governance is gated like send: a synced node AND a
+    // spending-enabled wallet. A read-only or unsynced wallet falls back to
+    // Portfolio.
+    content = canStake ? <Staking /> : <Portfolio />;
   } else if (route === "sign") {
     content = canSign ? <SignMessage account={toAccount(activeWallet)} /> : <Portfolio />;
   } else if (route === "verify") {
@@ -265,6 +278,7 @@ export function App() {
               activeWallet === null ||
               addingWallet ||
               (key === "send" && !canSend) ||
+              (key === "staking" && !canStake) ||
               (key === "sign" && !canSign) ||
               (key === "offline" && !canSign);
             const active = key === activeRoute;

--- a/ui/web/src/screens/Staking.test.tsx
+++ b/ui/web/src/screens/Staking.test.tsx
@@ -1,0 +1,359 @@
+import { act, render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Staking } from "./Staking";
+import * as client from "../api/client";
+import * as hooks from "../api/hooks";
+import type { DelegationPreview, TxResult, PoolInfo, DRepInfo } from "../api/types";
+
+const MOCK_POOL: PoolInfo = {
+  pool_id: "pool1abc",
+  hex: "abc",
+  vrf_key: "vrf",
+  active_stake: "4800000000",
+  live_stake: "12410000000000",
+  declared_pledge: "100000000000",
+  fixed_cost: "340000000",
+  margin_cost: 0.02,
+};
+
+const MOCK_DREP: DRepInfo = {
+  drep_id: "drep1abc",
+  hex: "abc",
+  has_script: false,
+  registered: true,
+  amount: "500000000",
+  active: true,
+  live_stake: "4200000000",
+};
+
+const MOCK_PREVIEW: DelegationPreview = {
+  pending_id: "del-pending-1",
+  certs: [
+    { kind: "stake_registration", summary: "Register stake key", deposit_lovelace: "2000000" },
+    { kind: "stake_delegation", summary: "Delegate stake to pool1abc" },
+    { kind: "vote_delegation", summary: "Delegate voting power to Always Abstain" },
+  ],
+  fee: "174000",
+  deposit: "2000000",
+  total: "2174000",
+};
+
+const MOCK_TX_RESULT: TxResult = {
+  tx_hash: "feedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface",
+};
+
+// mockDelegation controls the status panel / active-vs-fresh branch.
+function mockDelegation(
+  overrides: Partial<{
+    pool_id: string | null;
+    active: boolean;
+    rewards_sum: string;
+    withdrawable_amount: string;
+    provisional: boolean;
+    note: string;
+  }> = {},
+) {
+  vi.spyOn(hooks, "useDelegation").mockReturnValue({
+    data: {
+      pool_id: null,
+      active: false,
+      rewards_sum: "0",
+      withdrawable_amount: "0",
+      provisional: false,
+      note: "",
+      ...overrides,
+    },
+    error: null,
+    loading: false,
+    refresh: vi.fn(),
+  } as never);
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// --- fresh wallet: pool paste → verified readout ---
+
+test("(a) pasting a pool ID verifies it against the node and shows the readout", async () => {
+  mockDelegation({ active: false });
+  const getPool = vi.spyOn(client, "getPool").mockResolvedValue(MOCK_POOL);
+
+  render(<Staking />);
+
+  const poolInput = screen.getByPlaceholderText(/pool1\.\.\./i);
+  fireEvent.change(poolInput, { target: { value: "pool1abc" } });
+  fireEvent.blur(poolInput);
+
+  await waitFor(() => expect(getPool).toHaveBeenCalledWith("pool1abc"));
+
+  // Verified readout shows the node-verification tick (its own span) and the
+  // margin parsed from the pool params.
+  await waitFor(() =>
+    expect(screen.getByText("✓ Verified by your node")).toBeInTheDocument(),
+  );
+  expect(screen.getByText(/margin 2\.0%/i)).toBeInTheDocument();
+});
+
+test("(b) an unknown pool ID shows 'not found by your node' inline", async () => {
+  mockDelegation({ active: false });
+  vi.spyOn(client, "getPool").mockRejectedValue(new client.ApiError(404, "not found by your node"));
+
+  render(<Staking />);
+
+  const poolInput = screen.getByPlaceholderText(/pool1\.\.\./i);
+  fireEvent.change(poolInput, { target: { value: "pool1bad" } });
+  fireEvent.blur(poolInput);
+
+  await waitFor(() => expect(screen.getByText(/not found by your node/i)).toBeInTheDocument());
+});
+
+test("stale pool verification responses are ignored after the pool input changes", async () => {
+  mockDelegation({ active: false });
+  const pending = deferred<PoolInfo>();
+  const getPool = vi.spyOn(client, "getPool").mockReturnValue(pending.promise);
+
+  render(<Staking />);
+
+  const poolInput = screen.getByLabelText(/stake pool/i);
+  fireEvent.change(poolInput, { target: { value: "pool1old" } });
+  fireEvent.blur(poolInput);
+
+  await waitFor(() => expect(getPool).toHaveBeenCalledWith("pool1old"));
+
+  fireEvent.change(poolInput, { target: { value: "pool1new" } });
+
+  await act(async () => {
+    pending.resolve(MOCK_POOL);
+    await pending.promise;
+  });
+
+  expect(screen.queryByText("✓ Verified by your node")).not.toBeInTheDocument();
+});
+
+test("stale DRep verification responses are ignored after the DRep input changes", async () => {
+  mockDelegation({ active: false });
+  const pending = deferred<DRepInfo>();
+  const getDRep = vi.spyOn(client, "getDRep").mockReturnValue(pending.promise);
+
+  render(<Staking />);
+
+  fireEvent.click(screen.getByLabelText(/a specific drep/i));
+  const drepInput = screen.getByLabelText(/drep id/i);
+  fireEvent.change(drepInput, { target: { value: "drep1old" } });
+  fireEvent.blur(drepInput);
+
+  await waitFor(() => expect(getDRep).toHaveBeenCalledWith("drep1old"));
+
+  fireEvent.change(drepInput, { target: { value: "drep1new" } });
+
+  await act(async () => {
+    pending.resolve(MOCK_DREP);
+    await pending.promise;
+  });
+
+  expect(screen.queryByText("✓ Verified by your node")).not.toBeInTheDocument();
+});
+
+// --- compose → itemized preview ---
+
+test("(c) Review delegation builds the request and shows the itemized confirm", async () => {
+  mockDelegation({ active: false });
+  const build = vi.spyOn(client, "buildDelegation").mockResolvedValue(MOCK_PREVIEW);
+
+  render(<Staking />);
+
+  fireEvent.change(screen.getByPlaceholderText(/pool1\.\.\./i), { target: { value: "pool1abc" } });
+  // Pick "Always Abstain" (first vote option).
+  fireEvent.click(screen.getByLabelText(/always abstain/i));
+
+  fireEvent.click(screen.getByRole("button", { name: /review delegation/i }));
+
+  await waitFor(() =>
+    expect(build).toHaveBeenCalledWith({ pool_id: "pool1abc", vote: { type: "abstain" } }),
+  );
+
+  // Itemized confirm: each cert summary plus the 2 ADA deposit and total.
+  await waitFor(() => expect(screen.getByText(/register stake key/i)).toBeInTheDocument());
+  expect(screen.getByText(/delegate stake to pool1abc/i)).toBeInTheDocument();
+  expect(screen.getByText(/2 ₳ deposit/)).toBeInTheDocument(); // 2000000 lovelace
+  expect(screen.getByText(/2\.174 ₳/)).toBeInTheDocument(); // total 2174000 lovelace
+});
+
+// --- 4-way voting-power picker ---
+
+test("(d) the voting-power picker offers all four targets", () => {
+  mockDelegation({ active: false });
+  render(<Staking />);
+
+  expect(screen.getByLabelText(/always abstain/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/always no confidence/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/a specific drep/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/register myself as a drep/i)).toBeInTheDocument();
+});
+
+test("(e) choosing 'register self' reveals the optional anchor fields + deposit note", () => {
+  mockDelegation({ active: false });
+  render(<Staking />);
+
+  fireEvent.click(screen.getByLabelText(/register myself as a drep/i));
+
+  expect(screen.getByPlaceholderText(/example\.org\/my-drep/i)).toBeInTheDocument();
+  expect(screen.getByText(/exact deposit amounts are read from your node/i)).toBeInTheDocument();
+  expect(screen.queryByText(/500 ₳ deposit/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/2 ₳ stake-key deposit/i)).not.toBeInTheDocument();
+});
+
+test("register-self metadata hash without a URL blocks Review", async () => {
+  mockDelegation({ active: false });
+  const build = vi.spyOn(client, "buildDelegation");
+
+  render(<Staking />);
+
+  fireEvent.click(screen.getByLabelText(/register myself as a drep/i));
+  fireEvent.change(screen.getByLabelText(/metadata hash/i), {
+    target: { value: "ab".repeat(32) },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /review delegation/i }));
+
+  await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/metadata URL/i));
+  expect(build).not.toHaveBeenCalled();
+});
+
+test("(f) choosing 'a specific DRep' without an ID blocks Review with an error", async () => {
+  mockDelegation({ active: false });
+  const build = vi.spyOn(client, "buildDelegation");
+  render(<Staking />);
+
+  fireEvent.click(screen.getByLabelText(/a specific drep/i));
+  fireEvent.click(screen.getByRole("button", { name: /review delegation/i }));
+
+  await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+  expect(build).not.toHaveBeenCalled();
+});
+
+// --- preview → confirm (success) ---
+
+test("(g) confirm signs + submits via confirmDelegation; tx hash shown on success", async () => {
+  mockDelegation({ active: false });
+  vi.spyOn(client, "buildDelegation").mockResolvedValue(MOCK_PREVIEW);
+  const confirm = vi.spyOn(client, "confirmDelegation").mockResolvedValue(MOCK_TX_RESULT);
+
+  render(<Staking />);
+
+  fireEvent.change(screen.getByPlaceholderText(/pool1\.\.\./i), { target: { value: "pool1abc" } });
+  fireEvent.click(screen.getByLabelText(/always abstain/i));
+  fireEvent.click(screen.getByRole("button", { name: /review delegation/i }));
+
+  await waitFor(() => expect(screen.getByText(/register stake key/i)).toBeInTheDocument());
+
+  const password = screen.getByLabelText(/spending password/i);
+  fireEvent.change(password, { target: { value: "s3cr3t" } });
+  fireEvent.click(screen.getByRole("button", { name: /confirm & sign/i }));
+
+  await waitFor(() => expect(confirm).toHaveBeenCalledWith("del-pending-1", "s3cr3t"));
+  await waitFor(() =>
+    expect(screen.getByText(new RegExp(MOCK_TX_RESULT.tx_hash))).toBeInTheDocument(),
+  );
+});
+
+// --- error path: confirm error keeps preview ---
+
+test("(h) a confirm error keeps the preview so the user can retry", async () => {
+  mockDelegation({ active: false });
+  vi.spyOn(client, "buildDelegation").mockResolvedValue(MOCK_PREVIEW);
+  vi.spyOn(client, "confirmDelegation").mockRejectedValue(
+    new client.ApiError(401, "incorrect spending password"),
+  );
+
+  render(<Staking />);
+
+  fireEvent.change(screen.getByPlaceholderText(/pool1\.\.\./i), { target: { value: "pool1abc" } });
+  fireEvent.click(screen.getByLabelText(/always abstain/i));
+  fireEvent.click(screen.getByRole("button", { name: /review delegation/i }));
+
+  await waitFor(() => expect(screen.getByText(/register stake key/i)).toBeInTheDocument());
+
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "wrong" } });
+  fireEvent.click(screen.getByRole("button", { name: /confirm & sign/i }));
+
+  await waitFor(() => expect(screen.getByText(/incorrect spending password/i)).toBeInTheDocument());
+  // Still on preview: the password field is still present.
+  expect(screen.getByLabelText(/spending password/i)).toBeInTheDocument();
+});
+
+// --- active state: withdraw + change ---
+
+test("(i) active wallet shows withdraw + change; Withdraw builds a withdraw-only request", async () => {
+  mockDelegation({
+    active: true,
+    pool_id: "pool1active",
+    withdrawable_amount: "14207000",
+  });
+  const build = vi.spyOn(client, "buildDelegation").mockResolvedValue({
+    pending_id: "wd-1",
+    certs: [{ kind: "withdrawal", summary: "Withdraw staking rewards", amount_lovelace: "14207000" }],
+    fee: "170000",
+    deposit: "0",
+    withdrawal: "14207000",
+    total: "-14037000",
+  });
+
+  render(<Staking />);
+
+  // Status shows Registered + the withdrawable amount.
+  expect(screen.getByText(/registered/i)).toBeInTheDocument();
+  expect(screen.getByText(/14\.207 ₳/)).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("button", { name: /withdraw rewards/i }));
+
+  await waitFor(() => expect(build).toHaveBeenCalledWith({ withdraw: true }));
+  // Lands on the itemized confirm for the withdrawal.
+  await waitFor(() => expect(screen.getByText(/withdraw staking rewards/i)).toBeInTheDocument());
+});
+
+test("(j) active wallet 'Change delegation' switches to the set-up form", () => {
+  mockDelegation({ active: true, pool_id: "pool1active", withdrawable_amount: "0" });
+
+  render(<Staking />);
+
+  fireEvent.click(screen.getByRole("button", { name: /change delegation/i }));
+
+  // Set-up form is now shown.
+  expect(screen.getByRole("button", { name: /review delegation/i })).toBeInTheDocument();
+});
+
+test("(k) withdraw button is disabled when there are no withdrawable rewards", () => {
+  mockDelegation({ active: true, pool_id: "pool1active", withdrawable_amount: "0" });
+
+  render(<Staking />);
+
+  expect(screen.getByRole("button", { name: /withdraw rewards/i })).toBeDisabled();
+});
+
+// --- build error stays on compose ---
+
+test("(l) a buildDelegation error (e.g. no change) is shown inline on the form", async () => {
+  mockDelegation({ active: false });
+  vi.spyOn(client, "buildDelegation").mockRejectedValue(
+    new client.ApiError(422, "requested state matches current state; nothing to do"),
+  );
+
+  render(<Staking />);
+
+  fireEvent.change(screen.getByPlaceholderText(/pool1\.\.\./i), { target: { value: "pool1abc" } });
+  fireEvent.click(screen.getByRole("button", { name: /review delegation/i }));
+
+  await waitFor(() => expect(screen.getByText(/nothing to do/i)).toBeInTheDocument());
+  // Still on the set-up form.
+  expect(screen.getByRole("button", { name: /review delegation/i })).toBeInTheDocument();
+});

--- a/ui/web/src/screens/Staking.tsx
+++ b/ui/web/src/screens/Staking.tsx
@@ -1,0 +1,679 @@
+import { useRef, useState } from "react";
+import type {
+  DelegationRequest,
+  DelegationPreview,
+  DelegationVote,
+  VoteType,
+  PoolInfo,
+  DRepInfo,
+  TxResult,
+  Cert,
+} from "../api/types";
+import {
+  getPool,
+  getDRep,
+  buildDelegation,
+  confirmDelegation,
+  ApiError,
+} from "../api/client";
+import { useDelegation } from "../api/hooks";
+import { Card } from "../components/Card";
+import { Input } from "../components/Input";
+import { Button } from "../components/Button";
+import { StatusPill } from "../components/StatusPill";
+import { CopyButton } from "../components/CopyButton";
+import { formatAda } from "../format";
+
+type Phase = "status" | "compose" | "preview" | "done";
+
+function errorMessage(err: unknown): string {
+  if (err instanceof ApiError) return err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+// Percent display for a pool margin fraction (0.02 → "2.0%").
+function pct(fraction: number): string {
+  return `${(fraction * 100).toFixed(1)}%`;
+}
+
+// The four voting-power targets, in mockup order, with their copy.
+const VOTE_OPTIONS: { type: VoteType; title: string; sub: string }[] = [
+  {
+    type: "abstain",
+    title: "Always Abstain",
+    sub: "Your stake counts toward quorum but abstains on every vote.",
+  },
+  {
+    type: "no_confidence",
+    title: "Always No Confidence",
+    sub: "Your stake votes “no confidence” on all governance actions.",
+  },
+  {
+    type: "drep",
+    title: "A specific DRep",
+    sub: "Delegate to a DRep by ID — verified by your node.",
+  },
+  {
+    type: "register_self",
+    title: "Register myself as a DRep",
+    sub: "Become a DRep and delegate your own vote to yourself.",
+  },
+];
+
+// --- Status panel (shared header) ---
+
+function StatusPanel({
+  poolId,
+  active,
+}: {
+  poolId: string | null;
+  active: boolean;
+}) {
+  return (
+    <Card title="Current status">
+      <dl className="delegation-details">
+        <div className="dl-row">
+          <dt>Stake key</dt>
+          <dd>
+            {active ? (
+              <StatusPill tone="ok">Registered</StatusPill>
+            ) : (
+              <span className="muted">Not registered</span>
+            )}
+          </dd>
+        </div>
+        <div className="dl-row">
+          <dt>Delegated pool</dt>
+          <dd>{poolId ?? <span className="muted">—</span>}</dd>
+        </div>
+      </dl>
+    </Card>
+  );
+}
+
+// --- Compose phase ---
+
+interface ComposeProps {
+  poolId: string;
+  setPoolId: (v: string) => void;
+  voteType: VoteType | null;
+  setVoteType: (v: VoteType) => void;
+  drepId: string;
+  setDrepId: (v: string) => void;
+  anchorUrl: string;
+  setAnchorUrl: (v: string) => void;
+  anchorHash: string;
+  setAnchorHash: (v: string) => void;
+  onPreview: (preview: DelegationPreview) => void;
+}
+
+function Compose(props: ComposeProps) {
+  const {
+    poolId,
+    setPoolId,
+    voteType,
+    setVoteType,
+    drepId,
+    setDrepId,
+    anchorUrl,
+    setAnchorUrl,
+    anchorHash,
+    setAnchorHash,
+    onPreview,
+  } = props;
+
+  const [pool, setPool] = useState<PoolInfo | null>(null);
+  const [poolError, setPoolError] = useState<string | null>(null);
+  const [verifyingPool, setVerifyingPool] = useState(false);
+  const latestPoolId = useRef(poolId);
+  const poolVerifySeq = useRef(0);
+  latestPoolId.current = poolId;
+
+  const [drep, setDrep] = useState<DRepInfo | null>(null);
+  const [drepError, setDrepError] = useState<string | null>(null);
+  const [verifyingDrep, setVerifyingDrep] = useState(false);
+  const latestDrepId = useRef(drepId);
+  const drepVerifySeq = useRef(0);
+  latestDrepId.current = drepId;
+
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Verify a pasted pool ID against the node; the readout proves it exists.
+  async function handleVerifyPool() {
+    const id = poolId.trim();
+    const seq = ++poolVerifySeq.current;
+    setPool(null);
+    setPoolError(null);
+    if (!id) {
+      setVerifyingPool(false);
+      return;
+    }
+    setVerifyingPool(true);
+    try {
+      const info = await getPool(id);
+      if (poolVerifySeq.current !== seq || latestPoolId.current.trim() !== id) return;
+      setPool(info);
+    } catch (e) {
+      if (poolVerifySeq.current !== seq || latestPoolId.current.trim() !== id) return;
+      setPoolError(
+        e instanceof ApiError && e.status === 404
+          ? "Not found by your node"
+          : errorMessage(e),
+      );
+    } finally {
+      if (poolVerifySeq.current === seq) setVerifyingPool(false);
+    }
+  }
+
+  async function handleVerifyDrep() {
+    const id = drepId.trim();
+    const seq = ++drepVerifySeq.current;
+    setDrep(null);
+    setDrepError(null);
+    if (!id) {
+      setVerifyingDrep(false);
+      return;
+    }
+    setVerifyingDrep(true);
+    try {
+      const info = await getDRep(id);
+      if (drepVerifySeq.current !== seq || latestDrepId.current.trim() !== id) return;
+      setDrep(info);
+    } catch (e) {
+      if (drepVerifySeq.current !== seq || latestDrepId.current.trim() !== id) return;
+      setDrepError(
+        e instanceof ApiError && e.status === 404
+          ? "Not found by your node"
+          : errorMessage(e),
+      );
+    } finally {
+      if (drepVerifySeq.current === seq) setVerifyingDrep(false);
+    }
+  }
+
+  async function handleReview() {
+    setError(null);
+
+    const req: DelegationRequest = {};
+    if (poolId.trim()) req.pool_id = poolId.trim();
+    if (voteType) {
+      let vote: DelegationVote;
+      if (voteType === "abstain" || voteType === "no_confidence") {
+        vote = { type: voteType };
+      } else if (voteType === "drep") {
+        if (!drepId.trim()) {
+          setError("Enter a DRep ID to delegate your vote to.");
+          return;
+        }
+        vote = { type: "drep", drep_id: drepId.trim() };
+      } else {
+        const url = anchorUrl.trim();
+        const hash = anchorHash.trim();
+        if (url || hash) {
+          if (!url) {
+            setError("Enter the metadata URL for the metadata hash.");
+            return;
+          }
+          if (!hash) {
+            setError("Enter the metadata hash for the metadata URL.");
+            return;
+          }
+          vote = { type: "register_self", anchor: { url, hash } };
+        } else {
+          vote = { type: "register_self" };
+        }
+      }
+      req.vote = vote;
+    }
+
+    if (!req.pool_id && !req.vote) {
+      setError("Choose a pool or a voting-power target.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      onPreview(await buildDelegation(req));
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card title="Set up delegation">
+      <div className="staking-form">
+        <label htmlFor="pool-id">Stake pool</label>
+        <Input
+          id="pool-id"
+          type="text"
+          placeholder="pool1..."
+          value={poolId}
+          onChange={(e) => {
+            poolVerifySeq.current += 1;
+            setPoolId(e.target.value);
+            setPool(null);
+            setPoolError(null);
+            setVerifyingPool(false);
+          }}
+          onBlur={handleVerifyPool}
+          disabled={loading}
+        />
+        {verifyingPool && <p className="helper-text">Verifying pool…</p>}
+        {pool && (
+          <p className="verified-readout">
+            <span className="verified-tick">✓ Verified by your node</span>
+            {" · "}margin {pct(pool.margin_cost)}
+            {" · "}pledge {formatAda(pool.declared_pledge)} ₳
+            {" · "}fixed {formatAda(pool.fixed_cost)} ₳
+            {" · "}live stake {formatAda(pool.live_stake)} ₳
+          </p>
+        )}
+        {poolError && (
+          <p role="alert" className="error-text">
+            {poolError}
+          </p>
+        )}
+
+        <p className="field-label">Voting power</p>
+        <div className="vote-options">
+          {VOTE_OPTIONS.map((opt) => {
+            const selected = voteType === opt.type;
+            return (
+              <div key={opt.type} className={selected ? "vote-opt selected" : "vote-opt"}>
+                <label className="vote-opt-label">
+                  <input
+                    type="radio"
+                    name="vote-power"
+                    checked={selected}
+                    onChange={() => setVoteType(opt.type)}
+                    disabled={loading}
+                  />
+                  <span className="vote-opt-main">
+                    <span className="vote-opt-title">{opt.title}</span>
+                    <span className="vote-opt-sub">{opt.sub}</span>
+                  </span>
+                </label>
+
+                {selected && opt.type === "drep" && (
+                  <div className="vote-opt-extra">
+                    <label htmlFor="drep-id">DRep ID</label>
+                    <Input
+                      id="drep-id"
+                      type="text"
+                      placeholder="drep1..."
+                      value={drepId}
+                      onChange={(e) => {
+                        drepVerifySeq.current += 1;
+                        setDrepId(e.target.value);
+                        setDrep(null);
+                        setDrepError(null);
+                        setVerifyingDrep(false);
+                      }}
+                      onBlur={handleVerifyDrep}
+                      disabled={loading}
+                    />
+                    {verifyingDrep && <p className="helper-text">Verifying DRep…</p>}
+                    {drep && (
+                      <p className="verified-readout">
+                        <span className="verified-tick">✓ Verified by your node</span>
+                        {drep.registered ? " · registered" : " · not registered"}
+                      </p>
+                    )}
+                    {drepError && (
+                      <p role="alert" className="error-text">
+                        {drepError}
+                      </p>
+                    )}
+                  </div>
+                )}
+
+                {selected && opt.type === "register_self" && (
+                  <div className="vote-opt-extra">
+                    <label htmlFor="anchor-url">Metadata URL (optional)</label>
+                    <Input
+                      id="anchor-url"
+                      type="text"
+                      placeholder="https://example.org/my-drep.jsonld"
+                      value={anchorUrl}
+                      onChange={(e) => setAnchorUrl(e.target.value)}
+                      disabled={loading}
+                    />
+                    <label htmlFor="anchor-hash">Metadata hash (optional)</label>
+                    <Input
+                      id="anchor-hash"
+                      type="text"
+                      placeholder="blake2b-256 of the metadata file"
+                      value={anchorHash}
+                      onChange={(e) => setAnchorHash(e.target.value)}
+                      disabled={loading}
+                    />
+                    <p className="deposit-note">
+                      Registering as a DRep may lock a refundable protocol-parameter
+                      deposit. Exact deposit amounts are read from your node and shown
+                      on the review screen before you confirm.
+                    </p>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {error && (
+          <p role="alert" className="error-text">
+            {error}
+          </p>
+        )}
+
+        <Button
+          onClick={handleReview}
+          disabled={loading || (!poolId.trim() && !voteType)}
+        >
+          {loading ? "Building…" : "Review delegation"}
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+// --- Preview phase (itemized confirm) ---
+
+const CERT_MARK: Record<Cert["kind"], string> = {
+  stake_registration: "+",
+  stake_delegation: "→",
+  vote_delegation: "🗳",
+  drep_registration: "★",
+  withdrawal: "↓",
+};
+
+interface PreviewPhaseProps {
+  preview: DelegationPreview;
+  onBack: () => void;
+  onDone: (result: TxResult) => void;
+}
+
+function PreviewPhase({ preview, onBack, onDone }: PreviewPhaseProps) {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleConfirm() {
+    setError(null);
+    setLoading(true);
+    try {
+      onDone(await confirmDelegation(preview.pending_id, password));
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="staking">
+      <Card title="This transaction will">
+        <div className="cert-list">
+          {preview.certs.map((c, i) => (
+            <div key={i} className="cert-row">
+              <span className="cert-mark">{CERT_MARK[c.kind] ?? "•"}</span>
+              <span className="cert-body">{c.summary}</span>
+              <span className="cert-amt">
+                {c.deposit_lovelace
+                  ? `${formatAda(c.deposit_lovelace)} ₳ deposit`
+                  : c.amount_lovelace
+                    ? `${formatAda(c.amount_lovelace)} ₳`
+                    : "—"}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        <dl className="preview-summary">
+          <div className="dl-row">
+            <dt>Network fee</dt>
+            <dd>{formatAda(preview.fee)} ₳</dd>
+          </div>
+          {preview.deposit !== "0" && (
+            <div className="dl-row">
+              <dt>Refundable deposit</dt>
+              <dd>{formatAda(preview.deposit)} ₳</dd>
+            </div>
+          )}
+          {preview.withdrawal && (
+            <div className="dl-row">
+              <dt>Withdrawal</dt>
+              <dd>{formatAda(preview.withdrawal)} ₳</dd>
+            </div>
+          )}
+          <div className="dl-row">
+            <dt>Total to confirm</dt>
+            <dd className="total-accent">{formatAda(preview.total)} ₳</dd>
+          </div>
+        </dl>
+      </Card>
+
+      <Card title="Spending password">
+        <div className="staking-form">
+          <label htmlFor="staking-password">Spending password</label>
+          <Input
+            id="staking-password"
+            type="password"
+            placeholder="Spending password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            disabled={loading}
+          />
+          <p className="helper-text">
+            Signs locally; the transaction is submitted through your own node.
+          </p>
+
+          {error && (
+            <p role="alert" className="error-text">
+              {error}
+            </p>
+          )}
+
+          <div className="preview-actions">
+            <Button variant="ghost" onClick={onBack} disabled={loading}>
+              Back
+            </Button>
+            <Button onClick={handleConfirm} disabled={loading || !password}>
+              {loading ? "Submitting…" : "Confirm & sign"}
+            </Button>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+// --- Done phase ---
+
+function DonePhase({ result, onReset }: { result: TxResult; onReset: () => void }) {
+  return (
+    <Card title="Transaction Submitted">
+      <div className="done-details">
+        <p>Your delegation transaction has been submitted successfully.</p>
+        <p className="field-label">Transaction hash</p>
+        <div className="tx-hash-row">
+          <code className="tx-hash">{result.tx_hash}</code>
+          <CopyButton value={result.tx_hash} />
+        </div>
+        <Button onClick={onReset}>Back to staking</Button>
+      </div>
+    </Card>
+  );
+}
+
+// --- Active state: status + withdraw + change ---
+
+interface ActiveProps {
+  poolId: string;
+  withdrawable: string;
+  note: string;
+  onChange: () => void;
+  onWithdraw: (preview: DelegationPreview) => void;
+}
+
+function ActiveState({ poolId, withdrawable, note, onChange, onWithdraw }: ActiveProps) {
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const canWithdraw = /^\d+$/.test(withdrawable) && BigInt(withdrawable) > 0n;
+
+  async function handleWithdraw() {
+    setError(null);
+    setLoading(true);
+    try {
+      onWithdraw(await buildDelegation({ withdraw: true }));
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <StatusPanel poolId={poolId} active={true} />
+      <Card title="Rewards">
+        <div className="dl-row">
+          <dt className="field-label">Withdrawable</dt>
+          <dd className="total-accent mono">{formatAda(withdrawable)} ₳</dd>
+        </div>
+
+        {error && (
+          <p role="alert" className="error-text">
+            {error}
+          </p>
+        )}
+
+        <div className="preview-actions">
+          <Button onClick={handleWithdraw} disabled={loading || !canWithdraw}>
+            {loading ? "Building…" : "Withdraw rewards"}
+          </Button>
+          <Button variant="ghost" onClick={onChange} disabled={loading}>
+            Change delegation
+          </Button>
+        </div>
+        {note && <p className="helper-text">{note}</p>}
+      </Card>
+    </>
+  );
+}
+
+// --- Top-level Staking screen ---
+
+export function Staking() {
+  const delegation = useDelegation();
+
+  const [phase, setPhase] = useState<Phase>("status");
+  const [previewFrom, setPreviewFrom] = useState<Phase>("status");
+  const [preview, setPreview] = useState<DelegationPreview | null>(null);
+  const [txResult, setTxResult] = useState<TxResult | null>(null);
+
+  // Compose draft lives at the top so Back returns to in-progress entry.
+  const [poolId, setPoolId] = useState("");
+  const [voteType, setVoteType] = useState<VoteType | null>(null);
+  const [drepId, setDrepId] = useState("");
+  const [anchorUrl, setAnchorUrl] = useState("");
+  const [anchorHash, setAnchorHash] = useState("");
+
+  if (delegation.loading) {
+    return <p>Loading…</p>;
+  }
+  if (delegation.error) {
+    return (
+      <p role="alert" className="error-text">
+        {delegation.error.message}
+      </p>
+    );
+  }
+
+  const del = delegation.data;
+  const isActive = del?.active ?? false;
+
+  function goCompose() {
+    setPhase("compose");
+  }
+
+  function handlePreview(p: DelegationPreview, from: Phase = "compose") {
+    setPreview(p);
+    setPreviewFrom(from);
+    setPhase("preview");
+  }
+
+  function handleDone(result: TxResult) {
+    setTxResult(result);
+    setPhase("done");
+  }
+
+  function handleReset() {
+    setPreview(null);
+    setTxResult(null);
+    setPoolId("");
+    setVoteType(null);
+    setDrepId("");
+    setAnchorUrl("");
+    setAnchorHash("");
+    setPhase("status");
+    delegation.refresh();
+  }
+
+  if (phase === "done" && txResult) {
+    return (
+      <div className="staking">
+        <DonePhase result={txResult} onReset={handleReset} />
+      </div>
+    );
+  }
+
+  if (phase === "preview" && preview) {
+    return (
+      <PreviewPhase
+        preview={preview}
+        onBack={() => setPhase(previewFrom)}
+        onDone={handleDone}
+      />
+    );
+  }
+
+  // Status phase. An active wallet shows the active state (withdraw + change);
+  // a fresh wallet drops straight into the set-up form.
+  if (phase === "status" && isActive && del) {
+    return (
+      <div className="staking">
+        <ActiveState
+          poolId={del.pool_id ?? "—"}
+          withdrawable={del.withdrawable_amount}
+          note={del.provisional ? del.note : ""}
+          onChange={goCompose}
+          onWithdraw={(p) => handlePreview(p, "status")}
+        />
+      </div>
+    );
+  }
+
+  // Compose (set-up / change) form, with the status panel above it.
+  return (
+    <div className="staking">
+      <StatusPanel poolId={del?.pool_id ?? null} active={isActive} />
+      <Compose
+        poolId={poolId}
+        setPoolId={setPoolId}
+        voteType={voteType}
+        setVoteType={setVoteType}
+        drepId={drepId}
+        setDrepId={setDrepId}
+        anchorUrl={anchorUrl}
+        setAnchorUrl={setAnchorUrl}
+        anchorHash={anchorHash}
+        setAnchorHash={setAnchorHash}
+        onPreview={handlePreview}
+      />
+    </div>
+  );
+}

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -1023,7 +1023,7 @@ a:hover {
   border-color: var(--accent);
   background: var(--accent-dim);
 }
-.vote-opt-label {
+.staking-form .vote-opt-label {
   display: flex;
   gap: 11px;
   align-items: flex-start;
@@ -1037,7 +1037,7 @@ a:hover {
   color: var(--text);
   margin: 0;
 }
-.vote-opt-label input[type="radio"] {
+.staking-form .vote-opt-label input[type="radio"] {
   margin-top: 3px;
   accent-color: var(--accent);
   flex-shrink: 0;

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -260,9 +260,11 @@ a:hover {
 .portfolio,
 .receive,
 .activity,
+.staking,
 .screen-settings,
 .send-form,
 .sign-form,
+.staking-form,
 .preview-details,
 .done-details {
   display: flex;
@@ -305,6 +307,7 @@ a:hover {
 /* Field labels are instrument captions too. */
 .send-form label,
 .sign-form label,
+.staking-form label,
 .field-group label,
 .field-label {
   display: block;
@@ -344,7 +347,8 @@ a:hover {
 }
 /* Forms: inputs carry the rhythm; labels hug the input above them. */
 .send-form .field,
-.sign-form .field {
+.sign-form .field,
+.staking-form .field {
   margin-bottom: var(--space-3);
 }
 
@@ -986,6 +990,123 @@ a:hover {
 .tab.active {
   color: var(--accent);
   border-bottom-color: var(--accent);
+}
+
+/* --------------------------------------------------------------- staking -- */
+/* Node-verified pool/DRep readout under a pasted ID. */
+.verified-readout {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  margin: calc(-1 * var(--space-2)) 0 var(--space-3);
+  line-height: 1.7;
+  word-break: break-word;
+}
+.verified-tick {
+  color: var(--ok);
+}
+
+/* Voting-power picker — selectable instrument tiles. */
+.vote-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+.vote-opt {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--inset);
+  padding: 12px 14px;
+}
+.vote-opt.selected {
+  border-color: var(--accent);
+  background: var(--accent-dim);
+}
+.vote-opt-label {
+  display: flex;
+  gap: 11px;
+  align-items: flex-start;
+  cursor: pointer;
+  /* Override the instrument-caption label styling for the option title row. */
+  font-family: var(--font);
+  font-size: 0.9rem;
+  font-weight: 400;
+  letter-spacing: normal;
+  text-transform: none;
+  color: var(--text);
+  margin: 0;
+}
+.vote-opt-label input[type="radio"] {
+  margin-top: 3px;
+  accent-color: var(--accent);
+  flex-shrink: 0;
+}
+.vote-opt-main {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.vote-opt-title {
+  font-weight: 600;
+}
+.vote-opt-sub {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+.vote-opt-extra {
+  margin-top: var(--space-3);
+  padding-left: 26px;
+  display: flex;
+  flex-direction: column;
+}
+.vote-opt-extra .field:last-of-type {
+  margin-bottom: var(--space-2);
+}
+
+/* The larger separate DRep deposit notice. */
+.deposit-note {
+  background: color-mix(in srgb, var(--warn) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--warn) 35%, transparent);
+  border-radius: var(--radius);
+  padding: 9px 12px;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: var(--space-1);
+}
+
+/* Itemized confirm — one line per certificate/withdrawal. */
+.cert-list {
+  margin-bottom: var(--space-3);
+}
+.cert-row {
+  display: flex;
+  gap: 11px;
+  align-items: baseline;
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--border);
+}
+.cert-row:last-child {
+  border-bottom: none;
+}
+.cert-mark {
+  font-family: var(--mono);
+  color: var(--accent);
+  width: 1.2em;
+  flex-shrink: 0;
+}
+.cert-body {
+  flex: 1;
+  font-size: 0.9rem;
+}
+.cert-amt {
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  white-space: nowrap;
+  color: var(--text);
+}
+.total-accent {
+  color: var(--accent);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION

<img width="1280" height="860" alt="image" src="https://github.com/user-attachments/assets/64015ad7-6cdd-4451-a30b-a8ada18ad274" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds staking and governance delegation with node-verified pool/DRep lookups and a single-transaction flow for stake registration, pool delegation, vote delegation (Abstain/No Confidence/DRep/Self), self-DRep registration, and reward withdrawal. All reads and submissions go through the embedded node only; the wallet’s current and self DRep are resolved and shown.

- **New Features**
  - New Staking screen with paste-to-verify pool/DRep IDs, verified readouts, itemized preview, and confirm.
  - Backend composes stake registration, stake delegation, vote delegation (optional anchor), self-DRep registration, and reward withdrawal into one tx; Confirm reuses Send and includes required stake/DRep witnesses.
  - Node client/API add pool info, DRep lookup, and protocol params (key/DRep deposits), enriching from the embedded Dingo node’s local metadata DB; new endpoints: `/wallet/pool/{id}`, `/wallet/drep/{id}`, `buildDelegation`, `confirmDelegation`. Web client/types, UI, and tests added. Wallet account exposes `DRepKeyHash`; staking UI is gated like Send.

- **Bug Fixes**
  - Correctly resolve and display the wallet’s current DRep (including self) and detect unchanged delegation requests.
  - Clear errors for not-found pool/DRep IDs; handle pre-Conway networks where `drep_deposit` is null; minor UI/copy fixes from review.

<sup>Written for commit 851916a53e16025ecce985714332ef760c50032d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Staking screen for delegating stake, choosing voting preferences, and reviewing transactions before signing.
  * Added node-verified pool and DRep lookups with clearer verification feedback in the UI.
  * Enabled withdrawal of staking rewards and changing delegation from the active staking state.
  * Added a detailed confirmation view showing fees, deposits, withdrawals, and totals before submission.

* **Bug Fixes**
  * Improved handling for unchanged delegation requests and not-found lookup results.
  * Preserved DRep-related wallet details across wallet views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->