### PR TITLE
feat(mobile): SPA network resilience (retry/backoff, online-aware polling, offline banner)

### DIFF
--- a/.superpowers/sdd/f1-report.md
+++ b/.superpowers/sdd/f1-report.md
@@ -1,0 +1,79 @@
+# Feature 1 — SPA Network Resilience — Implementation Report
+
+**Date:** 2026-06-29  
+**Branch:** feat/mobile-net-resilience  
+**Spec:** docs/superpowers/specs/2026-06-29-mobile-resilience-design.md § Feature 1  
+**Approach:** TDD (RED→GREEN per piece, no production code before a failing test)
+
+---
+
+## Summary
+
+Three files changed in the SPA (`ui/web/src/`). All strictly TDD. 106 tests pass (16 files). Type-check clean. Build clean. Go embed unaffected.
+
+---
+
+## Changes
+
+### `ui/web/src/api/client.ts`
+
+Added bounded retry + capped exponential backoff inside the `request()` function:
+
+- **Retries only on `TypeError`** (network-level rejections — "Failed to fetch"). These are the only unrecoverable transport failures worth retrying.
+- **Does NOT retry on HTTP responses** (4xx, 5xx). A response, even an error one, means the server received and handled the request — retrying would be wrong.
+- **Does NOT retry on `AbortError`** (explicit timeout/abort signal). These are intentional cancellations.
+- **3 total attempts** (1 initial + 2 retries).
+- **Backoff:** 250ms after attempt 1, capped at 1000ms (250ms → 500ms).
+- Public API surface unchanged: `apiGet`, `apiPost`, `apiPut`, `apiDelete` return/throw the same types as before.
+
+### `ui/web/src/api/hooks.ts`
+
+Modified `useAsync()` to be online-aware:
+
+- **Poll suspension:** the `setInterval` callback skips the fetch if `navigator.onLine === false` OR `document.hidden === true`. The initial fetch (on mount / on `tick` change via `refresh()`) is always allowed regardless.
+- **Online recovery:** a `window 'online'` event listener triggers an immediate `run(false)` call so the UI recovers without waiting for the next poll cycle.
+- **Cleanup:** the `'online'` listener is removed in the effect's cleanup function (unmount or re-effect).
+- Existing `pollMs` behavior unchanged when online and visible.
+
+### `ui/web/src/app.tsx`
+
+Added a small dismissible `OfflineBanner` component:
+
+- Tracks `navigator.onLine` at mount; reacts to `window 'offline'` and `'online'` events via `useEffect`.
+- Going offline shows the banner; coming back online hides it automatically.
+- The user can dismiss it manually (sets a local `dismissed` flag that resets on the next offline/online cycle).
+- Banner uses `role="alert" aria-label="offline"` for screen reader accessibility.
+- Rendered at the top of every render path in `App` (including `FullScreen`, the syncing boot view, and the main unlocked layout), so it appears regardless of vault/unlock state.
+
+---
+
+## Tests
+
+| File | New tests | All tests |
+|------|-----------|-----------|
+| `src/api/client.test.ts` | 3 | 5 |
+| `src/api/hooks.test.tsx` | 3 | 4 |
+| `src/app.test.tsx` | 3 | 16 |
+
+Total suite: **106 tests, 16 files, all pass**.
+
+---
+
+## Verification
+
+```
+npm run type-check   → clean (exit 0)
+npm run test         → 106 passed, 0 failed
+npm run build        → built in ~1.7s, no warnings
+go build ./...       → exit 0 (embed unaffected)
+```
+
+dist/ artifacts restored with `git checkout -- ui/internal/webui/dist/` before commit.
+
+---
+
+## Concerns / Follow-ons
+
+- The retry backoff uses real `setTimeout` in tests — the `persistent network error` test takes ~754ms because it waits out two real backoff delays (250ms + 500ms). This is acceptable for correctness but could be replaced with `vi.useFakeTimers()` if test speed becomes an issue. Opted for real timers to keep tests closer to production behavior.
+- The banner state is local to each `App` mount; if in future the `OfflineBanner` needs to be shared across multiple sub-trees, extracting it to a context would be cleaner.
+- The `document.hidden` check in `useAsync` guards against polling in a background tab but does NOT add a `visibilitychange` listener to resume polling when the tab becomes visible again — that is explicitly Feature 3's scope (`feat/mobile-resume`).

