### PR TITLE
feat(ui): stake pool operations

### DIFF
--- a/ui/cmd/bursa-wallet/main.go
+++ b/ui/cmd/bursa-wallet/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/blinklabs-io/bursa/ui/internal/cardanonet"
 	"github.com/blinklabs-io/bursa/ui/internal/chain"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
+	"github.com/blinklabs-io/bursa/ui/internal/poolops"
 	"github.com/blinklabs-io/bursa/ui/internal/settings"
 	"github.com/blinklabs-io/bursa/ui/internal/spend"
 	"github.com/blinklabs-io/bursa/ui/internal/supervisor"
@@ -147,6 +148,17 @@ func run() error {
 	spendSvc := spend.NewService(chainCtx, vaultKeystore{v: vlt}, nil)
 	spendSvc.SetChainQuerier(chainClient)
 
+	// Stake Pool Operations: derives cold/VRF/KES credentials and builds/submits
+	// pool certificates on the active wallet, sharing the spend chain context for
+	// submission. Genesis (for KES-period math) comes from the node's loopback
+	// Blockfrost endpoint; the tip comes from the supervisor — no external call.
+	poolGenesis := chain.NewClient(blockfrostPort)
+	poolSvc := poolops.NewService(
+		chainCtx, vaultKeystore{v: vlt},
+		genesisAdapter{c: poolGenesis},
+		tipAdapter{sup: sup},
+	)
+
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
@@ -161,6 +173,7 @@ func run() error {
 			sup, vlt, walletSvc, spendSvc,
 			&settingsController{store: settingsStore, sup: sup},
 			chainClient,
+			poolSvc,
 			network, webui.Handler(),
 			api.WithLegacyKeystore(legacyKeyStore),
 		),
@@ -233,4 +246,33 @@ func (c *settingsController) HistoryExpiryRestartRequired() bool {
 		return false
 	}
 	return applied != c.store.HistoryExpiry()
+}
+
+// genesisAdapter adapts the loopback Blockfrost chain client to the genesis
+// subset the SPO toolkit's KES-period math needs.
+type genesisAdapter struct{ c *chain.Client }
+
+func (g genesisAdapter) Genesis(ctx context.Context) (poolops.Genesis, error) {
+	gen, err := g.c.Genesis(ctx)
+	if err != nil {
+		return poolops.Genesis{}, err
+	}
+	return poolops.Genesis{
+		SlotsPerKESPeriod: gen.SlotsPerKESPeriod,
+		MaxKESEvolutions:  gen.MaxKESEvolutions,
+		EpochLength:       gen.EpochLength,
+	}, nil
+}
+
+// tipAdapter exposes the supervisor's current tip slot to the SPO toolkit.
+// TipSlot returns an error when the node has not yet caught up to the chain
+// tip so that KES-period calculations do not silently use a stale slot.
+type tipAdapter struct{ sup *supervisor.Supervisor }
+
+func (t tipAdapter) TipSlot() (uint64, error) {
+	st := t.sup.Status()
+	if st.State != supervisor.StateReady {
+		return 0, fmt.Errorf("node is not synced (state: %s); wait for it to reach 'ready' before issuing opcerts", st.State)
+	}
+	return st.Tip, nil
 }

--- a/ui/go.mod
+++ b/ui/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/blinklabs-io/go-bip39 v0.2.0
 	github.com/blinklabs-io/gouroboros v0.186.0
 	github.com/blinklabs-io/plutigo v0.1.15
+	github.com/gowebpki/jcs v1.0.1
 	github.com/utxorpc/go-codegen v0.19.2
 	github.com/webview/webview_go v0.0.0-20240831120633-6173450d4dd6
 	golang.org/x/crypto v0.53.0

--- a/ui/go.sum
+++ b/ui/go.sum
@@ -296,6 +296,8 @@ github.com/googleapis/gax-go/v2 v2.22.0 h1:PjIWBpgGIVKGoCXuiCoP64altEJCj3/Ei+kSU
 github.com/googleapis/gax-go/v2 v2.22.0/go.mod h1:irWBbALSr0Sk3qlqb9SyJ1h68WjgeFuiOzI4Rqw5+aY=
 github.com/goware/prefixer v0.0.0-20160118172347-395022866408 h1:Y9iQJfEqnN3/Nce9cOegemcy/9Ai5k3huT6E80F3zaw=
 github.com/goware/prefixer v0.0.0-20160118172347-395022866408/go.mod h1:PE1ycukgRPJ7bJ9a1fdfQ9j8i/cEcRAoLZzbxYpNB/s=
+github.com/gowebpki/jcs v1.0.1 h1:Qjzg8EOkrOTuWP7DqQ1FbYtcpEbeTzUoTN9bptp8FOU=
+github.com/gowebpki/jcs v1.0.1/go.mod h1:CID1cNZ+sHp1CCpAR8mPf6QRtagFBgPJE0FCUQ6+BrI=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -18,12 +18,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
 	"github.com/blinklabs-io/bursa/ui/internal/chain"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
+	"github.com/blinklabs-io/bursa/ui/internal/poolops"
 	"github.com/blinklabs-io/bursa/ui/internal/spend"
 	"github.com/blinklabs-io/bursa/ui/internal/supervisor"
 	"github.com/blinklabs-io/bursa/ui/internal/vault"
@@ -127,6 +130,98 @@ type SettingsController interface {
 	HistoryExpiryRestartRequired() bool
 }
 
+// PoolOps is the Stake Pool Operations surface the API exposes. Credential
+// generation and seed-derived certificate/opcert building need the active
+// wallet + spending password; the air-gap builders (pool ID, opcert payload /
+// assembly, metadata, air-gap registration cert) need neither. Submission
+// (retirement) needs a synced node. It operates on the active wallet.
+type PoolOps interface {
+	// SetAccount binds the active wallet (both its ID and its read-only account)
+	// so pool operations always derive credentials from the same wallet whose
+	// account is in use. Passing an empty id and nil acct clears the binding.
+	SetAccount(id string, acct *wallet.Account)
+	Credentials(password string) (poolops.Credentials, error)
+	KESPeriod(ctx context.Context) (poolops.KESPeriodInfo, error)
+	IssueOpCert(password string, kesIndex uint32, issueNumber, kesPeriod uint64) (poolops.OpCert, error)
+	RotateKES(password string, newKESIndex uint32, prevIssueNumber, kesPeriod uint64) (poolops.OpCert, error)
+	OpCertPayload(kesVKeyHex string, issueNumber, kesPeriod uint64) (poolops.OpCertPayload, error)
+	AssembleOpCert(coldVKeyHex, kesVKeyHex, signatureHex string, issueNumber, kesPeriod uint64) (poolops.OpCert, error)
+	BuildMetadata(in poolops.MetadataInput) (poolops.MetadataResult, error)
+	PoolIDFromColdVKey(coldVKeyHex string) (poolID, poolIDHex string, err error)
+	BuildRegistrationFromSeed(password string, p poolops.RegistrationParams) (poolops.CertResult, error)
+	BuildRegistrationAirGap(p poolops.AirGapRegistrationParams) (poolops.CertResult, error)
+	BuildRetirementCert(password, coldVKeyHex string, epoch uint64) (poolops.CertResult, error)
+	SubmitRetirement(ctx context.Context, password string, epoch uint64) (poolops.TxResult, error)
+}
+
+type decimalUint64 uint64
+
+func (n *decimalUint64) UnmarshalJSON(data []byte) error {
+	raw := strings.TrimSpace(string(data))
+	if raw == "" || raw == "null" {
+		return errors.New("expected unsigned integer")
+	}
+	if raw[0] == '"' {
+		unquoted, err := strconv.Unquote(raw)
+		if err != nil {
+			return fmt.Errorf("invalid quoted unsigned integer: %w", err)
+		}
+		raw = strings.TrimSpace(unquoted)
+	}
+	if raw == "" {
+		return errors.New("expected unsigned integer")
+	}
+	for _, c := range raw {
+		if c < '0' || c > '9' {
+			return errors.New("expected unsigned integer")
+		}
+	}
+	v, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		return fmt.Errorf("unsigned integer out of range: %w", err)
+	}
+	*n = decimalUint64(v)
+	return nil
+}
+
+type poolRegistrationRequest struct {
+	Pledge        decimalUint64   `json:"pledge"`
+	Cost          decimalUint64   `json:"cost"`
+	MarginNum     int64           `json:"margin_num"`
+	MarginDenom   int64           `json:"margin_denom"`
+	RewardAddress string          `json:"reward_address,omitempty"`
+	Owners        []string        `json:"owners,omitempty"`
+	Relays        []poolops.Relay `json:"relays,omitempty"`
+	MetadataURL   string          `json:"metadata_url,omitempty"`
+	MetadataHash  string          `json:"metadata_hash,omitempty"`
+	ColdVKeyHex   string          `json:"cold_vkey_hex,omitempty"`
+}
+
+func (r poolRegistrationRequest) params() poolops.RegistrationParams {
+	return poolops.RegistrationParams{
+		Pledge:        uint64(r.Pledge),
+		Cost:          uint64(r.Cost),
+		MarginNum:     r.MarginNum,
+		MarginDenom:   r.MarginDenom,
+		RewardAddress: r.RewardAddress,
+		Owners:        r.Owners,
+		Relays:        r.Relays,
+		MetadataURL:   r.MetadataURL,
+		MetadataHash:  r.MetadataHash,
+		ColdVKeyHex:   r.ColdVKeyHex,
+	}
+}
+
+type poolRegistrationSeedRequest struct {
+	Password string `json:"password"`
+	poolRegistrationRequest
+}
+
+type poolRegistrationAirGapRequest struct {
+	poolRegistrationRequest
+	VRFKeyHashHex string `json:"vrf_key_hash_hex"`
+}
+
 const defaultWindow = 20
 
 // vaultStatus is the GET /vault/status response.
@@ -167,10 +262,10 @@ func toWalletView(w vault.WalletMeta, activeID string) walletView {
 // the encrypted multi-wallet store; the API pushes the active wallet onto wl/sp
 // whenever the selection changes. settings exposes user-facing app settings
 // (the lean-node profile). lookup verifies pasted pool/DRep IDs through the
-// node (may be nil, in which case those endpoints report unavailable). spa is
-// the embedded SPA, registered as the catch-all so the specific API routes
-// take precedence on the mux.
-func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings SettingsController, lookup PoolDRepLookup, network string, spa http.Handler, opts ...HandlerOption) http.Handler {
+// node (may be nil, in which case those endpoints report unavailable). po is
+// the Stake Pool Operations surface. spa is the embedded SPA, registered as
+// the catch-all so the specific API routes take precedence on the mux.
+func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings SettingsController, lookup PoolDRepLookup, po PoolOps, network string, spa http.Handler, opts ...HandlerOption) http.Handler {
 	cfg := handlerOptions{}
 	for _, opt := range opts {
 		opt(&cfg)
@@ -194,10 +289,19 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 		}
 		_ = wl.SetAccount(w.Account)
 		sp.SetAccount(w.ID, w.Account)
+		// Pool operations run on the same active wallet; attach both the wallet
+		// ID and its account so the SPO toolkit always derives credentials from
+		// the wallet whose account data is current.
+		if po != nil {
+			po.SetAccount(w.ID, w.Account)
+		}
 	}
 	clearActive := func() {
 		_ = wl.SetAccount(nil)
 		sp.SetAccount("", nil)
+		if po != nil {
+			po.SetAccount("", nil)
+		}
 	}
 	legacyAvailable := func() bool {
 		return !vlt.Exists() && cfg.legacy != nil && cfg.legacy.Exists()
@@ -578,6 +682,10 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 		serve(w, res, err)
 	}))
 
+	if po != nil {
+		registerPoolRoutes(mux, st, po)
+	}
+
 	// SPA catch-all: the specific API routes above take precedence on the mux;
 	// everything else is served by the embedded frontend.
 	mux.Handle("/", spa)
@@ -624,6 +732,179 @@ func serveLookup[T any](w http.ResponseWriter, v T, err error) {
 	default:
 		writeJSON(w, http.StatusBadGateway, errBody(err))
 	}
+}
+
+// registerPoolRoutes wires the Stake Pool Operations (SPO) endpoints under
+// /wallet/pool/. Air-gap builders (pool ID, opcert payload/assembly, metadata,
+// air-gap registration cert) are ungated and need no node — they are pure
+// transforms over operator-supplied data. Seed-derived credential/cert/opcert
+// building needs the active wallet + spending password but no node (offline).
+// KES-period and retirement submission need a node (gated / readyGate).
+func registerPoolRoutes(mux *http.ServeMux, st Statuser, po PoolOps) {
+	// 1. Credentials (active wallet + password; offline).
+	mux.HandleFunc("POST /wallet/pool/credentials", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Password string `json:"password"`
+		}
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		v, err := po.Credentials(req.Password)
+		serve(w, v, err)
+	})
+
+	// 2. KES period (node tip + genesis; gated on a queryable node).
+	mux.HandleFunc("GET /wallet/pool/kes-period", gated(st, func(w http.ResponseWriter, r *http.Request) {
+		v, err := po.KESPeriod(r.Context())
+		serve(w, v, err)
+	}))
+
+	// 2. Operational certificate: issue (seed).
+	mux.HandleFunc("POST /wallet/pool/opcert", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Password    string `json:"password"`
+			KESIndex    uint32 `json:"kes_index"`
+			IssueNumber uint64 `json:"issue_number"`
+			KESPeriod   uint64 `json:"kes_period"`
+		}
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		v, err := po.IssueOpCert(req.Password, req.KESIndex, req.IssueNumber, req.KESPeriod)
+		serve(w, v, err)
+	})
+
+	// 2. Operational certificate: KES rotation (seed) — new KES key + counter bump.
+	mux.HandleFunc("POST /wallet/pool/opcert/rotate", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Password        string `json:"password"`
+			NewKESIndex     uint32 `json:"new_kes_index"`
+			PrevIssueNumber uint64 `json:"prev_issue_number"`
+			KESPeriod       uint64 `json:"kes_period"`
+		}
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		v, err := po.RotateKES(req.Password, req.NewKESIndex, req.PrevIssueNumber, req.KESPeriod)
+		serve(w, v, err)
+	})
+
+	// Air-gap: opcert to-be-signed payload (no wallet needed).
+	mux.HandleFunc("POST /wallet/pool/opcert/payload", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			KESVKeyHex  string `json:"kes_vkey_hex"`
+			IssueNumber uint64 `json:"issue_number"`
+			KESPeriod   uint64 `json:"kes_period"`
+		}
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		v, err := po.OpCertPayload(req.KESVKeyHex, req.IssueNumber, req.KESPeriod)
+		serve(w, v, err)
+	})
+
+	// Air-gap: assemble opcert from an externally-produced cold-key signature.
+	mux.HandleFunc("POST /wallet/pool/opcert/assemble", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ColdVKeyHex  string `json:"cold_vkey_hex"`
+			KESVKeyHex   string `json:"kes_vkey_hex"`
+			SignatureHex string `json:"signature_hex"`
+			IssueNumber  uint64 `json:"issue_number"`
+			KESPeriod    uint64 `json:"kes_period"`
+		}
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		v, err := po.AssembleOpCert(req.ColdVKeyHex, req.KESVKeyHex, req.SignatureHex, req.IssueNumber, req.KESPeriod)
+		serve(w, v, err)
+	})
+
+	// 6. Metadata builder (pure transform; no wallet/node).
+	mux.HandleFunc("POST /wallet/pool/metadata", func(w http.ResponseWriter, r *http.Request) {
+		var in poolops.MetadataInput
+		if !decodeBody(w, r, &in) {
+			return
+		}
+		v, err := po.BuildMetadata(in)
+		serve(w, v, err)
+	})
+
+	// Air-gap import: pool ID from an external cold vkey (pure transform).
+	mux.HandleFunc("POST /wallet/pool/id", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ColdVKeyHex string `json:"cold_vkey_hex"`
+		}
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		id, idHex, err := po.PoolIDFromColdVKey(req.ColdVKeyHex)
+		serve(w, map[string]string{"pool_id": id, "pool_id_hex": idHex}, err)
+	})
+
+	// 3/4. Registration / update certificate (seed): build the canonical cert.
+	mux.HandleFunc("POST /wallet/pool/registration", func(w http.ResponseWriter, r *http.Request) {
+		var req poolRegistrationSeedRequest
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		v, err := po.BuildRegistrationFromSeed(req.Password, req.params())
+		serve(w, v, err)
+	})
+
+	// 3/4. Registration / update certificate (air-gap): build from imported keys.
+	mux.HandleFunc("POST /wallet/pool/registration/airgap", func(w http.ResponseWriter, r *http.Request) {
+		var req poolRegistrationAirGapRequest
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		v, err := po.BuildRegistrationAirGap(poolops.AirGapRegistrationParams{
+			RegistrationParams: req.params(),
+			VRFKeyHashHex:      req.VRFKeyHashHex,
+		})
+		serve(w, v, err)
+	})
+
+	// 5. Retirement certificate (seed or air-gap cold vkey).
+	mux.HandleFunc("POST /wallet/pool/retirement/cert", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Password    string `json:"password"`
+			ColdVKeyHex string `json:"cold_vkey_hex"`
+			Epoch       uint64 `json:"epoch"`
+		}
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		v, err := po.BuildRetirementCert(req.Password, req.ColdVKeyHex, req.Epoch)
+		serve(w, v, err)
+	})
+
+	// 5. Retirement transaction submission (seed; needs a fully synced node).
+	mux.HandleFunc("POST /wallet/pool/retirement/submit", readyGate(st, func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Password string `json:"password"`
+			Epoch    uint64 `json:"epoch"`
+		}
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		v, err := po.SubmitRetirement(r.Context(), req.Password, req.Epoch)
+		serve(w, v, err)
+	}))
+}
+
+// decodeBody decodes a JSON request body into v, writing a 400 and returning
+// false on malformed input.
+func decodeBody(w http.ResponseWriter, r *http.Request, v any) bool {
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(v); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+		return false
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+		return false
+	}
+	return true
 }
 
 // resolveNetwork returns the effective network for a wallet request, defaulting
