### PR TITLE
feat(mobile): foreground Service keeps the node alive in the background

### DIFF
--- a/.superpowers/sdd/f4-report.md
+++ b/.superpowers/sdd/f4-report.md
@@ -1,0 +1,72 @@
+# Feature 4 — foreground Service (Android) — report
+
+**Status:** complete. Android/Kotlin only; **Go unchanged**. Branch `feat/mobile-foreground`
+(stacked on `feat/mobile-resume`). Kotlin compiles only in CI — see gate note.
+
+## What changed (Android only)
+
+- **New `WalletService : Service`** (`mobile/android/app/src/main/java/io/blinklabs/bursa/WalletService.kt`)
+  now OWNS the gomobile `App`. Lifecycle:
+  - `onCreate`: create the low-importance notification channel (`IMPORTANCE_LOW`,
+    `bursa_sync`) — created **before** any `startForeground` (a missing channel
+    throws on API 26+).
+  - `onStartCommand`: call `startForeground(...)` **first** (before the slow node
+    boot, to beat the ~5s `startForegroundService` deadline) with
+    `FOREGROUND_SERVICE_TYPE_DATA_SYNC` passed on API 29+ (else the 2-arg form);
+    then `startWalletIfNeeded()` → `app.start(filesDir, "preview", true)`.
+    Idempotent via a `started` flag (no double-start). Returns `START_STICKY`.
+  - `onDestroy`: cancel debounce, **unregister the NetworkCallback**, `app.stop()`.
+  - **Binder (`LocalBinder`):** `port()` (returns 0 until booted), pass-throughs
+    `onNetworkChanged()` / `onResume()` to the service-held `App`.
+  - Notification: ongoing, low-priority "Bursa is syncing", `setOngoing(true)`,
+    tap → returns to `MainActivity` (immutable `PendingIntent`).
+- **F2 NetworkCallback MOVED into the service** — registered after the node boots,
+  500ms debounce, `onNetworkChanged()` on a background `Thread` (node Stop+relaunch
+  is blocking); unregistered in `onDestroy`. So re-dial works while backgrounded.
+- **`MainActivity`** no longer owns the App. `onCreate`:
+  `ContextCompat.startForegroundService(...)` + `bindService(BIND_AUTO_CREATE)`.
+  `onServiceConnected` → `loadWebViewWhenReady()` polls the binder's `port()` every
+  100ms and loads `http://127.0.0.1:<port>/` only once it is **non-zero**
+  (handles the bind-before-boot race). **F3 resume threshold (30s) stays in
+  MainActivity**: always cheap `webView.reload()`; route the heavy `onResume()`
+  re-dial to the binder off-main-thread only past the threshold. `onDestroy`
+  **unbinds but does NOT stop** the service (the node keeps running) and stops the
+  port poller.
+- **Manifest:** added `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC`,
+  `POST_NOTIFICATIONS`; `<service android:name=".WalletService"
+  android:exported="false" android:foregroundServiceType="dataSync"/>`. The type is
+  on both the `<service>` AND the `startForeground` call (API 34 requirement).
+- **Runtime POST_NOTIFICATIONS:** requested on API 33+ via
+  `ActivityResultContracts.RequestPermission`; result **ignored** — service runs and
+  the notification still posts whether granted or denied (denial only hides it).
+- **gradle:** added `androidx.core:core-ktx` (NotificationCompat/ContextCompat) and
+  `androidx.activity:activity-ktx` (registerForActivityResult) — both already
+  transitive via appcompat, declared explicitly for clarity.
+- **strings.xml:** channel + notification title/text strings.
+
+## Verification
+
+- **Go unchanged + cross-compiles:** `cd ui && go build ./...` → exit 0;
+  `GOOS=android GOARCH=arm64 CGO_ENABLED=0 go build ./...` → exit 0. `git diff` touches
+  only the 5 Android files; reused existing `Start/Stop/Port/OnNetworkChanged/OnResume`
+  gomobile methods — no new Go hook needed.
+- **Kotlin NOT compiled locally** (no Android SDK/NDK on this aarch64 box; the NDK is
+  x86_64-only). The **CI APK job (`mobile.yml`, `gomobile bind -target=android/arm64`)
+  is the compile gate.** Self-reviewed against: channel-before-startForeground,
+  foregroundServiceType on manifest + startForeground (API 34), 5s
+  startForegroundService deadline (startForeground called first), bind lifecycle
+  (unbind in onDestroy, no service stop), and the pre-26 startForegroundService
+  fallback handled by ContextCompat.
+
+## Lifecycle points I was less than 100% sure about (flagged)
+
+- **START_STICKY restart with a null intent:** `onStartCommand` handles a null intent
+  fine (it doesn't read intent extras), so a sticky restart re-boots cleanly. Worth a
+  manual-APK confirmation that the OS-restarted (Activity-less) service re-posts the
+  notification and re-syncs.
+- **Bind-after-process-death:** if the service process is killed and rebinds, `started`
+  resets with the process, so a fresh `onStartCommand` re-boots. The Activity's
+  `onServiceDisconnected` clears the binder and waits for rebind. Not exercised here.
+- **POST_NOTIFICATIONS denied:** API 34 still allows the dataSync foreground service to
+  run without the notification visible; confirm on a real API 34 device in the manual
+  pass (behaviour is documented but device-dependent).

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -49,4 +49,10 @@ dependencies {
     implementation(files("libs/bursa.aar"))
 
     implementation("androidx.appcompat:appcompat:1.7.0")
+    // NotificationCompat / ContextCompat for the foreground-service notification
+    // and the startForegroundService + permission-check helpers.
+    implementation("androidx.core:core-ktx:1.13.1")
+    // registerForActivityResult / ActivityResultContracts for the runtime
+    // POST_NOTIFICATIONS request on API 33+.
+    implementation("androidx.activity:activity-ktx:1.9.3")
 }

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,16 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <!-- The node lives in a foreground Service so it keeps syncing while the app
+         is backgrounded. FOREGROUND_SERVICE is required to run any foreground
+         service (API 28+); FOREGROUND_SERVICE_DATA_SYNC is the typed permission
+         required on API 34+ for the dataSync foregroundServiceType. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <!-- Required on API 33+ to post the ongoing "syncing" notification; requested
+         at runtime. The service still runs if the user denies it. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application
         android:allowBackup="false"
         android:label="Bursa"
@@ -28,5 +38,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- The foreground Service that owns the embedded node + loopback control
+             surface. foregroundServiceType="dataSync" is required on API 34+ and
+             MUST match the type passed to startForeground() in the service. Not
+             exported: only this app's MainActivity binds to it. -->
+        <service
+            android:name=".WalletService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
     </application>
 </manifest>

--- a/mobile/android/app/src/main/java/io/blinklabs/bursa/MainActivity.kt
+++ b/mobile/android/app/src/main/java/io/blinklabs/bursa/MainActivity.kt
@@ -126,6 +126,16 @@ class MainActivity : AppCompatActivity() {
     // re-polls on the main thread. Idempotent: loads at most once.
     private fun loadWebViewWhenReady() {
         if (webViewLoaded) return
+
+        // Check for a terminal boot failure first. If the node could not start,
+        // port() would stay 0 forever and we'd poll indefinitely behind a blank
+        // WebView. Surface the error and STOP polling (don't re-post).
+        val bootError = walletBinder?.bootError()
+        if (bootError != null) {
+            showBootError(bootError)
+            return
+        }
+
         val port = walletBinder?.port() ?: 0
         if (port == 0) {
             // Still booting (or briefly unbound) — try again shortly.
@@ -136,6 +146,30 @@ class MainActivity : AppCompatActivity() {
         }
         webViewLoaded = true
         webView.loadUrl("http://127.0.0.1:$port/")
+    }
+
+    // showBootError renders a minimal inline error page when the node fails to
+    // boot, replacing the blank WebView the user would otherwise stare at. Marks
+    // webViewLoaded so onResume's reload() and the poll loop both treat this as
+    // the terminal loaded state.
+    private fun showBootError(message: String) {
+        webViewLoaded = true
+        val escaped = android.text.TextUtils.htmlEncode(message)
+        val html = """
+            <!doctype html>
+            <html><head><meta name="viewport" content="width=device-width,initial-scale=1">
+            <style>
+              body{font-family:sans-serif;margin:0;padding:24px;background:#111;color:#eee;
+                   display:flex;flex-direction:column;justify-content:center;min-height:100vh}
+              h1{font-size:1.25rem;margin:0 0 12px}
+              p{margin:0;color:#bbb;line-height:1.5;word-break:break-word}
+            </style></head>
+            <body>
+              <h1>Wallet failed to start</h1>
+              <p>$escaped</p>
+            </body></html>
+        """.trimIndent()
+        webView.loadData(html, "text/html; charset=utf-8", "utf-8")
     }
 
     // onPause records when the app left the foreground so onResume can compute

--- a/mobile/android/app/src/main/java/io/blinklabs/bursa/MainActivity.kt
+++ b/mobile/android/app/src/main/java/io/blinklabs/bursa/MainActivity.kt
@@ -13,66 +13,80 @@
 // limitations under the License.
 package io.blinklabs.bursa
 
+import android.Manifest
 import android.annotation.SuppressLint
+import android.content.ComponentName
 import android.content.Context
-import android.net.ConnectivityManager
-import android.net.Network
-import android.net.NetworkCapabilities
-import android.net.NetworkRequest
+import android.content.Intent
+import android.content.ServiceConnection
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.os.Handler
+import android.os.IBinder
 import android.os.Looper
 import android.webkit.WebView
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 
-// The gomobile binding. `gomobile bind -javapkg io.blinklabs.bursa` emits the Go
-// `mobile` package as the Java class `io.blinklabs.bursa.mobile.Mobile`, with
-// `App` as `io.blinklabs.bursa.mobile.App`. The Go `New()` constructor becomes
-// `Mobile.new_()` (gomobile suffixes the Java keyword `new`).
-import io.blinklabs.bursa.mobile.App
-import io.blinklabs.bursa.mobile.Mobile
-
-// MainActivity boots the in-process wallet (the embedded lean Dingo node + the
-// loopback control surface that serves the API and the embedded SPA), then
-// points a full-screen WebView at the loopback URL the wallet chose.
+// MainActivity no longer owns the wallet. The embedded node + loopback control
+// surface live in WalletService (a foreground Service) so they survive the
+// Activity being backgrounded/destroyed. MainActivity starts that service,
+// binds to it, reads the loopback port() from the binder once the wallet has
+// booted, and points a full-screen WebView at it.
+//
+// The ConnectivityManager.NetworkCallback (F2) lives in the service now; the
+// onResume threshold logic (F3) stays here but routes its heavy re-dial to the
+// bound service-held App.
 class MainActivity : AppCompatActivity() {
 
-    private lateinit var app: App
     private lateinit var webView: WebView
-    private var connectivityManager: ConnectivityManager? = null
-    private var networkCallback: ConnectivityManager.NetworkCallback? = null
 
-    // Resume-threshold: only trigger a full OnResume re-dial when the app has
-    // been backgrounded longer than this. Quick app-switches (e.g. permission
-    // prompts, recent-apps gestures) do not bounce the node; only extended
-    // suspension causes peers to go stale.
+    // Binder to the wallet service. Non-null only while bound.
+    private var walletBinder: WalletService.LocalBinder? = null
+    private var bound = false
+
+    // Resume-threshold (F3): only trigger a full OnResume re-dial when the app
+    // has been backgrounded longer than this. Quick app-switches (permission
+    // prompts, recent-apps gestures) do not bounce the node.
     private val resumeThresholdMs = 30_000L
     private var pauseTimestampMs = 0L
 
-    // Debounce handler: avoid thrashing Reconnect on rapid network transitions
-    // (e.g. WiFi hand-off to cellular). A 500 ms window absorbs back-to-back
-    // onLost→onAvailable events from a single interface change.
-    private val debounceHandler = Handler(Looper.getMainLooper())
-    private val reconnectRunnable = Runnable { handleNetworkChange() }
-    private val debounceDelayMs = 500L
+    // The wallet boots asynchronously inside the service, so the port may be 0
+    // for a moment after we bind. We poll the binder until it reports a non-zero
+    // port, then load the WebView (handles the bind-before-boot race).
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val portPollDelayMs = 100L
+    private var webViewLoaded = false
+
+    private val connection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+            walletBinder = service as? WalletService.LocalBinder
+            bound = true
+            // The wallet may still be booting; wait for a real port.
+            loadWebViewWhenReady()
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            // The service process went away (e.g. crash). Drop the binder; the
+            // system will rebind when it returns.
+            walletBinder = null
+            bound = false
+        }
+    }
+
+    // Runtime POST_NOTIFICATIONS request (Android 13+). The result is ignored:
+    // the service still runs and the notification still posts whether or not the
+    // user grants it — denial only suppresses the visible notification.
+    private val requestNotificationPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* granted: Boolean — intentionally ignored */ }
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // Boot the wallet in-process. filesDir is the app-private writable data
-        // dir; "preview" is the network; lean = true selects the history-expiry
-        // profile (small on-disk footprint) appropriate for a phone. start()
-        // surfaces a boot failure as a (Java-checked) Exception; fail visibly
-        // rather than loading a WebView against a port that was never bound.
-        app = Mobile.new_()
-        try {
-            app.start(filesDir.absolutePath, "preview", true)
-        } catch (e: Exception) {
-            android.util.Log.e("bursa", "wallet start failed", e)
-            finish()
-            return
-        }
+        maybeRequestNotificationPermission()
 
         webView = WebView(this).apply {
             settings.javaScriptEnabled = true
@@ -84,106 +98,77 @@ class MainActivity : AppCompatActivity() {
         }
         setContentView(webView)
 
-        // app.port() is the OS-assigned loopback port the control surface bound.
-        webView.loadUrl("http://127.0.0.1:${app.port()}/")
-
-        registerNetworkCallback()
+        // Start the wallet as a foreground service so it keeps running even when
+        // this Activity is backgrounded or destroyed, then bind to read its
+        // loopback port. startForegroundService promotes the service to the
+        // foreground (it calls startForeground within the required window).
+        val intent = Intent(this, WalletService::class.java)
+        ContextCompat.startForegroundService(this, intent)
+        bindService(intent, connection, Context.BIND_AUTO_CREATE)
     }
 
-    // registerNetworkCallback subscribes to connectivity events so the node
-    // re-dials peers when the host network changes. ACCESS_NETWORK_STATE is
-    // declared in AndroidManifest.xml (no runtime prompt needed — it is a
-    // normal/install-time permission).
-    private fun registerNetworkCallback() {
-        val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
-            ?: return
-        connectivityManager = cm
-
-        val request = NetworkRequest.Builder()
-            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-            .build()
-
-        val callback = object : ConnectivityManager.NetworkCallback() {
-            override fun onAvailable(network: Network) {
-                // A new network is usable — schedule a debounced reconnect.
-                scheduleReconnect()
-            }
-
-            override fun onLost(network: Network) {
-                // The current network was lost — schedule a debounced reconnect
-                // so the node drops dead peers and re-dials on the next
-                // available interface.
-                scheduleReconnect()
-            }
+    // maybeRequestNotificationPermission asks for POST_NOTIFICATIONS on API 33+.
+    // On older versions the permission is granted at install time and no prompt
+    // is needed. The foreground service runs regardless of the answer.
+    private fun maybeRequestNotificationPermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        val granted = ContextCompat.checkSelfPermission(
+            this,
+            Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
+        if (!granted) {
+            requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
-        networkCallback = callback
-        cm.registerNetworkCallback(request, callback)
     }
 
-    private fun scheduleReconnect() {
-        // Cancel any pending reconnect and restart the debounce window so
-        // rapid transitions (onLost immediately followed by onAvailable) are
-        // collapsed into a single call.
-        debounceHandler.removeCallbacks(reconnectRunnable)
-        debounceHandler.postDelayed(reconnectRunnable, debounceDelayMs)
-    }
-
-    private fun handleNetworkChange() {
-        // Must NOT run on the main thread: app.onNetworkChanged() performs a
-        // node Stop+relaunch which is a blocking, I/O-bound operation.
-        Thread {
-            try {
-                app.onNetworkChanged()
-            } catch (e: Exception) {
-                android.util.Log.w("bursa", "onNetworkChanged failed", e)
+    // loadWebViewWhenReady loads the WebView once the bound service reports a
+    // non-zero loopback port. If the wallet is still booting (port == 0) it
+    // re-polls on the main thread. Idempotent: loads at most once.
+    private fun loadWebViewWhenReady() {
+        if (webViewLoaded) return
+        val port = walletBinder?.port() ?: 0
+        if (port == 0) {
+            // Still booting (or briefly unbound) — try again shortly.
+            if (bound) {
+                mainHandler.postDelayed({ loadWebViewWhenReady() }, portPollDelayMs)
             }
-            // Reload the WebView on the main thread after the node has
-            // re-dialled so the SPA reconnects to the refreshed control surface.
-            runOnUiThread {
-                if (this::webView.isInitialized) {
-                    webView.reload()
-                }
-            }
-        }.start()
+            return
+        }
+        webViewLoaded = true
+        webView.loadUrl("http://127.0.0.1:$port/")
     }
 
-    // onPause records the instant the app leaves the foreground so onResume can
-    // compute how long it was backgrounded.
+    // onPause records when the app left the foreground so onResume can compute
+    // how long it was backgrounded.
     override fun onPause() {
         super.onPause()
         pauseTimestampMs = System.currentTimeMillis()
     }
 
-    // onResume is called every time the activity becomes visible: on initial
-    // start, after a quick app-switch, and after extended background suspension.
-    //
-    // Strategy:
-    //  - Always reload the WebView (cheap) so the SPA's visibilitychange
-    //    listener fires and data views refetch.
-    //  - Only call app.onResume() (heavyweight: Stop+relaunch the node) when
-    //    the app has been suspended longer than resumeThresholdMs, because peers
-    //    only go fully stale after extended suspension. Quick switches are
-    //    handled by the SPA reload alone.
-    //  - Guard against being called before the wallet has been started.
+    // onResume (F3): on becoming visible again, always do the cheap WebView
+    // reload so the SPA refetches, and only route a heavy app.onResume() re-dial
+    // to the service when the app was suspended longer than the threshold.
     override fun onResume() {
         super.onResume()
 
-        // Always do the lightweight WebView reload so the SPA refetches.
-        if (this::webView.isInitialized) {
+        // Always do the lightweight WebView reload so the SPA refetches — but
+        // only once it has actually loaded a URL (avoid reloading about:blank
+        // before the first load).
+        if (webViewLoaded) {
             webView.reload()
         }
 
-        // Skip the heavy re-dial if the wallet has not been started yet or if
-        // the suspension was shorter than the threshold.
-        if (!this::app.isInitialized) return
+        // Skip the heavy re-dial if the suspension was shorter than the
+        // threshold (quick app-switch handled by the reload alone).
         val elapsed = if (pauseTimestampMs > 0) System.currentTimeMillis() - pauseTimestampMs else 0L
         if (elapsed < resumeThresholdMs) return
 
-        // The app was backgrounded long enough that TCP connections to peers
-        // may have been torn down. Re-dial on a background thread.
+        // Route the re-dial to the service-held App, off the main thread
+        // (onResume() does a node Stop+relaunch).
+        val binder = walletBinder ?: return
         Thread {
             try {
-                app.onResume()
+                binder.onResume()
             } catch (e: Exception) {
                 android.util.Log.w("bursa", "onResume re-dial failed", e)
             }
@@ -191,21 +176,18 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
-        // Cancel any pending debounced reconnect.
-        debounceHandler.removeCallbacks(reconnectRunnable)
+        // Stop polling for the port.
+        mainHandler.removeCallbacksAndMessages(null)
 
-        // Unregister the network callback before tearing the wallet down so
-        // no late callbacks try to call app.onNetworkChanged() after Stop.
-        networkCallback?.let { cb ->
-            connectivityManager?.unregisterNetworkCallback(cb)
+        // Unbind from — but do NOT stop — the service: the whole point is that
+        // the node keeps running (and syncing) after the Activity is gone. The
+        // system manages the foreground service's lifetime from here.
+        if (bound) {
+            unbindService(connection)
+            bound = false
         }
-        networkCallback = null
+        walletBinder = null
 
-        // Tear the wallet down: drains the control surface and winds down the
-        // in-process node.
-        if (this::app.isInitialized) {
-            app.stop()
-        }
         if (this::webView.isInitialized) {
             webView.destroy()
         }

--- a/mobile/android/app/src/main/java/io/blinklabs/bursa/WalletService.kt
+++ b/mobile/android/app/src/main/java/io/blinklabs/bursa/WalletService.kt
@@ -65,6 +65,12 @@ class WalletService : Service() {
     private var app: App? = null
     private var started = false
 
+    // Set to the failure message when the node could not boot (app.start threw).
+    // The service keeps its binder answering so the Activity can read this and
+    // surface the failure instead of polling port() forever. Guarded by the
+    // service's main thread like the other lifecycle state.
+    private var bootError: String? = null
+
     private val binder = LocalBinder()
 
     private var connectivityManager: ConnectivityManager? = null
@@ -82,6 +88,12 @@ class WalletService : Service() {
         // wallet has not finished starting. The Activity polls/loads only once
         // this is non-zero (handles the bind-before-boot race).
         fun port(): Int = app?.port()?.toInt() ?: 0
+
+        // bootError returns the node boot-failure message, or null if the wallet
+        // has not failed (still booting, or booted fine). The Activity checks
+        // this each poll so a boot failure ends the poll loop and surfaces an
+        // error instead of waiting on a port that will never arrive.
+        fun bootError(): String? = this@WalletService.bootError
 
         // onNetworkChanged / onResume are pass-throughs to the service-held App
         // so the Activity routes its lifecycle kicks to the wallet the service
@@ -109,7 +121,8 @@ class WalletService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         // Always (re)assert foreground status with the ongoing notification.
         // On API 29+ the foregroundServiceType MUST be passed here too — it has
-        // to match the manifest's android:foregroundServiceType="dataSync".
+        // to match the manifest's android:foregroundServiceType="dataSync"
+        // (which itself is a required manifest declaration as of API 34).
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             startForeground(
                 NOTIFICATION_ID,
@@ -131,8 +144,9 @@ class WalletService : Service() {
     // startWalletIfNeeded boots the gomobile App once. Guarded by `started` so
     // repeated onStartCommand deliveries don't attempt a second start (the Go
     // side also errors on double-start, but we gate here to avoid the throw).
+    // A boot failure is also terminal — once `bootError` is set we don't retry.
     private fun startWalletIfNeeded() {
-        if (started) return
+        if (started || bootError != null) return
         val instance = Mobile.new_()
         try {
             // filesDir = app-private writable dir; "preview" network; lean=true
@@ -140,10 +154,21 @@ class WalletService : Service() {
             instance.start(filesDir.absolutePath, "preview", true)
         } catch (e: Exception) {
             android.util.Log.e(TAG, "wallet start failed", e)
-            // Could not boot — drop foreground status and stop. The Activity's
-            // binder.port() will keep returning 0 and it will not load a dead
-            // port.
-            stopSelf()
+            // Could not boot. We must NOT silently stopSelf() here: the Activity
+            // is still bound and only learns of a dead node by polling port(),
+            // which would stay 0 forever (onServiceDisconnected does not fire on
+            // a stopSelf of a still-bound service). Instead, record the failure
+            // so the binder can report it, then drop the foreground notification
+            // (there is nothing syncing). Keep the service alive/bound so the
+            // Activity can read bootError() and surface it; the system tears the
+            // service down once the Activity unbinds in onDestroy.
+            bootError = e.message ?: e.toString()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                stopForeground(STOP_FOREGROUND_REMOVE)
+            } else {
+                @Suppress("DEPRECATION")
+                stopForeground(true)
+            }
             return
         }
         app = instance

--- a/mobile/android/app/src/main/java/io/blinklabs/bursa/WalletService.kt
+++ b/mobile/android/app/src/main/java/io/blinklabs/bursa/WalletService.kt
@@ -1,0 +1,262 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package io.blinklabs.bursa
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.os.Binder
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import androidx.core.app.NotificationCompat
+
+import io.blinklabs.bursa.mobile.App
+import io.blinklabs.bursa.mobile.Mobile
+
+// WalletService is a bound foreground Service that OWNS the gomobile App (the
+// embedded lean Dingo node + loopback control surface). Hosting the wallet in a
+// foreground service — rather than in the Activity — keeps the node alive and
+// syncing while the app is backgrounded, instead of being torn down with the UI
+// and killed by the OS.
+//
+// The Activity binds to this service to learn the loopback port() and to route
+// lifecycle "kicks" (onNetworkChanged / onResume) to the service-held App. The
+// ConnectivityManager.NetworkCallback also lives here (not in the Activity) so
+// the node re-dials on a network change even while backgrounded.
+class WalletService : Service() {
+
+    companion object {
+        private const val TAG = "bursa"
+
+        // Notification plumbing. The channel is created in onCreate (it MUST
+        // exist before startForeground posts a notification against it).
+        private const val CHANNEL_ID = "bursa_sync"
+        private const val NOTIFICATION_ID = 1
+
+        // Debounce window for network transitions (e.g. WiFi hand-off to
+        // cellular): a 500 ms window collapses back-to-back onLost→onAvailable
+        // events from a single interface change into one re-dial.
+        private const val DEBOUNCE_DELAY_MS = 500L
+    }
+
+    // The booted wallet. Null until started; guarded by the service's single
+    // (main) thread for lifecycle transitions. started gates double-start.
+    private var app: App? = null
+    private var started = false
+
+    private val binder = LocalBinder()
+
+    private var connectivityManager: ConnectivityManager? = null
+    private var networkCallback: ConnectivityManager.NetworkCallback? = null
+
+    private val debounceHandler = Handler(Looper.getMainLooper())
+    private val reconnectRunnable = Runnable { handleNetworkChange() }
+
+    // LocalBinder is the in-process binding surface. The Activity casts the
+    // IBinder it receives in onServiceConnected to this and calls through to the
+    // service-held App. All methods are safe before the wallet has started
+    // (port() returns 0; the kicks no-op).
+    inner class LocalBinder : Binder() {
+        // port returns the loopback port the control surface bound, or 0 if the
+        // wallet has not finished starting. The Activity polls/loads only once
+        // this is non-zero (handles the bind-before-boot race).
+        fun port(): Int = app?.port()?.toInt() ?: 0
+
+        // onNetworkChanged / onResume are pass-throughs to the service-held App
+        // so the Activity routes its lifecycle kicks to the wallet the service
+        // owns. They are blocking, I/O-bound node operations — callers MUST
+        // invoke them off the main thread.
+        fun onNetworkChanged() {
+            app?.onNetworkChanged()
+        }
+
+        fun onResume() {
+            app?.onResume()
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        // The channel must exist before any startForeground call posts against
+        // it (a missing channel throws on API 26+).
+        createNotificationChannel()
+    }
+
+    // onStartCommand promotes the service to the foreground and boots the
+    // wallet. It is idempotent: a redelivered start intent (or a second
+    // startForegroundService from the Activity) must not double-start the node.
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Always (re)assert foreground status with the ongoing notification.
+        // On API 29+ the foregroundServiceType MUST be passed here too — it has
+        // to match the manifest's android:foregroundServiceType="dataSync".
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                NOTIFICATION_ID,
+                buildNotification(),
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, buildNotification())
+        }
+
+        startWalletIfNeeded()
+
+        // STICKY: if the OS kills us under memory pressure, restart the service
+        // (with a null intent) so the node comes back up. We don't carry intent
+        // data, so we don't need REDELIVER_INTENT.
+        return START_STICKY
+    }
+
+    // startWalletIfNeeded boots the gomobile App once. Guarded by `started` so
+    // repeated onStartCommand deliveries don't attempt a second start (the Go
+    // side also errors on double-start, but we gate here to avoid the throw).
+    private fun startWalletIfNeeded() {
+        if (started) return
+        val instance = Mobile.new_()
+        try {
+            // filesDir = app-private writable dir; "preview" network; lean=true
+            // selects the small-footprint history-expiry profile for a phone.
+            instance.start(filesDir.absolutePath, "preview", true)
+        } catch (e: Exception) {
+            android.util.Log.e(TAG, "wallet start failed", e)
+            // Could not boot — drop foreground status and stop. The Activity's
+            // binder.port() will keep returning 0 and it will not load a dead
+            // port.
+            stopSelf()
+            return
+        }
+        app = instance
+        started = true
+
+        // Now that the node is running, watch for host network changes so it
+        // re-dials peers even while the Activity is gone/backgrounded.
+        registerNetworkCallback()
+    }
+
+    // registerNetworkCallback subscribes to connectivity events. Lives in the
+    // service (moved out of the Activity in F2) so re-dial works while
+    // backgrounded. ACCESS_NETWORK_STATE is a normal/install-time permission.
+    private fun registerNetworkCallback() {
+        if (networkCallback != null) return
+        val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+            ?: return
+        connectivityManager = cm
+
+        val request = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+
+        val callback = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                scheduleReconnect()
+            }
+
+            override fun onLost(network: Network) {
+                scheduleReconnect()
+            }
+        }
+        networkCallback = callback
+        cm.registerNetworkCallback(request, callback)
+    }
+
+    private fun scheduleReconnect() {
+        // Restart the debounce window so rapid onLost→onAvailable transitions
+        // collapse into a single reconnect.
+        debounceHandler.removeCallbacks(reconnectRunnable)
+        debounceHandler.postDelayed(reconnectRunnable, DEBOUNCE_DELAY_MS)
+    }
+
+    private fun handleNetworkChange() {
+        // onNetworkChanged performs a node Stop+relaunch — blocking, I/O-bound —
+        // so it MUST NOT run on the main thread.
+        val instance = app ?: return
+        Thread {
+            try {
+                instance.onNetworkChanged()
+            } catch (e: Exception) {
+                android.util.Log.w(TAG, "onNetworkChanged failed", e)
+            }
+        }.start()
+    }
+
+    override fun onBind(intent: Intent?): IBinder = binder
+
+    override fun onDestroy() {
+        // Cancel any pending debounced reconnect.
+        debounceHandler.removeCallbacks(reconnectRunnable)
+
+        // Unregister the network callback before tearing the wallet down so no
+        // late callback tries to call onNetworkChanged() after Stop.
+        networkCallback?.let { cb ->
+            connectivityManager?.unregisterNetworkCallback(cb)
+        }
+        networkCallback = null
+
+        // Wind down the in-process node and drain the control surface.
+        app?.stop()
+        app = null
+        started = false
+        super.onDestroy()
+    }
+
+    // createNotificationChannel registers the low-importance channel used for
+    // the ongoing "syncing" notification. No-op before API 26 (channels did not
+    // exist then). IMPORTANCE_LOW => no sound, collapsed by default.
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (manager.getNotificationChannel(CHANNEL_ID) != null) return
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            getString(R.string.sync_channel_name),
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = getString(R.string.sync_channel_description)
+            setShowBadge(false)
+        }
+        manager.createNotificationChannel(channel)
+    }
+
+    // buildNotification creates the ongoing, low-priority "Bursa is syncing"
+    // notification shown while the service runs. Tapping it returns to the app.
+    private fun buildNotification(): Notification {
+        val contentIntent = android.app.PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            },
+            android.app.PendingIntent.FLAG_IMMUTABLE,
+        )
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(getString(R.string.sync_notification_title))
+            .setContentText(getString(R.string.sync_notification_text))
+            .setSmallIcon(android.R.drawable.stat_notify_sync)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOngoing(true)
+            .setShowWhen(false)
+            .setContentIntent(contentIntent)
+            .build()
+    }
+}

--- a/mobile/android/app/src/main/res/values/strings.xml
+++ b/mobile/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Bursa</string>
+
+    <!-- Foreground-service notification + channel (the embedded node keeps
+         syncing in the background). -->
+    <string name="sync_channel_name">Wallet sync</string>
+    <string name="sync_channel_description">Keeps the embedded Cardano node synced while Bursa runs in the background.</string>
+    <string name="sync_notification_title">Bursa is syncing</string>
+    <string name="sync_notification_text">Keeping your wallet up to date in the background.</string>
 </resources>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Keep the embedded node alive in the background by moving it into a foreground `Service` with a low-priority ongoing notification. Android-only change; Go code unchanged.

- **New Features**
  - Added `WalletService` foreground service that owns the gomobile `App`; starts with `startForeground` using `dataSync` and returns `START_STICKY`.
  - `MainActivity` starts/binds to the service and polls `binder.port()` to load the `WebView` once ready; unbinds without stopping the service.
  - Moved network re-dial into the service via `ConnectivityManager.NetworkCallback` with 500 ms debounce; work runs off the main thread.
  - Ongoing "Bursa is syncing" notification on channel `bursa_sync`; tap returns to the app; runtime `POST_NOTIFICATIONS` requested on API 33+.
  - Surfaced node boot failures via `binder.bootError()` so the Activity shows an inline error instead of polling forever.

- **Dependencies**
  - Manifest: added `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC`, `POST_NOTIFICATIONS`, and declared the `<service ... foregroundServiceType="dataSync">`.
  - Gradle: added `androidx.core:core-ktx` and `androidx.activity:activity-ktx`.

<sup>Written for commit 0f44204d496eff74e11690157e17ed751cbb4e13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