--- a/docs/superpowers/specs/2026-06-29-mobile-resilience-design.md
+++ b/docs/superpowers/specs/2026-06-29-mobile-resilience-design.md
@@ -1,0 +1,116 @@
+# Mobile Resilience — design
+
+**Status:** approved direction (build) · **Date:** 2026-06-29 · **Base:** `feat/mobile` (`0547cb8`, rebased onto current `origin/main`)
+
+## Goal
+
+Make the embedded full-node wallet survive the realities of a phone: the
+network interface changing (WiFi↔cellular, loss→regain) and the app being
+suspended and resumed (Android doze / backgrounding). Today nothing reacts to
+either — the node never re-dials on a network change and nothing re-syncs or
+refetches on resume.
+
+## Architecture
+
+Four features, **stacked** (each builds on the previous), so the shared hot
+files (`mobile.go`, `boot.go`, `supervisor.go`, `MainActivity.kt`, `hooks.ts`,
+`app.tsx`) merge in one direction and the integration branch is just the top of
+the stack:
+
+```
+feat/mobile (rebased base)
+  └─ feat/mobile-net-resilience   (SPA-only; also helps desktop/browser)
+       └─ feat/mobile-reconnect    (Go supervisor + gomobile hook + Android NetworkCallback)
+            └─ feat/mobile-resume   (gomobile hook + Android onResume + SPA visibility)
+                 └─ feat/mobile-foreground  (Android foreground Service)
+integration/mobile-opts = feat/mobile-foreground  →  CI builds the test APK
+```
+
+## Global constraints (every feature)
+
+- **gomobile boundary:** any new EXPORTED method on `ui/mobile.App` may use only
+  gomobile-crossable types (bool, int/int64, float, string, []byte, error,
+  exported structs). New hooks take no args (or scalars) and return `error`.
+- **Pure Go / `CGO_ENABLED=0`** must hold; `GOOS=android GOARCH=arm64
+  CGO_ENABLED=0 go build ./...` must keep passing.
+- **Loopback-only**: no new external network surface; the node is the only thing
+  that talks to the outside.
+- Commits are unsigned WIP (`-c commit.gpgsign=false --no-gpg-sign`); user
+  squashes at merge. Do not push from implementers.
+
+## Feature 1 — `feat/mobile-net-resilience` (SPA only)
+
+**What:** the SPA tolerates transient connectivity loss and recovers fast.
+- `ui/web/src/api/client.ts`: wrap `fetch` with a small bounded retry +
+  backoff for *network* errors (TypeError/`Failed to fetch`), NOT for HTTP 4xx/5xx
+  (those are real responses). A couple of retries, capped backoff.
+- `ui/web/src/api/hooks.ts` (`useAsync`): when `navigator.onLine` is false or
+  `document.hidden`, suspend the poll interval; on the `online` window event,
+  fire an immediate refetch. (Keep the existing `pollMs` behavior otherwise.)
+- `ui/web/src/app.tsx`: a small, dismissible **offline banner** driven by
+  `navigator.onLine` + `online`/`offline` events.
+**Tests:** Vitest — retry-then-succeed on a flaky fetch; no retry on a 500;
+poll suspends when offline and refetches on `online`; banner shows/hides.
+**No Go, no Android.** Independently useful on desktop/browser too.
+
+## Feature 2 — `feat/mobile-reconnect` (Go + gomobile + Android)
+
+**What:** a host network change re-dials the node's peers instead of waiting.
+- `ui/internal/supervisor`: add `Reconnect(ctx)` — bounce the running node's
+  peer connections (re-dial). Simplest correct implementation: relaunch the node
+  run via the existing runID-versioned path (`bootstrapThenLaunch`/run
+  versioning) **preserving DataDir** (no re-bootstrap, no data loss); if dingo
+  exposes a cheaper connmanager re-dial, prefer that. No-op safely if not running.
+- `ui/internal/boot`: `App.OnNetworkChanged()` → `supervisor.Reconnect`.
+- `ui/mobile/mobile.go`: exported `(*App) OnNetworkChanged() error` → `boot.App`.
+- `mobile/android/.../MainActivity.kt`: register a
+  `ConnectivityManager.NetworkCallback`; on `onAvailable`/`onLost` (debounced),
+  call the bound `app.onNetworkChanged()` and reload the WebView.
+**Tests:** Go — `Reconnect` while running relaunches (new runID, DataDir
+unchanged) and is a safe no-op when stopped; `mobile.App.OnNetworkChanged`
+delegates. (Android glue verified in the manual APK pass.)
+
+## Feature 3 — `feat/mobile-resume` (gomobile + Android + SPA)
+
+**What:** on resume from background, the node catches up and the UI refetches.
+- `ui/mobile/mobile.go`: exported `(*App) OnResume() error` → `boot.App.OnResume()`
+  → a supervisor "kick" (status refresh / re-dial if the run died while
+  suspended; reuse `Reconnect` if that's the right primitive).
+- `mobile/android/.../MainActivity.kt`: `onResume()`/`onPause()` overrides →
+  call `app.onResume()` and trigger a WebView refresh.
+- `ui/web/src/app.tsx`: `document 'visibilitychange'` → on becoming visible,
+  refetch the active views (status/balance/activity).
+**Tests:** Go — `OnResume` delegates and is safe before Start; SPA — visibility
+→ refetch fires.
+
+## Feature 4 — `feat/mobile-foreground` (Android only)
+
+**What:** keep the node alive while backgrounded so it stays synced, with a
+persistent notification, rather than being killed by the OS.
+- A `ForegroundService` (Kotlin) that owns the booted wallet (moves the
+  `mobile.App` lifecycle into the service), started foreground with a
+  low-priority "Bursa is syncing" notification; `MainActivity` binds to it and
+  points the WebView at the service's loopback port.
+- `AndroidManifest.xml`: `FOREGROUND_SERVICE` (+ `FOREGROUND_SERVICE_DATA_SYNC`)
+  and `POST_NOTIFICATIONS` permissions; service declaration.
+**No Go change expected** (lifecycle moves Android-side). If a clean
+start/stop-from-service needs a Go hook, keep it scalar/error.
+**Tests:** none automatable here; covered by the manual APK checklist.
+
+## Integration & test APK
+
+- `integration/mobile-opts` = `feat/mobile-foreground` tip (the stack is linear,
+  so the top contains all four). Build the test APK in CI (the NDK is
+  x86_64-only; this dev box is aarch64 — CI is the only build path), via the
+  existing `mobile.yml` `gomobile bind -target=android/arm64` job.
+- Manual checklist (separate doc): install APK → toggle airplane mode / switch
+  WiFi↔cellular and confirm the node re-dials and the UI recovers → background
+  the app for minutes, confirm it stays synced (foreground service) → resume and
+  confirm catch-up + refetch.
+
+## Out of scope / follow-ons
+
+- iOS shell wiring of the same hooks (Android first).
+- TPM-sealed vault key — separate independent track (`feat/tpm-vault-key`,
+  desktop/server), not part of this stack or the APK.
+- Battery/doze tuning beyond keeping the node alive (measure first).

--- a/ui/web/src/api/client.test.ts
+++ b/ui/web/src/api/client.test.ts
@@ -19,3 +19,50 @@ test("apiGet throws ApiError with the server message + status on failure", async
   await expect(apiGet("/wallet/balance")).rejects.toMatchObject({ status: 409, message: "no wallet set" });
   await expect(apiGet("/wallet/balance")).rejects.toBeInstanceOf(ApiError);
 });