@@ -689,22 +970,25 @@ func serve[T any](w http.ResponseWriter, v T, err error) {
 	case errors.Is(err, vault.ErrDuplicateWallet):
 		writeJSON(w, http.StatusConflict, errBody(err)) // 409
 	case errors.Is(err, vault.ErrLocked), errors.Is(err, vault.ErrNoActiveWallet),
-		errors.Is(err, wallet.ErrNoWallet), errors.Is(err, spend.ErrNoWallet):
+		errors.Is(err, wallet.ErrNoWallet), errors.Is(err, spend.ErrNoWallet),
+		errors.Is(err, poolops.ErrNoWallet):
 		writeJSON(w, http.StatusConflict, errBody(err)) // 409: locked / no active wallet
 	case errors.Is(err, spend.ErrWalletChanged):
 		writeJSON(w, http.StatusConflict, errBody(err)) // 409: active wallet switched during build
-	case errors.Is(err, vault.ErrWrongPassword), errors.Is(err, spend.ErrWrongPassword):
+	case errors.Is(err, vault.ErrWrongPassword), errors.Is(err, spend.ErrWrongPassword),
+		errors.Is(err, poolops.ErrWrongPassword):
 		writeJSON(w, http.StatusUnauthorized, errBody(err)) // 401
 	case errors.Is(err, spend.ErrInvalidRequest),
 		errors.Is(err, spend.ErrInvalidTx),
-		errors.Is(err, spend.ErrInvalidWitness):
+		errors.Is(err, spend.ErrInvalidWitness),
+		errors.Is(err, poolops.ErrInvalidRequest):
 		writeJSON(w, http.StatusBadRequest, errBody(err)) // 400
 	case errors.Is(err, spend.ErrUnknownPending):
 		writeJSON(w, http.StatusNotFound, errBody(err)) // 404
 	case errors.Is(err, spend.ErrExpiredPending):
 		writeJSON(w, http.StatusGone, errBody(err)) // 410
 	case errors.Is(err, spend.ErrInsufficientFunds), errors.Is(err, spend.ErrSubmitRejected),
-		errors.Is(err, spend.ErrNoChange):
+		errors.Is(err, spend.ErrNoChange), errors.Is(err, poolops.ErrSubmitRejected):
 		// 422: the request was understood but cannot be fulfilled; the node's
 		// structured rejection reason (for submit), the funding shortfall, or the
 		// "already in the requested state" note rides along in the message.

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -1617,7 +1617,7 @@ func TestPoolRegistrationSeedAndAirGap(t *testing.T) {
 
 func TestPoolRegistrationAcceptsStringAmounts(t *testing.T) {
 	po := &fakePoolOps{cert: poolops.CertResult{PoolID: "pool1reg", CBORHex: "8a03"}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, po, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","pledge":"9007199254740993","cost":"18446744073709551615","margin_num":1,"margin_denom":50}`)

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
+	"github.com/blinklabs-io/bursa/ui/internal/poolops"
 	"github.com/blinklabs-io/bursa/ui/internal/spend"
 	"github.com/blinklabs-io/bursa/ui/internal/supervisor"
 	"github.com/blinklabs-io/bursa/ui/internal/vault"
@@ -223,7 +224,7 @@ func (f *fakeSettings) SetHistoryExpiry(enabled bool) error {
 func (f *fakeSettings) HistoryExpiryRestartRequired() bool { return f.restartRequired }
 
 func TestHealthAlwaysOK(t *testing.T) {
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
 	if rec.Code != http.StatusOK {
@@ -233,7 +234,7 @@ func TestHealthAlwaysOK(t *testing.T) {
 
 func TestStatusReturnsSnapshot(t *testing.T) {
 	want := supervisor.Status{State: supervisor.StateSyncing, Tip: 42, CaughtUp: true}
-	h := NewHandler(fakeStatuser{s: want}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{s: want}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
 	if rec.Code != http.StatusOK {
@@ -302,7 +303,7 @@ func (f *fakeWallet) Delegation(_ context.Context) (wallet.DelegationView, error
 
 func TestVaultStatusReports(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: true, wallets: []vault.WalletMeta{{ID: "a"}, {ID: "b"}}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/status", nil))
 	if rec.Code != http.StatusOK {
@@ -323,7 +324,7 @@ func TestVaultStatusReports(t *testing.T) {
 func TestVaultStatusReportsLegacyKeystore(t *testing.T) {
 	fv := &fakeVault{exists: false, locked: true}
 	legacy := &fakeLegacyKeystore{exists: true}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/status", nil))
 	if rec.Code != http.StatusOK {
@@ -340,7 +341,7 @@ func TestVaultStatusReportsLegacyKeystore(t *testing.T) {
 
 func TestVaultCreateRequiresPassword(t *testing.T) {
 	fv := &fakeVault{}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"short"}`)))
 	if rec.Code != http.StatusBadRequest {
@@ -353,7 +354,7 @@ func TestVaultCreateRequiresPassword(t *testing.T) {
 
 func TestVaultCreateOK(t *testing.T) {
 	fv := &fakeVault{}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusOK {
@@ -366,7 +367,7 @@ func TestVaultCreateOK(t *testing.T) {
 
 func TestVaultCreateConflict(t *testing.T) {
 	fv := &fakeVault{createErr: vault.ErrVaultExists}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusConflict {
@@ -383,7 +384,7 @@ func TestVaultUnlockBindsSoleWalletAndReads(t *testing.T) {
 		wallets: []vault.WalletMeta{{ID: "w1", Name: "main", Network: "preview", Account: sampleAccount("preview")}},
 	}
 	fw := &fakeWallet{balance: wallet.Balance{Lovelace: "1234"}}
-	h := NewHandler(st, fv, fw, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, fw, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
@@ -410,7 +411,7 @@ func TestVaultUnlockBindsSoleWalletAndReads(t *testing.T) {
 
 func TestVaultUnlockWrongPassword(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: true, unlockErr: fmt.Errorf("%w: bad", vault.ErrWrongPassword)}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"wrong-but-long-pw"}`)))
 	if rec.Code != http.StatusUnauthorized {
@@ -422,7 +423,7 @@ func TestVaultLock(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false}
 	fw := &fakeWallet{set: true}
 	sp := &fakeSpender{set: true}
-	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/lock", nil))
 	if rec.Code != http.StatusOK {
@@ -441,7 +442,7 @@ func TestMigrateLegacyKeystoreImportsAndBinds(t *testing.T) {
 	fw := &fakeWallet{}
 	sp := &fakeSpender{}
 	legacy := &fakeLegacyKeystore{exists: true, mnemonic: []byte("abandon abandon about")}
-	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 
 	body := `{"name":"Imported","vault_password":"valid-vault-password","spend_password":"legacy-spend-password"}`
 	rec := httptest.NewRecorder()
@@ -480,7 +481,7 @@ func TestMigrateLegacyKeystoreImportsAndBinds(t *testing.T) {
 func TestMigrateLegacyKeystoreWrongPassword(t *testing.T) {
 	fv := &fakeVault{exists: false, locked: true}
 	legacy := &fakeLegacyKeystore{exists: true, err: keystore.ErrDecryptFailed}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 
 	body := `{"name":"Imported","vault_password":"valid-vault-password","spend_password":"wrong-password"}`
 	rec := httptest.NewRecorder()
@@ -496,7 +497,7 @@ func TestMigrateLegacyKeystoreWrongPassword(t *testing.T) {
 func TestMigrateLegacyKeystoreRequiresSpendPasswordMinLength(t *testing.T) {
 	fv := &fakeVault{exists: false, locked: true}
 	legacy := &fakeLegacyKeystore{exists: true, mnemonic: []byte("abandon abandon about")}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 
 	body := `{"name":"Imported","vault_password":"valid-vault-password","spend_password":"short"}`
 	rec := httptest.NewRecorder()
@@ -519,7 +520,7 @@ func TestAddWalletEnablesReadsAndSpend(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false}
 	fw := &fakeWallet{balance: wallet.Balance{Lovelace: "1234"}}
 	sp := &fakeSpender{}
-	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
@@ -548,7 +549,7 @@ func TestAddWalletRequiresSpendPassword(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
 	sp := &fakeSpender{}
-	h := NewHandler(st, fv, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","vault_password":"valid-vault-password","spend_password":"short"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -563,7 +564,7 @@ func TestAddWalletRequiresSpendPassword(t *testing.T) {
 func TestAddWalletRequiresVaultPassword(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -575,7 +576,7 @@ func TestAddWalletRequiresVaultPassword(t *testing.T) {
 func TestAddWalletNetworkMismatch(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"mainnet","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -587,7 +588,7 @@ func TestAddWalletNetworkMismatch(t *testing.T) {
 func TestAddWalletDefaultNetworkIsNodeNetwork(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preprod", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preprod", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -602,7 +603,7 @@ func TestAddWalletDefaultNetworkIsNodeNetwork(t *testing.T) {
 func TestAddWalletDuplicateConflict(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false, addErr: vault.ErrDuplicateWallet}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -622,7 +623,7 @@ func TestActivateWalletBinds(t *testing.T) {
 	}
 	fw := &fakeWallet{}
 	sp := &fakeSpender{}
-	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/w2/activate", nil))
 	if rec.Code != http.StatusOK {
@@ -645,7 +646,7 @@ func TestActivateWalletBinds(t *testing.T) {
 
 func TestActivateUnknownWallet(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/nope/activate", nil))
 	if rec.Code != http.StatusNotFound {
@@ -655,7 +656,7 @@ func TestActivateUnknownWallet(t *testing.T) {
 
 func TestDeleteWalletRequiresVaultPassword(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false, wallets: []vault.WalletMeta{{ID: "w1"}}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/wallet/w1", bytes.NewBufferString(`{}`)))
 	if rec.Code != http.StatusBadRequest {
@@ -670,7 +671,7 @@ func TestDeleteWalletOK(t *testing.T) {
 	}
 	fw := &fakeWallet{set: true}
 	sp := &fakeSpender{set: true}
-	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/wallet/w1", bytes.NewBufferString(`{"vault_password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusOK {
@@ -688,7 +689,7 @@ func TestDeleteWalletOK(t *testing.T) {
 
 func TestWalletGatedWhileStarting(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/balance", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -699,7 +700,7 @@ func TestWalletGatedWhileStarting(t *testing.T) {
 func TestWalletGatedWhileBootstrapping(t *testing.T) {
 	// Mithril bootstrap is not a servable state: reads must be gated (503).
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateBootstrapping}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/balance", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -712,7 +713,7 @@ func TestWalletNoActiveWalletConflict(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	for _, path := range []string{"/wallet/balance", "/wallet/addresses", "/wallet/transactions", "/wallet/delegation"} {
 		t.Run(path, func(t *testing.T) {
-			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
 			if rec.Code != http.StatusConflict {
@@ -839,10 +840,140 @@ func (f *fakeSpender) BuildDelegation(_ context.Context, _ spend.DelegationReque
 	return spend.DelegationPreview{}, nil
 }
 
+// fakePoolOps implements the api.PoolOps interface for handler tests. Each
+// method returns a canned value or a configured error so the handler routing,
+// gating, and error-code mapping can be exercised without real key derivation.
+type fakePoolOps struct {
+	setAccountCalled bool
+	credErr          error
+	kesErr           error
+	opcertErr        error
+	metadataErr      error
+	idErr            error
+	regErr           error
+	retireErr        error
+	submitErr        error
+
+	creds     poolops.Credentials
+	kes       poolops.KESPeriodInfo
+	opcert    poolops.OpCert
+	payload   poolops.OpCertPayload
+	metadata  poolops.MetadataResult
+	cert      poolops.CertResult
+	tx        poolops.TxResult
+	poolID    string
+	poolIDHex string
+
+	credPassword     string
+	issuePassword    string
+	issueKESIndex    uint32
+	issueNumber      uint64
+	issueKESPeriod   uint64
+	rotatePassword   string
+	rotateKESIndex   uint32
+	rotatePrevIssue  uint64
+	rotateKESPeriod  uint64
+	payloadKESVKey   string
+	payloadIssue     uint64
+	payloadKESPeriod uint64
+	assembleColdVKey string
+	assembleKESVKey  string
+	assembleSig      string
+	assembleIssue    uint64
+	assemblePeriod   uint64
+	metadataInput    poolops.MetadataInput
+	idColdVKey       string
+	regPassword      string
+	regParams        poolops.RegistrationParams
+	airGapParams     poolops.AirGapRegistrationParams
+	retirePassword   string
+	retireColdVKey   string
+	retireEpoch      uint64
+	submitPassword   string
+	submitEpoch      uint64
+}
+
+func (f *fakePoolOps) SetAccount(_ string, _ *wallet.Account) { f.setAccountCalled = true }
+
+func (f *fakePoolOps) Credentials(password string) (poolops.Credentials, error) {
+	f.credPassword = password
+	return f.creds, f.credErr
+}
+
+func (f *fakePoolOps) KESPeriod(_ context.Context) (poolops.KESPeriodInfo, error) {
+	return f.kes, f.kesErr
+}
+
+func (f *fakePoolOps) IssueOpCert(password string, kesIndex uint32, issueNumber, kesPeriod uint64) (poolops.OpCert, error) {
+	f.issuePassword = password
+	f.issueKESIndex = kesIndex
+	f.issueNumber = issueNumber
+	f.issueKESPeriod = kesPeriod
+	return f.opcert, f.opcertErr
+}
+
+func (f *fakePoolOps) RotateKES(password string, newKESIndex uint32, prevIssueNumber, kesPeriod uint64) (poolops.OpCert, error) {
+	f.rotatePassword = password
+	f.rotateKESIndex = newKESIndex
+	f.rotatePrevIssue = prevIssueNumber
+	f.rotateKESPeriod = kesPeriod
+	return f.opcert, f.opcertErr
+}
+
+func (f *fakePoolOps) OpCertPayload(kesVKeyHex string, issueNumber, kesPeriod uint64) (poolops.OpCertPayload, error) {
+	f.payloadKESVKey = kesVKeyHex
+	f.payloadIssue = issueNumber
+	f.payloadKESPeriod = kesPeriod
+	return f.payload, f.opcertErr
+}
+
+func (f *fakePoolOps) AssembleOpCert(coldVKeyHex, kesVKeyHex, signatureHex string, issueNumber, kesPeriod uint64) (poolops.OpCert, error) {
+	f.assembleColdVKey = coldVKeyHex
+	f.assembleKESVKey = kesVKeyHex
+	f.assembleSig = signatureHex
+	f.assembleIssue = issueNumber
+	f.assemblePeriod = kesPeriod
+	return f.opcert, f.opcertErr
+}
+
+func (f *fakePoolOps) BuildMetadata(in poolops.MetadataInput) (poolops.MetadataResult, error) {
+	f.metadataInput = in
+	return f.metadata, f.metadataErr
+}
+
+func (f *fakePoolOps) PoolIDFromColdVKey(coldVKeyHex string) (string, string, error) {
+	f.idColdVKey = coldVKeyHex
+	return f.poolID, f.poolIDHex, f.idErr
+}
+
+func (f *fakePoolOps) BuildRegistrationFromSeed(password string, p poolops.RegistrationParams) (poolops.CertResult, error) {
+	f.regPassword = password
+	f.regParams = p
+	return f.cert, f.regErr
+}
+
+func (f *fakePoolOps) BuildRegistrationAirGap(p poolops.AirGapRegistrationParams) (poolops.CertResult, error) {
+	f.airGapParams = p
+	return f.cert, f.regErr
+}
+
+func (f *fakePoolOps) BuildRetirementCert(password, coldVKeyHex string, epoch uint64) (poolops.CertResult, error) {
+	f.retirePassword = password
+	f.retireColdVKey = coldVKeyHex
+	f.retireEpoch = epoch
+	return f.cert, f.retireErr
+}
+
+func (f *fakePoolOps) SubmitRetirement(_ context.Context, password string, epoch uint64) (poolops.TxResult, error) {
+	f.submitPassword = password
+	f.submitEpoch = epoch
+	return f.tx, f.submitErr
+}
+
 func TestSignDataReturnsSignature(t *testing.T) {
 	// Ungated: message signing needs no synced node, only the keystore.
 	sp := &fakeSpender{signSig: "84a1deadbeef", signKey: "a4010103"}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"address":"addr_test1xyz","message":"hello","password":"pw"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-data", body))
@@ -859,7 +990,7 @@ func TestSignDataReturnsSignature(t *testing.T) {
 
 func TestSignDataWrongPasswordReturns401(t *testing.T) {
 	sp := &fakeSpender{signErr: fmt.Errorf("%w: bad", spend.ErrWrongPassword)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"address":"a","message":"m","password":"bad"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-data", body))
@@ -871,7 +1002,7 @@ func TestSignDataWrongPasswordReturns401(t *testing.T) {
 func TestVerifyDataReturnsResult(t *testing.T) {
 	// Ungated: verification is pure crypto, needs no node and no keystore.
 	sp := &fakeSpender{verifyValid: true, verifyAddr: "addr_test1signed"}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"signature":"84a1","key":"a401","message":"hi","hashed":true,"expected_address":"addr_test1signed"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/verify-data", body))
@@ -893,7 +1024,7 @@ func TestVerifyDataReturnsResult(t *testing.T) {
 
 func TestVerifyDataInvalidArgsReturns400(t *testing.T) {
 	sp := &fakeSpender{verifyErr: fmt.Errorf("%w: bad hex", spend.ErrInvalidRequest)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"signature":"zz","key":"a4","message":"hi"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/verify-data", body))
@@ -904,7 +1035,7 @@ func TestVerifyDataInvalidArgsReturns400(t *testing.T) {
 
 func TestExportUnsignedRequiresReady(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend1/export-unsigned", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -918,7 +1049,7 @@ func TestExportUnsignedReturnsTx(t *testing.T) {
 		UnsignedTxCBOR:  "84a400",
 		RequiredSigners: []string{"deadbeef"},
 	}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend1/export-unsigned", nil))
 	if rec.Code != http.StatusOK {
@@ -936,7 +1067,7 @@ func TestSignTxUngated(t *testing.T) {
 	// Offline signing must not need a synced node -- only the keystore.
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
 	sp := &fakeSpender{witness: spend.Witness{WitnessCBOR: "81825820"}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","password":"pw","required_signers":["deadbeef"]}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-tx", body))
@@ -956,7 +1087,7 @@ func TestSignTxUngated(t *testing.T) {
 
 func TestSignTxWrongPasswordReturns401(t *testing.T) {
 	sp := &fakeSpender{signTxErr: fmt.Errorf("%w: bad", spend.ErrWrongPassword)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","password":"bad","required_signers":["deadbeef"]}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-tx", body))
@@ -967,7 +1098,7 @@ func TestSignTxWrongPasswordReturns401(t *testing.T) {
 
 func TestSignTxInvalidTxReturns400(t *testing.T) {
 	sp := &fakeSpender{signTxErr: fmt.Errorf("%w: bad cbor", spend.ErrInvalidTx)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"zz","password":"pw","required_signers":["deadbeef"]}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-tx", body))
@@ -978,7 +1109,7 @@ func TestSignTxInvalidTxReturns400(t *testing.T) {
 
 func TestSubmitSignedRequiresReady(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witness_cbor":"81"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-signed", body))
@@ -990,7 +1121,7 @@ func TestSubmitSignedRequiresReady(t *testing.T) {
 func TestSubmitSignedReturnsTxHash(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{submitResult: spend.TxResult{TxHash: "cafebabe"}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witness_cbor":"81825820"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-signed", body))
@@ -1008,7 +1139,7 @@ func TestSubmitSignedReturnsTxHash(t *testing.T) {
 func TestSubmitSignedInvalidWitnessReturns400(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{submitErr: fmt.Errorf("%w: bad cbor", spend.ErrInvalidWitness)}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witness_cbor":"zz"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-signed", body))
@@ -1020,7 +1151,7 @@ func TestSubmitSignedInvalidWitnessReturns400(t *testing.T) {
 func TestSpendSendReadyReturnsPreview(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{preview: spend.Preview{PendingID: "pend123", Fee: "170000"}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send", body))
@@ -1039,7 +1170,7 @@ func TestSpendSendReadyReturnsPreview(t *testing.T) {
 func TestSpendSendGatedWhileSyncing(t *testing.T) {
 	// Spending requires a fully synced node (StateReady), unlike reads.
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send", body))
@@ -1051,7 +1182,7 @@ func TestSpendSendGatedWhileSyncing(t *testing.T) {
 func TestSpendSendNoWalletConflict(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{buildErr: spend.ErrNoWallet}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send", body))
@@ -1063,7 +1194,7 @@ func TestSpendSendNoWalletConflict(t *testing.T) {
 func TestSpendConfirmReadyReturnsTxHash(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{result: spend.TxResult{TxHash: "deadbeef"}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-spend-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend123/confirm", body))
@@ -1084,7 +1215,7 @@ func TestSpendConfirmReadyReturnsTxHash(t *testing.T) {
 
 func TestSpendConfirmGatedWhileSyncing(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-spend-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend123/confirm", body))
@@ -1124,7 +1255,7 @@ func TestSpendErrorStatusCodes(t *testing.T) {
 				req = httptest.NewRequest(http.MethodPost, "/wallet/send",
 					bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`))
 			}
-			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, "preview", http.NotFoundHandler())
+			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
 			if rec.Code != tc.wantCode {
@@ -1166,7 +1297,7 @@ func TestGetHistoryExpiryReturnsState(t *testing.T) {
 	// node query).
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStopped}}
 	set := &fakeSettings{enabled: true, restartRequired: true}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/settings/history-expiry", nil))
 	if rec.Code != http.StatusOK {
@@ -1181,7 +1312,7 @@ func TestGetHistoryExpiryReturnsState(t *testing.T) {
 func TestGetHistoryExpiryDefaultOff(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{} // default off, no restart needed
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/settings/history-expiry", nil))
 	got := decodeHistoryExpiry(t, rec.Body)
@@ -1194,7 +1325,7 @@ func TestPutHistoryExpiryPersistsAndSignalsRestart(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	// Running node was built with off; flipping to on must signal a restart.
 	set := &fakeSettings{enabled: false, restartRequired: true}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"enabled":true}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
@@ -1216,7 +1347,7 @@ func TestPutHistoryExpiryPersistsAndSignalsRestart(t *testing.T) {
 func TestPutHistoryExpiryInvalidJSON(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{not json`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
@@ -1233,7 +1364,7 @@ func TestPutHistoryExpiryRequiresExplicitEnabled(t *testing.T) {
 		t.Run(bodyJSON, func(t *testing.T) {
 			st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 			set := &fakeSettings{}
-			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, "preview", http.NotFoundHandler())
+			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
 			body := bytes.NewBufferString(bodyJSON)
 			h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
@@ -1250,11 +1381,332 @@ func TestPutHistoryExpiryRequiresExplicitEnabled(t *testing.T) {
 func TestPutHistoryExpiryPersistError(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{setErr: errors.New("disk full")}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"enabled":true}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("PUT history-expiry with persist error = %d, want 500", rec.Code)
+	}
+}
+
+// --- Pool operations (SPO) ---
+
+// readyStatuser returns a fully-synced node for pool ops that need a node.
+func readyStatuser() fakeStatuser {
+	return fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+}
+
+func TestPoolCredentialsReturnsCreds(t *testing.T) {
+	po := &fakePoolOps{creds: poolops.Credentials{PoolID: "pool1abc", Network: "preview"}}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"password":"spend-password"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/credentials", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /wallet/pool/credentials = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "pool1abc") {
+		t.Fatalf("response missing pool ID: %s", rec.Body.String())
+	}
+	if po.credPassword != "spend-password" {
+		t.Fatalf("credentials password = %q, want spend-password", po.credPassword)
+	}
+}
+
+func TestPoolCredentialsRejectsTrailingJSON(t *testing.T) {
+	po := &fakePoolOps{creds: poolops.Credentials{PoolID: "pool1abc", Network: "preview"}}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"password":"spend-password"} {"password":"ignored"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/credentials", body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("credentials with trailing JSON = %d, want 400", rec.Code)
+	}
+	if po.credPassword != "" {
+		t.Fatalf("credentials was called despite trailing JSON: password=%q", po.credPassword)
+	}
+}
+
+func TestPoolCredentialsNoWalletConflict(t *testing.T) {
+	po := &fakePoolOps{credErr: poolops.ErrNoWallet}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"password":"x"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/credentials", body))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("credentials with no wallet = %d, want 409", rec.Code)
+	}
+}
+
+func TestPoolCredentialsWrongPassword401(t *testing.T) {
+	po := &fakePoolOps{credErr: fmt.Errorf("%w: bad", poolops.ErrWrongPassword)}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"password":"bad"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/credentials", body))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("credentials wrong password = %d, want 401", rec.Code)
+	}
+}
+
+func TestPoolKESPeriodGatedWhileStarting(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/pool/kes-period", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("kes-period while starting = %d, want 503", rec.Code)
+	}
+}
+
+func TestPoolKESPeriodReady(t *testing.T) {
+	po := &fakePoolOps{kes: poolops.KESPeriodInfo{CurrentPeriod: 7, SlotsPerKESPeriod: 129600}}
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/pool/kes-period", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("kes-period ready = %d, want 200", rec.Code)
+	}
+	var info poolops.KESPeriodInfo
+	if err := json.NewDecoder(rec.Body).Decode(&info); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if info.CurrentPeriod != 7 {
+		t.Fatalf("current period = %d, want 7", info.CurrentPeriod)
+	}
+}
+
+func TestPoolOpCertIssue(t *testing.T) {
+	po := &fakePoolOps{opcert: poolops.OpCert{IssueNumber: 3, KesPeriod: 7, KesVKeyHex: "abcd"}}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"password":"pw","kes_index":0,"issue_number":3,"kes_period":7}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/opcert", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("opcert issue = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "abcd") {
+		t.Fatalf("opcert response missing kes vkey: %s", rec.Body.String())
+	}
+	if po.issuePassword != "pw" || po.issueKESIndex != 0 || po.issueNumber != 3 || po.issueKESPeriod != 7 {
+		t.Fatalf("issue args = password %q index %d issue %d period %d, want pw/0/3/7", po.issuePassword, po.issueKESIndex, po.issueNumber, po.issueKESPeriod)
+	}
+}
+
+func TestPoolOpCertRotate(t *testing.T) {
+	po := &fakePoolOps{opcert: poolops.OpCert{IssueNumber: 4, KESIndex: 1}}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"password":"pw","new_kes_index":1,"prev_issue_number":3,"kes_period":7}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/opcert/rotate", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("opcert rotate = %d, want 200", rec.Code)
+	}
+	var got poolops.OpCert
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode opcert rotate response: %v", err)
+	}
+	if got.IssueNumber != 4 || got.KESIndex != 1 {
+		t.Fatalf("opcert rotate: got IssueNumber=%d KESIndex=%d, want 4/1", got.IssueNumber, got.KESIndex)
+	}
+	if po.rotatePassword != "pw" || po.rotateKESIndex != 1 || po.rotatePrevIssue != 3 || po.rotateKESPeriod != 7 {
+		t.Fatalf("rotate args = password %q index %d prev %d period %d, want pw/1/3/7", po.rotatePassword, po.rotateKESIndex, po.rotatePrevIssue, po.rotateKESPeriod)
+	}
+}
+
+func TestPoolOpCertPayloadAndAssembleAirGap(t *testing.T) {
+	po := &fakePoolOps{
+		payload: poolops.OpCertPayload{PayloadHex: "8203", KesVKeyHex: "ab"},
+		opcert:  poolops.OpCert{IssueNumber: 1},
+	}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, "preview", http.NotFoundHandler())
+
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"kes_vkey_hex":"ab","issue_number":1,"kes_period":2}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/opcert/payload", body))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "8203") {
+		t.Fatalf("opcert payload = %d body %s", rec.Code, rec.Body.String())
+	}
+	if po.payloadKESVKey != "ab" || po.payloadIssue != 1 || po.payloadKESPeriod != 2 {
+		t.Fatalf("payload args = vkey %q issue %d period %d, want ab/1/2", po.payloadKESVKey, po.payloadIssue, po.payloadKESPeriod)
+	}
+
+	rec = httptest.NewRecorder()
+	body = bytes.NewBufferString(`{"cold_vkey_hex":"aa","kes_vkey_hex":"bb","signature_hex":"cc","issue_number":1,"kes_period":2}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/opcert/assemble", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("opcert assemble = %d, want 200", rec.Code)
+	}
+	if po.assembleColdVKey != "aa" || po.assembleKESVKey != "bb" || po.assembleSig != "cc" || po.assembleIssue != 1 || po.assemblePeriod != 2 {
+		t.Fatalf("assemble args = cold %q kes %q sig %q issue %d period %d, want aa/bb/cc/1/2", po.assembleColdVKey, po.assembleKESVKey, po.assembleSig, po.assembleIssue, po.assemblePeriod)
+	}
+}
+
+func TestPoolAssembleOpCertBadSignature400(t *testing.T) {
+	po := &fakePoolOps{opcertErr: fmt.Errorf("%w: bad sig", poolops.ErrInvalidRequest)}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"cold_vkey_hex":"aa","kes_vkey_hex":"bb","signature_hex":"00","issue_number":1,"kes_period":2}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/opcert/assemble", body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("assemble bad sig = %d, want 400", rec.Code)
+	}
+}
+
+func TestPoolMetadataBuilder(t *testing.T) {
+	po := &fakePoolOps{metadata: poolops.MetadataResult{JSON: `{"name":"P"}`, HashHex: "deadbeef"}}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"name":"P","ticker":"POOL","homepage":"https://x","description":"d"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/metadata", body))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "deadbeef") {
+		t.Fatalf("metadata = %d body %s", rec.Code, rec.Body.String())
+	}
+	want := poolops.MetadataInput{Name: "P", Ticker: "POOL", Homepage: "https://x", Description: "d"}
+	if po.metadataInput != want {
+		t.Fatalf("metadata input = %+v, want %+v", po.metadataInput, want)
+	}
+}
+
+func TestPoolIDFromColdVKey(t *testing.T) {
+	po := &fakePoolOps{poolID: "pool1xyz", poolIDHex: "abcdef1234"}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"cold_vkey_hex":"` + strings.Repeat("ab", 32) + `"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/id", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("pool id status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "pool1xyz") {
+		t.Fatalf("pool id response missing bech32 pool_id: %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "abcdef1234") {
+		t.Fatalf("pool id response missing hex pool_id_hex: %s", rec.Body.String())
+	}
+	wantColdVKey := strings.Repeat("ab", 32)
+	if po.idColdVKey != wantColdVKey {
+		t.Fatalf("pool id cold vkey = %q, want %q", po.idColdVKey, wantColdVKey)
+	}
+}
+
+func TestPoolRegistrationSeedAndAirGap(t *testing.T) {
+	po := &fakePoolOps{cert: poolops.CertResult{PoolID: "pool1reg", CBORHex: "8a03"}}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, "preview", http.NotFoundHandler())
+
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"password":"pw","pledge":1,"cost":1,"margin_num":1,"margin_denom":50}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/registration", body))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "pool1reg") {
+		t.Fatalf("registration seed = %d body %s", rec.Code, rec.Body.String())
+	}
+	if po.regPassword != "pw" || po.regParams.Pledge != 1 || po.regParams.Cost != 1 || po.regParams.MarginNum != 1 || po.regParams.MarginDenom != 50 {
+		t.Fatalf("registration seed args = password %q params %+v, want pw and pledge/cost/margin 1/1/1/50", po.regPassword, po.regParams)
+	}
+
+	rec = httptest.NewRecorder()
+	body = bytes.NewBufferString(`{"cold_vkey_hex":"ab","vrf_key_hash_hex":"cd","pledge":1,"cost":1,"margin_num":0,"margin_denom":1}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/registration/airgap", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("registration airgap = %d, want 200", rec.Code)
+	}
+	if po.airGapParams.ColdVKeyHex != "ab" || po.airGapParams.VRFKeyHashHex != "cd" || po.airGapParams.Pledge != 1 || po.airGapParams.MarginDenom != 1 {
+		t.Fatalf("registration airgap args = %+v, want cold/vrf ab/cd and params", po.airGapParams)
+	}
+}
+
+func TestPoolRegistrationAcceptsStringAmounts(t *testing.T) {
+	po := &fakePoolOps{cert: poolops.CertResult{PoolID: "pool1reg", CBORHex: "8a03"}}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, po, "preview", http.NotFoundHandler())
+
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"password":"pw","pledge":"9007199254740993","cost":"18446744073709551615","margin_num":1,"margin_denom":50}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/registration", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("registration string amounts = %d body %s", rec.Code, rec.Body.String())
+	}
+	if po.regParams.Pledge != 9007199254740993 || po.regParams.Cost != ^uint64(0) {
+		t.Fatalf("registration string amount params = %+v, want pledge > safe int and max uint64 cost", po.regParams)
+	}
+}
+
+func TestPoolRetirementCert(t *testing.T) {
+	po := &fakePoolOps{cert: poolops.CertResult{PoolID: "pool1ret", CBORHex: "8304"}}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"password":"pw","epoch":500}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/retirement/cert", body))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "pool1ret") {
+		t.Fatalf("retirement cert = %d body %s", rec.Code, rec.Body.String())
+	}
+	if po.retirePassword != "pw" || po.retireColdVKey != "" || po.retireEpoch != 500 {
+		t.Fatalf("retirement seed args = password %q cold %q epoch %d, want pw//500", po.retirePassword, po.retireColdVKey, po.retireEpoch)
+	}
+
+	rec = httptest.NewRecorder()
+	body = bytes.NewBufferString(`{"cold_vkey_hex":"ab","epoch":501}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/retirement/cert", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("retirement airgap cert = %d, want 200", rec.Code)
+	}
+	if po.retirePassword != "" || po.retireColdVKey != "ab" || po.retireEpoch != 501 {
+		t.Fatalf("retirement airgap args = password %q cold %q epoch %d, want /ab/501", po.retirePassword, po.retireColdVKey, po.retireEpoch)
+	}
+}
+
+func TestPoolRetirementSubmitGatedWhileSyncing(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"password":"pw","epoch":500}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/retirement/submit", body))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("retirement submit while syncing = %d, want 503", rec.Code)
+	}
+}
+
+func TestPoolRetirementSubmitReady(t *testing.T) {
+	po := &fakePoolOps{tx: poolops.TxResult{TxHash: "feedface"}}
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"password":"pw","epoch":500}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/retirement/submit", body))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "feedface") {
+		t.Fatalf("retirement submit ready = %d body %s", rec.Code, rec.Body.String())
+	}
+	if po.submitPassword != "pw" || po.submitEpoch != 500 {
+		t.Fatalf("submit args = password %q epoch %d, want pw/500", po.submitPassword, po.submitEpoch)
+	}
+}
+
+func TestPoolRetirementSubmitRejected422(t *testing.T) {
+	po := &fakePoolOps{submitErr: fmt.Errorf("%w: ledger rule X", poolops.ErrSubmitRejected)}
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"password":"pw","epoch":500}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/retirement/submit", body))
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("retirement submit rejected = %d, want 422", rec.Code)
+	}
+}
+
+func TestVaultUnlockAttachesPoolWallet(t *testing.T) {
+	// Unlocking the vault must also bind the active wallet to the pool-ops service
+	// so credential/cert builders know which seed to derive from.
+	st := readyStatuser()
+	po := &fakePoolOps{}
+	fv := &fakeVault{
+		exists:  true,
+		locked:  true,
+		wallets: []vault.WalletMeta{{ID: "w1", Name: "main", Network: "preview", Account: sampleAccount("preview")}},
+	}
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /vault/unlock = %d, want 200", rec.Code)
+	}
+	if !po.setAccountCalled {
+		t.Fatal("pool service was not attached to the active wallet on vault unlock")
 	}
 }

--- a/ui/internal/chain/blockfrost.go
+++ b/ui/internal/chain/blockfrost.go
@@ -159,6 +159,24 @@ type DRepInfo struct {
 	LiveStake  string `json:"live_stake"`
 }
 
+// Genesis mirrors GET /api/v0/genesis: the network's immutable genesis
+// parameters. SlotsPerKESPeriod and EpochLength drive the SPO KES-period and
+// epoch math; both are served by the embedded node, never an external service.
+type Genesis struct {
+	EpochLength       int `json:"epoch_length"`
+	SlotsPerKESPeriod int `json:"slots_per_kes_period"`
+	SlotLength        int `json:"slot_length"`
+	MaxKESEvolutions  int `json:"max_kes_evolutions"`
+	NetworkMagic      int `json:"network_magic"`
+}
+
+// EpochInfo mirrors GET /api/v0/epochs/latest (the fields the wallet uses).
+type EpochInfo struct {
+	Epoch     uint64 `json:"epoch"`
+	StartTime int64  `json:"start_time"`
+	EndTime   int64  `json:"end_time"`
+}
+
 type accountAddress struct {
 	Address string `json:"address"`
 }
@@ -480,5 +498,19 @@ func (c *Client) cachePools(pools []PoolInfo, complete bool) {
 func (c *Client) DRep(ctx context.Context, drepID string) (DRepInfo, error) {
 	var out DRepInfo
 	err := c.get(ctx, "/api/v0/governance/dreps/"+url.PathEscape(drepID), &out)
+	return out, err
+}
+
+// Genesis fetches the network's genesis parameters from the embedded node.
+func (c *Client) Genesis(ctx context.Context) (Genesis, error) {
+	var out Genesis
+	err := c.get(ctx, "/api/v0/genesis", &out)
+	return out, err
+}
+
+// LatestEpoch fetches the current epoch info from the embedded node.
+func (c *Client) LatestEpoch(ctx context.Context) (EpochInfo, error) {
+	var out EpochInfo
+	err := c.get(ctx, "/api/v0/epochs/latest", &out)
 	return out, err
 }

--- a/ui/internal/chain/blockfrost_test.go
+++ b/ui/internal/chain/blockfrost_test.go
@@ -495,3 +495,47 @@ func TestErrorStatus(t *testing.T) {
 		t.Fatalf("404 should map to ErrNotFound, got %v", err)
 	}
 }
+
+func TestGenesis(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/genesis" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"epoch_length":432000,"slots_per_kes_period":129600,"slot_length":1,"max_kes_evolutions":62,"network_magic":2}`))
+	})
+	got, err := c.Genesis(context.Background())
+	if err != nil {
+		t.Fatalf("Genesis: %v", err)
+	}
+	if got.SlotsPerKESPeriod != 129600 || got.EpochLength != 432000 || got.MaxKESEvolutions != 62 {
+		t.Fatalf("unexpected genesis: %+v", got)
+	}
+	if got.SlotLength != 1 || got.NetworkMagic != 2 {
+		t.Fatalf("genesis SlotLength/NetworkMagic: got %+v", got)
+	}
+}
+
+func TestLatestEpoch(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/epochs/latest" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"epoch":512,"start_time":1700000000,"end_time":1700432000}`))
+	})
+	got, err := c.LatestEpoch(context.Background())
+	if err != nil {
+		t.Fatalf("LatestEpoch: %v", err)
+	}
+	if got.Epoch != 512 {
+		t.Fatalf("epoch = %d, want 512", got.Epoch)
+	}
+	if got.StartTime != 1700000000 || got.EndTime != 1700432000 {
+		t.Fatalf("epoch times: got StartTime=%d EndTime=%d, want 1700000000/1700432000", got.StartTime, got.EndTime)
+	}
+}

--- a/ui/internal/poolops/poolops.go
+++ b/ui/internal/poolops/poolops.go
@@ -1,0 +1,425 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package poolops is the Stake Pool Operations (SPO) toolkit for the Bursa
+// full-node wallet. It wraps bursa's existing key-derivation and certificate
+// primitives to:
+//
+//   - derive a pool's cold / VRF / KES credentials from the active wallet seed
+//     (CIP-1853) and report the verification keys, key hashes, and pool ID;
+//   - issue and rotate operational certificates;
+//   - build pool registration / update / retirement certificates and submit
+//     them as transactions witnessed by the cold key (reusing the spend
+//     build/sign/submit path);
+//   - build canonical (RFC 8785 / JCS) pool metadata JSON and its Blake2b-256
+//     hash for the operator to host; and
+//   - support an air-gapped cold key: import an external cold verification key
+//     to compute the pool ID and build the registration cert body without the
+//     signing key, and assemble an operational certificate from an externally
+//     produced cold-key signature.
+//
+// All chain data (node tip, genesis parameters, current epoch) comes from the
+// embedded node's loopback Blockfrost endpoint; this package never contacts an
+// external service and never fetches metadata.
+package poolops
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/bursa/bip32"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/gowebpki/jcs"
+	"golang.org/x/crypto/blake2b"
+)
+
+// Sentinel errors. The API layer maps these to HTTP status codes; callers match
+// them with errors.Is. Service methods wrap them with context.
+var (
+	// ErrNoWallet: no active wallet/keystore configured (→ 409).
+	ErrNoWallet = errors.New("no wallet set")
+	// ErrInvalidRequest: a malformed parameter (→ 400).
+	ErrInvalidRequest = errors.New("invalid pool operation request")
+	// ErrWrongPassword: keystore authentication failed (→ 401).
+	ErrWrongPassword = errors.New("incorrect spending password")
+	// ErrSubmitRejected: the node rejected the signed transaction (→ 422).
+	ErrSubmitRejected = errors.New("transaction rejected by node")
+)
+
+// coldVKeyLen is the length of a raw Ed25519 verification key (cold/VRF/KES are
+// all 32-byte keys at the verification level).
+const coldVKeyLen = 32
+
+// poolColdUseCase is the CIP-1853 usecase index (currently fixed to 0).
+const poolColdUseCase = 0
+
+// KeyInfo is a verification key plus its derived hashes, ready for display.
+type KeyInfo struct {
+	// VKeyHex is the raw 32-byte verification key, hex-encoded.
+	VKeyHex string `json:"vkey_hex"`
+	// VKeyBech32 is the cardano-cli-compatible bech32 of the vkey, when one
+	// applies (cold keys → addr_vk; VRF/KES have no standard bech32 vkey form
+	// here, so this is left empty for them).
+	VKeyBech32 string `json:"vkey_bech32,omitempty"`
+	// HashHex is the key's blake2b hash, hex-encoded (224-bit for the cold key,
+	// 256-bit for VRF/KES).
+	HashHex string `json:"hash_hex"`
+}
+
+// Credentials is the full set of derived pool credentials plus the pool ID.
+type Credentials struct {
+	// Network the credentials were derived for (matches the active wallet).
+	Network string `json:"network"`
+	// PoolID is the bech32 (pool1…) stake-pool identifier: blake2b-224 of the
+	// cold verification key.
+	PoolID string `json:"pool_id"`
+	// PoolIDHex is the same identifier, hex-encoded (the 28-byte operator hash).
+	PoolIDHex string `json:"pool_id_hex"`
+
+	Cold KeyInfo `json:"cold"`
+	VRF  KeyInfo `json:"vrf"`
+	KES  KeyInfo `json:"kes"`
+
+	// ColdIndex / VRFIndex / KESIndex are the derivation indices used.
+	ColdIndex uint32 `json:"cold_index"`
+	VRFIndex  uint32 `json:"vrf_index"`
+	KESIndex  uint32 `json:"kes_index"`
+}
+
+// coldKeyMaterial is the internally-consistent cold-key representation the
+// wallet uses for the pool ID, operator hash, operational-certificate signing,
+// and the transaction cold-key witness.
+//
+// The pool cold key is a CIP-1853 BIP32-Ed25519 extended key, but gouroboros'
+// CreateOpCert signs the operational certificate with a *standard* Ed25519 key
+// seeded from the extended key's first 32 bytes (k_L). For the opcert signature
+// to verify against the cold verification key — and for the registration cert's
+// operator hash and the tx vkey witness to all agree with it — the cold vkey
+// MUST be that same standard-Ed25519 public key (NOT the extended/bip32 public
+// key). seed/vkey here are derived accordingly; the rest of the package uses
+// only this representation so every artifact references one consistent cold key.
+type coldKeyMaterial struct {
+	seed []byte // 32-byte Ed25519 seed (k_L); secret — zero after use
+	vkey []byte // 32-byte standard Ed25519 public key
+}
+
+// deriveCold returns the consistent cold-key material for the active wallet's
+// root key at the given index.
+func deriveCold(root bip32.XPrv, index uint32) (coldKeyMaterial, error) {
+	cold, err := bursa.GetPoolColdKey(root, poolColdUseCase, index)
+	if err != nil {
+		return coldKeyMaterial{}, fmt.Errorf("derive pool cold key: %w", err)
+	}
+	seed := append([]byte(nil), cold.PrivateKey()[:32]...)
+	vkey := append([]byte(nil), ed25519.NewKeyFromSeed(seed).Public().(ed25519.PublicKey)...)
+	return coldKeyMaterial{seed: seed, vkey: vkey}, nil
+}
+
+// zero overwrites the secret seed.
+func (c *coldKeyMaterial) zero() {
+	zeroBytes(c.seed)
+}
+
+func zeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// poolID returns the operator key hash (blake2b-224 of the cold vkey).
+func poolIDFromVKey(coldVKey []byte) lcommon.PoolKeyHash {
+	return lcommon.Blake2b224Hash(coldVKey)
+}
+
+// deriveCredentials derives the full credential set from a root key.
+func deriveCredentials(root bip32.XPrv, network string, coldIdx, vrfIdx, kesIdx uint32) (Credentials, error) {
+	cold, err := deriveCold(root, coldIdx)
+	if err != nil {
+		return Credentials{}, err
+	}
+	defer cold.zero()
+
+	vrfSeed, err := bursa.GetVRFSeed(root, vrfIdx)
+	if err != nil {
+		return Credentials{}, fmt.Errorf("derive VRF seed: %w", err)
+	}
+	defer zeroBytes(vrfSeed)
+	vrfPub, vrfSKey, err := bursa.GetVRFKeyPair(vrfSeed)
+	zeroBytes(vrfSeed)
+	defer zeroBytes(vrfSKey)
+	if err != nil {
+		return Credentials{}, fmt.Errorf("derive VRF key pair: %w", err)
+	}
+
+	kesSeed, err := bursa.GetKESSeed(root, kesIdx)
+	if err != nil {
+		return Credentials{}, fmt.Errorf("derive KES seed: %w", err)
+	}
+	defer zeroBytes(kesSeed)
+	kesSKey, kesPub, err := bursa.GetKESKeyPair(kesSeed)
+	zeroBytes(kesSeed)
+	if kesSKey != nil {
+		defer zeroBytes(kesSKey.Data)
+	}
+	if err != nil {
+		return Credentials{}, fmt.Errorf("derive KES key pair: %w", err)
+	}
+
+	operator := poolIDFromVKey(cold.vkey)
+	vrfHash := lcommon.Blake2b256Hash(vrfPub)
+	kesHash := lcommon.Blake2b256Hash(kesPub)
+
+	return Credentials{
+		Network:   network,
+		PoolID:    operator.Bech32("pool"),
+		PoolIDHex: hex.EncodeToString(operator.Bytes()),
+		Cold: KeyInfo{
+			VKeyHex:    hex.EncodeToString(cold.vkey),
+			VKeyBech32: bip32.PublicKey(cold.vkey).String(),
+			HashHex:    hex.EncodeToString(operator.Bytes()),
+		},
+		VRF: KeyInfo{
+			VKeyHex: hex.EncodeToString(vrfPub),
+			HashHex: hex.EncodeToString(vrfHash.Bytes()),
+		},
+		KES: KeyInfo{
+			VKeyHex: hex.EncodeToString(kesPub),
+			HashHex: hex.EncodeToString(kesHash.Bytes()),
+		},
+		ColdIndex: coldIdx,
+		VRFIndex:  vrfIdx,
+		KESIndex:  kesIdx,
+	}, nil
+}
+
+// poolIDFromColdVKeyHex computes the pool ID from an externally-supplied cold
+// verification key (hex-encoded raw 32-byte Ed25519 key). Used by the air-gap
+// import flow where the wallet never holds the cold signing key.
+func poolIDFromColdVKeyHex(coldVKeyHex string) (lcommon.PoolKeyHash, error) {
+	vkey, err := decodeColdVKey(coldVKeyHex)
+	if err != nil {
+		return lcommon.PoolKeyHash{}, err
+	}
+	return poolIDFromVKey(vkey), nil
+}
+
+// decodeColdVKey decodes and validates a hex-encoded raw 32-byte cold vkey.
+func decodeColdVKey(coldVKeyHex string) ([]byte, error) {
+	vkey, err := hex.DecodeString(strings.TrimSpace(coldVKeyHex))
+	if err != nil {
+		return nil, fmt.Errorf("%w: cold vkey is not valid hex: %w", ErrInvalidRequest, err)
+	}
+	if len(vkey) != coldVKeyLen {
+		return nil, fmt.Errorf("%w: cold vkey must be %d bytes, got %d", ErrInvalidRequest, coldVKeyLen, len(vkey))
+	}
+	return vkey, nil
+}
+
+// ---------------------------------------------------------------------------
+// KES-period math
+// ---------------------------------------------------------------------------
+
+// Genesis is the subset of network genesis parameters the SPO toolkit needs for
+// KES-period math. It is supplied by a GenesisQuerier (the loopback Blockfrost
+// client, adapted by the API layer) so this package does not import
+// internal/chain.
+type Genesis struct {
+	SlotsPerKESPeriod int
+	MaxKESEvolutions  int
+	EpochLength       int
+}
+
+// KESPeriodInfo reports the current KES period and the genesis parameters it is
+// derived from. CurrentPeriod = tipSlot / slotsPerKESPeriod.
+type KESPeriodInfo struct {
+	CurrentPeriod     uint64 `json:"current_period"`
+	TipSlot           uint64 `json:"tip_slot"`
+	SlotsPerKESPeriod uint64 `json:"slots_per_kes_period"`
+	MaxKESEvolutions  uint64 `json:"max_kes_evolutions"`
+}
+
+// kesPeriod computes the current KES period from the node tip slot and the
+// genesis slots-per-KES-period. It is the integer division tipSlot ÷ spkp.
+func kesPeriod(tipSlot, slotsPerKESPeriod uint64) (uint64, error) {
+	if slotsPerKESPeriod == 0 {
+		return 0, errors.New("slots_per_kes_period is zero (genesis not available)")
+	}
+	return tipSlot / slotsPerKESPeriod, nil
+}
+
+// ---------------------------------------------------------------------------
+// Pool metadata builder
+// ---------------------------------------------------------------------------
+
+// MetadataInput is the operator-supplied pool metadata. The fields mirror the
+// CIP-6 / SMASH pool-metadata schema the registration certificate references.
+type MetadataInput struct {
+	Name        string `json:"name"`
+	Ticker      string `json:"ticker"`
+	Homepage    string `json:"homepage"`
+	Description string `json:"description"`
+}
+
+// MetadataResult is the canonical JSON the operator hosts plus its hash. The
+// registration certificate references the URL where this JSON is served and the
+// hash so that downstream consumers can verify the hosted content is unchanged.
+type MetadataResult struct {
+	// JSON is the RFC 8785 (JCS) canonicalized metadata document.
+	JSON string `json:"json"`
+	// HashHex is the Blake2b-256 hash of the canonical JSON, hex-encoded — the
+	// value that goes in the registration cert's metadata field.
+	HashHex string `json:"hash_hex"`
+}
+
+// buildMetadata canonicalizes the metadata to RFC 8785 (JCS) JSON and hashes it
+// with Blake2b-256, mirroring the parent bursa CLI's RunHashMetadata. Marshaling
+// the struct directly keeps the field set well-formed; JCS then fixes ordering
+// and formatting so the hash is reproducible.
+func buildMetadata(in MetadataInput) (MetadataResult, error) {
+	in.Name = strings.TrimSpace(in.Name)
+	in.Ticker = strings.TrimSpace(in.Ticker)
+	in.Homepage = strings.TrimSpace(in.Homepage)
+	in.Description = strings.TrimSpace(in.Description)
+	if err := validateMetadata(in); err != nil {
+		return MetadataResult{}, err
+	}
+
+	raw, err := json.Marshal(in)
+	if err != nil {
+		return MetadataResult{}, fmt.Errorf("marshal metadata: %w", err)
+	}
+	canonical, err := jcs.Transform(raw)
+	if err != nil {
+		return MetadataResult{}, fmt.Errorf("canonicalize metadata (RFC 8785): %w", err)
+	}
+	sum := blake2b.Sum256(canonical)
+	return MetadataResult{
+		JSON:    string(canonical),
+		HashHex: hex.EncodeToString(sum[:]),
+	}, nil
+}
+
+const (
+	metadataNameMax        = 50
+	metadataTickerMin      = 3
+	metadataTickerMax      = 5
+	metadataHomepageMax    = 64
+	metadataDescriptionMax = 255
+)
+
+func validateMetadata(in MetadataInput) error {
+	if in.Name == "" || in.Ticker == "" || in.Homepage == "" {
+		return fmt.Errorf("%w: metadata name, ticker, and homepage are required", ErrInvalidRequest)
+	}
+	if utf8.RuneCountInString(in.Name) > metadataNameMax {
+		return fmt.Errorf("%w: metadata name must be at most %d characters", ErrInvalidRequest, metadataNameMax)
+	}
+	tickerLen := utf8.RuneCountInString(in.Ticker)
+	if tickerLen < metadataTickerMin || tickerLen > metadataTickerMax {
+		return fmt.Errorf("%w: metadata ticker must be %d to %d characters", ErrInvalidRequest, metadataTickerMin, metadataTickerMax)
+	}
+	if utf8.RuneCountInString(in.Homepage) > metadataHomepageMax {
+		return fmt.Errorf("%w: metadata homepage must be at most %d characters", ErrInvalidRequest, metadataHomepageMax)
+	}
+	if utf8.RuneCountInString(in.Description) > metadataDescriptionMax {
+		return fmt.Errorf("%w: metadata description must be at most %d characters", ErrInvalidRequest, metadataDescriptionMax)
+	}
+	u, err := url.Parse(in.Homepage)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return fmt.Errorf("%w: metadata homepage must be a valid http(s) URL", ErrInvalidRequest)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Relays
+// ---------------------------------------------------------------------------
+
+// Relay is the wallet's relay input. Type selects the encoding:
+//
+//	"single_host_address" → ipv4/ipv6 + optional port
+//	"single_host_name"    → hostname (DNS A/AAAA) + optional port
+//	"multi_host_name"     → hostname (DNS SRV), no port
+type Relay struct {
+	Type     string  `json:"type"`
+	IPv4     string  `json:"ipv4,omitempty"`
+	IPv6     string  `json:"ipv6,omitempty"`
+	Hostname string  `json:"hostname,omitempty"`
+	Port     *uint32 `json:"port,omitempty"`
+}
+
+// toPoolRelay converts a wallet Relay into a gouroboros PoolRelay.
+func (r Relay) toPoolRelay() (lcommon.PoolRelay, error) {
+	if r.Port != nil && *r.Port > 65535 {
+		return lcommon.PoolRelay{}, fmt.Errorf("%w: relay port must be between 0 and 65535", ErrInvalidRequest)
+	}
+	switch r.Type {
+	case "single_host_address":
+		pr := lcommon.PoolRelay{Type: lcommon.PoolRelayTypeSingleHostAddress, Port: r.Port}
+		if r.IPv4 == "" && r.IPv6 == "" {
+			return lcommon.PoolRelay{}, fmt.Errorf("%w: single_host_address relay needs ipv4 or ipv6", ErrInvalidRequest)
+		}
+		if r.IPv4 != "" {
+			ip := net.ParseIP(strings.TrimSpace(r.IPv4))
+			if ip == nil || ip.To4() == nil {
+				return lcommon.PoolRelay{}, fmt.Errorf("%w: invalid ipv4 %q", ErrInvalidRequest, r.IPv4)
+			}
+			v4 := ip.To4()
+			pr.Ipv4 = &v4
+		}
+		if r.IPv6 != "" {
+			ip := net.ParseIP(strings.TrimSpace(r.IPv6))
+			if ip == nil || ip.To4() != nil || ip.To16() == nil {
+				return lcommon.PoolRelay{}, fmt.Errorf("%w: invalid ipv6 %q", ErrInvalidRequest, r.IPv6)
+			}
+			v6 := ip.To16()
+			pr.Ipv6 = &v6
+		}
+		return pr, nil
+	case "single_host_name":
+		host := strings.TrimSpace(r.Hostname)
+		if host == "" {
+			return lcommon.PoolRelay{}, fmt.Errorf("%w: single_host_name relay needs a hostname", ErrInvalidRequest)
+		}
+		return lcommon.PoolRelay{Type: lcommon.PoolRelayTypeSingleHostName, Hostname: &host, Port: r.Port}, nil
+	case "multi_host_name":
+		host := strings.TrimSpace(r.Hostname)
+		if host == "" {
+			return lcommon.PoolRelay{}, fmt.Errorf("%w: multi_host_name relay needs a hostname", ErrInvalidRequest)
+		}
+		return lcommon.PoolRelay{Type: lcommon.PoolRelayTypeMultiHostName, Hostname: &host}, nil
+	default:
+		return lcommon.PoolRelay{}, fmt.Errorf("%w: unknown relay type %q", ErrInvalidRequest, r.Type)
+	}
+}
+
+func relaysToPoolRelays(relays []Relay) ([]lcommon.PoolRelay, error) {
+	out := make([]lcommon.PoolRelay, 0, len(relays))
+	for i, r := range relays {
+		pr, err := r.toPoolRelay()
+		if err != nil {
+			return nil, fmt.Errorf("relay %d: %w", i, err)
+		}
+		out = append(out, pr)
+	}
+	return out, nil
+}

--- a/ui/internal/poolops/poolops_test.go
+++ b/ui/internal/poolops/poolops_test.go
@@ -1,0 +1,400 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package poolops
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"golang.org/x/crypto/blake2b"
+)
+
+// testMnemonic is the standard 24-word BIP-39 "abandon…art" test vector.
+const testMnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art"
+
+func mustRoot(t *testing.T) (root []byte) {
+	t.Helper()
+	r, err := bursa.GetRootKeyFromMnemonic(testMnemonic, "")
+	if err != nil {
+		t.Fatalf("root key: %v", err)
+	}
+	return r
+}
+
+// TestDeriveCredentials checks the derived cold/VRF/KES key lengths, the pool
+// ID derivation, and that the cold vkey is the standard-Ed25519 public key
+// (the representation the opcert and tx witness agree with).
+func TestDeriveCredentials(t *testing.T) {
+	creds, err := deriveCredentials(mustRoot(t), "preview", 0, 0, 0)
+	if err != nil {
+		t.Fatalf("deriveCredentials: %v", err)
+	}
+	if !strings.HasPrefix(creds.PoolID, "pool1") {
+		t.Fatalf("pool ID does not start with pool1: %q", creds.PoolID)
+	}
+	coldVkey, err := hex.DecodeString(creds.Cold.VKeyHex)
+	if err != nil || len(coldVkey) != 32 {
+		t.Fatalf("cold vkey hex invalid: %v len=%d", err, len(coldVkey))
+	}
+	// Pool ID hex must equal blake2b-224 of the cold vkey.
+	wantHash := lcommon.Blake2b224Hash(coldVkey)
+	if creds.PoolIDHex != hex.EncodeToString(wantHash.Bytes()) {
+		t.Fatalf("pool ID hex = %q, want %q", creds.PoolIDHex, hex.EncodeToString(wantHash.Bytes()))
+	}
+	vrf, _ := hex.DecodeString(creds.VRF.VKeyHex)
+	if len(vrf) != 32 {
+		t.Fatalf("VRF vkey len = %d, want 32", len(vrf))
+	}
+	kes, _ := hex.DecodeString(creds.KES.VKeyHex)
+	if len(kes) != 32 {
+		t.Fatalf("KES vkey len = %d, want 32", len(kes))
+	}
+	// Deterministic: re-derive yields the same pool ID.
+	creds2, _ := deriveCredentials(mustRoot(t), "preview", 0, 0, 0)
+	if creds.PoolID != creds2.PoolID {
+		t.Fatalf("non-deterministic pool ID: %q vs %q", creds.PoolID, creds2.PoolID)
+	}
+}
+
+// TestPoolIDFromColdVKeyHex checks the air-gap pool-ID computation matches the
+// seed-derived one for the same cold vkey, and rejects malformed input.
+func TestPoolIDFromColdVKeyHex(t *testing.T) {
+	creds, _ := deriveCredentials(mustRoot(t), "preview", 0, 0, 0)
+	id, err := poolIDFromColdVKeyHex(creds.Cold.VKeyHex)
+	if err != nil {
+		t.Fatalf("poolIDFromColdVKeyHex: %v", err)
+	}
+	if id.Bech32("pool") != creds.PoolID {
+		t.Fatalf("air-gap pool ID %q != seed pool ID %q", id.Bech32("pool"), creds.PoolID)
+	}
+	if _, err := poolIDFromColdVKeyHex("zz"); err == nil {
+		t.Fatal("expected error for non-hex cold vkey")
+	}
+	if _, err := poolIDFromColdVKeyHex("abcd"); err == nil {
+		t.Fatal("expected error for wrong-length cold vkey")
+	}
+}
+
+// TestKESPeriodMath checks the integer-division KES-period formula and the
+// zero-divisor guard.
+func TestKESPeriodMath(t *testing.T) {
+	cases := []struct {
+		tip, spkp, want uint64
+	}{
+		{0, 129600, 0},
+		{129599, 129600, 0},
+		{129600, 129600, 1},
+		{259200, 129600, 2},
+		{300000, 129600, 2},
+	}
+	for _, c := range cases {
+		got, err := kesPeriod(c.tip, c.spkp)
+		if err != nil {
+			t.Fatalf("kesPeriod(%d,%d): %v", c.tip, c.spkp, err)
+		}
+		if got != c.want {
+			t.Fatalf("kesPeriod(%d,%d) = %d, want %d", c.tip, c.spkp, got, c.want)
+		}
+	}
+	if _, err := kesPeriod(100, 0); err == nil {
+		t.Fatal("expected error when slots_per_kes_period is zero")
+	}
+}
+
+// TestBuildMetadataCanonicalHash checks the metadata is canonicalized (JCS) and
+// hashed with Blake2b-256, that the hash is reproducible regardless of input
+// key ordering/whitespace, and that required fields are enforced.
+func TestBuildMetadataCanonicalHash(t *testing.T) {
+	in := MetadataInput{Name: "My Pool", Ticker: "POOL", Homepage: "https://pool.example", Description: "A pool."}
+	res, err := buildMetadata(in)
+	if err != nil {
+		t.Fatalf("buildMetadata: %v", err)
+	}
+	// The hash must equal Blake2b-256 of the canonical JSON.
+	sum := blake2b.Sum256([]byte(res.JSON))
+	if res.HashHex != hex.EncodeToString(sum[:]) {
+		t.Fatalf("hash %q does not match blake2b-256 of canonical JSON", res.HashHex)
+	}
+	// Canonical JSON must be valid and key-sorted (JCS): "description" < "homepage" < "name" < "ticker".
+	if !json.Valid([]byte(res.JSON)) {
+		t.Fatalf("canonical JSON invalid: %s", res.JSON)
+	}
+	wantOrder := []string{"description", "homepage", "name", "ticker"}
+	last := -1
+	for _, k := range wantOrder {
+		idx := strings.Index(res.JSON, "\""+k+"\"")
+		if idx < 0 || idx < last {
+			t.Fatalf("canonical JSON keys not sorted (%s): %s", k, res.JSON)
+		}
+		last = idx
+	}
+	// Whitespace differences in inputs must not change the hash (canonicalization).
+	res2, _ := buildMetadata(MetadataInput{Name: "  My Pool  ", Ticker: " POOL ", Homepage: "https://pool.example", Description: "A pool."})
+	if res2.HashHex != res.HashHex {
+		t.Fatalf("hash changed under whitespace: %q vs %q", res2.HashHex, res.HashHex)
+	}
+	// Missing required fields are rejected.
+	if _, err := buildMetadata(MetadataInput{Ticker: "X"}); err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if _, err := buildMetadata(MetadataInput{Name: "X"}); err == nil {
+		t.Fatal("expected error for missing ticker")
+	}
+}
+
+func TestBuildMetadataValidation(t *testing.T) {
+	longName := strings.Repeat("n", metadataNameMax+1)
+	longHomepage := "https://" + strings.Repeat("h", metadataHomepageMax)
+	longDescription := strings.Repeat("d", metadataDescriptionMax+1)
+	cases := []struct {
+		name string
+		in   MetadataInput
+	}{
+		{
+			name: "name too long",
+			in:   MetadataInput{Name: longName, Ticker: "POOL", Homepage: "https://pool.example"},
+		},
+		{
+			name: "ticker too short",
+			in:   MetadataInput{Name: "Pool", Ticker: "PO", Homepage: "https://pool.example"},
+		},
+		{
+			name: "ticker too long",
+			in:   MetadataInput{Name: "Pool", Ticker: "POOLS1", Homepage: "https://pool.example"},
+		},
+		{
+			name: "homepage too long",
+			in:   MetadataInput{Name: "Pool", Ticker: "POOL", Homepage: longHomepage},
+		},
+		{
+			name: "description too long",
+			in:   MetadataInput{Name: "Pool", Ticker: "POOL", Homepage: "https://pool.example", Description: longDescription},
+		},
+		{
+			name: "invalid homepage",
+			in:   MetadataInput{Name: "Pool", Ticker: "POOL", Homepage: "pool.example"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := buildMetadata(tc.in); !errors.Is(err, ErrInvalidRequest) {
+				t.Fatalf("buildMetadata error = %v, want ErrInvalidRequest", err)
+			}
+		})
+	}
+}
+
+func TestRelayValidation(t *testing.T) {
+	port := uint32(65536)
+	if _, err := (Relay{Type: "single_host_address", IPv4: "1.2.3.4", Port: &port}).toPoolRelay(); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("oversized port error = %v, want ErrInvalidRequest", err)
+	}
+	if _, err := (Relay{Type: "single_host_address", IPv6: "1.2.3.4"}).toPoolRelay(); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("ipv4-as-ipv6 error = %v, want ErrInvalidRequest", err)
+	}
+}
+
+// TestBuildRegistrationCert checks the registration cert encodes a 29-byte
+// reward account (full stake address per the Cardano CDDL) and references the
+// supplied metadata, owners, and relays.
+func TestBuildRegistrationCert(t *testing.T) {
+	s := &Service{}
+	creds, _ := deriveCredentials(mustRoot(t), "preview", 0, 0, 0)
+	coldVkey, _ := hex.DecodeString(creds.Cold.VKeyHex)
+	vrfHash, _ := hex.DecodeString(creds.VRF.HashHex)
+
+	// reward + owner stake address from the test wallet
+	root := mustRoot(t)
+	acctKey, _ := bursa.GetAccountKey(root, 0)
+	stakeKey, _ := bursa.GetStakeKey(acctKey, 0)
+	stakeHash := stakeKey.Public().PublicKey().Hash()
+	stakeAddr, _ := lcommon.NewAddressFromParts(lcommon.AddressTypeNoneKey, 0, nil, stakeHash)
+
+	metaHash := strings.Repeat("ab", 32) // 32-byte hex
+	port := uint32(3001)
+	p := RegistrationParams{
+		Pledge:        100_000_000,
+		Cost:          340_000_000,
+		MarginNum:     3,
+		MarginDenom:   100,
+		RewardAddress: stakeAddr.String(),
+		Owners:        []string{stakeAddr.String()},
+		Relays: []Relay{
+			{Type: "single_host_address", IPv4: "1.2.3.4", Port: &port},
+			{Type: "single_host_name", Hostname: "relay.example.com", Port: &port},
+		},
+		MetadataURL:  "https://pool.example/meta.json",
+		MetadataHash: metaHash,
+	}
+	res, err := s.buildRegistration(coldVkey, vrfHash, p, nil)
+	if err != nil {
+		t.Fatalf("buildRegistration: %v", err)
+	}
+	if res.PoolID != creds.PoolID {
+		t.Fatalf("pool ID %q != %q", res.PoolID, creds.PoolID)
+	}
+	raw, err := hex.DecodeString(res.CBORHex)
+	if err != nil {
+		t.Fatalf("cbor hex: %v", err)
+	}
+	// Decode the cert array and inspect the reward account (element index 6).
+	var arr []cbor.RawMessage
+	if _, err := cbor.Decode(raw, &arr); err != nil {
+		t.Fatalf("decode cert array: %v", err)
+	}
+	if len(arr) != 10 {
+		t.Fatalf("cert array len = %d, want 10", len(arr))
+	}
+	var reward []byte
+	if _, err := cbor.Decode(arr[6], &reward); err != nil {
+		t.Fatalf("decode reward account: %v", err)
+	}
+	if len(reward) != 29 {
+		t.Fatalf("reward account len = %d, want 29 (full stake address)", len(reward))
+	}
+	wantHeader := byte(lcommon.AddressTypeNoneKey<<4 | lcommon.AddressNetworkTestnet)
+	if reward[0] != wantHeader {
+		t.Fatalf("reward account header = %x, want %x", reward[0], wantHeader)
+	}
+}
+
+// TestBuildRegistrationMarginValidation rejects out-of-range margins.
+func TestBuildRegistrationMarginValidation(t *testing.T) {
+	s := &Service{}
+	creds, _ := deriveCredentials(mustRoot(t), "preview", 0, 0, 0)
+	coldVkey, _ := hex.DecodeString(creds.Cold.VKeyHex)
+	vrfHash, _ := hex.DecodeString(creds.VRF.HashHex)
+	root := mustRoot(t)
+	acctKey, _ := bursa.GetAccountKey(root, 0)
+	stakeKey, _ := bursa.GetStakeKey(acctKey, 0)
+	stakeHash := stakeKey.Public().PublicKey().Hash()
+	stakeAddr, _ := lcommon.NewAddressFromParts(lcommon.AddressTypeNoneKey, 0, nil, stakeHash)
+
+	base := RegistrationParams{RewardAddress: stakeAddr.String(), Owners: []string{stakeAddr.String()}}
+	// zero denominator
+	bad := base
+	bad.MarginNum, bad.MarginDenom = 1, 0
+	if _, err := s.buildRegistration(coldVkey, vrfHash, bad, nil); err == nil {
+		t.Fatal("expected error for zero margin denominator")
+	}
+	// margin > 1
+	bad = base
+	bad.MarginNum, bad.MarginDenom = 3, 2
+	if _, err := s.buildRegistration(coldVkey, vrfHash, bad, nil); err == nil {
+		t.Fatal("expected error for margin > 1")
+	}
+}
+
+// TestRetirementCertEncoding checks the retirement cert matches bursa's direct
+// construction (type 4, operator hash, epoch).
+func TestRetirementCertEncoding(t *testing.T) {
+	s := &Service{}
+	creds, _ := deriveCredentials(mustRoot(t), "preview", 0, 0, 0)
+	res, err := s.BuildRetirementCert("", creds.Cold.VKeyHex, 500)
+	if err != nil {
+		t.Fatalf("BuildRetirementCert: %v", err)
+	}
+	if res.PoolID != creds.PoolID {
+		t.Fatalf("pool ID %q != %q", res.PoolID, creds.PoolID)
+	}
+	coldVkey, _ := hex.DecodeString(creds.Cold.VKeyHex)
+	op := lcommon.Blake2b224Hash(coldVkey)
+	want, _ := bursa.CreatePoolRetirementCertificate(&bursa.PoolRetirementCertificateParams{PoolKeyHash: op, Epoch: 500})
+	if res.CBORHex != hex.EncodeToString(want) {
+		t.Fatalf("retirement cbor %q != %q", res.CBORHex, hex.EncodeToString(want))
+	}
+}
+
+// TestOpCertPayloadAndAssemble checks the air-gap opcert flow: the payload is
+// CBOR([kesVkey, issue, period]); a cold-key signature over it verifies and is
+// assembled into an opcert; a wrong signature is rejected.
+func TestOpCertPayloadAndAssemble(t *testing.T) {
+	s := &Service{}
+	creds, _ := deriveCredentials(mustRoot(t), "preview", 0, 0, 0)
+	kesVKeyHex := creds.KES.VKeyHex
+	coldVKeyHex := creds.Cold.VKeyHex
+
+	payload, err := s.OpCertPayload(kesVKeyHex, 7, 3)
+	if err != nil {
+		t.Fatalf("OpCertPayload: %v", err)
+	}
+	// Payload must equal CBOR([kesVkey, issue, period]).
+	kesVkey, _ := hex.DecodeString(kesVKeyHex)
+	wantPayload, _ := cbor.Encode([]any{kesVkey, uint64(7), uint64(3)})
+	if payload.PayloadHex != hex.EncodeToString(wantPayload) {
+		t.Fatalf("payload %q != %q", payload.PayloadHex, hex.EncodeToString(wantPayload))
+	}
+
+	// Produce a real cold-key signature using the seed (simulating the air-gap
+	// signer) and assemble.
+	root := mustRoot(t)
+	cold, _ := deriveCold(root, 0)
+	defer cold.zero()
+	payloadBytes, _ := hex.DecodeString(payload.PayloadHex)
+	sig := ed25519.Sign(ed25519.NewKeyFromSeed(cold.seed), payloadBytes)
+	opcert, err := s.AssembleOpCert(coldVKeyHex, kesVKeyHex, hex.EncodeToString(sig), 7, 3)
+	if err != nil {
+		t.Fatalf("AssembleOpCert: %v", err)
+	}
+	if opcert.IssueNumber != 7 || opcert.KesPeriod != 3 {
+		t.Fatalf("opcert issue/period = %d/%d, want 7/3", opcert.IssueNumber, opcert.KesPeriod)
+	}
+	if opcert.ColdSignatureHex != hex.EncodeToString(sig) {
+		t.Fatal("assembled opcert signature mismatch")
+	}
+
+	// A wrong signature (all zeros) must be rejected.
+	if _, err := s.AssembleOpCert(coldVKeyHex, kesVKeyHex, strings.Repeat("00", 64), 7, 3); err == nil {
+		t.Fatal("expected AssembleOpCert to reject a non-verifying signature")
+	}
+}
+
+// TestRelayConversion checks relay encoding for each relay type and validation.
+func TestRelayConversion(t *testing.T) {
+	port := uint32(6000)
+	maxPort := uint32(65535)
+	badPort := uint32(65536)
+	cases := []struct {
+		name    string
+		relay   Relay
+		wantErr bool
+	}{
+		{"ipv4", Relay{Type: "single_host_address", IPv4: "10.0.0.1", Port: &port}, false},
+		{"ipv6", Relay{Type: "single_host_address", IPv6: "2001:db8::1"}, false},
+		{"hostname", Relay{Type: "single_host_name", Hostname: "relay.example", Port: &port}, false},
+		{"hostname-max-port", Relay{Type: "single_host_name", Hostname: "relay.example", Port: &maxPort}, false},
+		{"multihost", Relay{Type: "multi_host_name", Hostname: "_relays.example"}, false},
+		{"bad-ipv4", Relay{Type: "single_host_address", IPv4: "999.1.1.1"}, true},
+		{"addr-no-ip", Relay{Type: "single_host_address"}, true},
+		{"name-no-host", Relay{Type: "single_host_name"}, true},
+		{"name-bad-port", Relay{Type: "single_host_name", Hostname: "relay.example", Port: &badPort}, true},
+		{"unknown", Relay{Type: "carrier_pigeon"}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := c.relay.toPoolRelay()
+			if (err != nil) != c.wantErr {
+				t.Fatalf("toPoolRelay err = %v, wantErr %v", err, c.wantErr)
+			}
+		})
+	}
+}

--- a/ui/internal/poolops/service.go
+++ b/ui/internal/poolops/service.go
@@ -1,0 +1,887 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package poolops
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	apollo "github.com/blinklabs-io/apollo/v2"
+	"github.com/blinklabs-io/apollo/v2/backend"
+	"github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/bursa/bip32"
+	"github.com/blinklabs-io/bursa/ui/internal/keystore"
+	"github.com/blinklabs-io/bursa/ui/internal/wallet"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// Keystore is the minimal interface satisfied by *keystore.Keystore; it is
+// accepted as an interface so the service can run with a nil keystore (offline
+// builders only) and be faked in tests.
+type Keystore interface {
+	Exists() bool
+	Unlock(password string) (mnemonic []byte, err error)
+}
+
+type walletSeedStore interface {
+	UnlockFor(walletID, password string) (mnemonic []byte, err error)
+}
+
+// GenesisQuerier provides the genesis parameters the KES-period math needs. The
+// API layer adapts the loopback Blockfrost client's chain.Genesis to the local
+// poolops.Genesis so this package does not import internal/chain.
+type GenesisQuerier interface {
+	Genesis(ctx context.Context) (genesis Genesis, err error)
+}
+
+// Tipper reports the node's current tip slot. TipSlot returns an error when
+// the node has not yet caught up to the chain tip, because a stale slot would
+// produce an incorrect KES period that is silently accepted but wrong.
+type Tipper interface {
+	TipSlot() (uint64, error)
+}
+
+// defaultColdIndex / defaultVRFIndex / defaultKESIndex are the conventional
+// derivation indices for a single pool operated from one wallet.
+const (
+	defaultColdIndex = 0
+	defaultVRFIndex  = 0
+	defaultKESIndex  = 0
+
+	retirementFeePaddingLovelace = 1000
+)
+
+type paymentKeyRole uint32
+
+const (
+	paymentKeyRoleReceive paymentKeyRole = 0
+	paymentKeyRoleChange  paymentKeyRole = 1
+)
+
+type ownedPaymentAddress struct {
+	address string
+	role    paymentKeyRole
+	index   uint32
+}
+
+// Service is the SPO toolkit bound to the active wallet. Credential derivation,
+// opcert issuance/rotation, and certificate/tx construction all operate on the
+// wallet recorded via SetAccount and unlock the keystore on demand.
+type Service struct {
+	chain   backend.ChainContext // build/sign/submit (nil for offline-only use)
+	keys    Keystore             // nil for offline-only use
+	genesis GenesisQuerier
+	tipper  Tipper
+
+	mu       sync.Mutex
+	walletID string
+	account  *wallet.Account
+}
+
+// NewService constructs a Service. cc/ks may be nil when only the offline
+// builders (credentials require ks; cert/metadata builders do not) are needed.
+func NewService(cc backend.ChainContext, ks Keystore, gq GenesisQuerier, tp Tipper) *Service {
+	return &Service{chain: cc, keys: ks, genesis: gq, tipper: tp}
+}
+
+// SetAccount records the active wallet ID and account so pool operations always
+// derive credentials from the wallet whose account data is current. Pass an
+// empty id and nil acct to clear the binding (e.g. on vault lock).
+func (s *Service) SetAccount(id string, acct *wallet.Account) {
+	s.mu.Lock()
+	s.walletID = id
+	s.account = acct
+	s.mu.Unlock()
+}
+
+func (s *Service) currentAccount() *wallet.Account {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.account
+}
+
+func (s *Service) currentBinding() (string, *wallet.Account) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.walletID, s.account
+}
+
+// unlockRoot decrypts the keystore with password and returns the wallet root
+// key plus a zeroizer the caller must defer. Maps a decrypt failure to
+// ErrWrongPassword.
+func (s *Service) unlockRoot(walletID, password string) (bip32.XPrv, func(), error) {
+	if s.keys == nil {
+		return nil, func() {}, errors.New("no keystore configured")
+	}
+	var (
+		mnemonic []byte
+		err      error
+	)
+	if walletID != "" {
+		ks, ok := s.keys.(walletSeedStore)
+		if !ok {
+			return nil, func() {}, fmt.Errorf("wallet-bound seed unlock requires UnlockFor support for wallet %q", walletID)
+		}
+		mnemonic, err = ks.UnlockFor(walletID, password)
+	} else {
+		mnemonic, err = s.keys.Unlock(password)
+	}
+	if err != nil {
+		if errors.Is(err, keystore.ErrDecryptFailed) {
+			return nil, func() {}, fmt.Errorf("%w: %w", ErrWrongPassword, err)
+		}
+		return nil, func() {}, fmt.Errorf("unlock keystore: %w", err)
+	}
+	root, err := bursa.GetRootKeyFromMnemonic(string(mnemonic), "")
+	if err != nil {
+		keystore.Zero(mnemonic)
+		return nil, func() {}, fmt.Errorf("root key: %w", err)
+	}
+	zero := func() {
+		keystore.Zero(mnemonic)
+		for i := range root {
+			root[i] = 0
+		}
+	}
+	return root, zero, nil
+}
+
+// ---------------------------------------------------------------------------
+// 1. Generate pool credentials
+// ---------------------------------------------------------------------------
+
+// Credentials derives the active wallet's pool cold/VRF/KES credentials and
+// reports their verification keys, hashes, and the pool ID. It requires the
+// spending password to unlock the wallet seed; no node is needed.
+func (s *Service) Credentials(password string) (Credentials, error) {
+	walletID, acct := s.currentBinding()
+	if acct == nil {
+		return Credentials{}, ErrNoWallet
+	}
+	root, zero, err := s.unlockRoot(walletID, password)
+	if err != nil {
+		return Credentials{}, err
+	}
+	defer zero()
+	return deriveCredentials(root, acct.Network, defaultColdIndex, defaultVRFIndex, defaultKESIndex)
+}
+
+// ---------------------------------------------------------------------------
+// 2. Operational certificate (issue + KES rotation) + KES-period math
+// ---------------------------------------------------------------------------
+
+// OpCert is an operational certificate ready for the node's KES config. The
+// fields mirror gouroboros' OpCert; KesVKeyHex/ColdSignatureHex are hex for the
+// JSON surface, and KesPeriod/IssueNumber drive node forging.
+type OpCert struct {
+	KesVKeyHex       string `json:"kes_vkey_hex"`
+	IssueNumber      uint64 `json:"issue_number"`
+	KesPeriod        uint64 `json:"kes_period"`
+	ColdSignatureHex string `json:"cold_signature_hex"`
+	// KESIndex is the derivation index of the KES key used (rotation bumps it).
+	KESIndex uint32 `json:"kes_index"`
+}
+
+// KESPeriod returns the current KES period derived from the node tip slot and
+// genesis slots-per-KES-period, with the genesis inputs for display. No
+// external call: tip comes from the supervisor and genesis from the node.
+func (s *Service) KESPeriod(ctx context.Context) (KESPeriodInfo, error) {
+	if s.genesis == nil || s.tipper == nil {
+		return KESPeriodInfo{}, errors.New("node data source not configured")
+	}
+	g, err := s.genesis.Genesis(ctx)
+	if err != nil {
+		return KESPeriodInfo{}, fmt.Errorf("genesis: %w", err)
+	}
+	tip, err := s.tipper.TipSlot()
+	if err != nil {
+		return KESPeriodInfo{}, fmt.Errorf("tip slot: %w", err)
+	}
+	if g.SlotsPerKESPeriod < 0 {
+		return KESPeriodInfo{}, fmt.Errorf("genesis slots_per_kes_period is negative: %d", g.SlotsPerKESPeriod)
+	}
+	if g.MaxKESEvolutions < 0 {
+		return KESPeriodInfo{}, fmt.Errorf("genesis max_kes_evolutions is negative: %d", g.MaxKESEvolutions)
+	}
+	spkp := uint64(g.SlotsPerKESPeriod) //nolint:gosec // genesis value is non-negative
+	period, err := kesPeriod(tip, spkp)
+	if err != nil {
+		return KESPeriodInfo{}, err
+	}
+	return KESPeriodInfo{
+		CurrentPeriod:     period,
+		TipSlot:           tip,
+		SlotsPerKESPeriod: spkp,
+		MaxKESEvolutions:  uint64(g.MaxKESEvolutions), //nolint:gosec // genesis value is non-negative
+	}, nil
+}
+
+// IssueOpCert issues an operational certificate from the active wallet's
+// seed-derived cold + KES keys. kesIndex selects the KES key (rotation passes a
+// new index); issueNumber is the certificate counter (incremented on rotation);
+// kesPeriod is the period at which the cert becomes valid (default: the current
+// period). The cold key signs the (KES vkey, issue, period) tuple in-app.
+func (s *Service) IssueOpCert(password string, kesIndex uint32, issueNumber, kesPeriod uint64) (OpCert, error) {
+	walletID, acct := s.currentBinding()
+	if acct == nil {
+		return OpCert{}, ErrNoWallet
+	}
+	root, zero, err := s.unlockRoot(walletID, password)
+	if err != nil {
+		return OpCert{}, err
+	}
+	defer zero()
+
+	cold, err := deriveCold(root, defaultColdIndex)
+	if err != nil {
+		return OpCert{}, err
+	}
+	defer cold.zero()
+
+	kesSeed, err := bursa.GetKESSeed(root, kesIndex)
+	if err != nil {
+		return OpCert{}, fmt.Errorf("derive KES seed: %w", err)
+	}
+	defer zeroBytes(kesSeed)
+	kesSKey, kesPub, err := bursa.GetKESKeyPair(kesSeed)
+	zeroBytes(kesSeed)
+	if kesSKey != nil {
+		defer zeroBytes(kesSKey.Data)
+	}
+	if err != nil {
+		return OpCert{}, fmt.Errorf("derive KES key pair: %w", err)
+	}
+
+	opcert, err := bursa.CreateOperationalCertificate(kesPub, issueNumber, kesPeriod, cold.seed)
+	if err != nil {
+		return OpCert{}, fmt.Errorf("create operational certificate: %w", err)
+	}
+	return OpCert{
+		KesVKeyHex:       hex.EncodeToString(opcert.KesVkey),
+		IssueNumber:      opcert.IssueNumber,
+		KesPeriod:        opcert.KesPeriod,
+		ColdSignatureHex: hex.EncodeToString(opcert.ColdSignature),
+		KESIndex:         kesIndex,
+	}, nil
+}
+
+// RotateKES performs a KES rotation: it derives the next KES key (kesIndex+1 by
+// convention, supplied by the caller) and issues a fresh opcert with the issue
+// counter incremented. The current issue number is supplied by the caller (read
+// from the previous opcert / counter file); the new cert uses prevIssue+1.
+func (s *Service) RotateKES(password string, newKESIndex uint32, prevIssueNumber, kesPeriod uint64) (OpCert, error) {
+	return s.IssueOpCert(password, newKESIndex, prevIssueNumber+1, kesPeriod)
+}
+
+// ---------------------------------------------------------------------------
+// Air-gap: operational certificate offline
+// ---------------------------------------------------------------------------
+
+// OpCertPayload is the to-be-signed payload for an air-gapped opcert: the cold
+// key (held on an offline machine) signs PayloadHex with a standard Ed25519
+// key, and the resulting signature is fed back to AssembleOpCert. PayloadHex is
+// CBOR([kes_vkey, issue_number, kes_period]) — exactly what gouroboros'
+// CreateOpCert signs — so an external signer reproduces the same bytes.
+type OpCertPayload struct {
+	PayloadHex  string `json:"payload_hex"`
+	KesVKeyHex  string `json:"kes_vkey_hex"`
+	IssueNumber uint64 `json:"issue_number"`
+	KesPeriod   uint64 `json:"kes_period"`
+}
+
+// OpCertPayloadForVKey builds the to-be-signed opcert payload for an externally
+// supplied KES verification key. No wallet/keystore is needed — this is the
+// air-gap path where the cold key never touches this machine.
+func (s *Service) OpCertPayload(kesVKeyHex string, issueNumber, kesPeriod uint64) (OpCertPayload, error) {
+	kesVkey, err := hex.DecodeString(strings.TrimSpace(kesVKeyHex))
+	if err != nil {
+		return OpCertPayload{}, fmt.Errorf("%w: KES vkey is not valid hex: %w", ErrInvalidRequest, err)
+	}
+	if len(kesVkey) != coldVKeyLen {
+		return OpCertPayload{}, fmt.Errorf("%w: KES vkey must be %d bytes, got %d", ErrInvalidRequest, coldVKeyLen, len(kesVkey))
+	}
+	// CBOR([kes_vkey, issue_number, kes_period]) — matches ledger.CreateOpCert.
+	payload, err := cbor.Encode([]any{kesVkey, issueNumber, kesPeriod})
+	if err != nil {
+		return OpCertPayload{}, fmt.Errorf("encode opcert payload: %w", err)
+	}
+	return OpCertPayload{
+		PayloadHex:  hex.EncodeToString(payload),
+		KesVKeyHex:  hex.EncodeToString(kesVkey),
+		IssueNumber: issueNumber,
+		KesPeriod:   kesPeriod,
+	}, nil
+}
+
+// AssembleOpCert assembles an operational certificate from an externally
+// produced cold-key signature (the air-gap path). It validates that the
+// signature verifies against the supplied cold verification key over the
+// canonical opcert payload before returning — so a wrong key or corrupted
+// signature is rejected rather than producing an invalid certificate.
+func (s *Service) AssembleOpCert(coldVKeyHex, kesVKeyHex, signatureHex string, issueNumber, kesPeriod uint64) (OpCert, error) {
+	coldVkey, err := decodeColdVKey(coldVKeyHex)
+	if err != nil {
+		return OpCert{}, err
+	}
+	payload, err := s.OpCertPayload(kesVKeyHex, issueNumber, kesPeriod)
+	if err != nil {
+		return OpCert{}, err
+	}
+	payloadBytes, err := hex.DecodeString(payload.PayloadHex)
+	if err != nil {
+		return OpCert{}, fmt.Errorf("decode payload: %w", err)
+	}
+	sig, err := hex.DecodeString(strings.TrimSpace(signatureHex))
+	if err != nil {
+		return OpCert{}, fmt.Errorf("%w: signature is not valid hex: %w", ErrInvalidRequest, err)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return OpCert{}, fmt.Errorf("%w: signature must be %d bytes, got %d", ErrInvalidRequest, ed25519.SignatureSize, len(sig))
+	}
+	if !ed25519.Verify(coldVkey, payloadBytes, sig) {
+		return OpCert{}, fmt.Errorf("%w: signature does not verify against the supplied cold vkey", ErrInvalidRequest)
+	}
+	return OpCert{
+		KesVKeyHex:       payload.KesVKeyHex,
+		IssueNumber:      issueNumber,
+		KesPeriod:        kesPeriod,
+		ColdSignatureHex: hex.EncodeToString(sig),
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// 6. Metadata builder
+// ---------------------------------------------------------------------------
+
+// BuildMetadata canonicalizes operator-supplied pool metadata to RFC 8785 JSON
+// and returns it with its Blake2b-256 hash. The operator hosts the JSON and
+// references the URL + hash in the registration certificate. No node needed.
+func (s *Service) BuildMetadata(in MetadataInput) (MetadataResult, error) {
+	return buildMetadata(in)
+}
+
+// ---------------------------------------------------------------------------
+// PoolID (air-gap import of an external cold vkey)
+// ---------------------------------------------------------------------------
+
+// PoolIDFromColdVKey computes the pool ID from an externally-supplied cold
+// verification key (raw 32-byte Ed25519, hex). Used by the air-gap flow where
+// the wallet never holds the cold signing key.
+func (s *Service) PoolIDFromColdVKey(coldVKeyHex string) (string, string, error) {
+	id, err := poolIDFromColdVKeyHex(coldVKeyHex)
+	if err != nil {
+		return "", "", err
+	}
+	return id.Bech32("pool"), hex.EncodeToString(id.Bytes()), nil
+}
+
+// ---------------------------------------------------------------------------
+// 3/4/5. Registration / update / retirement certificate + tx
+// ---------------------------------------------------------------------------
+
+// RegistrationParams is the operator-supplied input for a pool registration or
+// update certificate. RewardAddress defaults to the active wallet's stake
+// address when empty. ColdVKeyHex, when set, supplies an external cold vkey for
+// the air-gap path (build the cert body without the signing key); when empty the
+// cold vkey is derived from the active wallet seed (and SignAndSubmit may sign
+// it in-app).
+type RegistrationParams struct {
+	Pledge        uint64   `json:"pledge"`
+	Cost          uint64   `json:"cost"`
+	MarginNum     int64    `json:"margin_num"`
+	MarginDenom   int64    `json:"margin_denom"`
+	RewardAddress string   `json:"reward_address,omitempty"`
+	Owners        []string `json:"owners,omitempty"` // stake-key-hash hex or stake-address bech32
+	Relays        []Relay  `json:"relays,omitempty"`
+	MetadataURL   string   `json:"metadata_url,omitempty"`
+	MetadataHash  string   `json:"metadata_hash,omitempty"` // blake2b-256 hex
+	ColdVKeyHex   string   `json:"cold_vkey_hex,omitempty"` // air-gap: external cold vkey
+}
+
+// CertResult is a built certificate ready to display, host in an unsigned tx, or
+// hand to an offline signer.
+type CertResult struct {
+	PoolID  string `json:"pool_id"`
+	CBORHex string `json:"cbor_hex"`
+}
+
+// resolveRewardAccount returns the 29-byte reward-account bytes for the params,
+// defaulting to the active wallet's stake address.
+func (s *Service) resolveRewardAccount(p RegistrationParams, acct *wallet.Account) ([]byte, error) {
+	addrStr := strings.TrimSpace(p.RewardAddress)
+	if addrStr == "" {
+		if acct == nil {
+			return nil, fmt.Errorf("%w: no reward address and no active wallet", ErrInvalidRequest)
+		}
+		addrStr = acct.StakeAddress
+	}
+	addr, err := lcommon.NewAddress(addrStr)
+	if err != nil {
+		return nil, fmt.Errorf("%w: reward address %q: %w", ErrInvalidRequest, addrStr, err)
+	}
+	if addr.Type() != lcommon.AddressTypeNoneKey && addr.Type() != lcommon.AddressTypeNoneScript {
+		return nil, fmt.Errorf("%w: reward address must be a stake/reward address", ErrInvalidRequest)
+	}
+	b, err := addr.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("%w: reward address bytes: %w", ErrInvalidRequest, err)
+	}
+	if len(b) != 1+lcommon.AddressHashSize {
+		return nil, fmt.Errorf("%w: reward address must be %d bytes, got %d", ErrInvalidRequest, 1+lcommon.AddressHashSize, len(b))
+	}
+	return b, nil
+}
+
+// resolveOwners returns the pool-owner stake key hashes. Each owner may be a
+// 28-byte stake key hash (hex) or a bech32 stake address. Defaults to the active
+// wallet's own stake key hash when none are supplied.
+func (s *Service) resolveOwners(owners []string, acct *wallet.Account) ([]lcommon.AddrKeyHash, error) {
+	if len(owners) == 0 {
+		if acct == nil {
+			return nil, fmt.Errorf("%w: no owners and no active wallet", ErrInvalidRequest)
+		}
+		addr, err := lcommon.NewAddress(acct.StakeAddress)
+		if err != nil {
+			return nil, fmt.Errorf("wallet stake address: %w", err)
+		}
+		return []lcommon.AddrKeyHash{addr.StakeKeyHash()}, nil
+	}
+	out := make([]lcommon.AddrKeyHash, 0, len(owners))
+	for _, o := range owners {
+		o = strings.TrimSpace(o)
+		if strings.HasPrefix(o, "stake") {
+			addr, err := lcommon.NewAddress(o)
+			if err != nil {
+				return nil, fmt.Errorf("%w: owner address %q: %w", ErrInvalidRequest, o, err)
+			}
+			out = append(out, addr.StakeKeyHash())
+			continue
+		}
+		hb, err := hex.DecodeString(o)
+		if err != nil {
+			return nil, fmt.Errorf("%w: owner %q is not a stake address or hex key hash: %w", ErrInvalidRequest, o, err)
+		}
+		if len(hb) != lcommon.Blake2b224Size {
+			return nil, fmt.Errorf("%w: owner key hash %q must be %d bytes, got %d", ErrInvalidRequest, o, lcommon.Blake2b224Size, len(hb))
+		}
+		out = append(out, lcommon.NewBlake2b224(hb))
+	}
+	return out, nil
+}
+
+// buildRegistration assembles the registration certificate from cold vkey, VRF
+// hash, reward account, owners, relays, and optional metadata, returning the
+// CBOR and pool ID. It is shared by the seed and air-gap paths.
+func (s *Service) buildRegistration(coldVKey, vrfHash []byte, p RegistrationParams, acct *wallet.Account) (CertResult, error) {
+	if p.MarginDenom == 0 {
+		return CertResult{}, fmt.Errorf("%w: margin denominator must not be zero", ErrInvalidRequest)
+	}
+	if p.MarginNum < 0 || p.MarginDenom < 0 || p.MarginNum > p.MarginDenom {
+		return CertResult{}, fmt.Errorf("%w: margin must be between 0 and 1", ErrInvalidRequest)
+	}
+	reward, err := s.resolveRewardAccount(p, acct)
+	if err != nil {
+		return CertResult{}, err
+	}
+	owners, err := s.resolveOwners(p.Owners, acct)
+	if err != nil {
+		return CertResult{}, err
+	}
+	relays, err := relaysToPoolRelays(p.Relays)
+	if err != nil {
+		return CertResult{}, err
+	}
+
+	operator := poolIDFromVKey(coldVKey)
+	cert := &bursa.PoolRegistrationCertificate{
+		Operator:      operator,
+		VrfKeyHash:    lcommon.NewBlake2b256(vrfHash),
+		Pledge:        p.Pledge,
+		Cost:          p.Cost,
+		MarginNum:     p.MarginNum,
+		MarginDenom:   p.MarginDenom,
+		RewardAccount: reward,
+		PoolOwners:    owners,
+		Relays:        relays,
+	}
+	metadataURL := strings.TrimSpace(p.MetadataURL)
+	metadataHash := strings.TrimSpace(p.MetadataHash)
+	if metadataHash != "" && metadataURL == "" {
+		return CertResult{}, fmt.Errorf("%w: metadata hash requires metadata URL", ErrInvalidRequest)
+	}
+	if metadataURL != "" {
+		hb, err := hex.DecodeString(metadataHash)
+		if err != nil {
+			return CertResult{}, fmt.Errorf("%w: metadata hash is not valid hex: %w", ErrInvalidRequest, err)
+		}
+		if len(hb) != lcommon.Blake2b256Size {
+			return CertResult{}, fmt.Errorf("%w: metadata hash must be %d bytes, got %d", ErrInvalidRequest, lcommon.Blake2b256Size, len(hb))
+		}
+		cert.MetadataURL = metadataURL
+		cert.MetadataHash = lcommon.NewBlake2b256(hb)
+	}
+
+	cborBytes, err := bursa.CreatePoolRegistrationCertificate(cert)
+	if err != nil {
+		return CertResult{}, fmt.Errorf("create pool registration certificate: %w", err)
+	}
+	return CertResult{
+		PoolID:  operator.Bech32("pool"),
+		CBORHex: hex.EncodeToString(cborBytes),
+	}, nil
+}
+
+// BuildRegistrationFromSeed builds the registration/update certificate using the
+// active wallet's seed-derived cold + VRF keys. It requires the spending
+// password. The returned cert is the canonical CBOR (correct 29-byte reward
+// account) — submission is handled separately (see SubmitRetirement and the
+// package-level TODO about registration tx submission).
+func (s *Service) BuildRegistrationFromSeed(password string, p RegistrationParams) (CertResult, error) {
+	walletID, acct := s.currentBinding()
+	if acct == nil {
+		return CertResult{}, ErrNoWallet
+	}
+	root, zero, err := s.unlockRoot(walletID, password)
+	if err != nil {
+		return CertResult{}, err
+	}
+	defer zero()
+	cold, err := deriveCold(root, defaultColdIndex)
+	if err != nil {
+		return CertResult{}, err
+	}
+	defer cold.zero()
+	cold.zero()
+	vrfSeed, err := bursa.GetVRFSeed(root, defaultVRFIndex)
+	if err != nil {
+		return CertResult{}, fmt.Errorf("derive VRF seed: %w", err)
+	}
+	defer zeroBytes(vrfSeed)
+	vrfPub, _, err := bursa.GetVRFKeyPair(vrfSeed)
+	zeroBytes(vrfSeed)
+	if err != nil {
+		return CertResult{}, fmt.Errorf("derive VRF key pair: %w", err)
+	}
+	vrfHash := lcommon.Blake2b256Hash(vrfPub)
+	return s.buildRegistration(cold.vkey, vrfHash.Bytes(), p, acct)
+}
+
+// AirGapRegistrationParams is the air-gap registration input: an external cold
+// vkey and VRF key hash, with the standard registration params.
+type AirGapRegistrationParams struct {
+	RegistrationParams
+	VRFKeyHashHex string `json:"vrf_key_hash_hex"`
+}
+
+// BuildRegistrationAirGap builds the registration/update certificate from an
+// imported external cold vkey + VRF hash, without any signing key — the air-gap
+// path. The resulting cert body is handed to an offline cold-key signer; the
+// pool-registration tx is then assembled and submitted (see the offline tx-witness
+// TODO). No keystore needed.
+func (s *Service) BuildRegistrationAirGap(p AirGapRegistrationParams) (CertResult, error) {
+	coldVkey, err := decodeColdVKey(p.ColdVKeyHex)
+	if err != nil {
+		return CertResult{}, err
+	}
+	vrfHash, err := hex.DecodeString(strings.TrimSpace(p.VRFKeyHashHex))
+	if err != nil {
+		return CertResult{}, fmt.Errorf("%w: VRF key hash is not valid hex: %w", ErrInvalidRequest, err)
+	}
+	if len(vrfHash) != lcommon.Blake2b256Size {
+		return CertResult{}, fmt.Errorf("%w: VRF key hash must be %d bytes, got %d", ErrInvalidRequest, lcommon.Blake2b256Size, len(vrfHash))
+	}
+	return s.buildRegistration(coldVkey, vrfHash, p.RegistrationParams, s.currentAccount())
+}
+
+// BuildRetirementCert builds a pool retirement certificate for the given epoch.
+// coldVKeyHex, when set, uses an external cold vkey (air-gap); otherwise the
+// cold vkey is derived from the active wallet seed (requires the password).
+func (s *Service) BuildRetirementCert(password, coldVKeyHex string, epoch uint64) (CertResult, error) {
+	var coldVKey []byte
+	if strings.TrimSpace(coldVKeyHex) != "" {
+		b, err := decodeColdVKey(coldVKeyHex)
+		if err != nil {
+			return CertResult{}, err
+		}
+		coldVKey = b
+	} else {
+		walletID, acct := s.currentBinding()
+		if acct == nil {
+			return CertResult{}, ErrNoWallet
+		}
+		root, zero, err := s.unlockRoot(walletID, password)
+		if err != nil {
+			return CertResult{}, err
+		}
+		defer zero()
+		cold, err := deriveCold(root, defaultColdIndex)
+		if err != nil {
+			return CertResult{}, err
+		}
+		defer cold.zero()
+		coldVKey = append([]byte(nil), cold.vkey...)
+	}
+	operator := poolIDFromVKey(coldVKey)
+	cborBytes, err := bursa.CreatePoolRetirementCertificate(&bursa.PoolRetirementCertificateParams{
+		PoolKeyHash: operator,
+		Epoch:       epoch,
+	})
+	if err != nil {
+		return CertResult{}, fmt.Errorf("create pool retirement certificate: %w", err)
+	}
+	return CertResult{PoolID: operator.Bech32("pool"), CBORHex: hex.EncodeToString(cborBytes)}, nil
+}
+
+// TxResult is returned after a successful pool-operation submission.
+type TxResult struct {
+	TxHash string `json:"tx_hash"`
+}
+
+// SubmitRetirement builds, signs (with the wallet's first receive-address key
+// for fees + the cold key as the pool witness), and submits a pool retirement
+// transaction to the embedded node. It requires the spending password and a
+// synced node. Retirement is the one pool operation whose certificate encodes
+// identically through apollo's typed path (verified), so it is submitted in-app.
+func (s *Service) SubmitRetirement(ctx context.Context, password string, epoch uint64) (TxResult, error) {
+	walletID, acct := s.currentBinding()
+	if acct == nil {
+		return TxResult{}, ErrNoWallet
+	}
+	if s.chain == nil {
+		return TxResult{}, errors.New("no chain context configured")
+	}
+	if len(acct.ReceiveAddresses) == 0 {
+		return TxResult{}, errors.New("account has no receive addresses")
+	}
+	root, zero, err := s.unlockRoot(walletID, password)
+	if err != nil {
+		return TxResult{}, err
+	}
+	defer zero()
+	cold, err := deriveCold(root, defaultColdIndex)
+	if err != nil {
+		return TxResult{}, err
+	}
+	defer cold.zero()
+	operator := poolIDFromVKey(cold.vkey)
+
+	acctKey, err := bursa.GetAccountKey(root, 0)
+	if err != nil {
+		return TxResult{}, fmt.Errorf("account key: %w", err)
+	}
+	defer zeroBytes(acctKey)
+
+	changeAddr, err := lcommon.NewAddress(acct.ReceiveAddresses[0])
+	if err != nil {
+		return TxResult{}, fmt.Errorf("change address: %w", err)
+	}
+	a := apollo.New(s.chain).
+		SetWallet(apollo.NewExternalWallet(changeAddr)).
+		SetChangeAddress(changeAddr).
+		SetFeePadding(retirementFeePaddingLovelace)
+
+	fundingAddrs, err := retirementFundingAddresses(acct, acctKey)
+	if err != nil {
+		return TxResult{}, err
+	}
+	utxoAddr := make(map[string]ownedPaymentAddress)
+	for _, owner := range fundingAddrs {
+		addrStr := owner.address
+		addr, err := lcommon.NewAddress(addrStr)
+		if err != nil {
+			return TxResult{}, fmt.Errorf("address %q: %w", addrStr, err)
+		}
+		utxos, err := s.chain.Utxos(ctx, addr)
+		if err != nil {
+			return TxResult{}, fmt.Errorf("utxos for %s: %w", addrStr, err)
+		}
+		if len(utxos) > 0 {
+			a = a.AddLoadedUTxOs(utxos...)
+			for _, u := range utxos {
+				ref := hex.EncodeToString(u.Id.Id().Bytes()) + "#" + strconv.FormatUint(uint64(u.Id.Index()), 10)
+				utxoAddr[ref] = owner
+			}
+		}
+	}
+
+	// Retirement certificate; the cold key must witness the tx.
+	a = a.DeregisterPool(operator, epoch).
+		AddRequiredSigner(operator)
+
+	a, err = a.CompleteContext(ctx)
+	if err != nil {
+		return TxResult{}, fmt.Errorf("complete transaction: %w", err)
+	}
+
+	// Sign for fee inputs with the wallet payment keys, then add the cold-key
+	// witness. Apollo's Sign() APPENDs a witness per SetWallet+Sign call.
+	tx := a.GetTx()
+	if tx == nil {
+		return TxResult{}, errors.New("transaction not built")
+	}
+	seen := map[string]bool{}
+	for _, inp := range tx.Body.TxInputs.Items() {
+		ref := hex.EncodeToString(inp.TxId.Bytes()) + "#" + strconv.FormatUint(uint64(inp.OutputIndex), 10)
+		owner, ok := utxoAddr[ref]
+		if !ok || seen[owner.address] {
+			continue
+		}
+		seen[owner.address] = true
+		payKey, err := deriveOwnedPaymentKey(acctKey, owner)
+		if err != nil {
+			return TxResult{}, fmt.Errorf("%s payment key idx %d: %w", owner.role, owner.index, err)
+		}
+		if err := func() error {
+			defer zeroBytes(payKey)
+			addr, err := lcommon.NewAddress(owner.address)
+			if err != nil {
+				return fmt.Errorf("parse address %s: %w", owner.address, err)
+			}
+			kw, err := apollo.NewKeyPairWallet(addr, payKey)
+			if err != nil {
+				return fmt.Errorf("key pair wallet %s idx %d: %w", owner.role, owner.index, err)
+			}
+			a = a.SetWallet(kw)
+			a, err = a.Sign()
+			if err != nil {
+				return fmt.Errorf("sign %s idx %d: %w", owner.role, owner.index, err)
+			}
+			return nil
+		}(); err != nil {
+			return TxResult{}, err
+		}
+	}
+	// Cold-key witness: SignWithSkey accepts the 32-byte Ed25519 seed and adds a
+	// vkey witness whose key is the standard Ed25519 cold vkey — matching the
+	// operator hash in the retirement certificate.
+	a, err = a.SignWithSkey(cold.seed)
+	cold.zero()
+	if err != nil {
+		return TxResult{}, fmt.Errorf("cold-key witness: %w", err)
+	}
+
+	txHash, err := a.SubmitContext(context.WithoutCancel(ctx))
+	if err != nil {
+		return TxResult{}, fmt.Errorf("%w: %w", ErrSubmitRejected, err)
+	}
+	return TxResult{TxHash: hex.EncodeToString(txHash.Bytes())}, nil
+}
+
+func (r paymentKeyRole) String() string {
+	switch r {
+	case paymentKeyRoleReceive:
+		return "receive"
+	case paymentKeyRoleChange:
+		return "change"
+	default:
+		return fmt.Sprintf("role-%d", r)
+	}
+}
+
+func retirementFundingAddresses(acct *wallet.Account, acctKey bip32.XPrv) ([]ownedPaymentAddress, error) {
+	seen := make(map[string]bool, len(acct.ReceiveAddresses)+len(acct.ChangeAddresses))
+	out := make([]ownedPaymentAddress, 0, len(acct.ReceiveAddresses)+len(acct.ChangeAddresses))
+	add := func(addr string, role paymentKeyRole, index uint32) {
+		if addr == "" || seen[addr] {
+			return
+		}
+		seen[addr] = true
+		out = append(out, ownedPaymentAddress{address: addr, role: role, index: index})
+	}
+
+	for i, addr := range acct.ReceiveAddresses {
+		add(addr, paymentKeyRoleReceive, uint32(i)) //nolint:gosec // bounded by the derived address window
+	}
+
+	changeAddresses := append([]string(nil), acct.ChangeAddresses...)
+	if len(changeAddresses) < len(acct.ReceiveAddresses) {
+		derived, err := deriveChangeAddresses(acct.ReceiveAddresses[0], acctKey, len(acct.ReceiveAddresses))
+		if err != nil {
+			return nil, err
+		}
+		changeAddresses = append(changeAddresses, derived[len(changeAddresses):]...)
+	}
+	for i, addr := range changeAddresses {
+		add(addr, paymentKeyRoleChange, uint32(i)) //nolint:gosec // bounded by the derived address window
+	}
+	return out, nil
+}
+
+func deriveChangeAddresses(referenceAddr string, acctKey bip32.XPrv, count int) ([]string, error) {
+	ref, err := lcommon.NewAddress(referenceAddr)
+	if err != nil {
+		return nil, fmt.Errorf("reference receive address: %w", err)
+	}
+	var networkID uint8
+	switch ref.NetworkId() {
+	case uint(lcommon.AddressNetworkTestnet):
+		networkID = lcommon.AddressNetworkTestnet
+	case uint(lcommon.AddressNetworkMainnet):
+		networkID = lcommon.AddressNetworkMainnet
+	default:
+		return nil, fmt.Errorf("reference receive address network id %d is invalid", ref.NetworkId())
+	}
+	stakeHash := ref.StakeKeyHash()
+	out := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		idx := uint32(i) //nolint:gosec // bounded by the derived address window
+		changeKey, err := deriveOwnedPaymentKey(acctKey, ownedPaymentAddress{
+			role:  paymentKeyRoleChange,
+			index: idx,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("change payment key idx %d: %w", idx, err)
+		}
+		payHash := changeKey.Public().PublicKey().Hash()
+		zeroBytes(changeKey)
+		addr, err := lcommon.NewAddressFromParts(
+			lcommon.AddressTypeKeyKey,
+			networkID,
+			payHash,
+			stakeHash.Bytes(),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("change address idx %d: %w", idx, err)
+		}
+		out = append(out, addr.String())
+	}
+	return out, nil
+}
+
+func deriveOwnedPaymentKey(acctKey bip32.XPrv, owner ownedPaymentAddress) (bip32.XPrv, error) {
+	switch owner.role {
+	case paymentKeyRoleReceive:
+		return bursa.GetPaymentKey(acctKey, owner.index)
+	case paymentKeyRoleChange:
+		if owner.index >= 0x80000000 {
+			return nil, bursa.ErrInvalidDerivationIndex
+		}
+		roleKey := acctKey.Derive(uint32(paymentKeyRoleChange))
+		defer zeroBytes(roleKey)
+		return roleKey.Derive(owner.index), nil
+	default:
+		return nil, fmt.Errorf("unknown payment key role %d", owner.role)
+	}
+}
+
+// compile-time guard: *keystore.Keystore satisfies Keystore.
+var _ Keystore = (*keystore.Keystore)(nil)

--- a/ui/internal/poolops/service_test.go
+++ b/ui/internal/poolops/service_test.go
@@ -1,0 +1,569 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package poolops
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/apollo/v2/backend"
+	"github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/bursa/ui/internal/keystore"
+	"github.com/blinklabs-io/bursa/ui/internal/wallet"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/blinklabs-io/plutigo/data"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+// fakeKeystore unlocks to a fixed mnemonic, or returns ErrDecryptFailed when the
+// password does not match — mirroring the real keystore's wrong-password path.
+type fakeKeystore struct {
+	mnemonic string
+	password string
+	exists   bool
+}
+
+func (f *fakeKeystore) Exists() bool { return f.exists }
+
+func (f *fakeKeystore) Unlock(password string) ([]byte, error) {
+	if password != f.password {
+		return nil, keystore.ErrDecryptFailed
+	}
+	return []byte(f.mnemonic), nil
+}
+
+func (f *fakeKeystore) UnlockFor(_ string, password string) ([]byte, error) {
+	return f.Unlock(password)
+}
+
+func newSeedService(t *testing.T) (*Service, *wallet.Account) {
+	t.Helper()
+	acct, err := wallet.Derive(testMnemonic, "preview", 2)
+	if err != nil {
+		t.Fatalf("derive account: %v", err)
+	}
+	ks := &fakeKeystore{mnemonic: testMnemonic, password: "spend-password", exists: true}
+	s := NewService(nil, ks, fakeGenesis{}, fakeTip{slot: 259200})
+	s.SetAccount("test-wallet-id", acct)
+	return s, acct
+}
+
+type fakeGenesis struct {
+	err     error
+	genesis *Genesis
+}
+
+func (f fakeGenesis) Genesis(_ context.Context) (Genesis, error) {
+	if f.err != nil {
+		return Genesis{}, f.err
+	}
+	if f.genesis != nil {
+		return *f.genesis, nil
+	}
+	return Genesis{SlotsPerKESPeriod: 129600, MaxKESEvolutions: 62, EpochLength: 432000}, nil
+}
+
+type fakeTip struct{ slot uint64 }
+
+func (f fakeTip) TipSlot() (uint64, error) { return f.slot, nil }
+
+const differentMnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+type genericOnlyKeystore struct {
+	mnemonic    string
+	unlockCalls int
+}
+
+func (g *genericOnlyKeystore) Exists() bool { return true }
+
+func (g *genericOnlyKeystore) Unlock(string) ([]byte, error) {
+	g.unlockCalls++
+	return []byte(g.mnemonic), nil
+}
+
+type walletBoundKeystore struct {
+	genericMnemonic string
+	mnemonicByID    map[string]string
+	unlockCalls     int
+	unlockForIDs    []string
+}
+
+func (w *walletBoundKeystore) Exists() bool { return true }
+
+func (w *walletBoundKeystore) Unlock(string) ([]byte, error) {
+	w.unlockCalls++
+	return []byte(w.genericMnemonic), nil
+}
+
+func (w *walletBoundKeystore) UnlockFor(id, _ string) ([]byte, error) {
+	w.unlockForIDs = append(w.unlockForIDs, id)
+	mnemonic, ok := w.mnemonicByID[id]
+	if !ok {
+		return nil, keystore.ErrDecryptFailed
+	}
+	return []byte(mnemonic), nil
+}
+
+type retirementFakeChain struct {
+	utxos      map[string][]lcommon.Utxo
+	pp         backend.ProtocolParameters
+	submitHash lcommon.Blake2b256
+	submitCbor []byte
+}
+
+func newRetirementFakeChain(addr string, lovelace uint64) *retirementFakeChain {
+	var h lcommon.Blake2b256
+	b, _ := hex.DecodeString("deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	copy(h[:], b)
+
+	fc := &retirementFakeChain{
+		utxos: map[string][]lcommon.Utxo{},
+		pp: backend.ProtocolParameters{
+			MinFeeConstant:    155381,
+			MinFeeCoefficient: 44,
+			MaxTxSize:         16384,
+			CoinsPerUtxoByte:  "4310",
+			KeyDeposits:       "2000000",
+			PoolDeposits:      "500000000",
+		},
+		submitHash: h,
+	}
+	fc.addUTxO(addr, lovelace, "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890", 0)
+	return fc
+}
+
+func (fc *retirementFakeChain) addUTxO(addrStr string, lovelace uint64, txHashHex string, outIdx uint32) {
+	var txID lcommon.Blake2b256
+	b, _ := hex.DecodeString(txHashHex)
+	copy(txID[:], b)
+	addr, _ := lcommon.NewAddress(addrStr)
+	fc.utxos[addrStr] = append(fc.utxos[addrStr], lcommon.Utxo{
+		Id:     shelley.ShelleyTransactionInput{TxId: txID, OutputIndex: outIdx},
+		Output: &retirementFakeOutput{address: addr, lovelace: lovelace},
+	})
+}
+
+func (fc *retirementFakeChain) ProtocolParams(context.Context) (backend.ProtocolParameters, error) {
+	return fc.pp, nil
+}
+
+func (fc *retirementFakeChain) GenesisParams(context.Context) (backend.GenesisParameters, error) {
+	return backend.GenesisParameters{NetworkMagic: 1}, nil
+}
+
+func (fc *retirementFakeChain) NetworkId() uint8 { return 0 }
+
+func (fc *retirementFakeChain) CurrentEpoch(context.Context) (uint64, error) { return 500, nil }
+
+func (fc *retirementFakeChain) MaxTxFee(context.Context) (uint64, error) {
+	return backend.ComputeMaxTxFee(fc.pp)
+}
+
+func (fc *retirementFakeChain) Tip(context.Context) (uint64, error) { return 10_000_000, nil }
+
+func (fc *retirementFakeChain) Utxos(_ context.Context, address lcommon.Address) ([]lcommon.Utxo, error) {
+	return fc.utxos[address.String()], nil
+}
+
+func (fc *retirementFakeChain) SubmitTx(_ context.Context, tx []byte) (lcommon.Blake2b256, error) {
+	fc.submitCbor = append(fc.submitCbor[:0], tx...)
+	return fc.submitHash, nil
+}
+
+func (fc *retirementFakeChain) EvaluateTx(context.Context, []byte, []lcommon.Utxo) (map[lcommon.RedeemerKey]lcommon.ExUnits, error) {
+	return nil, nil
+}
+
+func (fc *retirementFakeChain) UtxoByRef(_ context.Context, txHash lcommon.Blake2b256, index uint32) (*lcommon.Utxo, error) {
+	for _, utxos := range fc.utxos {
+		for _, u := range utxos {
+			if u.Id.Id() == txHash && u.Id.Index() == index {
+				cp := u
+				return &cp, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (fc *retirementFakeChain) ScriptCbor(context.Context, lcommon.Blake2b224) ([]byte, error) {
+	return nil, nil
+}
+
+type retirementFakeOutput struct {
+	address  lcommon.Address
+	lovelace uint64
+}
+
+func (o *retirementFakeOutput) Address() lcommon.Address { return o.address }
+func (o *retirementFakeOutput) Amount() *big.Int         { return new(big.Int).SetUint64(o.lovelace) }
+func (o *retirementFakeOutput) Assets() *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput] {
+	return nil
+}
+func (o *retirementFakeOutput) Datum() *lcommon.Datum               { return nil }
+func (o *retirementFakeOutput) DatumHash() *lcommon.Blake2b256      { return nil }
+func (o *retirementFakeOutput) Cbor() []byte                        { return nil }
+func (o *retirementFakeOutput) Utxorpc() (*utxorpc.TxOutput, error) { return nil, nil }
+func (o *retirementFakeOutput) ScriptRef() lcommon.Script           { return nil }
+func (o *retirementFakeOutput) ToPlutusData() data.PlutusData       { return nil }
+func (o *retirementFakeOutput) String() string                      { return o.address.String() }
+
+// TestServiceCredentials checks credential derivation through the keystore and
+// the wrong-password and no-wallet error paths.
+func TestServiceCredentials(t *testing.T) {
+	s, _ := newSeedService(t)
+	creds, err := s.Credentials("spend-password")
+	if err != nil {
+		t.Fatalf("Credentials: %v", err)
+	}
+	if creds.Network != "preview" || creds.PoolID == "" {
+		t.Fatalf("unexpected credentials: %+v", creds)
+	}
+
+	if _, err := s.Credentials("wrong"); !errors.Is(err, ErrWrongPassword) {
+		t.Fatalf("wrong password: got %v, want ErrWrongPassword", err)
+	}
+
+	empty := NewService(nil, &fakeKeystore{password: "x"}, nil, nil)
+	if _, err := empty.Credentials("x"); !errors.Is(err, ErrNoWallet) {
+		t.Fatalf("no wallet: got %v, want ErrNoWallet", err)
+	}
+}
+
+func TestServiceWalletBoundUnlockRequiresUnlockFor(t *testing.T) {
+	acct, err := wallet.Derive(testMnemonic, "preview", 2)
+	if err != nil {
+		t.Fatalf("derive account: %v", err)
+	}
+	ks := &genericOnlyKeystore{mnemonic: testMnemonic}
+	s := NewService(nil, ks, nil, nil)
+	s.SetAccount("wallet-a", acct)
+
+	if _, err := s.Credentials("pw"); err == nil {
+		t.Fatal("Credentials with wallet-bound generic keystore succeeded, want error")
+	} else if !strings.Contains(err.Error(), "UnlockFor") {
+		t.Fatalf("Credentials error = %v, want UnlockFor support error", err)
+	}
+	if ks.unlockCalls != 0 {
+		t.Fatalf("generic Unlock calls = %d, want 0", ks.unlockCalls)
+	}
+}
+
+func TestServiceCredentialsUseWalletBoundSeed(t *testing.T) {
+	acct, err := wallet.Derive(testMnemonic, "preview", 2)
+	if err != nil {
+		t.Fatalf("derive account: %v", err)
+	}
+	ks := &walletBoundKeystore{
+		genericMnemonic: differentMnemonic,
+		mnemonicByID:    map[string]string{"wallet-a": testMnemonic},
+	}
+	s := NewService(nil, ks, nil, nil)
+	s.SetAccount("wallet-a", acct)
+
+	creds, err := s.Credentials("pw")
+	if err != nil {
+		t.Fatalf("Credentials: %v", err)
+	}
+	want, err := deriveCredentials(mustRoot(t), "preview", 0, 0, 0)
+	if err != nil {
+		t.Fatalf("derive want credentials: %v", err)
+	}
+	rootB, err := bursa.GetRootKeyFromMnemonic(differentMnemonic, "")
+	if err != nil {
+		t.Fatalf("root B: %v", err)
+	}
+	other, err := deriveCredentials(rootB, "preview", 0, 0, 0)
+	if err != nil {
+		t.Fatalf("derive other credentials: %v", err)
+	}
+	if creds.PoolID != want.PoolID {
+		t.Fatalf("pool ID = %q, want wallet-bound %q", creds.PoolID, want.PoolID)
+	}
+	if creds.PoolID == other.PoolID {
+		t.Fatal("pool ID matched generic unlock mnemonic; wallet-bound seed was not used")
+	}
+	if ks.unlockCalls != 0 {
+		t.Fatalf("generic Unlock calls = %d, want 0", ks.unlockCalls)
+	}
+	if len(ks.unlockForIDs) != 1 || ks.unlockForIDs[0] != "wallet-a" {
+		t.Fatalf("UnlockFor ids = %v, want [wallet-a]", ks.unlockForIDs)
+	}
+}
+
+// TestServiceKESPeriod checks the KES period is tip/slotsPerKESPeriod and that
+// a genesis error propagates.
+func TestServiceKESPeriod(t *testing.T) {
+	s, _ := newSeedService(t)
+	info, err := s.KESPeriod(context.Background())
+	if err != nil {
+		t.Fatalf("KESPeriod: %v", err)
+	}
+	if info.CurrentPeriod != 2 { // 259200 / 129600
+		t.Fatalf("current period = %d, want 2", info.CurrentPeriod)
+	}
+	if info.SlotsPerKESPeriod != 129600 || info.MaxKESEvolutions != 62 {
+		t.Fatalf("genesis passthrough wrong: %+v", info)
+	}
+
+	bad := NewService(nil, &fakeKeystore{}, fakeGenesis{err: errors.New("boom")}, fakeTip{})
+	if _, err := bad.KESPeriod(context.Background()); err == nil {
+		t.Fatal("expected KESPeriod error when genesis fails")
+	}
+}
+
+func TestServiceKESPeriodRejectsNegativeGenesis(t *testing.T) {
+	cases := []Genesis{
+		{SlotsPerKESPeriod: -1, MaxKESEvolutions: 62},
+		{SlotsPerKESPeriod: 129600, MaxKESEvolutions: -1},
+	}
+	for _, g := range cases {
+		s := NewService(nil, &fakeKeystore{}, fakeGenesis{genesis: &g}, fakeTip{slot: 1})
+		if _, err := s.KESPeriod(context.Background()); err == nil {
+			t.Fatalf("KESPeriod(%+v) expected error", g)
+		}
+	}
+}
+
+// TestServiceIssueAndRotateOpCert checks an issued opcert verifies against the
+// cold vkey, and that rotation derives a new KES key + bumps the issue counter.
+func TestServiceIssueOpCert(t *testing.T) {
+	s, _ := newSeedService(t)
+	creds, err := s.Credentials("spend-password")
+	if err != nil {
+		t.Fatalf("Credentials: %v", err)
+	}
+	coldVkey, _ := hex.DecodeString(creds.Cold.VKeyHex)
+
+	opcert, err := s.IssueOpCert("spend-password", 0, 5, 2)
+	if err != nil {
+		t.Fatalf("IssueOpCert: %v", err)
+	}
+	if opcert.IssueNumber != 5 || opcert.KesPeriod != 2 {
+		t.Fatalf("issue/period = %d/%d, want 5/2", opcert.IssueNumber, opcert.KesPeriod)
+	}
+	// The opcert ColdSignature must verify against the cold vkey over
+	// CBOR([kesVkey, issue, period]).
+	kesVkey, _ := hex.DecodeString(opcert.KesVKeyHex)
+	sig, _ := hex.DecodeString(opcert.ColdSignatureHex)
+	payload, _ := cbor.Encode([]any{kesVkey, uint64(5), uint64(2)})
+	if !ed25519.Verify(coldVkey, payload, sig) {
+		t.Fatal("issued opcert does not verify against the cold vkey")
+	}
+
+	if _, err := s.IssueOpCert("wrong", 0, 5, 2); !errors.Is(err, ErrWrongPassword) {
+		t.Fatalf("wrong password: got %v", err)
+	}
+}
+
+func TestServiceRotateKES(t *testing.T) {
+	s, _ := newSeedService(t)
+	// Rotation: new KES index 1, previous issue 3 → new issue 4.
+	rotated, err := s.RotateKES("spend-password", 1, 3, 5)
+	if err != nil {
+		t.Fatalf("RotateKES: %v", err)
+	}
+	if rotated.IssueNumber != 4 {
+		t.Fatalf("rotated issue number = %d, want 4 (prev 3 + 1)", rotated.IssueNumber)
+	}
+	if rotated.KESIndex != 1 {
+		t.Fatalf("rotated KES index = %d, want 1", rotated.KESIndex)
+	}
+	// The rotated opcert must use the KES key at index 1 (different from index 0).
+	idx0, err := s.IssueOpCert("spend-password", 0, 4, 5)
+	if err != nil {
+		t.Fatalf("IssueOpCert: %v", err)
+	}
+	if rotated.KesVKeyHex == idx0.KesVKeyHex {
+		t.Fatal("rotated KES vkey equals index-0 vkey; rotation did not change keys")
+	}
+}
+
+// TestServiceBuildRegistrationFromSeed checks the seed path builds a cert whose
+// pool ID matches the derived credentials and defaults the reward account to the
+// wallet's stake address.
+func TestServiceBuildRegistrationFromSeed(t *testing.T) {
+	s, acct := newSeedService(t)
+	creds, err := s.Credentials("spend-password")
+	if err != nil {
+		t.Fatalf("Credentials: %v", err)
+	}
+	p := RegistrationParams{Pledge: 1_000_000, Cost: 340_000_000, MarginNum: 1, MarginDenom: 50}
+	res, err := s.BuildRegistrationFromSeed("spend-password", p)
+	if err != nil {
+		t.Fatalf("BuildRegistrationFromSeed: %v", err)
+	}
+	if res.PoolID != creds.PoolID {
+		t.Fatalf("pool ID %q != %q", res.PoolID, creds.PoolID)
+	}
+	// reward account defaults to the wallet stake address — decode the cert CBOR and
+	// confirm the embedded reward-account bytes match the account's stake address.
+	raw, _ := hex.DecodeString(res.CBORHex)
+	var arr []cbor.RawMessage
+	if _, err := cbor.Decode(raw, &arr); err != nil {
+		t.Fatalf("decode cert: %v", err)
+	}
+	var reward []byte
+	_, _ = cbor.Decode(arr[6], &reward)
+	if len(reward) != 29 {
+		t.Fatalf("default reward account len = %d, want 29", len(reward))
+	}
+	// Confirm the embedded bytes match acct.StakeAddress.
+	wantAddr, err := lcommon.NewAddress(acct.StakeAddress)
+	if err != nil {
+		t.Fatalf("parse stake address: %v", err)
+	}
+	wantBytes, err := wantAddr.Bytes()
+	if err != nil {
+		t.Fatalf("stake address bytes: %v", err)
+	}
+	if !bytes.Equal(reward, wantBytes) {
+		t.Fatalf("reward account bytes mismatch: got %x, want %x", reward, wantBytes)
+	}
+}
+
+func TestResolveRewardAccountRejectsNonRewardAddress(t *testing.T) {
+	s, acct := newSeedService(t)
+	_, err := s.resolveRewardAccount(RegistrationParams{RewardAddress: acct.ReceiveAddresses[0]}, acct)
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("resolveRewardAccount base address error = %v, want ErrInvalidRequest", err)
+	}
+}
+
+func TestBuildRegistrationRejectsMetadataHashWithoutURL(t *testing.T) {
+	s, _ := newSeedService(t)
+	_, err := s.BuildRegistrationFromSeed("spend-password", RegistrationParams{
+		Pledge:       1,
+		Cost:         1,
+		MarginNum:    0,
+		MarginDenom:  1,
+		MetadataHash: strings.Repeat("ab", 32),
+	})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("BuildRegistrationFromSeed metadata hash without URL error = %v, want ErrInvalidRequest", err)
+	}
+}
+
+// TestServiceAirGapRegistration checks the air-gap path builds a registration
+// cert from an imported cold vkey + VRF hash without any keystore.
+func TestServiceAirGapRegistration(t *testing.T) {
+	// Service with no keystore (offline-only).
+	acct, _ := wallet.Derive(testMnemonic, "preview", 2)
+	s := NewService(nil, nil, nil, nil)
+	s.SetAccount("test-wallet-id", acct)
+
+	creds, _ := deriveCredentials(mustRoot(t), "preview", 0, 0, 0)
+	p := AirGapRegistrationParams{
+		RegistrationParams: RegistrationParams{
+			Pledge: 1, Cost: 1, MarginNum: 0, MarginDenom: 1,
+			ColdVKeyHex: creds.Cold.VKeyHex,
+		},
+		VRFKeyHashHex: creds.VRF.HashHex,
+	}
+	res, err := s.BuildRegistrationAirGap(p)
+	if err != nil {
+		t.Fatalf("BuildRegistrationAirGap: %v", err)
+	}
+	if res.PoolID != creds.PoolID {
+		t.Fatalf("air-gap pool ID %q != %q", res.PoolID, creds.PoolID)
+	}
+}
+
+// TestServicePoolIDFromColdVKey checks the air-gap import returns matching
+// bech32 + hex IDs.
+func TestServicePoolIDFromColdVKey(t *testing.T) {
+	s := NewService(nil, nil, nil, nil)
+	creds, _ := deriveCredentials(mustRoot(t), "preview", 0, 0, 0)
+	id, idHex, err := s.PoolIDFromColdVKey(creds.Cold.VKeyHex)
+	if err != nil {
+		t.Fatalf("PoolIDFromColdVKey: %v", err)
+	}
+	if id != creds.PoolID || idHex != creds.PoolIDHex {
+		t.Fatalf("got id=%q hex=%q, want %q / %q", id, idHex, creds.PoolID, creds.PoolIDHex)
+	}
+}
+
+func TestSubmitRetirementPadsFeeForFinalWitnesses(t *testing.T) {
+	acct, err := wallet.Derive(testMnemonic, "preview", 2)
+	if err != nil {
+		t.Fatalf("derive account: %v", err)
+	}
+	chain := newRetirementFakeChain(acct.ReceiveAddresses[0], 5_000_000)
+	ks := &fakeKeystore{mnemonic: testMnemonic, password: "spend-password", exists: true}
+	s := NewService(chain, ks, fakeGenesis{}, fakeTip{slot: 259200})
+	s.SetAccount("wallet-a", acct)
+
+	res, err := s.SubmitRetirement(context.Background(), "spend-password", 520)
+	if err != nil {
+		t.Fatalf("SubmitRetirement: %v", err)
+	}
+	if res.TxHash == "" {
+		t.Fatal("SubmitRetirement returned empty tx hash")
+	}
+	if len(chain.submitCbor) == 0 {
+		t.Fatal("SubmitRetirement did not submit transaction CBOR")
+	}
+
+	var tx conway.ConwayTransaction
+	if _, err := cbor.Decode(chain.submitCbor, &tx); err != nil {
+		t.Fatalf("decode submitted tx: %v", err)
+	}
+	finalMinFee := uint64(int64(len(chain.submitCbor))*chain.pp.MinFeeCoefficient + chain.pp.MinFeeConstant) //nolint:gosec // test protocol params are non-negative and small
+	if tx.Body.TxFee < finalMinFee+retirementFeePaddingLovelace {
+		t.Fatalf("retirement fee = %d, want at least final min %d + padding %d", tx.Body.TxFee, finalMinFee, retirementFeePaddingLovelace)
+	}
+	if got := len(tx.WitnessSet.VkeyWitnesses.Items()); got != 2 {
+		t.Fatalf("vkey witness count = %d, want payment + cold witnesses", got)
+	}
+}
+
+func TestSubmitRetirementUsesDerivedChangeAddressUTxOs(t *testing.T) {
+	acct, err := wallet.Derive(testMnemonic, "preview", 2)
+	if err != nil {
+		t.Fatalf("derive account: %v", err)
+	}
+	if len(acct.ChangeAddresses) == 0 {
+		t.Fatal("derived account has no change addresses")
+	}
+	changeAddr := acct.ChangeAddresses[0]
+	acct.ChangeAddresses = nil // simulate older vault metadata without persisted change window
+	chain := newRetirementFakeChain(changeAddr, 5_000_000)
+	ks := &fakeKeystore{mnemonic: testMnemonic, password: "spend-password", exists: true}
+	s := NewService(chain, ks, fakeGenesis{}, fakeTip{slot: 259200})
+	s.SetAccount("wallet-a", acct)
+
+	res, err := s.SubmitRetirement(context.Background(), "spend-password", 520)
+	if err != nil {
+		t.Fatalf("SubmitRetirement: %v", err)
+	}
+	if res.TxHash == "" {
+		t.Fatal("SubmitRetirement returned empty tx hash")
+	}
+	if len(chain.submitCbor) == 0 {
+		t.Fatal("SubmitRetirement did not submit transaction CBOR")
+	}
+}
+
+// compile-time guard: the real keystore satisfies the generic interface used here.
+var _ Keystore = (*keystore.Keystore)(nil)

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -882,6 +882,7 @@ func cloneAccount(acct *wallet.Account) *wallet.Account {
 	}
 	cp := *acct
 	cp.ReceiveAddresses = append([]string(nil), acct.ReceiveAddresses...)
+	cp.ChangeAddresses = append([]string(nil), acct.ChangeAddresses...)
 	return &cp
 }
 

--- a/ui/internal/vault/vault.go
+++ b/ui/internal/vault/vault.go
@@ -637,6 +637,7 @@ func cloneWallet(w *WalletMeta) *WalletMeta {
 	if w.Account != nil {
 		acct := *w.Account
 		acct.ReceiveAddresses = append([]string(nil), w.Account.ReceiveAddresses...)
+		acct.ChangeAddresses = append([]string(nil), w.Account.ChangeAddresses...)
 		c.Account = &acct
 	}
 	return &c

--- a/ui/internal/wallet/account.go
+++ b/ui/internal/wallet/account.go
@@ -15,8 +15,8 @@ import (
 )
 
 // Account is a derived, read-only view of a wallet: its stake address (the
-// query key) and a window of external (receive) payment addresses, all sharing
-// the canonical stake key at index 0.
+// query key) plus windows of external (receive) and internal (change) payment
+// addresses, all sharing the canonical stake key at index 0.
 //
 // DRepKeyHash is the wallet's own DRep verification-key hash (CIP-0105,
 // derivation role 3), derived at the same time as the addresses. It carries the
@@ -28,6 +28,7 @@ type Account struct {
 	StakeAddress     string   `json:"stake_address"`
 	ReceiveAddresses []string `json:"receive_addresses"`
 	DRepKeyHash      string   `json:"drep_key_hash,omitempty"`
+	ChangeAddresses  []string `json:"change_addresses,omitempty"`
 }
 
 // AccountXpub returns the Bech32-encoded extended public key for the CIP-1852
@@ -62,8 +63,9 @@ func accountXpubFromRoot(root bip32.XPrv) (string, error) {
 }
 
 // Derive builds the account for the given mnemonic and network, producing the
-// stake address plus windowN external receive addresses (indices 0..windowN-1),
-// all bound to the canonical stake key m/1852'/1815'/0'/2/0.
+// stake address plus windowN external receive addresses and windowN internal
+// change addresses (indices 0..windowN-1), all bound to the canonical stake key
+// m/1852'/1815'/0'/2/0.
 func Derive(mnemonic, network string, windowN int) (*Account, error) {
 	netID, err := validateDeriveInputs(network, windowN)
 	if err != nil {
@@ -128,19 +130,33 @@ func deriveFromRoot(root bip32.XPrv, network string, netID uint8, windowN int) (
 		return nil, fmt.Errorf("stake address: %w", err)
 	}
 
-	receive := make([]string, 0, windowN)
-	for i := 0; i < windowN; i++ {
-		payKey, err := bursa.GetPaymentKey(acctKey, uint32(i))
-		if err != nil {
-			return nil, fmt.Errorf("payment key %d: %w", i, err)
-		}
+	deriveAddr := func(chain uint32, i int) (string, error) {
+		idx := uint32(i) //nolint:gosec // i is bounded by the configured window size
+		roleKey := acctKey.Derive(chain)
+		defer zeroXPrv(roleKey)
+		payKey := roleKey.Derive(idx)
+		defer zeroXPrv(payKey)
 		payHash := payKey.Public().PublicKey().Hash()
-		zeroXPrv(payKey)
 		addr, err := lcommon.NewAddressFromParts(lcommon.AddressTypeKeyKey, netID, payHash, stakeHash)
 		if err != nil {
-			return nil, fmt.Errorf("address %d: %w", i, err)
+			return "", err
 		}
-		receive = append(receive, addr.String())
+		return addr.String(), nil
+	}
+
+	receive := make([]string, 0, windowN)
+	change := make([]string, 0, windowN)
+	for i := 0; i < windowN; i++ {
+		addr, err := deriveAddr(0, i)
+		if err != nil {
+			return nil, fmt.Errorf("receive address %d: %w", i, err)
+		}
+		receive = append(receive, addr)
+		addr, err = deriveAddr(1, i)
+		if err != nil {
+			return nil, fmt.Errorf("change address %d: %w", i, err)
+		}
+		change = append(change, addr)
 	}
 
 	return &Account{
@@ -148,6 +164,7 @@ func deriveFromRoot(root bip32.XPrv, network string, netID uint8, windowN int) (
 		StakeAddress:     stakeAddr.String(),
 		ReceiveAddresses: receive,
 		DRepKeyHash:      drepHash,
+		ChangeAddresses:  change,
 	}, nil
 }
 

--- a/ui/internal/wallet/account_test.go
+++ b/ui/internal/wallet/account_test.go
@@ -20,6 +20,9 @@ func TestDerivePreview(t *testing.T) {
 	if len(acct.ReceiveAddresses) != 5 {
 		t.Fatalf("got %d receive addresses, want 5", len(acct.ReceiveAddresses))
 	}
+	if len(acct.ChangeAddresses) != 5 {
+		t.Fatalf("got %d change addresses, want 5", len(acct.ChangeAddresses))
+	}
 	seen := map[string]bool{}
 	for i, a := range acct.ReceiveAddresses {
 		if !strings.HasPrefix(a, "addr_test1") {
@@ -27,6 +30,15 @@ func TestDerivePreview(t *testing.T) {
 		}
 		if seen[a] {
 			t.Fatalf("receive[%d] = %q is a duplicate", i, a)
+		}
+		seen[a] = true
+	}
+	for i, a := range acct.ChangeAddresses {
+		if !strings.HasPrefix(a, "addr_test1") {
+			t.Fatalf("change[%d] = %q, want addr_test1… prefix", i, a)
+		}
+		if seen[a] {
+			t.Fatalf("change[%d] = %q duplicates a derived address", i, a)
 		}
 		seen[a] = true
 	}
@@ -59,6 +71,11 @@ func TestDeriveDeterministic(t *testing.T) {
 			t.Fatalf("receive[%d] not deterministic", i)
 		}
 	}
+	for i := range a1.ChangeAddresses {
+		if a1.ChangeAddresses[i] != a2.ChangeAddresses[i] {
+			t.Fatalf("change[%d] not deterministic", i)
+		}
+	}
 }
 
 func TestDeriveFromMnemonicBytesMatchesStringDerive(t *testing.T) {
@@ -76,9 +93,17 @@ func TestDeriveFromMnemonicBytesMatchesStringDerive(t *testing.T) {
 	if len(fromBytes.ReceiveAddresses) != len(fromString.ReceiveAddresses) {
 		t.Fatalf("got %d receive addresses, want %d", len(fromBytes.ReceiveAddresses), len(fromString.ReceiveAddresses))
 	}
+	if len(fromBytes.ChangeAddresses) != len(fromString.ChangeAddresses) {
+		t.Fatalf("got %d change addresses, want %d", len(fromBytes.ChangeAddresses), len(fromString.ChangeAddresses))
+	}
 	for i := range fromString.ReceiveAddresses {
 		if fromBytes.ReceiveAddresses[i] != fromString.ReceiveAddresses[i] {
 			t.Fatalf("receive[%d] = %q, want %q", i, fromBytes.ReceiveAddresses[i], fromString.ReceiveAddresses[i])
+		}
+	}
+	for i := range fromString.ChangeAddresses {
+		if fromBytes.ChangeAddresses[i] != fromString.ChangeAddresses[i] {
+			t.Fatalf("change[%d] = %q, want %q", i, fromBytes.ChangeAddresses[i], fromString.ChangeAddresses[i])
 		}
 	}
 

--- a/ui/internal/wallet/service.go
+++ b/ui/internal/wallet/service.go
@@ -63,6 +63,7 @@ func cloneAccount(acct *Account) *Account {
 		StakeAddress:     acct.StakeAddress,
 		ReceiveAddresses: cloneStringSlice(acct.ReceiveAddresses),
 		DRepKeyHash:      acct.DRepKeyHash,
+		ChangeAddresses:  cloneStringSlice(acct.ChangeAddresses),
 	}
 }
 

--- a/ui/internal/webui/dist/index.html
+++ b/ui/internal/webui/dist/index.html
@@ -1,7 +1,39 @@
 <!doctype html>
 <html lang="en">
-  <head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Bursa Wallet</title>  <script type="module" crossorigin src="/assets/index-B_Wl8VO8.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-C2kL1fv_.css">
-</head>
-  <body><div id="root"></div></body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Bursa Wallet</title>
+  </head>
+  <body>
+    <!--
+      Pre-build placeholder.
+
+      This file is the only thing under ui/internal/webui/dist/ that is tracked
+      in git (the hashed JS/CSS bundles are .gitignore'd build output). It exists
+      so `//go:embed dist` compiles from a clean checkout, and it is served as-is
+      if the binary is run before the web UI has been built — hence the message
+      below. `npm run build` (vite, emptyOutDir) overwrites this with the real
+      compiled index.html and its assets; do not commit that build output.
+
+      No inline CSS/JS on purpose: the server sends Content-Security-Policy
+      `default-src 'self'`, which blocks inline styles and scripts, so this page
+      stays intentionally plain.
+    -->
+    <h1>Bursa Wallet — web UI not built yet</h1>
+    <p>
+      The single-page app that ships embedded in <code>bursa-wallet</code> has
+      not been built. You are seeing the placeholder that is committed in its
+      place.
+    </p>
+    <p>To build the web UI, run:</p>
+    <pre>cd ui/web
+npm install
+npm run build</pre>
+    <p>
+      That compiles the app into <code>ui/internal/webui/dist/</code> (replacing
+      this file). Rebuild the <code>bursa-wallet</code> binary afterwards so the
+      embedded assets are picked up.
+    </p>
+  </body>
 </html>

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -26,6 +26,15 @@ import type {
   DRepInfo,
   DelegationRequest,
   DelegationPreview,
+  PoolCredentials,
+  KESPeriodInfo,
+  OpCert,
+  OpCertPayload,
+  PoolMetadataInput,
+  PoolMetadataResult,
+  PoolRegistrationParams,
+  PoolCertResult,
+  PoolIDResult,
 } from "./types";
 
 export class ApiError extends Error {
@@ -126,3 +135,53 @@ export const buildDelegation = (req: DelegationRequest) =>
   apiPost<DelegationPreview>("/wallet/delegation", req);
 export const confirmDelegation = (id: string, password: string) =>
   apiPost<TxResult>(`/wallet/delegation/${encodeURIComponent(id)}/confirm`, { password });
+
+// --- Stake Pool Operations (SPO) ---
+
+export const poolCredentials = (password: string) =>
+  apiPost<PoolCredentials>("/wallet/pool/credentials", { password });
+export const poolKESPeriod = () => apiGet<KESPeriodInfo>("/wallet/pool/kes-period");
+export const poolIssueOpCert = (req: {
+  password: string;
+  kes_index: number;
+  issue_number: number;
+  kes_period: number;
+}) => apiPost<OpCert>("/wallet/pool/opcert", req);
+export const poolRotateKES = (req: {
+  password: string;
+  new_kes_index: number;
+  prev_issue_number: number;
+  kes_period: number;
+}) => apiPost<OpCert>("/wallet/pool/opcert/rotate", req);
+export const poolOpCertPayload = (req: {
+  kes_vkey_hex: string;
+  issue_number: number;
+  kes_period: number;
+}) => apiPost<OpCertPayload>("/wallet/pool/opcert/payload", req);
+export const poolAssembleOpCert = (req: {
+  cold_vkey_hex: string;
+  kes_vkey_hex: string;
+  signature_hex: string;
+  issue_number: number;
+  kes_period: number;
+}) => apiPost<OpCert>("/wallet/pool/opcert/assemble", req);
+export const poolBuildMetadata = (req: PoolMetadataInput) =>
+  apiPost<PoolMetadataResult>("/wallet/pool/metadata", req);
+export const poolIDFromColdVKey = (cold_vkey_hex: string) =>
+  apiPost<PoolIDResult>("/wallet/pool/id", { cold_vkey_hex });
+export const poolBuildRegistration = (req: PoolRegistrationParams & { password: string }) =>
+  apiPost<PoolCertResult>("/wallet/pool/registration", req);
+export type PoolRegistrationAirGapRequest = PoolRegistrationParams & {
+  cold_vkey_hex: string;
+  vrf_key_hash_hex: string;
+};
+export const poolBuildRegistrationAirGap = (req: PoolRegistrationAirGapRequest) =>
+  apiPost<PoolCertResult>("/wallet/pool/registration/airgap", req);
+export type PoolBuildRetirementCertRequest = { epoch: number } & (
+  | { password: string; cold_vkey_hex?: never }
+  | { cold_vkey_hex: string; password?: never }
+);
+export const poolBuildRetirementCert = (req: PoolBuildRetirementCertRequest) =>
+  apiPost<PoolCertResult>("/wallet/pool/retirement/cert", req);
+export const poolSubmitRetirement = (req: { password: string; epoch: number }) =>
+  apiPost<TxResult>("/wallet/pool/retirement/submit", req);

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -234,6 +234,93 @@ export interface DelegationPreview {
   total: string; // net cost (fee + deposits − withdrawals), decimal lovelace
 }
 
+// --- Stake Pool Operations (SPO) ---
+
+export interface PoolKeyInfo {
+  vkey_hex: string;
+  vkey_bech32?: string;
+  hash_hex: string;
+}
+
+export interface PoolCredentials {
+  network: string;
+  pool_id: string;
+  pool_id_hex: string;
+  cold: PoolKeyInfo;
+  vrf: PoolKeyInfo;
+  kes: PoolKeyInfo;
+  cold_index: number;
+  vrf_index: number;
+  kes_index: number;
+}
+
+export interface KESPeriodInfo {
+  current_period: number;
+  tip_slot: number;
+  slots_per_kes_period: number;
+  max_kes_evolutions: number;
+}
+
+export interface OpCert {
+  kes_vkey_hex: string;
+  issue_number: number;
+  kes_period: number;
+  cold_signature_hex: string;
+  kes_index: number;
+}
+
+export interface OpCertPayload {
+  payload_hex: string;
+  kes_vkey_hex: string;
+  issue_number: number;
+  kes_period: number;
+}
+
+export interface PoolMetadataInput {
+  name: string;
+  ticker: string;
+  homepage: string;
+  description: string;
+}
+
+export interface PoolMetadataResult {
+  json: string;
+  hash_hex: string;
+}
+
+export interface PoolRelayInput {
+  type: "single_host_address" | "single_host_name" | "multi_host_name";
+  ipv4?: string;
+  ipv6?: string;
+  hostname?: string;
+  port?: number;
+}
+
+// RegistrationParams mirrors the backend poolops.RegistrationParams. cold_vkey_hex
+// is only set in the air-gap path (then vrf_key_hash_hex is required too).
+export interface PoolRegistrationParams {
+  pledge: string;
+  cost: string;
+  margin_num: number;
+  margin_denom: number;
+  reward_address?: string;
+  owners?: string[];
+  relays?: PoolRelayInput[];
+  metadata_url?: string;
+  metadata_hash?: string;
+  cold_vkey_hex?: string;
+}
+
+export interface PoolCertResult {
+  pool_id: string;
+  cbor_hex: string;
+}
+
+export interface PoolIDResult {
+  pool_id: string;
+  pool_id_hex: string;
+}
+
 // A wallet as listed by the vault: read-only fields plus whether it's active.
 // The encrypted seed is never exposed.
 export interface WalletView {

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -20,6 +20,7 @@ import { Staking } from "./screens/Staking";
 import { SignMessage } from "./screens/SignMessage";
 import { VerifyMessage } from "./screens/VerifyMessage";
 import { Offline } from "./screens/Offline";
+import { Operate } from "./screens/Operate";
 import { Settings } from "./screens/Settings";
 
 // A Map (not a plain object) so a crafted hash like "#/constructor" or
@@ -41,6 +42,7 @@ const NAV: { key: string; label: string }[] = [
   { key: "sign", label: "Sign" },
   { key: "verify", label: "Verify" },
   { key: "offline", label: "Offline" },
+  { key: "operate", label: "Operate" },
   { key: "settings", label: "Settings" },
 ];
 
@@ -207,6 +209,7 @@ export function App() {
     else if (route === "sign" && canSign) activeRoute = "sign";
     else if (route === "verify") activeRoute = "verify";
     else if (route === "offline" && canSign) activeRoute = "offline";
+    else if (route === "operate" && canSign) activeRoute = "operate";
     else if (ROUTES.has(route) && route !== "send") activeRoute = route;
     else activeRoute = "portfolio";
   }
@@ -247,6 +250,12 @@ export function App() {
     // Air-gap signing needs the active wallet's seed (to sign) but no node for
     // the sign step; falls back to Portfolio without an active wallet.
     content = canSign ? <Offline /> : <Portfolio />;
+  } else if (route === "operate") {
+    // Pool operations derive cold/VRF/KES keys from the seed and need the spend
+    // password. A wallet must be active; otherwise fall back to Portfolio. Most
+    // pool ops are offline; only retirement submission needs a synced node,
+    // gated at the API.
+    content = canSign ? <Operate account={toAccount(activeWallet)} /> : <Portfolio />;
   } else {
     const Screen = ROUTES.get(route) ?? Portfolio;
     content = <Screen />;
@@ -280,7 +289,8 @@ export function App() {
               (key === "send" && !canSend) ||
               (key === "staking" && !canStake) ||
               (key === "sign" && !canSign) ||
-              (key === "offline" && !canSign);
+              (key === "offline" && !canSign) ||
+              (key === "operate" && !canSign);
             const active = key === activeRoute;
             return (
               <button

--- a/ui/web/src/components/CopyButton.tsx
+++ b/ui/web/src/components/CopyButton.tsx
@@ -2,10 +2,17 @@ import { useState } from "react";
 
 interface CopyButtonProps {
   value: string;
+  ariaLabel?: string;
+  "aria-label"?: string;
 }
 
-export function CopyButton({ value }: CopyButtonProps) {
+export function CopyButton({
+  value,
+  ariaLabel,
+  "aria-label": ariaLabelAttribute,
+}: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
+  const label = ariaLabel ?? ariaLabelAttribute;
 
   function handleClick() {
     navigator.clipboard
@@ -21,7 +28,7 @@ export function CopyButton({ value }: CopyButtonProps) {
   }
 
   return (
-    <button type="button" className="btn ghost" onClick={handleClick}>
+    <button type="button" className="btn ghost" onClick={handleClick} aria-label={label}>
       {copied ? "Copied" : "Copy"}
     </button>
   );

--- a/ui/web/src/screens/Activity.test.tsx
+++ b/ui/web/src/screens/Activity.test.tsx
@@ -38,7 +38,7 @@ test("(a) renders block heights for each transaction", () => {
   expect(screen.getByText("12300")).toBeInTheDocument();
 });
 
-test("(b) renders truncated tx hash with a CopyButton that copies the FULL hash", () => {
+test("(b) renders truncated tx hash with a CopyButton that copies the FULL hash", async () => {
   const writeText = vi.fn().mockResolvedValue(undefined);
   Object.assign(navigator, { clipboard: { writeText } });
   mockTransactions([TX1]);
@@ -49,6 +49,7 @@ test("(b) renders truncated tx hash with a CopyButton that copies the FULL hash"
   expect(copyButtons.length).toBeGreaterThanOrEqual(1);
   fireEvent.click(copyButtons[0]);
   expect(writeText).toHaveBeenCalledWith(TX1.tx_hash);
+  expect(await screen.findByText("Copied")).toBeInTheDocument();
 
   // At least the beginning of the hash should be visible
   expect(screen.getByText(new RegExp(TX1.tx_hash.slice(0, 8)))).toBeInTheDocument();

--- a/ui/web/src/screens/Operate.test.tsx
+++ b/ui/web/src/screens/Operate.test.tsx
@@ -1,0 +1,341 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Operate } from "./Operate";
+import * as client from "../api/client";
+import type { Account } from "../api/types";
+
+const account: Account = {
+  network: "preview",
+  stake_address: "stake_test1xreward",
+  receive_addresses: ["addr_test1aaa", "addr_test1bbb"],
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("Operate tabs switch with ArrowRight and ArrowLeft", () => {
+  render(<Operate account={account} />);
+
+  const credentials = screen.getByRole("tab", { name: /credentials/i });
+  credentials.focus();
+  fireEvent.keyDown(credentials, { key: "ArrowRight" });
+
+  const opcert = screen.getByRole("tab", { name: /operational cert/i });
+  expect(opcert).toHaveAttribute("aria-selected", "true");
+  expect(opcert).toHaveFocus();
+  expect(screen.getByRole("button", { name: /read current kes period/i })).toBeInTheDocument();
+
+  fireEvent.keyDown(opcert, { key: "ArrowLeft" });
+
+  expect(credentials).toHaveAttribute("aria-selected", "true");
+  expect(credentials).toHaveFocus();
+  expect(screen.getByRole("button", { name: /generate credentials/i })).toBeInTheDocument();
+});
+
+test("Operate tab aria-controls targets stay mounted", () => {
+  render(<Operate account={account} />);
+
+  for (const tab of screen.getAllByRole("tab")) {
+    const panelID = tab.getAttribute("aria-controls");
+    expect(panelID).toBeTruthy();
+    expect(document.getElementById(panelID!)).toBeInTheDocument();
+  }
+
+  fireEvent.click(screen.getByRole("tab", { name: /retirement/i }));
+
+  for (const tab of screen.getAllByRole("tab")) {
+    const panelID = tab.getAttribute("aria-controls");
+    expect(panelID).toBeTruthy();
+    expect(document.getElementById(panelID!)).toBeInTheDocument();
+  }
+});
+
+test("Credentials tab derives and shows the pool ID + key hashes", async () => {
+  vi.spyOn(client, "poolCredentials").mockResolvedValue({
+    network: "preview",
+    pool_id: "pool1deadbeef",
+    pool_id_hex: "abcd",
+    cold: { vkey_hex: "c0ld", hash_hex: "c0ldhash" },
+    vrf: { vkey_hex: "5f", hash_hex: "5fhash" },
+    kes: { vkey_hex: "ke5", hash_hex: "ke5hash" },
+    cold_index: 0,
+    vrf_index: 0,
+    kes_index: 0,
+  });
+
+  render(<Operate account={account} />);
+  // Credentials is the default tab.
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /generate credentials/i }));
+
+  await waitFor(() => expect(client.poolCredentials).toHaveBeenCalledWith("pw"));
+  expect(await screen.findByText("pool1deadbeef")).toBeInTheDocument();
+  expect(screen.getByText("c0ldhash")).toBeInTheDocument();
+  expect(screen.getByText("5fhash")).toBeInTheDocument();
+  expect(screen.getByText("ke5hash")).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /copy cold verification key/i })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /copy cold key hash/i })).toBeInTheDocument();
+});
+
+test("Credentials password form submits without clicking the button", async () => {
+  vi.spyOn(client, "poolCredentials").mockResolvedValue({
+    network: "preview",
+    pool_id: "pool1deadbeef",
+    pool_id_hex: "abcd",
+    cold: { vkey_hex: "c0ld", hash_hex: "c0ldhash" },
+    vrf: { vkey_hex: "5f", hash_hex: "5fhash" },
+    kes: { vkey_hex: "ke5", hash_hex: "ke5hash" },
+    cold_index: 0,
+    vrf_index: 0,
+    kes_index: 0,
+  });
+
+  render(<Operate account={account} />);
+  const password = screen.getByLabelText(/spending password/i);
+  fireEvent.change(password, { target: { value: "pw" } });
+  fireEvent.submit(password.closest("form")!);
+
+  await waitFor(() => expect(client.poolCredentials).toHaveBeenCalledWith("pw"));
+});
+
+test("Credentials surfaces the API error", async () => {
+  vi.spyOn(client, "poolCredentials").mockRejectedValue(
+    new client.ApiError(401, "incorrect spending password"),
+  );
+  render(<Operate account={account} />);
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "bad" } });
+  fireEvent.click(screen.getByRole("button", { name: /generate credentials/i }));
+  await waitFor(() =>
+    expect(screen.getByText(/incorrect spending password/i)).toBeInTheDocument(),
+  );
+});
+
+test("Operational cert tab reads the current KES period", async () => {
+  vi.spyOn(client, "poolKESPeriod").mockResolvedValue({
+    current_period: 42,
+    tip_slot: 5_443_200,
+    slots_per_kes_period: 129600,
+    max_kes_evolutions: 62,
+  });
+  render(<Operate account={account} />);
+  fireEvent.click(screen.getByRole("tab", { name: /operational cert/i }));
+  fireEvent.click(screen.getByRole("button", { name: /read current kes period/i }));
+  await waitFor(() => expect(screen.getByText("42")).toBeInTheDocument());
+  expect(screen.getByLabelText(/^KES period$/i)).toHaveValue(42);
+});
+
+test("Operational cert clears stale current KES period on refresh failure", async () => {
+  vi.spyOn(client, "poolKESPeriod")
+    .mockResolvedValueOnce({
+      current_period: 42,
+      tip_slot: 5_443_200,
+      slots_per_kes_period: 129600,
+      max_kes_evolutions: 62,
+    })
+    .mockRejectedValueOnce(new client.ApiError(503, "tip unavailable"));
+  render(<Operate account={account} />);
+  fireEvent.click(screen.getByRole("tab", { name: /operational cert/i }));
+
+  fireEvent.click(screen.getByRole("button", { name: /read current kes period/i }));
+  await waitFor(() => expect(screen.getByText("42")).toBeInTheDocument());
+
+  fireEvent.click(screen.getByRole("button", { name: /read current kes period/i }));
+  await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/tip unavailable/i));
+  expect(screen.queryByText("42")).not.toBeInTheDocument();
+  expect(screen.getByLabelText(/^KES period$/i)).toHaveValue(null);
+});
+
+test("Operational cert tab issues an opcert from the seed", async () => {
+  vi.spyOn(client, "poolIssueOpCert").mockResolvedValue({
+    kes_vkey_hex: "ke5vkey",
+    issue_number: 3,
+    kes_period: 7,
+    cold_signature_hex: "5ig",
+    kes_index: 0,
+  });
+  render(<Operate account={account} />);
+  fireEvent.click(screen.getByRole("tab", { name: /operational cert/i }));
+  fireEvent.change(screen.getByLabelText(/^KES period$/i), { target: { value: "7" } });
+  const password = screen.getByLabelText(/spending password/i);
+  fireEvent.change(password, { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /issue certificate/i }));
+  await waitFor(() => expect(client.poolIssueOpCert).toHaveBeenCalled());
+  await waitFor(() => expect(password).toHaveValue(""));
+  expect(await screen.findByText("ke5vkey")).toBeInTheDocument();
+});
+
+test("Registration tab builds a certificate with string lovelace amounts", async () => {
+  vi.spyOn(client, "poolBuildRegistration").mockResolvedValue({
+    pool_id: "pool1reg",
+    cbor_hex: "8a03cafe",
+  });
+  render(<Operate account={account} />);
+  fireEvent.click(screen.getByRole("tab", { name: /registration/i }));
+  fireEvent.change(screen.getByLabelText(/^pledge/i), { target: { value: "9007199254740993" } });
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /build certificate/i }));
+
+  await waitFor(() => expect(client.poolBuildRegistration).toHaveBeenCalled());
+  const call = vi.mocked(client.poolBuildRegistration).mock.calls[0][0];
+  expect(call.password).toBe("pw");
+  expect(call.pledge).toBe("9007199254740993");
+  expect(call.cost).toBe("340000000");
+  expect(await screen.findByText("pool1reg")).toBeInTheDocument();
+  expect(screen.getByText("8a03cafe")).toBeInTheDocument();
+});
+
+test("Registration relay editor adds a relay that is sent to the API", async () => {
+  vi.spyOn(client, "poolBuildRegistration").mockResolvedValue({
+    pool_id: "pool1reg",
+    cbor_hex: "8a03",
+  });
+  render(<Operate account={account} />);
+  fireEvent.click(screen.getByRole("tab", { name: /registration/i }));
+  fireEvent.change(screen.getByLabelText(/^pledge/i), { target: { value: "1" } });
+  fireEvent.click(screen.getByRole("button", { name: /add relay/i }));
+  fireEvent.change(screen.getByLabelText(/relay host/i), { target: { value: "1.2.3.4" } });
+  fireEvent.change(screen.getByLabelText(/relay port/i), { target: { value: "3001" } });
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /build certificate/i }));
+
+  await waitFor(() => expect(client.poolBuildRegistration).toHaveBeenCalled());
+  const call = vi.mocked(client.poolBuildRegistration).mock.calls[0][0];
+  expect(call.relays).toEqual([
+    { type: "single_host_address", ipv4: "1.2.3.4", port: 3001 },
+  ]);
+});
+
+test("Registration clears hidden relay port when switching to DNS SRV", async () => {
+  vi.spyOn(client, "poolBuildRegistration").mockResolvedValue({
+    pool_id: "pool1reg",
+    cbor_hex: "8a03",
+  });
+  render(<Operate account={account} />);
+  fireEvent.click(screen.getByRole("tab", { name: /registration/i }));
+  fireEvent.change(screen.getByLabelText(/^pledge/i), { target: { value: "1" } });
+  fireEvent.click(screen.getByRole("button", { name: /add relay/i }));
+  fireEvent.change(screen.getByLabelText(/relay port/i), { target: { value: "3001" } });
+  fireEvent.change(screen.getByLabelText(/relay type/i), {
+    target: { value: "multi_host_name" },
+  });
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /build certificate/i }));
+
+  await waitFor(() => expect(client.poolBuildRegistration).toHaveBeenCalled());
+  const call = vi.mocked(client.poolBuildRegistration).mock.calls[0][0];
+  expect(call.relays).toBeUndefined();
+});
+
+test("Registration rejects decimal pledge and cost before calling the API", () => {
+  vi.spyOn(client, "poolBuildRegistration").mockResolvedValue({
+    pool_id: "pool1reg",
+    cbor_hex: "8a03",
+  });
+  render(<Operate account={account} />);
+  fireEvent.click(screen.getByRole("tab", { name: /registration/i }));
+
+  fireEvent.change(screen.getByLabelText(/^pledge/i), { target: { value: "1.5" } });
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /build certificate/i }));
+  expect(screen.getByRole("alert")).toHaveTextContent(/pledge must be an integer/i);
+  expect(client.poolBuildRegistration).not.toHaveBeenCalled();
+
+  fireEvent.change(screen.getByLabelText(/^pledge/i), { target: { value: "1" } });
+  fireEvent.change(screen.getByLabelText(/fixed cost/i), {
+    target: { value: "340000000.5" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /build certificate/i }));
+  expect(screen.getByRole("alert")).toHaveTextContent(/cost must be an integer/i);
+  expect(client.poolBuildRegistration).not.toHaveBeenCalled();
+});
+
+test("Registration rejects lovelace amounts above uint64", () => {
+  vi.spyOn(client, "poolBuildRegistration").mockResolvedValue({
+    pool_id: "pool1reg",
+    cbor_hex: "8a03",
+  });
+  render(<Operate account={account} />);
+  fireEvent.click(screen.getByRole("tab", { name: /registration/i }));
+
+  fireEvent.change(screen.getByLabelText(/^pledge/i), {
+    target: { value: "18446744073709551616" },
+  });
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /build certificate/i }));
+
+  expect(screen.getByRole("alert")).toHaveTextContent(/pledge is out of uint64 range/i);
+  expect(client.poolBuildRegistration).not.toHaveBeenCalled();
+});
+
+test("Metadata tab builds the canonical JSON + hash", async () => {
+  vi.spyOn(client, "poolBuildMetadata").mockResolvedValue({
+    json: '{"name":"P","ticker":"T"}',
+    hash_hex: "feedface",
+  });
+  render(<Operate account={account} />);
+  fireEvent.click(screen.getByRole("tab", { name: /metadata/i }));
+  fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: "My Pool" } });
+  fireEvent.change(screen.getByLabelText(/^ticker/i), { target: { value: "POOL" } });
+  fireEvent.click(screen.getByRole("button", { name: /build metadata/i }));
+
+  await waitFor(() => expect(client.poolBuildMetadata).toHaveBeenCalled());
+  expect(await screen.findByText("feedface")).toBeInTheDocument();
+});
+
+test("Retirement tab builds an air-gap certificate from a cold vkey", async () => {
+  vi.spyOn(client, "poolBuildRetirementCert").mockResolvedValue({
+    pool_id: "pool1ret",
+    cbor_hex: "8304",
+  });
+  render(<Operate account={account} />);
+  fireEvent.click(screen.getByRole("tab", { name: /retirement/i }));
+  fireEvent.click(screen.getByRole("button", { name: /air-gap/i }));
+  fireEvent.change(screen.getByLabelText(/retirement epoch/i), { target: { value: "520" } });
+  fireEvent.change(screen.getByLabelText(/cold verification key/i), {
+    target: { value: "c0ld" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /build certificate/i }));
+
+  await waitFor(() =>
+    expect(client.poolBuildRetirementCert).toHaveBeenCalledWith({
+      cold_vkey_hex: "c0ld",
+      epoch: 520,
+    }),
+  );
+  expect(await screen.findByText("pool1ret")).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /copy retirement pool id/i })).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: /copy retirement certificate cbor hex/i }),
+  ).toBeInTheDocument();
+});
+
+test("Retirement tab submits a retirement transaction", async () => {
+  vi.spyOn(client, "poolSubmitRetirement").mockResolvedValue({ tx_hash: "deadbeef" });
+  render(<Operate account={account} />);
+  fireEvent.click(screen.getByRole("tab", { name: /retirement/i }));
+  fireEvent.change(screen.getByLabelText(/retirement epoch/i), { target: { value: "520" } });
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /build & submit retirement/i }));
+
+  await waitFor(() =>
+    expect(client.poolSubmitRetirement).toHaveBeenCalledWith({ password: "pw", epoch: 520 }),
+  );
+  expect(await screen.findByText("deadbeef")).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: /copy retirement transaction hash/i }),
+  ).toBeInTheDocument();
+});
+
+test("Retirement rejects unsafe epoch integers before calling the API", () => {
+  vi.spyOn(client, "poolSubmitRetirement").mockResolvedValue({ tx_hash: "deadbeef" });
+  render(<Operate account={account} />);
+  fireEvent.click(screen.getByRole("tab", { name: /retirement/i }));
+  fireEvent.change(screen.getByLabelText(/retirement epoch/i), {
+    target: { value: "9007199254740993" },
+  });
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /build & submit retirement/i }));
+
+  expect(screen.getByRole("alert")).toHaveTextContent(/retirement epoch must be a non-negative integer/i);
+  expect(client.poolSubmitRetirement).not.toHaveBeenCalled();
+});

--- a/ui/web/src/screens/Operate.tsx
+++ b/ui/web/src/screens/Operate.tsx
@@ -1,0 +1,104 @@
+import { useRef } from "react";
+import { useState } from "react";
+import type { KeyboardEvent } from "react";
+import type { Account } from "../api/types";
+import { Card } from "../components/Card";
+import { Credentials } from "./operate/Credentials";
+import { OperationalCert } from "./operate/OperationalCert";
+import { Registration } from "./operate/Registration";
+import { Retirement } from "./operate/Retirement";
+import { MetadataBuilder } from "./operate/MetadataBuilder";
+
+interface OperateProps {
+  account: Account;
+}
+
+type Tab = "credentials" | "opcert" | "registration" | "retirement" | "metadata";
+
+const TABS: { key: Tab; label: string }[] = [
+  { key: "credentials", label: "Credentials" },
+  { key: "opcert", label: "Operational cert" },
+  { key: "registration", label: "Registration" },
+  { key: "retirement", label: "Retirement" },
+  { key: "metadata", label: "Metadata" },
+];
+
+// Operate is the Stake Pool Operations (SPO) toolkit: generate cold/VRF/KES
+// credentials, issue/rotate operational certificates, build pool
+// registration/update/retirement certificates, and build hostable pool
+// metadata. Each tab maps to a backend /wallet/pool/… endpoint and operates on
+// the active wallet (spending operations require the spend password).
+export function Operate({ account }: OperateProps) {
+  const [tab, setTab] = useState<Tab>("credentials");
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  function handleKeyDown(e: KeyboardEvent<HTMLButtonElement>, idx: number) {
+    let next = idx;
+    if (e.key === "ArrowRight") {
+      next = (idx + 1) % TABS.length;
+    } else if (e.key === "ArrowLeft") {
+      next = (idx - 1 + TABS.length) % TABS.length;
+    } else {
+      return;
+    }
+    e.preventDefault();
+    setTab(TABS[next].key);
+    tabRefs.current[next]?.focus();
+  }
+
+  function renderPanel(key: Tab) {
+    switch (key) {
+      case "credentials":
+        return <Credentials />;
+      case "opcert":
+        return <OperationalCert />;
+      case "registration":
+        return <Registration account={account} />;
+      case "retirement":
+        return <Retirement />;
+      case "metadata":
+        return <MetadataBuilder />;
+    }
+  }
+
+  return (
+    <div className="operate">
+      <Card title="Stake Pool Operations">
+        <p className="helper-text">
+          Operate a stake pool from this wallet&rsquo;s seed, or air-gap the cold
+          key. All data comes from your own node — nothing is fetched externally.
+        </p>
+        <div className="operate-tabs" role="tablist">
+          {TABS.map(({ key, label }, idx) => (
+            <button
+              key={key}
+              ref={(el) => { tabRefs.current[idx] = el; }}
+              role="tab"
+              id={`operate-tab-${key}`}
+              aria-selected={tab === key}
+              aria-controls={`operate-panel-${key}`}
+              tabIndex={tab === key ? 0 : -1}
+              className={tab === key ? "operate-tab active" : "operate-tab"}
+              onClick={() => setTab(key)}
+              onKeyDown={(e) => handleKeyDown(e, idx)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </Card>
+
+      {TABS.map(({ key }) => (
+        <div
+          key={key}
+          role="tabpanel"
+          id={`operate-panel-${key}`}
+          aria-labelledby={`operate-tab-${key}`}
+          hidden={tab !== key}
+        >
+          {tab === key ? renderPanel(key) : null}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/ui/web/src/screens/Receive.test.tsx
+++ b/ui/web/src/screens/Receive.test.tsx
@@ -23,7 +23,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-test("(a) next unused address card copies the FULL address", () => {
+test("(a) next unused address card copies the FULL address", async () => {
   const writeText = vi.fn().mockResolvedValue(undefined);
   Object.assign(navigator, { clipboard: { writeText } });
   mockAddresses();
@@ -38,6 +38,7 @@ test("(a) next unused address card copies the FULL address", () => {
   expect(copyButtons.length).toBeGreaterThanOrEqual(1);
   fireEvent.click(copyButtons[0]);
   expect(writeText).toHaveBeenCalledWith(ADDR_B);
+  expect(await screen.findByText("Copied")).toBeInTheDocument();
 });
 
 test("(b) renders a table listing all receive addresses", () => {

--- a/ui/web/src/screens/Settings.test.tsx
+++ b/ui/web/src/screens/Settings.test.tsx
@@ -44,7 +44,7 @@ test("(a) renders network from account prop", () => {
   expect(screen.getByText("preview")).toBeInTheDocument();
 });
 
-test("(b) renders stake address in monospace and a CopyButton for it", () => {
+test("(b) renders stake address in monospace and a CopyButton for it", async () => {
   const writeText = vi.fn().mockResolvedValue(undefined);
   Object.assign(navigator, { clipboard: { writeText } });
   mockStatus("ready", 12345, true);
@@ -56,6 +56,7 @@ test("(b) renders stake address in monospace and a CopyButton for it", () => {
   // The copy button must copy the FULL stake address.
   fireEvent.click(screen.getByRole("button", { name: /copy/i }));
   expect(writeText).toHaveBeenCalledWith(mockAccount.stake_address);
+  expect(await screen.findByText("Copied")).toBeInTheDocument();
 });
 
 test("(c) renders sync state pill from useStatus", () => {

--- a/ui/web/src/screens/operate/Credentials.tsx
+++ b/ui/web/src/screens/operate/Credentials.tsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import { Card } from "../../components/Card";
+import { Input } from "../../components/Input";
+import { Button } from "../../components/Button";
+import { CopyButton } from "../../components/CopyButton";
+import { poolCredentials } from "../../api/client";
+import type { PoolCredentials, PoolKeyInfo } from "../../api/types";
+import { errorMessage } from "./shared";
+
+function KeyReadout({ label, info }: { label: string; info: PoolKeyInfo }) {
+  return (
+    <div className="key-readout">
+      <p className="field-label">{label} verification key</p>
+      <div className="tx-hash-row">
+        <code className="tx-hash">{info.vkey_hex}</code>
+        <CopyButton value={info.vkey_hex} aria-label={`Copy ${label} verification key`} />
+      </div>
+      <p className="field-label">{label} key hash</p>
+      <div className="tx-hash-row">
+        <code className="tx-hash">{info.hash_hex}</code>
+        <CopyButton value={info.hash_hex} aria-label={`Copy ${label} key hash`} />
+      </div>
+    </div>
+  );
+}
+
+// Credentials derives the active wallet's pool cold/VRF/KES credentials from
+// the wallet seed (CIP-1853) and shows the verification keys, key hashes, and
+// the derived pool ID. It requires the spending password; no node is needed.
+export function Credentials() {
+  const [password, setPassword] = useState("");
+  const [creds, setCreds] = useState<PoolCredentials | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleGenerate() {
+    if (loading || !password) return;
+    setError(null);
+    setCreds(null);
+    setLoading(true);
+    try {
+      setCreds(await poolCredentials(password));
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setPassword("");
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card title="Pool credentials">
+      <form
+        className="operate-form"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void handleGenerate();
+        }}
+      >
+        <p className="helper-text">
+          Derive this pool&rsquo;s cold, VRF, and KES keys from the wallet seed and
+          show the resulting pool ID. The cold signing key never leaves memory.
+        </p>
+        <label htmlFor="cred-password">Spending password</label>
+        <Input
+          id="cred-password"
+          type="password"
+          value={password}
+          onChange={(e) => {
+            setPassword(e.target.value);
+            setError(null);
+          }}
+          placeholder="Spending password"
+          aria-label="Spending password"
+          disabled={loading}
+        />
+        {error && (
+          <p role="alert" className="error-text">
+            {error}
+          </p>
+        )}
+        <Button type="submit" disabled={loading || !password}>
+          {loading ? "Deriving…" : "Generate credentials"}
+        </Button>
+
+        {creds && (
+          <div className="creds-result">
+            <p className="field-label">Pool ID</p>
+            <div className="tx-hash-row">
+              <code className="tx-hash accent">{creds.pool_id}</code>
+              <CopyButton value={creds.pool_id} aria-label="Copy Pool ID" />
+            </div>
+            <KeyReadout label="Cold" info={creds.cold} />
+            <KeyReadout label="VRF" info={creds.vrf} />
+            <KeyReadout label="KES" info={creds.kes} />
+          </div>
+        )}
+      </form>
+    </Card>
+  );
+}

--- a/ui/web/src/screens/operate/MetadataBuilder.tsx
+++ b/ui/web/src/screens/operate/MetadataBuilder.tsx
@@ -1,0 +1,120 @@
+import { useState } from "react";
+import { Card } from "../../components/Card";
+import { Input } from "../../components/Input";
+import { Button } from "../../components/Button";
+import { CopyButton } from "../../components/CopyButton";
+import { poolBuildMetadata } from "../../api/client";
+import type { PoolMetadataResult } from "../../api/types";
+import { errorMessage } from "./shared";
+
+// MetadataBuilder turns operator-supplied pool metadata (name, ticker, homepage,
+// description) into canonical RFC 8785 (JCS) JSON and its Blake2b-256 hash. The
+// operator hosts the JSON and references the URL + hash in the registration
+// certificate. Nothing is fetched — the metadata is provided here.
+export function MetadataBuilder() {
+  const [name, setName] = useState("");
+  const [ticker, setTicker] = useState("");
+  const [homepage, setHomepage] = useState("");
+  const [description, setDescription] = useState("");
+  const [result, setResult] = useState<PoolMetadataResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleBuild() {
+    setError(null);
+    setResult(null);
+    setLoading(true);
+    try {
+      setResult(
+        await poolBuildMetadata({
+          name: name.trim(),
+          ticker: ticker.trim(),
+          homepage: homepage.trim(),
+          description: description.trim(),
+        }),
+      );
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card title="Pool metadata">
+      <div className="operate-form">
+        <p className="helper-text">
+          Build the metadata document you host and reference in registration. The
+          hash below is what goes in the registration certificate.
+        </p>
+
+        <label htmlFor="md-name">Name</label>
+        <Input
+          id="md-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="My Stake Pool"
+          disabled={loading}
+        />
+
+        <label htmlFor="md-ticker">Ticker</label>
+        <Input
+          id="md-ticker"
+          type="text"
+          value={ticker}
+          onChange={(e) => setTicker(e.target.value)}
+          placeholder="POOL"
+          disabled={loading}
+        />
+
+        <label htmlFor="md-homepage">Homepage</label>
+        <Input
+          id="md-homepage"
+          type="text"
+          value={homepage}
+          onChange={(e) => setHomepage(e.target.value)}
+          placeholder="https://pool.example"
+          disabled={loading}
+        />
+
+        <label htmlFor="md-description">Description</label>
+        <textarea
+          id="md-description"
+          className="field"
+          rows={3}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="A short description of your pool…"
+          aria-label="Description"
+          disabled={loading}
+        />
+
+        {error && (
+          <p role="alert" className="error-text">
+            {error}
+          </p>
+        )}
+
+        <Button onClick={handleBuild} disabled={loading || !name.trim() || !ticker.trim()}>
+          {loading ? "Building…" : "Build metadata"}
+        </Button>
+
+        {result && (
+          <div className="metadata-result">
+            <p className="field-label">Metadata hash (Blake2b-256)</p>
+            <div className="tx-hash-row">
+              <code className="tx-hash accent">{result.hash_hex}</code>
+              <CopyButton value={result.hash_hex} />
+            </div>
+            <p className="field-label">Canonical JSON (host this at your metadata URL)</p>
+            <div className="tx-hash-row">
+              <code className="tx-hash">{result.json}</code>
+              <CopyButton value={result.json} />
+            </div>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/ui/web/src/screens/operate/OperationalCert.tsx
+++ b/ui/web/src/screens/operate/OperationalCert.tsx
@@ -1,0 +1,419 @@
+import { useEffect, useRef, useState } from "react";
+import { Card } from "../../components/Card";
+import { Input } from "../../components/Input";
+import { Button } from "../../components/Button";
+import { CopyButton } from "../../components/CopyButton";
+import {
+  poolKESPeriod,
+  poolIssueOpCert,
+  poolRotateKES,
+  poolOpCertPayload,
+  poolAssembleOpCert,
+} from "../../api/client";
+import type { OpCert, OpCertPayload, KESPeriodInfo } from "../../api/types";
+import { errorMessage } from "./shared";
+
+type Mode = "seed" | "airgap";
+
+function useKESPeriodInput(currentKESPeriod?: number) {
+  const initialAutoValue = currentKESPeriod == null ? null : String(currentKESPeriod);
+  const autoValue = useRef<string | null>(initialAutoValue);
+  const [kesPeriod, setKesPeriod] = useState(initialAutoValue ?? "");
+
+  useEffect(() => {
+    const nextAutoValue = currentKESPeriod == null ? null : String(currentKESPeriod);
+    setKesPeriod((prev) => {
+      const wasAutoFilled = autoValue.current !== null && prev === autoValue.current;
+      const shouldUseCurrent =
+        nextAutoValue !== null && (wasAutoFilled || prev.trim() === "" || prev.trim() === "0");
+      const shouldClearStale = nextAutoValue === null && wasAutoFilled;
+      autoValue.current = nextAutoValue;
+      if (shouldUseCurrent) return nextAutoValue;
+      if (shouldClearStale) return "";
+      return prev;
+    });
+  }, [currentKESPeriod]);
+
+  return [kesPeriod, setKesPeriod] as const;
+}
+
+function parseNonNegativeInteger(value: string, label: string): number {
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(`${label} must be a whole number`);
+  }
+  const n = Number(trimmed);
+  if (!Number.isSafeInteger(n)) {
+    throw new Error(`${label} is out of safe integer range`);
+  }
+  return n;
+}
+
+function OpCertResult({ opcert }: { opcert: OpCert }) {
+  return (
+    <div className="opcert-result">
+      <dl className="preview-summary">
+        <div className="dl-row">
+          <dt>Issue number</dt>
+          <dd>{opcert.issue_number}</dd>
+        </div>
+        <div className="dl-row">
+          <dt>KES period</dt>
+          <dd>{opcert.kes_period}</dd>
+        </div>
+      </dl>
+      <p className="field-label">KES verification key</p>
+      <div className="tx-hash-row">
+        <code className="tx-hash">{opcert.kes_vkey_hex}</code>
+        <CopyButton value={opcert.kes_vkey_hex} />
+      </div>
+      <p className="field-label">Cold signature</p>
+      <div className="tx-hash-row">
+        <code className="tx-hash">{opcert.cold_signature_hex}</code>
+        <CopyButton value={opcert.cold_signature_hex} />
+      </div>
+    </div>
+  );
+}
+
+// OperationalCert issues an operational certificate (binding the KES key to the
+// cold key), supports KES rotation (new KES key + incremented issue counter),
+// and shows the current KES period (node tip ÷ slots-per-KES-period). It works
+// from the wallet seed or via an air-gapped cold key.
+export function OperationalCert() {
+  const [mode, setMode] = useState<Mode>("seed");
+  const [kes, setKes] = useState<KESPeriodInfo | null>(null);
+  const [kesError, setKesError] = useState<string | null>(null);
+
+  async function loadKESPeriod() {
+    setKesError(null);
+    setKes(null);
+    try {
+      setKes(await poolKESPeriod());
+    } catch (e) {
+      setKesError(errorMessage(e));
+    }
+  }
+
+  return (
+    <Card title="Operational certificate">
+      <div className="operate-form">
+        <div className="kes-period">
+          <Button variant="ghost" onClick={loadKESPeriod}>
+            Read current KES period
+          </Button>
+          {kes && (
+            <dl className="preview-summary">
+              <div className="dl-row">
+                <dt>Current KES period</dt>
+                <dd className="accent">{kes.current_period}</dd>
+              </div>
+              <div className="dl-row">
+                <dt>Tip slot</dt>
+                <dd>{kes.tip_slot}</dd>
+              </div>
+              <div className="dl-row">
+                <dt>Slots / KES period</dt>
+                <dd>{kes.slots_per_kes_period}</dd>
+              </div>
+            </dl>
+          )}
+          {kesError && (
+            <p role="alert" className="error-text">
+              {kesError}
+            </p>
+          )}
+        </div>
+
+        <div className="mode-toggle">
+          <button
+            type="button"
+            aria-pressed={mode === "seed"}
+            className={mode === "seed" ? "operate-tab active" : "operate-tab"}
+            onClick={() => setMode("seed")}
+          >
+            From wallet seed
+          </button>
+          <button
+            type="button"
+            aria-pressed={mode === "airgap"}
+            className={mode === "airgap" ? "operate-tab active" : "operate-tab"}
+            onClick={() => setMode("airgap")}
+          >
+            Air-gap
+          </button>
+        </div>
+
+        {mode === "seed" ? (
+          <SeedOpCert currentKESPeriod={kes?.current_period} />
+        ) : (
+          <AirGapOpCert currentKESPeriod={kes?.current_period} />
+        )}
+      </div>
+    </Card>
+  );
+}
+
+// SeedOpCert issues or rotates an opcert using the wallet seed.
+function SeedOpCert({ currentKESPeriod }: { currentKESPeriod?: number }) {
+  const [rotate, setRotate] = useState(false);
+  const [password, setPassword] = useState("");
+  const [kesIndex, setKesIndex] = useState("0");
+  const [issueNumber, setIssueNumber] = useState("0");
+  const [kesPeriod, setKesPeriod] = useKESPeriodInput(currentKESPeriod);
+  const [opcert, setOpcert] = useState<OpCert | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit() {
+    setError(null);
+    setOpcert(null);
+    setLoading(true);
+    const spendingPassword = password;
+    setPassword("");
+    try {
+      const kesIndexN = parseNonNegativeInteger(kesIndex, rotate ? "New KES key index" : "KES key index");
+      const issueNumberN = parseNonNegativeInteger(issueNumber, rotate ? "Previous issue number" : "Issue number");
+      const kesPeriodN = parseNonNegativeInteger(kesPeriod, "KES period");
+      if (rotate) {
+        setOpcert(
+          await poolRotateKES({
+            password: spendingPassword,
+            new_kes_index: kesIndexN,
+            prev_issue_number: issueNumberN,
+            kes_period: kesPeriodN,
+          }),
+        );
+      } else {
+        setOpcert(
+          await poolIssueOpCert({
+            password: spendingPassword,
+            kes_index: kesIndexN,
+            issue_number: issueNumberN,
+            kes_period: kesPeriodN,
+          }),
+        );
+      }
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="operate-subform">
+      <label className="checkbox-row">
+        <input
+          type="checkbox"
+          checked={rotate}
+          onChange={(e) => setRotate(e.target.checked)}
+          aria-label="KES rotation"
+        />
+        KES rotation (new KES key + incremented counter)
+      </label>
+
+      <label htmlFor="oc-kes-index">{rotate ? "New KES key index" : "KES key index"}</label>
+      <Input
+        id="oc-kes-index"
+        type="number"
+        min="0"
+        value={kesIndex}
+        onChange={(e) => setKesIndex(e.target.value)}
+        disabled={loading}
+      />
+
+      <label htmlFor="oc-issue">{rotate ? "Previous issue number" : "Issue number"}</label>
+      <Input
+        id="oc-issue"
+        type="number"
+        min="0"
+        value={issueNumber}
+        onChange={(e) => setIssueNumber(e.target.value)}
+        disabled={loading}
+      />
+
+      <label htmlFor="oc-period">KES period</label>
+      <Input
+        id="oc-period"
+        type="number"
+        min="0"
+        value={kesPeriod}
+        onChange={(e) => setKesPeriod(e.target.value)}
+        placeholder={currentKESPeriod == null ? "Read current KES period first" : undefined}
+        disabled={loading}
+      />
+
+      <label htmlFor="oc-password">Spending password</label>
+      <Input
+        id="oc-password"
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Spending password"
+        aria-label="Spending password"
+        disabled={loading}
+      />
+
+      {error && (
+        <p role="alert" className="error-text">
+          {error}
+        </p>
+      )}
+
+      <Button onClick={handleSubmit} disabled={loading || !password}>
+        {loading ? "Working…" : rotate ? "Rotate KES" : "Issue certificate"}
+      </Button>
+
+      {opcert && <OpCertResult opcert={opcert} />}
+    </div>
+  );
+}
+
+// AirGapOpCert produces the to-be-signed payload for an offline cold key, then
+// assembles an opcert from the externally-produced signature.
+function AirGapOpCert({ currentKESPeriod }: { currentKESPeriod?: number }) {
+  const [kesVKey, setKesVKey] = useState("");
+  const [coldVKey, setColdVKey] = useState("");
+  const [issueNumber, setIssueNumber] = useState("0");
+  const [kesPeriod, setKesPeriod] = useKESPeriodInput(currentKESPeriod);
+  const [signature, setSignature] = useState("");
+  const [payload, setPayload] = useState<OpCertPayload | null>(null);
+  const [opcert, setOpcert] = useState<OpCert | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handlePayload() {
+    setError(null);
+    setPayload(null);
+    setOpcert(null);
+    setLoading(true);
+    try {
+      const issueNumberN = parseNonNegativeInteger(issueNumber, "Issue number");
+      const kesPeriodN = parseNonNegativeInteger(kesPeriod, "KES period");
+      setPayload(
+        await poolOpCertPayload({
+          kes_vkey_hex: kesVKey.trim(),
+          issue_number: issueNumberN,
+          kes_period: kesPeriodN,
+        }),
+      );
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleAssemble() {
+    setError(null);
+    setOpcert(null);
+    setLoading(true);
+    try {
+      const issueNumberN = parseNonNegativeInteger(issueNumber, "Issue number");
+      const kesPeriodN = parseNonNegativeInteger(kesPeriod, "KES period");
+      setOpcert(
+        await poolAssembleOpCert({
+          cold_vkey_hex: coldVKey.trim(),
+          kes_vkey_hex: kesVKey.trim(),
+          signature_hex: signature.trim(),
+          issue_number: issueNumberN,
+          kes_period: kesPeriodN,
+        }),
+      );
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="operate-subform">
+      <p className="helper-text">
+        Step 1: produce the to-be-signed payload. Step 2: sign it offline with the
+        cold key, then paste the signature to assemble the certificate.
+      </p>
+
+      <label htmlFor="oc-ag-kesvkey">KES verification key (hex)</label>
+      <Input
+        id="oc-ag-kesvkey"
+        type="text"
+        value={kesVKey}
+        onChange={(e) => { setKesVKey(e.target.value); setPayload(null); }}
+        placeholder="32-byte KES vkey, hex"
+        disabled={loading}
+      />
+
+      <label htmlFor="oc-ag-issue">Issue number</label>
+      <Input
+        id="oc-ag-issue"
+        type="number"
+        min="0"
+        value={issueNumber}
+        onChange={(e) => { setIssueNumber(e.target.value); setPayload(null); }}
+        disabled={loading}
+      />
+
+      <label htmlFor="oc-ag-period">KES period</label>
+      <Input
+        id="oc-ag-period"
+        type="number"
+        min="0"
+        value={kesPeriod}
+        onChange={(e) => { setKesPeriod(e.target.value); setPayload(null); }}
+        placeholder={currentKESPeriod == null ? "Read current KES period first" : undefined}
+        disabled={loading}
+      />
+
+      <Button variant="ghost" onClick={handlePayload} disabled={loading || !kesVKey.trim()}>
+        {loading ? "Working…" : "Build to-be-signed payload"}
+      </Button>
+
+      {payload && (
+        <div>
+          <p className="field-label">Payload to sign (hex)</p>
+          <div className="tx-hash-row">
+            <code className="tx-hash">{payload.payload_hex}</code>
+            <CopyButton value={payload.payload_hex} />
+          </div>
+        </div>
+      )}
+
+      <label htmlFor="oc-ag-coldvkey">Cold verification key (hex)</label>
+      <Input
+        id="oc-ag-coldvkey"
+        type="text"
+        value={coldVKey}
+        onChange={(e) => setColdVKey(e.target.value)}
+        placeholder="32-byte cold vkey, hex"
+        disabled={loading}
+      />
+
+      <label htmlFor="oc-ag-sig">Cold signature (hex)</label>
+      <Input
+        id="oc-ag-sig"
+        type="text"
+        value={signature}
+        onChange={(e) => setSignature(e.target.value)}
+        placeholder="64-byte signature, hex"
+        disabled={loading}
+      />
+
+      {error && (
+        <p role="alert" className="error-text">
+          {error}
+        </p>
+      )}
+
+      <Button
+        onClick={handleAssemble}
+        disabled={loading || !coldVKey.trim() || !signature.trim() || !kesVKey.trim()}
+      >
+        {loading ? "Working…" : "Assemble certificate"}
+      </Button>
+
+      {opcert && <OpCertResult opcert={opcert} />}
+    </div>
+  );
+}

--- a/ui/web/src/screens/operate/Registration.tsx
+++ b/ui/web/src/screens/operate/Registration.tsx
@@ -1,0 +1,441 @@
+import { useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
+import { Card } from "../../components/Card";
+import { Input } from "../../components/Input";
+import { Select } from "../../components/Select";
+import { Button } from "../../components/Button";
+import { CopyButton } from "../../components/CopyButton";
+import { poolBuildRegistration, poolBuildRegistrationAirGap } from "../../api/client";
+import type { Account, PoolCertResult, PoolRegistrationParams, PoolRelayInput } from "../../api/types";
+import { errorMessage } from "./shared";
+
+type Mode = "seed" | "airgap";
+
+interface RelayRow {
+  type: PoolRelayInput["type"];
+  host: string; // ipv4 / ipv6 / hostname depending on type
+  port: string;
+}
+
+const RELAY_TYPES = [
+  { value: "single_host_address", label: "IP address" },
+  { value: "single_host_name", label: "DNS name" },
+  { value: "multi_host_name", label: "DNS (SRV)" },
+];
+const UINT64_MAX = BigInt("18446744073709551615");
+
+function toRelayInput(r: RelayRow): PoolRelayInput {
+  const out: PoolRelayInput = { type: r.type };
+  const host = r.host.trim();
+  if (r.type === "single_host_address") {
+    // Heuristic: an address containing ":" is IPv6, otherwise IPv4.
+    if (host.includes(":")) out.ipv6 = host;
+    else out.ipv4 = host;
+  } else {
+    out.hostname = host;
+  }
+  if (r.type !== "multi_host_name" && r.port.trim()) {
+    out.port = Number(r.port);
+  }
+  return out;
+}
+
+function activeRelayRows(rows: RelayRow[]): RelayRow[] {
+  return rows.filter((r) => r.host.trim() || r.port.trim());
+}
+
+function parseIntegerField(value: string, label: string): number {
+  const trimmed = value.trim();
+  if (!/^-?\d+$/.test(trimmed)) {
+    throw new Error(`${label} must be an integer`);
+  }
+  const n = Number(trimmed);
+  if (!Number.isSafeInteger(n)) {
+    throw new Error(`${label} is out of safe integer range`);
+  }
+  return n;
+}
+
+function parseUint64Field(value: string, label: string): string {
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(`${label} must be an integer`);
+  }
+  if (BigInt(trimmed) > UINT64_MAX) {
+    throw new Error(`${label} is out of uint64 range`);
+  }
+  return trimmed;
+}
+
+// validateRelays returns an error message if any relay row is partial or any
+// relay port is out of range/non-integer, so bad relays are caught client-side.
+function validateRelays(rows: RelayRow[]): string | null {
+  for (const r of activeRelayRows(rows)) {
+    if (!r.host.trim()) {
+      return "Relay host is required";
+    }
+    if (r.type === "multi_host_name" || !r.port.trim()) continue;
+    const p = Number(r.port);
+    if (!Number.isFinite(p) || !Number.isInteger(p) || p < 0 || p > 65535) {
+      return `Relay port "${r.port}" is invalid - must be an integer between 0 and 65535`;
+    }
+  }
+  return null;
+}
+
+// Registration builds a pool registration (or update — same certificate with
+// new params) from pledge/cost/margin, the reward account, owners, relays, and
+// optional metadata. It works from the wallet seed or an air-gapped cold vkey
+// (plus VRF key hash). The certificate is the canonical CBOR an operator submits
+// or hands to an offline cold-key signer.
+export function Registration({ account }: { account: Account }) {
+  const [mode, setMode] = useState<Mode>("seed");
+
+  // Shared params.
+  const [pledge, setPledge] = useState("");
+  const [cost, setCost] = useState("340000000");
+  const [marginNum, setMarginNum] = useState("3");
+  const [marginDenom, setMarginDenom] = useState("100");
+  const [rewardAddress, setRewardAddress] = useState("");
+  const [owners, setOwners] = useState("");
+  const [relays, setRelays] = useState<RelayRow[]>([]);
+  const [metadataUrl, setMetadataUrl] = useState("");
+  const [metadataHash, setMetadataHash] = useState("");
+
+  // Mode-specific.
+  const [password, setPassword] = useState("");
+  const [coldVKey, setColdVKey] = useState("");
+  const [vrfHash, setVrfHash] = useState("");
+
+  const [result, setResult] = useState<PoolCertResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  function commonParams() {
+    const ownerList = owners
+      .split(/[\s,]+/)
+      .map((o) => o.trim())
+      .filter(Boolean);
+    const marginNumN = parseIntegerField(marginNum, "Margin numerator");
+    const marginDenomN = parseIntegerField(marginDenom, "Margin denominator");
+    const pledgeN = parseUint64Field(pledge, "Pledge");
+    const costN = parseUint64Field(cost, "Cost");
+    if (marginNumN < 0) {
+      throw new Error("Margin numerator must be greater than or equal to 0");
+    }
+    if (marginDenomN <= 0) {
+      throw new Error("Margin denominator must be greater than 0");
+    }
+    const relayInputs = activeRelayRows(relays).map(toRelayInput);
+    return {
+      pledge: pledgeN,
+      cost: costN,
+      margin_num: marginNumN,
+      margin_denom: marginDenomN,
+      ...(rewardAddress.trim() ? { reward_address: rewardAddress.trim() } : {}),
+      ...(ownerList.length > 0 ? { owners: ownerList } : {}),
+      ...(relayInputs.length > 0 ? { relays: relayInputs } : {}),
+      ...(metadataUrl.trim() ? { metadata_url: metadataUrl.trim() } : {}),
+      ...(metadataHash.trim() ? { metadata_hash: metadataHash.trim() } : {}),
+    };
+  }
+
+  async function handleBuild() {
+    setError(null);
+    setResult(null);
+    if (!pledge.trim() || !cost.trim()) {
+      setError("Pledge and cost are required");
+      return;
+    }
+    const relayErr = validateRelays(relays);
+    if (relayErr) {
+      setError(relayErr);
+      return;
+    }
+    let params: PoolRegistrationParams;
+    try {
+      params = commonParams();
+    } catch (e) {
+      setError(errorMessage(e));
+      return;
+    }
+    setLoading(true);
+    try {
+      if (mode === "seed") {
+        setResult(await poolBuildRegistration({ password, ...params }));
+      } else {
+        setResult(
+          await poolBuildRegistrationAirGap({
+            cold_vkey_hex: coldVKey.trim(),
+            vrf_key_hash_hex: vrfHash.trim(),
+            ...params,
+          }),
+        );
+      }
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card title="Pool registration / update">
+      <div className="operate-form">
+        <div className="mode-toggle">
+          <button
+            type="button"
+            aria-pressed={mode === "seed"}
+            className={mode === "seed" ? "operate-tab active" : "operate-tab"}
+            onClick={() => setMode("seed")}
+          >
+            From wallet seed
+          </button>
+          <button
+            type="button"
+            aria-pressed={mode === "airgap"}
+            className={mode === "airgap" ? "operate-tab active" : "operate-tab"}
+            onClick={() => setMode("airgap")}
+          >
+            Air-gap
+          </button>
+        </div>
+
+        <label htmlFor="reg-pledge">Pledge (lovelace)</label>
+        <Input
+          id="reg-pledge"
+          type="text"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          value={pledge}
+          onChange={(e) => setPledge(e.target.value)}
+          placeholder="100000000"
+          disabled={loading}
+        />
+
+        <label htmlFor="reg-cost">Fixed cost per epoch (lovelace)</label>
+        <Input
+          id="reg-cost"
+          type="text"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          value={cost}
+          onChange={(e) => setCost(e.target.value)}
+          disabled={loading}
+        />
+
+        <div className="field-group">
+          <div>
+            <label htmlFor="reg-margin-num">Margin numerator</label>
+            <Input
+              id="reg-margin-num"
+              type="number"
+              min="0"
+              value={marginNum}
+              onChange={(e) => setMarginNum(e.target.value)}
+              disabled={loading}
+            />
+          </div>
+          <div>
+            <label htmlFor="reg-margin-denom">Margin denominator</label>
+            <Input
+              id="reg-margin-denom"
+              type="number"
+              min="1"
+              value={marginDenom}
+              onChange={(e) => setMarginDenom(e.target.value)}
+              disabled={loading}
+            />
+          </div>
+        </div>
+
+        <label htmlFor="reg-reward">Reward account (defaults to this wallet)</label>
+        <Input
+          id="reg-reward"
+          type="text"
+          value={rewardAddress}
+          onChange={(e) => setRewardAddress(e.target.value)}
+          placeholder={account.stake_address}
+          disabled={loading}
+        />
+
+        <label htmlFor="reg-owners">
+          Owners (stake addresses or key hashes; defaults to this wallet)
+        </label>
+        <Input
+          id="reg-owners"
+          type="text"
+          value={owners}
+          onChange={(e) => setOwners(e.target.value)}
+          placeholder="stake1…, stake1… (comma or space separated)"
+          disabled={loading}
+        />
+
+        <RelayEditor relays={relays} setRelays={setRelays} disabled={loading} />
+
+        <label htmlFor="reg-meta-url">Metadata URL (optional)</label>
+        <Input
+          id="reg-meta-url"
+          type="text"
+          value={metadataUrl}
+          onChange={(e) => setMetadataUrl(e.target.value)}
+          placeholder="https://pool.example/meta.json"
+          disabled={loading}
+        />
+
+        <label htmlFor="reg-meta-hash">Metadata hash (hex, from the Metadata tab)</label>
+        <Input
+          id="reg-meta-hash"
+          type="text"
+          value={metadataHash}
+          onChange={(e) => setMetadataHash(e.target.value)}
+          placeholder="blake2b-256 hex"
+          disabled={loading}
+        />
+
+        {mode === "seed" ? (
+          <>
+            <label htmlFor="reg-password">Spending password</label>
+            <Input
+              id="reg-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Spending password"
+              aria-label="Spending password"
+              disabled={loading}
+            />
+          </>
+        ) : (
+          <>
+            <label htmlFor="reg-coldvkey">Cold verification key (hex)</label>
+            <Input
+              id="reg-coldvkey"
+              type="text"
+              value={coldVKey}
+              onChange={(e) => setColdVKey(e.target.value)}
+              placeholder="32-byte cold vkey, hex"
+              disabled={loading}
+            />
+            <label htmlFor="reg-vrfhash">VRF key hash (hex)</label>
+            <Input
+              id="reg-vrfhash"
+              type="text"
+              value={vrfHash}
+              onChange={(e) => setVrfHash(e.target.value)}
+              placeholder="32-byte VRF key hash, hex"
+              disabled={loading}
+            />
+          </>
+        )}
+
+        {error && (
+          <p role="alert" className="error-text">
+            {error}
+          </p>
+        )}
+
+        <Button
+          onClick={handleBuild}
+          disabled={
+            loading ||
+            (mode === "seed" ? !password : !coldVKey.trim() || !vrfHash.trim())
+          }
+        >
+          {loading ? "Building…" : "Build certificate"}
+        </Button>
+
+        <p className="helper-text">
+          Note: building produces the registration certificate (CBOR). Submitting
+          a registration transaction in-app is not yet wired (see the in-repo TODO
+          on the pool-registration tx path); hand the certificate to your stake-pool
+          tooling, or export it for offline cold-key signing.
+        </p>
+
+        {result && (
+          <div className="cert-result">
+            <p className="field-label">Pool ID</p>
+            <div className="tx-hash-row">
+              <code className="tx-hash accent">{result.pool_id}</code>
+              <CopyButton value={result.pool_id} />
+            </div>
+            <p className="field-label">Certificate (CBOR hex)</p>
+            <div className="tx-hash-row">
+              <code className="tx-hash">{result.cbor_hex}</code>
+              <CopyButton value={result.cbor_hex} />
+            </div>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+interface RelayEditorProps {
+  relays: RelayRow[];
+  setRelays: Dispatch<SetStateAction<RelayRow[]>>;
+  disabled: boolean;
+}
+
+function RelayEditor({ relays, setRelays, disabled }: RelayEditorProps) {
+  function add() {
+    setRelays((prev) => [...prev, { type: "single_host_address", host: "", port: "" }]);
+  }
+  function remove(i: number) {
+    setRelays((prev) => prev.filter((_, idx) => idx !== i));
+  }
+  function update(i: number, field: keyof RelayRow, value: string) {
+    setRelays((prev) =>
+      prev.map((r, idx) => {
+        if (idx !== i) return r;
+        const next = { ...r, [field]: value };
+        if (field === "type" && value === "multi_host_name") {
+          next.port = "";
+        }
+        return next;
+      }),
+    );
+  }
+
+  return (
+    <div className="relay-editor">
+      <p className="field-label">Relays</p>
+      {relays.map((r, i) => (
+        <div key={i} className="relay-row">
+          <Select
+            options={RELAY_TYPES}
+            value={r.type}
+            onChange={(e) => update(i, "type", e.target.value)}
+            aria-label="Relay type"
+            disabled={disabled}
+          />
+          <Input
+            type="text"
+            value={r.host}
+            onChange={(e) => update(i, "host", e.target.value)}
+            placeholder={r.type === "single_host_address" ? "IP address" : "hostname"}
+            aria-label="Relay host"
+            disabled={disabled}
+          />
+          {r.type !== "multi_host_name" && (
+            <Input
+              type="number"
+              min="0"
+              value={r.port}
+              onChange={(e) => update(i, "port", e.target.value)}
+              placeholder="port"
+              aria-label="Relay port"
+              disabled={disabled}
+            />
+          )}
+          <Button variant="ghost" onClick={() => remove(i)} disabled={disabled}>
+            Remove
+          </Button>
+        </div>
+      ))}
+      <Button variant="ghost" onClick={add} disabled={disabled}>
+        + Add relay
+      </Button>
+    </div>
+  );
+}

--- a/ui/web/src/screens/operate/Retirement.tsx
+++ b/ui/web/src/screens/operate/Retirement.tsx
@@ -1,0 +1,194 @@
+import { useState } from "react";
+import { Card } from "../../components/Card";
+import { Input } from "../../components/Input";
+import { Button } from "../../components/Button";
+import { CopyButton } from "../../components/CopyButton";
+import { poolBuildRetirementCert, poolSubmitRetirement } from "../../api/client";
+import type { PoolCertResult, TxResult } from "../../api/types";
+import { errorMessage } from "./shared";
+
+type Mode = "seed" | "airgap";
+
+// Retirement builds a pool retirement certificate for a given epoch and (in the
+// seed path) submits it as a transaction witnessed by the cold key. Retirement
+// is the one pool operation whose tx is submitted in-app; the certificate can
+// also be exported for an air-gapped cold key.
+export function Retirement() {
+  const [mode, setMode] = useState<Mode>("seed");
+  const [epoch, setEpoch] = useState("");
+  const [password, setPassword] = useState("");
+  const [coldVKey, setColdVKey] = useState("");
+  const [cert, setCert] = useState<PoolCertResult | null>(null);
+  const [tx, setTx] = useState<TxResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  function parseEpoch(): number | null {
+    const trimmed = epoch.trim();
+    if (!/^\d+$/.test(trimmed)) return null;
+    const n = Number(trimmed);
+    if (!Number.isSafeInteger(n)) return null;
+    return n;
+  }
+
+  async function handleBuild() {
+    setError(null);
+    setCert(null);
+    setTx(null);
+    if (!epoch.trim()) {
+      setError("Retirement epoch is required");
+      return;
+    }
+    const epochNum = parseEpoch();
+    if (epochNum === null) {
+      setError("Retirement epoch must be a non-negative integer");
+      return;
+    }
+    setLoading(true);
+    try {
+      if (mode === "seed") {
+        setCert(await poolBuildRetirementCert({ password, epoch: epochNum }));
+      } else {
+        setCert(await poolBuildRetirementCert({ cold_vkey_hex: coldVKey.trim(), epoch: epochNum }));
+      }
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleSubmit() {
+    setError(null);
+    setTx(null);
+    const epochNum = parseEpoch();
+    if (epochNum === null) {
+      setError("Retirement epoch must be a non-negative integer");
+      return;
+    }
+    setLoading(true);
+    try {
+      setTx(await poolSubmitRetirement({ password, epoch: epochNum }));
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card title="Pool retirement">
+      <div className="operate-form">
+        <p className="helper-text">
+          Retire the pool at the start of the given epoch. Building shows the
+          certificate; submitting broadcasts a retirement transaction signed by
+          the cold key (needs a synced node).
+        </p>
+
+        <div className="mode-toggle">
+          <button
+            type="button"
+            aria-pressed={mode === "seed"}
+            className={mode === "seed" ? "operate-tab active" : "operate-tab"}
+            onClick={() => setMode("seed")}
+          >
+            From wallet seed
+          </button>
+          <button
+            type="button"
+            aria-pressed={mode === "airgap"}
+            className={mode === "airgap" ? "operate-tab active" : "operate-tab"}
+            onClick={() => setMode("airgap")}
+          >
+            Air-gap
+          </button>
+        </div>
+
+        <label htmlFor="ret-epoch">Retirement epoch</label>
+        <Input
+          id="ret-epoch"
+          type="number"
+          min="0"
+          value={epoch}
+          onChange={(e) => setEpoch(e.target.value)}
+          placeholder="e.g. 520"
+          disabled={loading}
+        />
+
+        {mode === "seed" ? (
+          <>
+            <label htmlFor="ret-password">Spending password</label>
+            <Input
+              id="ret-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Spending password"
+              aria-label="Spending password"
+              disabled={loading}
+            />
+          </>
+        ) : (
+          <>
+            <label htmlFor="ret-coldvkey">Cold verification key (hex)</label>
+            <Input
+              id="ret-coldvkey"
+              type="text"
+              value={coldVKey}
+              onChange={(e) => setColdVKey(e.target.value)}
+              placeholder="32-byte cold vkey, hex"
+              disabled={loading}
+            />
+          </>
+        )}
+
+        {error && (
+          <p role="alert" className="error-text">
+            {error}
+          </p>
+        )}
+
+        <div className="preview-actions">
+          <Button
+            variant="ghost"
+            onClick={handleBuild}
+            disabled={loading || (mode === "seed" ? !password : !coldVKey.trim())}
+          >
+            {loading ? "Working…" : "Build certificate"}
+          </Button>
+          {mode === "seed" && (
+            <Button onClick={handleSubmit} disabled={loading || !password || !epoch.trim()}>
+              {loading ? "Submitting…" : "Build & submit retirement"}
+            </Button>
+          )}
+        </div>
+
+        {cert && (
+          <div className="cert-result">
+            <p className="field-label">Pool ID</p>
+            <div className="tx-hash-row">
+              <code className="tx-hash accent">{cert.pool_id}</code>
+              <CopyButton value={cert.pool_id} aria-label="Copy retirement pool ID" />
+            </div>
+            <p className="field-label">Certificate (CBOR hex)</p>
+            <div className="tx-hash-row">
+              <code className="tx-hash">{cert.cbor_hex}</code>
+              <CopyButton value={cert.cbor_hex} aria-label="Copy retirement certificate CBOR hex" />
+            </div>
+          </div>
+        )}
+
+        {tx && (
+          <div className="done-details">
+            <p>Retirement transaction submitted.</p>
+            <p className="field-label">Transaction hash</p>
+            <div className="tx-hash-row">
+              <code className="tx-hash">{tx.tx_hash}</code>
+              <CopyButton value={tx.tx_hash} aria-label="Copy retirement transaction hash" />
+            </div>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/ui/web/src/screens/operate/shared.ts
+++ b/ui/web/src/screens/operate/shared.ts
@@ -1,0 +1,9 @@
+import { ApiError } from "../../api/client";
+
+// errorMessage normalizes a thrown value into a display string, matching the
+// pattern used across the spending screens.
+export function errorMessage(err: unknown): string {
+  if (err instanceof ApiError) return err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -926,9 +926,6 @@ a:hover {
 }
 .setting-copy ul {
   list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
 }
 .setting-copy li {
   position: relative;
@@ -1107,6 +1104,124 @@ a:hover {
 }
 .total-accent {
   color: var(--accent);
+}
+
+/* ----------------------------------------------- pool operations (SPO) -- */
+.operate {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.operate-form,
+.operate-subform {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-width: 880px;
+}
+.operate-form label,
+.operate-subform label {
+  display: block;
+  font-family: var(--mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: var(--space-1);
+}
+/* Tab / mode strips read as instrument selectors. */
+.operate-tabs,
+.mode-toggle {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  border-top: 1px solid var(--border);
+  padding-top: var(--space-3);
+}
+.operate-tab {
+  font-family: var(--mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: var(--inset);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px var(--space-3);
+  cursor: pointer;
+}
+.operate-tab:hover {
+  color: var(--text);
+  border-color: var(--accent);
+}
+.operate-tab.active {
+  color: var(--accent-text);
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.operate-tab:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-dim);
+}
+
+/* Gold-accented readout for identity values (pool ID, hashes). */
+.tx-hash.accent {
+  color: var(--accent);
+}
+
+.creds-result,
+.opcert-result,
+.cert-result,
+.metadata-result {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  border-top: 1px solid var(--border);
+  padding-top: var(--space-3);
+}
+.key-readout {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-2) 0;
+  border-top: 1px dashed var(--border);
+}
+
+.operate-form .checkbox-row,
+.operate-subform .checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  text-transform: none;
+  letter-spacing: normal;
+  font-family: var(--font);
+  font-size: 0.8125rem;
+  color: var(--text);
+}
+
+.kes-period {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.relay-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.relay-row {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  flex-wrap: wrap;
+}
+.relay-row .field {
+  margin-bottom: 0;
+  flex: 1 1 8rem;
+  min-width: 6rem;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION

<img width="1280" height="860" alt="image" src="https://github.com/user-attachments/assets/6bae049a-0023-4370-8c0d-0267527168b4" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a full Stake Pool Operations toolkit to the wallet, including seed‑derived cold/VRF/KES credentials, KES‑period reading, op cert issue/rotation (seed and air‑gap), pool registration/update/retirement builders, and a metadata builder. Adds `/wallet/pool/*` APIs and an Operate screen; genesis and latest epoch come from the embedded node’s loopback `blockfrost` endpoint (no external calls).

- **New Features**
  - Backend: `poolops` service for CIP‑1853 cold/VRF/KES derivation, pool ID, KES‑period math from new `blockfrost` `Genesis`/latest‑epoch, op cert issue/rotate (seed + air‑gap payload/assembly), and registration/update/retirement builders; metadata uses `github.com/gowebpki/jcs` for RFC 8785 canonical JSON.
  - API: new `/wallet/pool/*` endpoints for credentials, KES period, op cert issue/rotate/payload/assembly, metadata hash+JSON, registration/update/retirement builders, and retirement submit; operates on the active wallet (seed paths require the spending password).
  - Frontend: Operate screen (Credentials, Operational cert, Registration, Retirement, Metadata), client/types, styles, and tests; keyboard tab navigation and improved copy‑to‑clipboard feedback.

- **Bug Fixes**
  - Restore pre‑build placeholder `ui/internal/webui/dist/index.html` so the embedded UI serves a helpful default and builds from a clean checkout.
  - Accessibility and reliability: `CopyButton` now supports ARIA labels; tests wait for the “Copied” state.
  - Account cloning now includes `ChangeAddresses`; account derivation exposes a change address window with tests.
  - Tests updated to call APIs with the correct signatures.

<sup>Written for commit 276e15ac9f5676f2ae824dbf29e4c6b02d761248. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Stake Pool Operations area for managing pool credentials, operational certificates, metadata, registration, and retirement from the app.
  * Added support for viewing the current KES period and generating pool-related certificates and transaction details.
  * Introduced improved copy-to-clipboard and keyboard navigation behavior across the new pool operations screens.

* **Bug Fixes**
  * Improved error handling and form validation for pool operation workflows.
  * Updated copy actions to show confirmation feedback more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->