+
+// --- Retry / backoff tests ---------------------------------------------------
+
+test("a flaky fetch (rejects once with TypeError then resolves) is retried and succeeds", async () => {
+  let calls = 0;
+  globalThis.fetch = vi.fn().mockImplementation(async () => {
+    calls++;
+    if (calls === 1) throw new TypeError("Failed to fetch");
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ lovelace: "1000000", assets: [] }),
+    };
+  }) as unknown as typeof fetch;
+
+  const result = await apiGet("/wallet/balance");
+  expect(result).toEqual({ lovelace: "1000000", assets: [] });
+  expect(calls).toBe(2);
+});
+
+test("a fetch returning HTTP 500 is NOT retried — one call, error surfaced immediately", async () => {
+  let calls = 0;
+  globalThis.fetch = vi.fn().mockImplementation(async () => {
+    calls++;
+    return {
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "internal server error" }),
+    };
+  }) as unknown as typeof fetch;
+
+  await expect(apiGet("/wallet/balance")).rejects.toMatchObject({ status: 500 });
+  expect(calls).toBe(1);
+});
+
+test("a persistent network error (TypeError every attempt) exhausts retries and throws", async () => {
+  let calls = 0;
+  globalThis.fetch = vi.fn().mockImplementation(async () => {
+    calls++;
+    throw new TypeError("Failed to fetch");
+  }) as unknown as typeof fetch;
+
+  await expect(apiGet("/wallet/balance")).rejects.toBeInstanceOf(ApiError);
+  // Should have retried a bounded number of times (2-3 total attempts max)
+  expect(calls).toBeGreaterThan(1);
+  expect(calls).toBeLessThanOrEqual(4);
+});

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -29,39 +29,60 @@ export class ApiError extends Error {
 }
 
 const REQUEST_TIMEOUT_MS = 30_000;
+// Retry only on network failures (TypeError/"Failed to fetch"), not HTTP errors.
+const RETRY_ATTEMPTS = 3; // total attempts (1 initial + 2 retries)
+const RETRY_BACKOFF_BASE_MS = 250;
+const RETRY_BACKOFF_CAP_MS = 1_000;
 
 async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-  let res: Response;
-  try {
-    res = await fetch(path, {
-      method,
-      headers: body ? { "Content-Type": "application/json" } : undefined,
-      body: body ? JSON.stringify(body) : undefined,
-      signal: controller.signal,
-    });
-  } catch (e) {
-    // Normalize transport failures (network down, timeout/abort) into ApiError
-    // so callers handle them uniformly; status 0 means no HTTP response.
-    const msg =
-      e instanceof DOMException && e.name === "AbortError" ? "request timed out" : "network error";
-    throw new ApiError(0, msg);
-  } finally {
-    clearTimeout(timer);
-  }
-  if (!res.ok) {
-    let message = `request failed (${res.status})`;
-    try {
-      const j = await res.json();
-      if (j && typeof j.error === "string") message = j.error;
-    } catch {
-      /* non-JSON */
+  let lastNetworkError: ApiError | null = null;
+
+  for (let attempt = 0; attempt < RETRY_ATTEMPTS; attempt++) {
+    if (attempt > 0) {
+      // Capped exponential backoff: 250ms, 500ms, ... capped at 1000ms
+      const delay = Math.min(RETRY_BACKOFF_BASE_MS * Math.pow(2, attempt - 1), RETRY_BACKOFF_CAP_MS);
+      await new Promise<void>((resolve) => setTimeout(resolve, delay));
     }
-    throw new ApiError(res.status, message);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    let res: Response;
+    try {
+      res = await fetch(path, {
+        method,
+        headers: body ? { "Content-Type": "application/json" } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+    } catch (e) {
+      clearTimeout(timer);
+      // Only retry on network failures (TypeError). AbortError (timeout) is not retried.
+      if (e instanceof TypeError) {
+        lastNetworkError = new ApiError(0, "network error");
+        continue;
+      }
+      // Timeout / abort — treat as a terminal error, don't retry.
+      throw new ApiError(0, "request timed out");
+    }
+    clearTimeout(timer);
+
+    if (!res.ok) {
+      let message = `request failed (${res.status})`;
+      try {
+        const j = await res.json();
+        if (j && typeof j.error === "string") message = j.error;
+      } catch {
+        /* non-JSON */
+      }
+      // HTTP error responses are real responses — do not retry.
+      throw new ApiError(res.status, message);
+    }
+    // All our endpoints return JSON.
+    return (await res.json()) as T;
   }
-  // All our endpoints return JSON.
-  return (await res.json()) as T;
+
+  // Exhausted all retry attempts for network failures.
+  throw lastNetworkError ?? new ApiError(0, "network error");
 }
 
 export const apiGet = <T>(path: string) => request<T>("GET", path);

--- a/ui/web/src/api/hooks.test.tsx
+++ b/ui/web/src/api/hooks.test.tsx
@@ -1,10 +1,13 @@
 import { renderHook, waitFor, act } from "@testing-library/react";
-import { useStatus } from "./hooks";
+import { useStatus, useAsync } from "./hooks";
 import * as client from "./client";
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.useRealTimers();
+  // Restore navigator.onLine and document.hidden defaults
+  Object.defineProperty(navigator, "onLine", { value: true, configurable: true, writable: true });
+  Object.defineProperty(document, "hidden", { value: false, configurable: true, writable: true });
 });
 
 test("useStatus loads then polls", async () => {
@@ -17,4 +20,69 @@ test("useStatus loads then polls", async () => {
   await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
   await waitFor(() => expect(result.current.data?.state).toBe("ready"));
   expect(spy).toHaveBeenCalledTimes(2);
+});
+
+// --- Online-aware polling tests ----------------------------------------------
+
+test("poll is suspended when navigator.onLine is false — interval fires but fetch is skipped", async () => {
+  Object.defineProperty(navigator, "onLine", { value: false, configurable: true, writable: true });
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+
+  let calls = 0;
+  const fn = vi.fn(async () => {
+    calls++;
+    return { state: "ready", tip: calls, caughtUp: true } as never;
+  });
+
+  const { result } = renderHook(() => useAsync(fn, { pollMs: 500 }));
+  // Initial fetch fires regardless of online state
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  const callsAfterInit = calls;
+
+  // Advance time — poll should NOT fire extra calls while offline
+  await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+  expect(calls).toBe(callsAfterInit);
+});
+
+test("poll is suspended when document.hidden is true — fetch is skipped while hidden", async () => {
+  Object.defineProperty(document, "hidden", { value: true, configurable: true, writable: true });
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+
+  let calls = 0;
+  const fn = vi.fn(async () => {
+    calls++;
+    return { state: "syncing", tip: calls, caughtUp: false } as never;
+  });
+
+  const { result } = renderHook(() => useAsync(fn, { pollMs: 500 }));
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  const callsAfterInit = calls;
+
+  await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+  expect(calls).toBe(callsAfterInit);
+});
+
+test("an 'online' window event triggers an immediate refetch", async () => {
+  Object.defineProperty(navigator, "onLine", { value: false, configurable: true, writable: true });
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+
+  let calls = 0;
+  const fn = vi.fn(async () => {
+    calls++;
+    return { state: "ready", tip: calls, caughtUp: true } as never;
+  });
+
+  const { result } = renderHook(() => useAsync(fn, { pollMs: 500 }));
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  const callsAfterInit = calls;
+
+  // Come back online — fire the 'online' event
+  Object.defineProperty(navigator, "onLine", { value: true, configurable: true, writable: true });
+  await act(async () => {
+    window.dispatchEvent(new Event("online"));
+    // Small tick for the async refetch to settle
+    await vi.advanceTimersByTimeAsync(50);
+  });
+
+  await waitFor(() => expect(calls).toBeGreaterThan(callsAfterInit));
 });

--- a/ui/web/src/api/hooks.ts
+++ b/ui/web/src/api/hooks.ts
@@ -38,6 +38,9 @@ export function useAsync<T>(fn: () => Promise<T>, opts?: { pollMs?: number }): A
     let inFlight = false;
 
     const run = (isInitial: boolean) => {
+      // Suspend polling when the network is down or the page is hidden — avoid
+      // firing requests into a dead network or a backgrounded tab.
+      if (!isInitial && (!navigator.onLine || document.hidden)) return;
       // Skip if a request is still pending: prevents overlapping polls and
       // out-of-order responses from overwriting fresher data.
       if (inFlight) return;
@@ -67,9 +70,15 @@ export function useAsync<T>(fn: () => Promise<T>, opts?: { pollMs?: number }): A
       id = setInterval(() => run(false), opts.pollMs);
     }
 
+    // When the network comes back, trigger an immediate refetch so the UI
+    // recovers without waiting for the next poll interval.
+    const onOnline = () => run(false);
+    window.addEventListener("online", onOnline);
+
     return () => {
       cancelled = true;
       if (id !== undefined) clearInterval(id);
+      window.removeEventListener("online", onOnline);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tick]);

--- a/ui/web/src/app.test.tsx
+++ b/ui/web/src/app.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
 import { App } from "./app";
 import * as hooks from "./api/hooks";
 import * as client from "./api/client";
@@ -266,4 +266,56 @@ test("Add wallet action opens the add-wallet form", async () => {
   fireEvent.click(screen.getByRole("button", { name: /add wallet/i }));
   // The add-wallet form (with a recovery-phrase field) appears.
   await waitFor(() => expect(screen.getByLabelText(/recovery phrase/i)).toBeInTheDocument());
+});
+
+// --- Offline banner tests ----------------------------------------------------
+
+test("offline banner appears when an 'offline' event is fired", async () => {
+  stubStatus("ready");
+  stubVault({ exists: false, locked: true, wallet_count: 0 });
+
+  render(<App />);
+  await waitFor(() => expect(screen.getByRole("button", { name: /create vault/i })).toBeInTheDocument());
+
+  expect(screen.queryByRole("alert", { name: /offline/i })).not.toBeInTheDocument();
+
+  act(() => {
+    window.dispatchEvent(new Event("offline"));
+  });
+
+  await waitFor(() => expect(screen.getByRole("alert", { name: /offline/i })).toBeInTheDocument());
+});
+
+test("offline banner hides when an 'online' event fires after going offline", async () => {
+  stubStatus("ready");
+  stubVault({ exists: false, locked: true, wallet_count: 0 });
+
+  render(<App />);
+  await waitFor(() => expect(screen.getByRole("button", { name: /create vault/i })).toBeInTheDocument());
+
+  act(() => {
+    window.dispatchEvent(new Event("offline"));
+  });
+  await waitFor(() => expect(screen.getByRole("alert", { name: /offline/i })).toBeInTheDocument());
+
+  act(() => {
+    window.dispatchEvent(new Event("online"));
+  });
+  await waitFor(() => expect(screen.queryByRole("alert", { name: /offline/i })).not.toBeInTheDocument());
+});
+
+test("offline banner can be dismissed by the user", async () => {
+  stubStatus("ready");
+  stubVault({ exists: false, locked: true, wallet_count: 0 });
+
+  render(<App />);
+  await waitFor(() => expect(screen.getByRole("button", { name: /create vault/i })).toBeInTheDocument());
+
+  act(() => {
+    window.dispatchEvent(new Event("offline"));
+  });
+  await waitFor(() => expect(screen.getByRole("alert", { name: /offline/i })).toBeInTheDocument());
+
+  fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+  expect(screen.queryByRole("alert", { name: /offline/i })).not.toBeInTheDocument();
 });

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { ReactElement } from "react";
 import type { Account, WalletView } from "./api/types";
 import { useStatus, useVaultStatus } from "./api/hooks";
@@ -148,6 +148,7 @@ export function App() {
   if (!unlocked && !loadAnyway && status.data && status.data.state !== "ready") {
     return (
       <div className="app">
+        <OfflineBanner />
         <SyncBanner status={status.data} />
         <main className="content content-boot">
           <Syncing status={status.data} onLoadAnyway={() => setLoadAnyway(true)} />
@@ -227,6 +228,7 @@ export function App() {
 
   return (
     <div className="app">
+      <OfflineBanner />
       {status.data && <SyncBanner status={status.data} />}
       <div className="layout">
         <nav className="sidebar">
@@ -283,6 +285,7 @@ function FullScreen({
 }) {
   return (
     <div className="app">
+      <OfflineBanner />
       {status && <SyncBanner status={status} />}
       <main className="content content-centered">{children}</main>
     </div>
@@ -304,5 +307,41 @@ function VaultStatusUnavailable({
       </p>
       <Button onClick={onRetry}>Retry</Button>
     </section>
+  );
+}
+
+// Small dismissible banner that appears when the browser reports no network.
+function OfflineBanner() {
+  const [offline, setOffline] = useState(!navigator.onLine);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    const onOffline = () => { setOffline(true); setDismissed(false); };
+    const onOnline = () => { setOffline(false); setDismissed(false); };
+    window.addEventListener("offline", onOffline);
+    window.addEventListener("online", onOnline);
+    return () => {
+      window.removeEventListener("offline", onOffline);
+      window.removeEventListener("online", onOnline);
+    };
+  }, []);
+
+  if (!offline || dismissed) return null;
+
+  return (
+    <div
+      role="alert"
+      aria-label="offline"
+      className="offline-banner"
+    >
+      <span>You are offline. Some features may be unavailable.</span>
+      <button
+        className="offline-banner-dismiss"
+        aria-label="dismiss"
+        onClick={() => setDismissed(true)}
+      >
+        ✕
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds SPA network resilience with bounded network retries, online-aware polling, and a global offline banner. Improves recovery on flaky mobile connections and reduces wasted polling.

- **New Features**
  - `api/client.ts`: Retry only on network `TypeError` (not HTTP or `AbortError`), 3 attempts total with 250ms→500ms backoff capped at 1s; API unchanged.
  - `api/hooks.ts` (`useAsync`): Skip poll ticks when offline or tab is hidden; trigger immediate refetch on `window:online`; cleans up listeners.
  - `app.tsx`: Dismissible `OfflineBanner` (`role="alert"`) shows when offline and hides on reconnect; rendered across all app states.

<sup>Written for commit 0619a7ca1126b1ca35210f10435ce00cf757b951. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

