### PR TITLE
feat(ui): mobile-resilience wave — network/wake robustness + foreground service

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -1,0 +1,128 @@
+name: mobile
+
+# Builds the Bursa mobile apps. Manual (workflow_dispatch) and on tags only —
+# the toolchains (Android SDK/NDK, Xcode) are heavy, so this does not run on
+# every push/PR like the Go/web CI does.
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: read
+
+env:
+  GOMOBILE_VERSION: v0.0.0-20260611195102-4dd8f1dbf5d2
+  XCODEGEN_VERSION: 2.45.4
+  XCODEGEN_SHA256: 090ec29491aad50aec10631bf6e62253fed733c50f3aab0f5ffc86bc170bdbef
+
+jobs:
+  # Android is built via the canonical Docker image (mobile/android/Dockerfile):
+  # it carries the full toolchain (Go + gomobile + Android SDK/NDK + JDK + Gradle)
+  # so the AAR + APK build identically here and on a developer's machine, with no
+  # Android SDK installed on the runner. The build script (build-in-docker.sh)
+  # runs `gomobile bind` then `./gradlew assembleDebug` and emits the APK to /out.
+  android:
+    name: android
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/releases/tag/v7.0.0
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0 https://github.com/docker/setup-buildx-action/releases/tag/v4.1.0
+      - name: Build Android toolchain image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0 https://github.com/docker/build-push-action/releases/tag/v7.2.0
+        with:
+          context: .
+          file: mobile/android/Dockerfile
+          tags: bursa-android-build:ci
+          build-args: |
+            BUILDER_UID=1001
+            BUILDER_GID=1001
+          push: false
+          load: true
+      - name: Build AAR + APK (in container)
+        run: |
+          mkdir -p out
+          docker run --rm \
+            -v "${{ github.workspace }}":/code \
+            -v "${{ github.workspace }}/out":/out \
+            bursa-android-build:ci
+      - name: Upload APK
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0 https://github.com/actions/upload-artifact/releases/tag/v5.0.0
+        with:
+          name: bursa-android-apk
+          path: out/*.apk
+          if-no-files-found: error
+
+  # iOS MUST be built on macOS: Xcode cannot run in a Linux container, so Docker
+  # does not apply here. gomobile builds the xcframework natively, then xcodegen
+  # generates the project and xcodebuild produces an (unsigned, simulator) .app.
+  ios:
+    name: ios
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 https://github.com/actions/checkout/releases/tag/v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
+        with:
+          go-version: 1.26.x
+          cache: false
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0 https://github.com/actions/setup-node/releases/tag/v6.0.0
+        with:
+          node-version: 22
+      # Build the web bundle first so the //go:embed dist target carries the
+      # production SPA before gomobile compiles the binding.
+      - name: Build web bundle
+        run: cd ui/web && npm ci && npm run build
+      - name: Install gomobile
+        run: |
+          go install "golang.org/x/mobile/cmd/gomobile@${GOMOBILE_VERSION}"
+          go install "golang.org/x/mobile/cmd/gobind@${GOMOBILE_VERSION}"
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - name: gomobile init
+        run: gomobile init
+      - name: Build xcframework
+        run: |
+          cd ui && gomobile bind \
+            -target=ios \
+            -o ../mobile/ios/Bursa.xcframework \
+            ./mobile
+      - name: Install xcodegen
+        run: |
+          curl -fsSL "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip" -o xcodegen.zip
+          echo "${XCODEGEN_SHA256}  xcodegen.zip" | shasum -a 256 -c -
+          unzip -q xcodegen.zip -d /tmp
+          sudo cp -R /tmp/xcodegen/bin /usr/local/
+          sudo cp -R /tmp/xcodegen/share /usr/local/
+          xcodegen --version
+      - name: Generate Xcode project
+        run: cd mobile/ios && xcodegen generate
+      - name: Build app (simulator, unsigned)
+        run: |
+          cd mobile/ios && xcodebuild \
+            -project Bursa.xcodeproj \
+            -scheme Bursa \
+            -sdk iphonesimulator \
+            -configuration Debug \
+            -derivedDataPath build \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+      - name: Package .app
+        run: |
+          cd mobile/ios
+          APP=$(find build/Build/Products -name 'Bursa.app' -type d | head -n1)
+          if [ -z "$APP" ]; then
+            echo "Bursa.app was not produced by xcodebuild" >&2
+            exit 1
+          fi
+          mkdir -p ../../out
+          ditto -c -k --sequesterRsrc --keepParent "$APP" ../../out/Bursa-ios-sim.zip
+      - name: Upload .app
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0 https://github.com/actions/upload-artifact/releases/tag/v5.0.0
+        with:
+          name: bursa-ios-app
+          path: out/Bursa-ios-sim.zip
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ stake.addr
 stake.skey
 stake.vkey
 .worktrees/
+.superpowers/

--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -1,0 +1,16 @@
+# Build-generated native artifacts (produced by gomobile / CI / Docker).
+# The Go binding (ui/mobile) is the source of truth; these are derived.
+
+# Android: the gomobile AAR and Gradle build output / wrapper jar.
+android/app/libs/*.aar
+android/app/build/
+android/.gradle/
+android/build/
+android/local.properties
+android/gradle/wrapper/gradle-wrapper.jar
+
+# iOS: the gomobile xcframework and the xcodegen-generated project.
+ios/Bursa.xcframework/
+ios/*.xcodeproj/
+ios/build/
+ios/DerivedData/

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,164 @@
+# Bursa Mobile (Phase 1)
+
+Native Android and iOS shells for the Bursa full-node wallet. Both shells embed
+the **same Go wallet core** — the supervised in-process Dingo node + the loopback
+control surface that serves the HTTP API and the embedded React SPA — via a
+[gomobile](https://pkg.go.dev/golang.org/x/mobile/cmd/gomobile) binding, and
+point a system WebView at the loopback URL the wallet serves the SPA on.
+
+This is Phase 1: the binding, the native shells, and the CI/Docker build path.
+The apps carry whatever wallet features are on this branch's base (main + the
+lean-node history-expiry profile); further features arrive automatically as their
+branches merge — the shells just load the embedded SPA, so no shell change is
+needed per feature.
+
+## Architecture
+
+```
+   ┌──────────────────────────── device ────────────────────────────┐
+   │                                                                 │
+   │  Native shell (Kotlin / Swift)                                  │
+   │  ┌───────────────┐         ┌──────────────────────────────────┐ │
+   │  │ System WebView │ ──http──▶│  Go wallet core (gomobile lib)   │ │
+   │  │  loads the SPA │ 127.0.0.1│  • boot.Boot()                   │ │
+   │  │  + calls /api  │  :<port> │  • supervised embedded Dingo node│ │
+   │  └───────────────┘         │  • wallet / spend services       │ │
+   │        ▲                    │  • api.Handler + embedded SPA    │ │
+   │        │ loadUrl/load       └──────────────────────────────────┘ │
+   │        └── app.start(dataDir, "preview", lean=true); app.port()  │
+   └─────────────────────────────────────────────────────────────────┘
+```
+
+- **Shared core.** The boot logic lives in `ui/internal/boot` (`boot.Boot`),
+  shared by the desktop binary (`ui/cmd/bursa-wallet`) and the mobile binding
+  (`ui/mobile`) so every front end brings up an identical stack.
+- **gomobile binding** (`ui/mobile`): an opaque `App` handle with three methods —
+  `Start(dataDir, network string, lean bool) error`, `Port() int`, `Stop() error`.
+  Start binds the control surface on `127.0.0.1:0` (an OS-assigned loopback port),
+  boots the wallet with the lean (history-expiry) profile, and serves the SPA +
+  API there; `Port()` returns the chosen port for the WebView. Only
+  gomobile-marshalable types cross the boundary (bool/int/int64/float/string/
+  []byte/error + the opaque `App` handle) — no maps, slices-of-structs, or
+  channels.
+- **In-process lean node.** The embedded Dingo node runs in-process with the
+  history-expiry ("lean") profile on by default, pruning immutable block history
+  past the stability window for a small on-disk footprint, and Mithril fast-sync
+  for a practical first sync.
+
+## Layout
+
+```
+mobile/
+├── README.md                  ← this file
+├── android/
+│   ├── Dockerfile             ← canonical Android build env (no host SDK needed)
+│   ├── build-in-docker.sh     ← in-container build: gomobile bind → ./gradlew
+│   ├── settings.gradle.kts, build.gradle.kts, gradle.properties
+│   └── app/
+│       ├── build.gradle.kts   ← consumes app/libs/bursa.aar; minSdk 24
+│       ├── libs/              ← bursa.aar lands here (built by CI/Docker)
+│       └── src/main/
+│           ├── AndroidManifest.xml             ← INTERNET + network-security-config
+│           ├── java/io/blinklabs/bursa/MainActivity.kt
+│           └── res/xml/network_security_config.xml  ← cleartext to 127.0.0.1 only
+└── ios/
+    ├── project.yml            ← xcodegen spec (embeds Bursa.xcframework)
+    └── Bursa/
+        ├── AppDelegate.swift
+        ├── WalletViewController.swift          ← WKWebView onto the loopback port
+        └── Info.plist                          ← ATS localhost exception
+```
+
+## Why Docker for Android (and not for iOS)
+
+The Android build is **Dockerized** (`android/Dockerfile`): the image carries the
+full toolchain — Go 1.26 + gomobile, the Android SDK cmdline-tools + a platform +
+the NDK, and JDK 17 + Gradle — so the AAR and APK build **identically in CI and
+locally**, with nothing Android-specific installed on the host. This is the
+canonical Android build mechanism; CI uses the same image.
+
+**iOS cannot be Dockerized.** Xcode requires macOS and does not run in a Linux
+container, so the iOS xcframework and `.app` are built on a **macOS** machine /
+CI runner (`macos-latest`). There is no Docker path for iOS.
+
+> **Host architecture: build Android on an `amd64` host.** The Android NDK ships
+> only a `linux-x86_64` toolchain prebuilt, and `gomobile bind -target=android`
+> panics (`unsupported GOARCH: arm64`) when run on an `arm64` Linux host because
+> it cannot find a matching NDK toolchain. Run the Android Docker build on an
+> `amd64` machine (or `docker build/run --platform linux/amd64` under emulation
+> on Apple Silicon / arm64 Linux). CI's `ubuntu-latest` runners are `amd64`, so
+> this is automatic there.
+
+## Building locally
+
+### Android (via Docker — recommended)
+
+From the **repo root** (the build context is the repo so the image can reach
+`ui/`):
+
+```sh
+# 1. Build the toolchain image (one time; ~heavy, downloads SDK + NDK)
+docker build -f mobile/android/Dockerfile -t bursa-android-build .
+
+# 2. Run the build: mounts the repo + an output dir. Produces the AAR at
+#    mobile/android/app/libs/bursa.aar and copies the debug APK to ./out/
+mkdir -p out
+docker run --rm -v "$PWD":/code -v "$PWD/out":/out bursa-android-build
+```
+
+The in-container script (`mobile/android/build-in-docker.sh`) runs, in order:
+
+```sh
+cd ui && gomobile bind -target=android -androidapi 24 \
+    -javapkg io.blinklabs.bursa -o ../mobile/android/app/libs/bursa.aar ./mobile
+cd mobile/android && ./gradlew assembleDebug
+```
+
+(The Gradle wrapper jar is not committed; the script materializes it with the
+image's Gradle on first run.)
+
+### Android (host toolchain, if you prefer)
+
+Requires Go 1.26, JDK 17, the Android SDK + NDK, and the pinned `gomobile`
+version used by CI (`go install
+golang.org/x/mobile/cmd/gomobile@v0.0.0-20260611195102-4dd8f1dbf5d2 && gomobile init`):
+
+```sh
+cd ui/web && npm ci && npm run build          # populate the embedded SPA
+cd ../ && gomobile bind -target=android -androidapi 24 \
+    -javapkg io.blinklabs.bursa -o ../mobile/android/app/libs/bursa.aar ./mobile
+cd ../mobile/android && ./gradlew assembleDebug
+```
+
+### iOS (requires macOS + Xcode)
+
+```sh
+cd ui/web && npm ci && npm run build          # populate the embedded SPA
+cd ../ && gomobile bind -target=ios -o ../mobile/ios/Bursa.xcframework ./mobile
+cd ../mobile/ios && xcodegen generate          # brew install xcodegen
+xcodebuild -project Bursa.xcodeproj -scheme Bursa \
+    -sdk iphonesimulator -configuration Debug build
+```
+
+## CI
+
+`.github/workflows/mobile.yml` (triggers: `workflow_dispatch` + tags):
+
+- **`android`** (ubuntu): builds the `mobile/android/Dockerfile` image and runs
+  the in-container build (`gomobile bind` → `./gradlew assembleDebug`), then
+  uploads the APK artifact. Same image as the local Docker path → reproducible.
+- **`ios`** (`macos-latest`): installs gomobile, `gomobile bind -target=ios` →
+  `Bursa.xcframework`, `xcodegen generate`, `xcodebuild` (simulator, unsigned),
+  then uploads the `.app`. macOS-only — Docker does not apply.
+
+## Artifacts produced only in CI / on a Mac
+
+The Go binding compiles and cross-compiles (android/arm64, ios/arm64, CGO off)
+in any environment, but the native artifacts need their platform toolchains:
+
+| Artifact            | Where it is produced                                  |
+|---------------------|-------------------------------------------------------|
+| `bursa.aar`         | Android Docker image (CI `android` job or local Docker) |
+| `bursa-debug.apk`   | same — `./gradlew assembleDebug` in the container     |
+| `Bursa.xcframework` | macOS only (CI `ios` job / a Mac with Xcode)          |
+| `Bursa.app`         | macOS only — `xcodebuild`                             |

--- a/mobile/android/Dockerfile
+++ b/mobile/android/Dockerfile
@@ -1,0 +1,139 @@
+# Copyright 2026 Blink Labs Software
+# Licensed under the Apache License, Version 2.0.
+#
+# Android build environment for the Bursa mobile wallet. This is the CANONICAL
+# Android build mechanism: it provides the full toolchain (Go + Node/npm +
+# gomobile + Android SDK + NDK + JDK 17 + Gradle) so the AAR and APK build
+# identically in CI and on a developer's machine, with no host Android SDK
+# required.
+#
+# It does NOT help iOS: Xcode requires macOS and cannot run in a Linux container.
+# The iOS xcframework + .app are built on a macOS CI runner / a Mac (see the CI
+# workflow's `ios` job and ../README.md).
+#
+# Build the image (run from the repo root so the build context is the repo):
+#   docker build --platform linux/amd64 -f mobile/android/Dockerfile -t bursa-android-build .
+# Then run the build (mounts the repo + an output dir for the APK):
+#   docker run --rm -v "$PWD":/code -v "$PWD/out":/out bursa-android-build
+# (See mobile/android/build-in-docker.sh, the image's default entrypoint.)
+
+FROM eclipse-temurin:17-jdk-noble
+
+# --- Versions (override at build time with --build-arg) -----------------------
+# Pin everything so the image — and therefore the artifact — is reproducible.
+ARG GO_VERSION=1.26.0
+ARG GO_LINUX_AMD64_SHA256=aac1b08a0fb0c4e0a7c1555beb7b59180b05dfc5a3d62e40e9de90cd42f88235
+ARG NODE_VERSION=22.21.1
+ARG ANDROID_CMDLINE_TOOLS_VERSION=11076708
+ARG ANDROID_CMDLINE_TOOLS_SHA256=2d2d50857e4eb553af5a6dc3ad507a17adf43d115264b1afc116f95c92e5e258
+ARG ANDROID_PLATFORM=android-35
+ARG ANDROID_BUILD_TOOLS=35.0.0
+ARG ANDROID_NDK_VERSION=27.2.12479018
+ARG GRADLE_VERSION=8.11.1
+ARG GRADLE_SHA256=f397b287023acdba1e9f6fc5ea72d22dd63669d59ed4a289a29b1a76eee151c6
+ARG GOMOBILE_VERSION=v0.0.0-20260611195102-4dd8f1dbf5d2
+ARG TARGETARCH
+ARG BUILDER_UID=1000
+ARG BUILDER_GID=1000
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV GRADLE_VERSION="${GRADLE_VERSION}"
+
+RUN set -eux; \
+    case "${TARGETARCH:-amd64}" in \
+        amd64) ;; \
+        arm64) echo "linux/arm64 Android container builds are not supported because gomobile init fails on linux/arm64; rebuild with --platform linux/amd64" >&2; exit 1 ;; \
+        *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl ca-certificates unzip git make xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- Go -----------------------------------------------------------------------
+# Fetch the Go toolchain for the supported image host architecture (amd64).
+RUN set -eux; \
+    case "${TARGETARCH:-amd64}" in \
+        amd64) goarch=amd64; go_sha256="${GO_LINUX_AMD64_SHA256}" ;; \
+        *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${goarch}.tar.gz" -o /tmp/go.tgz; \
+    echo "${go_sha256}  /tmp/go.tgz" | sha256sum -c -; \
+    tar -C /usr/local -xzf /tmp/go.tgz; \
+    rm /tmp/go.tgz
+ENV GOPATH="/home/builder/go"
+ENV PATH="/usr/local/go/bin:${GOPATH}/bin:${PATH}"
+
+# --- Node/npm ----------------------------------------------------------------
+# Needed by build-in-docker.sh so the canonical local Docker build embeds the
+# production SPA instead of the committed webui placeholder.
+RUN set -eux; \
+    case "${TARGETARCH:-amd64}" in \
+        amd64) nodearch=x64 ;; \
+        *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    nodefile="node-v${NODE_VERSION}-linux-${nodearch}.tar.xz"; \
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/${nodefile}" -o "/tmp/${nodefile}"; \
+    curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt" -o /tmp/node-SHASUMS256.txt; \
+    awk -v nodefile="${nodefile}" '$2 == nodefile { print; found = 1 } END { exit !found }' /tmp/node-SHASUMS256.txt > /tmp/node-SHASUMS256-selected.txt; \
+    cd /tmp; \
+    sha256sum -c node-SHASUMS256-selected.txt; \
+    tar -C /usr/local --strip-components=1 -xJf "/tmp/${nodefile}"; \
+    rm "/tmp/${nodefile}" /tmp/node-SHASUMS256.txt /tmp/node-SHASUMS256-selected.txt; \
+    node --version; \
+    npm --version
+
+# --- Android SDK + NDK --------------------------------------------------------
+ENV ANDROID_HOME="/opt/android-sdk"
+ENV ANDROID_SDK_ROOT="${ANDROID_HOME}"
+RUN set -eux; \
+    mkdir -p "${ANDROID_HOME}/cmdline-tools"; \
+    curl -fsSL "https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_CMDLINE_TOOLS_VERSION}_latest.zip" -o /tmp/cmdline-tools.zip; \
+    echo "${ANDROID_CMDLINE_TOOLS_SHA256}  /tmp/cmdline-tools.zip" | sha256sum -c -; \
+    unzip -q /tmp/cmdline-tools.zip -d "${ANDROID_HOME}/cmdline-tools"; \
+    mv "${ANDROID_HOME}/cmdline-tools/cmdline-tools" "${ANDROID_HOME}/cmdline-tools/latest"; \
+    rm /tmp/cmdline-tools.zip
+ENV PATH="${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools:${PATH}"
+RUN set -eux; \
+    yes | sdkmanager --licenses >/dev/null; \
+    sdkmanager --install \
+        "platform-tools" \
+        "platforms;${ANDROID_PLATFORM}" \
+        "build-tools;${ANDROID_BUILD_TOOLS}" \
+        "ndk;${ANDROID_NDK_VERSION}" >/dev/null
+ENV ANDROID_NDK_HOME="${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}"
+ENV ANDROID_NDK_ROOT="${ANDROID_NDK_HOME}"
+
+# --- Gradle -------------------------------------------------------------------
+# Installed so the build script can materialize the project's Gradle wrapper
+# (gradle wrapper) and then run ./gradlew, keeping the in-repo wrapper authoritative.
+RUN set -eux; \
+    curl -fsSL "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" -o /tmp/gradle.zip; \
+    echo "${GRADLE_SHA256}  /tmp/gradle.zip" | sha256sum -c -; \
+    unzip -q /tmp/gradle.zip -d /opt; \
+    rm /tmp/gradle.zip; \
+    ln -s "/opt/gradle-${GRADLE_VERSION}/bin/gradle" /usr/local/bin/gradle
+
+# --- Non-root build user ------------------------------------------------------
+ENV HOME="/home/builder"
+RUN set -eux; \
+    groupadd --gid "${BUILDER_GID}" builder; \
+    useradd --uid "${BUILDER_UID}" --gid "${BUILDER_GID}" --create-home --shell /usr/sbin/nologin builder; \
+    mkdir -p "${GOPATH}"; \
+    chown -R builder:builder /home/builder
+
+# --- gomobile -----------------------------------------------------------------
+USER builder
+RUN set -eux; \
+    go install "golang.org/x/mobile/cmd/gomobile@${GOMOBILE_VERSION}"; \
+    go install "golang.org/x/mobile/cmd/gobind@${GOMOBILE_VERSION}"; \
+    gomobile init
+
+USER root
+WORKDIR /code
+COPY mobile/android/build-in-docker.sh /usr/local/bin/build-in-docker.sh
+RUN set -eux; \
+    chmod +x /usr/local/bin/build-in-docker.sh; \
+    chown builder:builder /code
+USER builder
+ENTRYPOINT ["/usr/local/bin/build-in-docker.sh"]

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -1,0 +1,63 @@
+// Copyright 2026 Blink Labs Software
+// Licensed under the Apache License, Version 2.0.
+
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "io.blinklabs.bursa"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "io.blinklabs.bursa"
+        minSdk = 24
+        targetSdk = 35
+        versionCode = 1
+        versionName = "0.1.0"
+    }
+
+    buildTypes {
+        getByName("debug") {
+            isMinifyEnabled = false
+        }
+        getByName("release") {
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    // The gomobile AAR is dropped here by CI / the Docker build:
+    //   gomobile bind -target=android/arm64 -androidapi 24 -javapkg io.blinklabs.bursa \
+    //       -o ../mobile/android/app/libs/bursa.aar ./mobile
+    // It already bundles the per-ABI native .so libraries, so no extra ABI/NDK
+    // config is needed in this module.
+}
+
+dependencies {
+    // The gomobile-generated binding (the embedded wallet core). Consumed as a
+    // local AAR so the app does not depend on a published artifact.
+    implementation(files("libs/bursa.aar"))
+
+    implementation("androidx.appcompat:appcompat:1.7.0")
+    // NotificationCompat / ContextCompat for the foreground-service notification
+    // and the startForegroundService + permission-check helpers.
+    implementation("androidx.core:core-ktx:1.13.1")
+    // registerForActivityResult / ActivityResultContracts for the runtime
+    // POST_NOTIFICATIONS request on API 33+.
+    implementation("androidx.activity:activity-ktx:1.9.3")
+}

--- a/mobile/android/app/libs/.gitkeep
+++ b/mobile/android/app/libs/.gitkeep
@@ -1,0 +1,2 @@
+# The gomobile AAR (bursa.aar) is written here at build time (CI / Docker).
+# This file keeps the otherwise-empty directory tracked so the build target exists.

--- a/mobile/android/app/proguard-rules.pro
+++ b/mobile/android/app/proguard-rules.pro
@@ -1,0 +1,6 @@
+# Keep gomobile's generated Java bindings stable for JNI. R8 can still shrink
+# and obfuscate the app shell around them.
+-keep class io.blinklabs.bursa.mobile.** { *; }
+-keepclasseswithmembernames class * {
+    native <methods>;
+}

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2026 Blink Labs Software
+  Licensed under the Apache License, Version 2.0.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- The wallet boots an embedded Cardano node and serves a loopback control
+         surface that the WebView loads; INTERNET is needed for both the node's
+         peer connections and the loopback HTTP. -->
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+    <!-- The node lives in a foreground Service so it keeps syncing while the app
+         is backgrounded. FOREGROUND_SERVICE is required to run any foreground
+         service (API 28+); FOREGROUND_SERVICE_DATA_SYNC is the typed permission
+         required on API 34+ for the dataSync foregroundServiceType. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <!-- Required on API 33+ to post the ongoing "syncing" notification; requested
+         at runtime. The service still runs if the user denies it. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <application
+        android:allowBackup="false"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.NoActionBar"
+        android:usesCleartextTraffic="false"
+        android:networkSecurityConfig="@xml/network_security_config">
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:configChanges="orientation|screenSize|screenLayout|uiMode|keyboardHidden">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <!-- The foreground Service that owns the embedded node + loopback control
+             surface. foregroundServiceType="dataSync" is required on API 34+ and
+             MUST match the type passed to startForeground() in the service. Not
+             exported: only this app's MainActivity binds to it. -->
+        <service
+            android:name=".WalletService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
+    </application>
+</manifest>

--- a/mobile/android/app/src/main/java/io/blinklabs/bursa/MainActivity.kt
+++ b/mobile/android/app/src/main/java/io/blinklabs/bursa/MainActivity.kt
@@ -1,0 +1,280 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package io.blinklabs.bursa
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.view.ViewGroup
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+
+// MainActivity no longer owns the wallet. The embedded node + loopback control
+// surface live in WalletService (a foreground Service) so they survive the
+// Activity being backgrounded/destroyed. MainActivity starts that service,
+// binds to it, reads the loopback port() from the binder once the wallet has
+// booted, and points a full-screen WebView at it.
+//
+// The ConnectivityManager.NetworkCallback (F2) lives in the service now; the
+// onResume threshold logic (F3) stays here but routes its heavy re-dial to the
+// bound service-held App.
+class MainActivity : AppCompatActivity() {
+
+    private lateinit var webView: WebView
+
+    // Binder to the wallet service. Non-null only while bound.
+    private var walletBinder: WalletService.LocalBinder? = null
+    private var bindRequested = false
+    private var bound = false
+
+    // Resume-threshold (F3): only trigger a full OnResume re-dial when the app
+    // has been backgrounded longer than this. Quick app-switches (permission
+    // prompts, recent-apps gestures) do not bounce the node.
+    private val resumeThresholdMs = 30_000L
+    private var pauseTimestampMs = 0L
+
+    // The wallet boots asynchronously inside the service, so the port may be 0
+    // for a moment after we bind. We poll the binder until it reports a non-zero
+    // port, then load the WebView (handles the bind-before-boot race).
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val portPollDelayMs = 100L
+    private var webViewLoaded = false
+    private var walletPort = 0
+
+    private val connection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+            walletBinder = service as? WalletService.LocalBinder
+            bound = true
+            // The wallet may still be booting; wait for a real port.
+            loadWebViewWhenReady()
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            // The service process went away (e.g. crash). Drop the binder; the
+            // system will rebind when it returns.
+            walletBinder = null
+            bound = false
+        }
+    }
+
+    // Runtime POST_NOTIFICATIONS request (Android 13+). The result is ignored:
+    // the service still runs and the notification still posts whether or not the
+    // user grants it — denial only suppresses the visible notification.
+    private val requestNotificationPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* granted: Boolean — intentionally ignored */ }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        maybeRequestNotificationPermission()
+
+        webView = WebView(this).apply {
+            settings.javaScriptEnabled = true
+            settings.domStorageEnabled = true
+            // The SPA talks to the same loopback origin, so no cross-origin or
+            // file-access surface is needed.
+            settings.allowFileAccess = false
+            settings.allowContentAccess = false
+            webViewClient = object : WebViewClient() {
+                override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+                    val uri = request.url
+                    if (isWalletHttp(uri)) return false
+                    showBootError("Blocked navigation to ${uri.host ?: uri}")
+                    return true
+                }
+
+                override fun onReceivedError(
+                    view: WebView,
+                    request: WebResourceRequest,
+                    error: WebResourceError,
+                ) {
+                    if (request.isForMainFrame) {
+                        showBootError(error.description?.toString() ?: "Page failed to load.")
+                    }
+                }
+
+                override fun onReceivedHttpError(
+                    view: WebView,
+                    request: WebResourceRequest,
+                    errorResponse: WebResourceResponse,
+                ) {
+                    if (request.isForMainFrame) {
+                        showBootError("Page failed to load (${errorResponse.statusCode}).")
+                    }
+                }
+            }
+        }
+        setContentView(webView)
+
+        // Start the wallet as a foreground service so it keeps running even when
+        // this Activity is backgrounded or destroyed, then bind to read its
+        // loopback port. startForegroundService promotes the service to the
+        // foreground (it calls startForeground within the required window).
+        val intent = Intent(this, WalletService::class.java)
+        ContextCompat.startForegroundService(this, intent)
+        if (bindService(intent, connection, Context.BIND_AUTO_CREATE)) {
+            bindRequested = true
+        } else {
+            showBootError(getString(R.string.wallet_service_bind_failed))
+            stopService(intent)
+        }
+    }
+
+    // maybeRequestNotificationPermission asks for POST_NOTIFICATIONS on API 33+.
+    // On older versions the permission is granted at install time and no prompt
+    // is needed. The foreground service runs regardless of the answer.
+    private fun maybeRequestNotificationPermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        val granted = ContextCompat.checkSelfPermission(
+            this,
+            Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
+        if (!granted) {
+            requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
+
+    private fun isWalletHttp(uri: Uri): Boolean {
+        val host = uri.host ?: return false
+        val port = walletPort
+        return uri.scheme == "http" &&
+            port > 0 &&
+            uri.port == port &&
+            (host == "127.0.0.1" || host == "localhost" || host == "::1")
+    }
+
+    // loadWebViewWhenReady loads the WebView once the bound service reports a
+    // non-zero loopback port. If the wallet is still booting (port == 0) it
+    // re-polls on the main thread. Idempotent: loads at most once.
+    private fun loadWebViewWhenReady() {
+        if (webViewLoaded) return
+
+        // Check for a terminal boot failure first. If the node could not start,
+        // port() would stay 0 forever and we'd poll indefinitely behind a blank
+        // WebView. Surface the error and STOP polling (don't re-post).
+        val bootError = walletBinder?.bootError()
+        if (bootError != null) {
+            showBootError(bootError)
+            return
+        }
+
+        val port = walletBinder?.port() ?: 0
+        if (port == 0) {
+            // Still booting (or briefly unbound) — try again shortly.
+            if (bound) {
+                mainHandler.postDelayed({ loadWebViewWhenReady() }, portPollDelayMs)
+            }
+            return
+        }
+        webViewLoaded = true
+        walletPort = port
+        webView.loadUrl("http://127.0.0.1:$port/")
+    }
+
+    // showBootError renders a minimal inline error page when the node fails to
+    // boot, replacing the blank WebView the user would otherwise stare at. Marks
+    // webViewLoaded so onResume's reload() and the poll loop both treat this as
+    // the terminal loaded state.
+    private fun showBootError(message: String) {
+        webViewLoaded = true
+        val escaped = android.text.TextUtils.htmlEncode(message)
+        val html = """
+            <!doctype html>
+            <html><head><meta name="viewport" content="width=device-width,initial-scale=1">
+            <style>
+              body{font-family:sans-serif;margin:0;padding:24px;background:#111;color:#eee;
+                   display:flex;flex-direction:column;justify-content:center;min-height:100vh}
+              h1{font-size:1.25rem;margin:0 0 12px}
+              p{margin:0;color:#bbb;line-height:1.5;word-break:break-word}
+            </style></head>
+            <body>
+              <h1>Wallet failed to start</h1>
+              <p>$escaped</p>
+            </body></html>
+        """.trimIndent()
+        webView.loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
+    }
+
+    // onPause records when the app left the foreground so onResume can compute
+    // how long it was backgrounded.
+    override fun onPause() {
+        super.onPause()
+        pauseTimestampMs = System.currentTimeMillis()
+    }
+
+    // onResume (F3): on becoming visible again, always do the cheap WebView
+    // reload so the SPA refetches, and only route a heavy app.onResume() re-dial
+    // to the service when the app was suspended longer than the threshold.
+    override fun onResume() {
+        super.onResume()
+
+        // Always do the lightweight WebView reload so the SPA refetches — but
+        // only once it has actually loaded a URL (avoid reloading about:blank
+        // before the first load).
+        if (webViewLoaded) {
+            webView.reload()
+        }
+
+        // Skip the heavy re-dial if the suspension was shorter than the
+        // threshold (quick app-switch handled by the reload alone).
+        val elapsed = if (pauseTimestampMs > 0) System.currentTimeMillis() - pauseTimestampMs else 0L
+        if (elapsed < resumeThresholdMs) return
+
+        // Route the re-dial to the service-held App. The service serializes
+        // the heavy node Stop+relaunch work off this thread.
+        val binder = walletBinder ?: return
+        binder.onResume()
+    }
+
+    override fun onDestroy() {
+        // Stop polling for the port.
+        mainHandler.removeCallbacksAndMessages(null)
+
+        // Unbind from — but do NOT stop — the service: the whole point is that
+        // the node keeps running (and syncing) after the Activity is gone. The
+        // system manages the foreground service's lifetime from here.
+        if (bindRequested || bound) {
+            try {
+                unbindService(connection)
+            } catch (e: IllegalArgumentException) {
+            }
+            bindRequested = false
+            bound = false
+        }
+        walletBinder = null
+
+        if (this::webView.isInitialized) {
+            (webView.parent as? ViewGroup)?.removeView(webView)
+            webView.destroy()
+        }
+        super.onDestroy()
+    }
+}

--- a/mobile/android/app/src/main/java/io/blinklabs/bursa/WalletService.kt
+++ b/mobile/android/app/src/main/java/io/blinklabs/bursa/WalletService.kt
@@ -1,0 +1,358 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package io.blinklabs.bursa
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.os.Binder
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import androidx.core.app.NotificationCompat
+
+import io.blinklabs.bursa.mobile.App
+import io.blinklabs.bursa.mobile.Mobile
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+
+// WalletService is a bound foreground Service that OWNS the gomobile App (the
+// embedded lean Dingo node + loopback control surface). Hosting the wallet in a
+// foreground service — rather than in the Activity — keeps the node alive and
+// syncing while the app is backgrounded, instead of being torn down with the UI
+// and killed by the OS.
+//
+// The Activity binds to this service to learn the loopback port() and to route
+// lifecycle "kicks" (onNetworkChanged / onResume) to the service-held App. The
+// ConnectivityManager.NetworkCallback also lives here (not in the Activity) so
+// the node re-dials on a network change even while backgrounded.
+class WalletService : Service() {
+
+    companion object {
+        private const val TAG = "bursa"
+
+        // Notification plumbing. The channel is created in onCreate (it MUST
+        // exist before startForeground posts a notification against it).
+        private const val CHANNEL_ID = "bursa_sync"
+        private const val NOTIFICATION_ID = 1
+
+        // Debounce window for network transitions (e.g. WiFi hand-off to
+        // cellular): a 500 ms window collapses back-to-back onLost→onAvailable
+        // events from a single interface change into one re-dial.
+        private const val DEBOUNCE_DELAY_MS = 500L
+    }
+
+    // The booted wallet. Null until started; guarded by walletLock because
+    // binder calls, connectivity callbacks, and service teardown can arrive on
+    // different threads. started gates double-start.
+    private val walletLock = Any()
+    private val walletExecutor = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "bursa-wallet-lifecycle")
+    }
+    @Volatile
+    private var shuttingDown = false
+    private var reconnectInFlight = false
+    private var app: App? = null
+    private var started = false
+
+    // Set to the failure message when the node could not boot (app.start threw).
+    // The service keeps its binder answering so the Activity can read this and
+    // surface the failure instead of polling port() forever. Guarded by
+    // walletLock like the other lifecycle state.
+    private var bootError: String? = null
+
+    private val binder = LocalBinder()
+
+    private var connectivityManager: ConnectivityManager? = null
+    private var networkCallback: ConnectivityManager.NetworkCallback? = null
+
+    private val debounceHandler = Handler(Looper.getMainLooper())
+    private val reconnectRunnable = Runnable { handleNetworkChange() }
+
+    // LocalBinder is the in-process binding surface. The Activity casts the
+    // IBinder it receives in onServiceConnected to this and calls through to the
+    // service-held App. All methods are safe before the wallet has started
+    // (port() returns 0; the kicks no-op).
+    inner class LocalBinder : Binder() {
+        // port returns the loopback port the control surface bound, or 0 if the
+        // wallet has not finished starting. The Activity polls/loads only once
+        // this is non-zero (handles the bind-before-boot race).
+        fun port(): Int = synchronized(walletLock) {
+            app?.port()?.toInt() ?: 0
+        }
+
+        // bootError returns the node boot-failure message, or null if the wallet
+        // has not failed (still booting, or booted fine). The Activity checks
+        // this each poll so a boot failure ends the poll loop and surfaces an
+        // error instead of waiting on a port that will never arrive.
+        fun bootError(): String? = synchronized(walletLock) {
+            this@WalletService.bootError
+        }
+
+        // onNetworkChanged / onResume enqueue serialized service-held App kicks.
+        // The Go side performs a node Stop+relaunch cycle, so only one lifecycle
+        // kick may run at a time and none may overlap service teardown.
+        fun onNetworkChanged() {
+            enqueueWalletKick("onNetworkChanged") { it.onNetworkChanged() }
+        }
+
+        fun onResume() {
+            enqueueWalletKick("onResume") { it.onResume() }
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        // The channel must exist before any startForeground call posts against
+        // it (a missing channel throws on API 26+).
+        createNotificationChannel()
+    }
+
+    // onStartCommand promotes the service to the foreground and dispatches the
+    // wallet boot off the service thread. It is idempotent: a redelivered start
+    // intent (or a second startForegroundService from the Activity) must not
+    // double-start the node.
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Always (re)assert foreground status with the ongoing notification.
+        // On API 29+ the foregroundServiceType MUST be passed here too — it has
+        // to match the manifest's android:foregroundServiceType="dataSync"
+        // (which itself is a required manifest declaration as of API 34).
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                NOTIFICATION_ID,
+                buildNotification(),
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, buildNotification())
+        }
+
+        try {
+            walletExecutor.execute { startWalletIfNeeded() }
+        } catch (e: RejectedExecutionException) {
+            android.util.Log.w(TAG, "wallet start rejected", e)
+        }
+
+        // STICKY: if the OS kills us under memory pressure, restart the service
+        // (with a null intent) so the node comes back up. We don't carry intent
+        // data, so we don't need REDELIVER_INTENT.
+        return START_STICKY
+    }
+
+    // startWalletIfNeeded boots the gomobile App once. Guarded by `started` so
+    // repeated onStartCommand deliveries don't attempt a second start (the Go
+    // side also errors on double-start, but we gate here to avoid the throw).
+    // A boot failure is also terminal — once `bootError` is set we don't retry.
+    private fun startWalletIfNeeded() {
+        synchronized(walletLock) {
+            if (started || bootError != null || shuttingDown) return
+        }
+        val instance = Mobile.new_()
+        try {
+            // filesDir = app-private writable dir; "preview" network; lean=true
+            // selects the small-footprint history-expiry profile for a phone.
+            instance.start(filesDir.absolutePath, "preview", true)
+        } catch (e: Exception) {
+            android.util.Log.e(TAG, "wallet start failed", e)
+            // Could not boot. We must NOT silently stopSelf() here: the Activity
+            // is still bound and only learns of a dead node by polling port(),
+            // which would stay 0 forever (onServiceDisconnected does not fire on
+            // a stopSelf of a still-bound service). Instead, record the failure
+            // so the binder can report it, then drop the foreground notification
+            // (there is nothing syncing). Keep the service alive/bound so the
+            // Activity can read bootError() and surface it; the system tears the
+            // service down once the Activity unbinds in onDestroy.
+            synchronized(walletLock) {
+                bootError = e.message ?: e.toString()
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                stopForeground(STOP_FOREGROUND_REMOVE)
+            } else {
+                @Suppress("DEPRECATION")
+                stopForeground(true)
+            }
+            return
+        }
+        var stopStartedInstance = false
+        synchronized(walletLock) {
+            if (shuttingDown) {
+                stopStartedInstance = true
+            } else {
+                app = instance
+                started = true
+            }
+        }
+        if (stopStartedInstance) {
+            instance.stop()
+            return
+        }
+
+        // Now that the node is running, watch for host network changes so it
+        // re-dials peers even while the Activity is gone/backgrounded.
+        registerNetworkCallback()
+    }
+
+    // registerNetworkCallback subscribes to connectivity events. Lives in the
+    // service (moved out of the Activity in F2) so re-dial works while
+    // backgrounded. ACCESS_NETWORK_STATE is a normal/install-time permission.
+    private fun registerNetworkCallback() {
+        if (networkCallback != null) return
+        val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+            ?: return
+        connectivityManager = cm
+
+        val request = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+
+        val callback = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                scheduleReconnect()
+            }
+
+            override fun onLost(network: Network) {
+                scheduleReconnect()
+            }
+        }
+        networkCallback = callback
+        cm.registerNetworkCallback(request, callback)
+    }
+
+    private fun scheduleReconnect() {
+        // Restart the debounce window so rapid onLost→onAvailable transitions
+        // collapse into a single reconnect.
+        debounceHandler.removeCallbacks(reconnectRunnable)
+        debounceHandler.postDelayed(reconnectRunnable, DEBOUNCE_DELAY_MS)
+    }
+
+    private fun handleNetworkChange() {
+        enqueueWalletKick("onNetworkChanged") { it.onNetworkChanged() }
+    }
+
+    private fun enqueueWalletKick(label: String, action: (App) -> Unit) {
+        if (shuttingDown) return
+        synchronized(walletLock) {
+            if (shuttingDown || app == null || reconnectInFlight) return
+            reconnectInFlight = true
+        }
+        try {
+            walletExecutor.execute {
+                // Grab the instance under the lock, then release it before making
+                // the blocking Go call (a node Stop+relaunch, which takes seconds).
+                // Holding walletLock for that whole call would also block the
+                // binder's port()/bootError() queries and onDestroy() if they run
+                // on the main thread concurrently, risking an ANR. The Go side
+                // (supervisor.lifecycleMu) already serializes Stop against
+                // Reconnect/OnResume, so running action() on this reference after
+                // a concurrent onDestroy()/Stop() is safe.
+                val instance = synchronized(walletLock) {
+                    if (shuttingDown) null else app
+                }
+                try {
+                    instance?.let { action(it) }
+                } catch (e: Exception) {
+                    android.util.Log.w(TAG, "$label failed", e)
+                } finally {
+                    synchronized(walletLock) {
+                        reconnectInFlight = false
+                    }
+                }
+            }
+        } catch (e: RejectedExecutionException) {
+            synchronized(walletLock) {
+                reconnectInFlight = false
+            }
+            android.util.Log.w(TAG, "$label rejected", e)
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder = binder
+
+    override fun onDestroy() {
+        shuttingDown = true
+
+        // Cancel any pending debounced reconnect.
+        debounceHandler.removeCallbacks(reconnectRunnable)
+
+        // Unregister the network callback before tearing the wallet down so no
+        // late callback tries to call onNetworkChanged() after Stop.
+        networkCallback?.let { cb ->
+            connectivityManager?.unregisterNetworkCallback(cb)
+        }
+        networkCallback = null
+
+        // Wind down the in-process node and drain the control surface. Taking
+        // walletLock waits for any in-flight reconnect/resume kick to finish
+        // before Stop runs against the same Go App instance.
+        val instance = synchronized(walletLock) {
+            val current = app
+            app = null
+            started = false
+            reconnectInFlight = false
+            current
+        }
+        instance?.stop()
+        walletExecutor.shutdownNow()
+        super.onDestroy()
+    }
+
+    // createNotificationChannel registers the low-importance channel used for
+    // the ongoing "syncing" notification. No-op before API 26 (channels did not
+    // exist then). IMPORTANCE_LOW => no sound, collapsed by default.
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (manager.getNotificationChannel(CHANNEL_ID) != null) return
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            getString(R.string.sync_channel_name),
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = getString(R.string.sync_channel_description)
+            setShowBadge(false)
+        }
+        manager.createNotificationChannel(channel)
+    }
+
+    // buildNotification creates the ongoing, low-priority "Bursa is syncing"
+    // notification shown while the service runs. Tapping it returns to the app.
+    private fun buildNotification(): Notification {
+        val contentIntent = android.app.PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            },
+            android.app.PendingIntent.FLAG_IMMUTABLE,
+        )
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(getString(R.string.sync_notification_title))
+            .setContentText(getString(R.string.sync_notification_text))
+            .setSmallIcon(android.R.drawable.stat_notify_sync)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOngoing(true)
+            .setShowWhen(false)
+            .setContentIntent(contentIntent)
+            .build()
+    }
+}

--- a/mobile/android/app/src/main/res/values/strings.xml
+++ b/mobile/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Bursa</string>
+
+    <!-- Foreground-service notification + channel (the embedded node keeps
+         syncing in the background). -->
+    <string name="sync_channel_name">Wallet sync</string>
+    <string name="sync_channel_description">Keeps your wallet up to date while Bursa runs in the background.</string>
+    <string name="sync_notification_title">Bursa is syncing</string>
+    <string name="sync_notification_text">Keeping your wallet up to date in the background.</string>
+    <string name="wallet_service_bind_failed">Could not connect to the wallet service.</string>
+</resources>

--- a/mobile/android/app/src/main/res/xml/network_security_config.xml
+++ b/mobile/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  The wallet's loopback control surface is plain http on 127.0.0.1 (TLS over
+  loopback would add no security and just complicate cert handling). Permit
+  cleartext only to the loopback addresses; everything else stays cleartext-off.
+
+  A base-config with cleartextTrafficPermitted="false" is required to enforce
+  cleartext-off for all other domains on API 24-27 devices. On those API levels
+  the platform default is cleartext-on, and the manifest's usesCleartextTraffic
+  attribute is ignored when networkSecurityConfig is present — so without this
+  base-config, all non-loopback cleartext is permitted on older devices.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">127.0.0.1</domain>
+        <domain includeSubdomains="false">localhost</domain>
+    </domain-config>
+</network-security-config>

--- a/mobile/android/build-in-docker.sh
+++ b/mobile/android/build-in-docker.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Copyright 2026 Blink Labs Software
+# Licensed under the Apache License, Version 2.0.
+#
+# Builds the Bursa Android app inside the bursa-android-build container:
+#   1. gomobile bind  -> mobile/android/app/libs/bursa.aar  (the wallet core)
+#   2. ./gradlew assembleDebug -> the debug APK
+#   3. copies the APK to /out (a mounted host dir) if one is mounted.
+#
+# It expects the repo mounted at /code (the image WORKDIR) and, optionally, an
+# output dir mounted at /out. See mobile/android/Dockerfile for the run command.
+set -euo pipefail
+
+REPO=/code
+OUT=/out
+
+echo "==> Building web bundle (populates the //go:embed dist target)"
+# The webui package embeds ui/internal/webui/dist; the repo ships an index.html
+# placeholder only so Go builds before the SPA is compiled. The Android image
+# includes pinned Node/npm, so the canonical container build must produce the
+# production bundle before gomobile embeds it.
+(cd "${REPO}/ui/web" && npm ci && npm run build)
+
+echo "==> gomobile bind (android AAR)"
+mkdir -p "${REPO}/mobile/android/app/libs"
+# arm64 only: the 32-bit Android ABIs (armeabi-v7a/x86) overflow math.MaxUint32
+# (int is 32-bit there) in the apollo/dingo deps, so restrict to android/arm64.
+(cd "${REPO}/ui" && gomobile bind \
+    -target=android/arm64 \
+    -androidapi 24 \
+    -javapkg io.blinklabs.bursa \
+    -o "${REPO}/mobile/android/app/libs/bursa.aar" \
+    ./mobile)
+echo "    wrote mobile/android/app/libs/bursa.aar"
+
+echo "==> Materializing Gradle wrapper (if missing)"
+cd "${REPO}/mobile/android"
+if [ ! -f gradle/wrapper/gradle-wrapper.jar ]; then
+    # The wrapper .jar is binary and not committed; generate it from the pinned
+    # Gradle in the image. gradle-wrapper.properties pins the distribution.
+    gradle wrapper --gradle-version "${GRADLE_VERSION:-8.11.1}"
+fi
+
+echo "==> ./gradlew assembleDebug"
+./gradlew --no-daemon assembleDebug
+
+APK=$(find "${REPO}/mobile/android/app/build/outputs/apk/debug" -name '*.apk' | head -n1 || true)
+if [ -n "${APK}" ]; then
+    echo "==> Built APK: ${APK}"
+    if [ -d "${OUT}" ]; then
+        cp "${APK}" "${OUT}/"
+        echo "    copied to ${OUT}/$(basename "${APK}")"
+    fi
+else
+    echo "!! No APK produced" >&2
+    exit 1
+fi

--- a/mobile/android/build.gradle.kts
+++ b/mobile/android/build.gradle.kts
@@ -1,0 +1,9 @@
+// Copyright 2026 Blink Labs Software
+// Licensed under the Apache License, Version 2.0.
+
+// Top-level build file. Plugin versions are declared (apply false) here and
+// applied in the module build.gradle.kts.
+plugins {
+    id("com.android.application") version "8.7.3" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+}

--- a/mobile/android/gradle.properties
+++ b/mobile/android/gradle.properties
@@ -1,0 +1,5 @@
+# Copyright 2026 Blink Labs Software
+# Licensed under the Apache License, Version 2.0.
+android.useAndroidX=true
+kotlin.code.style=official
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8

--- a/mobile/android/gradle/wrapper/gradle-wrapper.properties
+++ b/mobile/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,8 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionSha256Sum=f397b287023acdba1e9f6fc5ea72d22dd63669d59ed4a289a29b1a76eee151c6
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/mobile/android/settings.gradle.kts
+++ b/mobile/android/settings.gradle.kts
@@ -1,0 +1,21 @@
+// Copyright 2026 Blink Labs Software
+// Licensed under the Apache License, Version 2.0.
+
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "Bursa"
+include(":app")

--- a/mobile/ios/Bursa/AppDelegate.swift
+++ b/mobile/ios/Bursa/AppDelegate.swift
@@ -1,0 +1,94 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Network
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    // Observes host connectivity so the wallet re-dials peers on a network
+    // transition (WiFi<->cellular, loss->regain), mirroring the Android
+    // ConnectivityManager.NetworkCallback in WalletService.kt. Lives here
+    // (rather than in the view controller) because AppDelegate is the
+    // process-lifetime owner, matching where Android hosts its callback.
+    private let pathMonitor = NWPathMonitor()
+    private let pathMonitorQueue = DispatchQueue(label: "io.blinklabs.bursa.pathmonitor")
+    private var reconnectWorkItem: DispatchWorkItem?
+
+    // 500 ms debounce window collapsing back-to-back path updates (e.g. a
+    // brief drop during a WiFi<->cellular hand-off) into a single reconnect.
+    // Matches WalletService.kt's DEBOUNCE_DELAY_MS.
+    private static let networkDebounceDelay: TimeInterval = 0.5
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = WalletViewController()
+        window.makeKeyAndVisible()
+        self.window = window
+        startPathMonitor()
+        return true
+    }
+
+    // Re-dial peers when the app returns to the foreground. Peer connections go
+    // stale during suspension; calling onResume() triggers a node Stop+relaunch
+    // cycle that re-establishes them. WalletViewController exposes the wallet via
+    // a public accessor so the delegate can reach it here.
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        guard let vc = window?.rootViewController as? WalletViewController else { return }
+        DispatchQueue.global(qos: .utility).async { [weak vc] in
+            vc?.onResume()
+        }
+    }
+
+    // Best-effort termination cleanup. WalletViewController.deinit calls stop()
+    // for normal app lifecycle; applicationWillTerminate gives one last short
+    // synchronous window when iOS delivers the termination callback.
+    func applicationWillTerminate(_ application: UIApplication) {
+        pathMonitor.cancel()
+        guard let vc = window?.rootViewController as? WalletViewController else { return }
+        vc.stopWallet()
+    }
+
+    // startPathMonitor begins observing host connectivity for the process
+    // lifetime. Every path update (gained or lost) is debounced and forwarded
+    // to WalletViewController.onNetworkChanged(), which is a safe no-op before
+    // the wallet has started or after it has stopped — so it is safe to start
+    // this immediately at launch rather than gating it on boot completion.
+    private func startPathMonitor() {
+        pathMonitor.pathUpdateHandler = { [weak self] _ in
+            self?.scheduleReconnect()
+        }
+        pathMonitor.start(queue: pathMonitorQueue)
+    }
+
+    // scheduleReconnect (re)starts the debounce window, coalescing rapid
+    // connectivity flaps into a single reconnect. Runs on pathMonitorQueue.
+    private func scheduleReconnect() {
+        reconnectWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            // window/rootViewController are UIKit and must be read on main.
+            DispatchQueue.main.async { [weak self] in
+                guard let vc = self?.window?.rootViewController as? WalletViewController else { return }
+                vc.onNetworkChanged()
+            }
+        }
+        reconnectWorkItem = workItem
+        pathMonitorQueue.asyncAfter(deadline: .now() + Self.networkDebounceDelay, execute: workItem)
+    }
+}

--- a/mobile/ios/Bursa/Info.plist
+++ b/mobile/ios/Bursa/Info.plist
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2026 Blink Labs Software
+  Licensed under the Apache License, Version 2.0.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <!--
+      App Transport Security: the wallet's loopback control surface is plain http
+      on 127.0.0.1 (TLS over loopback adds no security). Permit cleartext only to
+      localhost; everything else keeps ATS's secure defaults.
+    -->
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsLocalNetworking</key>
+        <true/>
+    </dict>
+</dict>
+</plist>

--- a/mobile/ios/Bursa/WalletViewController.swift
+++ b/mobile/ios/Bursa/WalletViewController.swift
@@ -1,0 +1,270 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+import WebKit
+import OSLog
+
+// Mobile is the gomobile-generated framework. `gomobile bind -target=ios`
+// compiles the Go `mobile` package into Bursa.xcframework; the Go package name
+// becomes the Objective-C symbol prefix `Mobile`. So the Go `App` struct is the
+// class `MobileApp`, and the Go `New()` constructor is the free function
+// `MobileNew()`. (Bursa.xcframework is the framework module Swift imports.)
+import Bursa
+
+// WalletViewController boots the in-process wallet (the embedded lean Dingo node
+// + the loopback control surface serving the API and the embedded SPA), then
+// points a full-screen WKWebView at the loopback URL the wallet chose.
+class WalletViewController: UIViewController, WKNavigationDelegate {
+
+    // os.Logger redacts dynamic string interpolations (e.g. error descriptions,
+    // which could carry file paths) by default, unlike NSLog which writes raw
+    // text into the public system log console.
+    private static let logger = Logger(subsystem: "io.blinklabs.bursa", category: "wallet")
+
+    private var app: MobileApp?
+    private var webView: WKWebView!
+    private var walletPort = 0
+    private static let stateQueueKey = DispatchSpecificKey<String>()
+    private let stateQueue: DispatchQueue = {
+        let queue = DispatchQueue(label: "io.blinklabs.bursa.wallet.state")
+        queue.setSpecific(key: WalletViewController.stateQueueKey, value: "state")
+        return queue
+    }()
+    private var stopping = false
+
+    override func loadView() {
+        let config = WKWebViewConfiguration()
+        // The SPA uses DOM storage; WKWebView enables JavaScript by default.
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = self
+        self.webView = webView
+        view = webView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Boot the wallet in-process. The Documents dir is the app's writable
+        // data dir; "preview" is the network; lean = true selects the
+        // history-expiry profile (small on-disk footprint) for a phone.
+        let dataDir = NSSearchPathForDirectoriesInDomains(
+            .documentDirectory, .userDomainMask, true
+        ).first ?? NSTemporaryDirectory()
+
+        startWallet(dataDir: dataDir)
+    }
+
+    private func startWallet(dataDir: String) {
+        let app = MobileNew()
+        stateQueue.async { [weak self] in
+            guard let self = self else {
+                Self.stopApp(app)
+                return
+            }
+            guard !self.stopping else {
+                return
+            }
+            self.app = app
+
+            do {
+                try app?.start(dataDir, network: "preview", lean: true)
+            } catch {
+                Self.logger.error("wallet start failed: \(String(describing: error))")
+                Self.stopApp(app)
+                self.app = nil
+                DispatchQueue.main.async { [weak self] in
+                    self?.showStartupError("Wallet failed to start", detail: error.localizedDescription)
+                }
+                return
+            }
+
+            // app.port() is the OS-assigned loopback port the control surface bound.
+            let port = app?.port() ?? 0
+            guard port > 0, let url = URL(string: "http://127.0.0.1:\(port)/") else {
+                Self.logger.error("wallet returned invalid port \(port)")
+                self.app = nil
+                Self.stopApp(app)
+                DispatchQueue.main.async { [weak self] in
+                    self?.showStartupError(
+                        "Wallet failed to start",
+                        detail: "The wallet did not bind to a valid port."
+                    )
+                }
+                return
+            }
+
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else {
+                    Self.stopApp(app)
+                    return
+                }
+                guard self.shouldUseStartedApp() else {
+                    Self.stopApp(app)
+                    return
+                }
+                self.walletPort = port
+                self.webView.load(URLRequest(url: url))
+            }
+        }
+    }
+
+    private func shouldUseStartedApp() -> Bool {
+        syncState {
+            !stopping && app != nil
+        }
+    }
+
+    private func showStartupError(_ title: String, detail: String) {
+        if syncState({ !stopping && app == nil }) {
+            showError(title, detail: detail)
+        }
+    }
+
+    // onResume re-dials the node's peers after the app returns from the
+    // background. Called by AppDelegate.applicationWillEnterForeground.
+    //
+    // The Go-side call is a blocking node Stop+relaunch cycle (seconds), so it
+    // must never run synchronously on the caller's thread. AppDelegate already
+    // hops to a background queue before calling this, but dispatching onto
+    // stateQueue here too makes the method itself safe regardless of caller,
+    // and serializes it against startWallet/stopWallet's state mutations.
+    func onResume() {
+        stateQueue.async { [weak self] in
+            guard let self = self, !self.stopping else { return }
+            do {
+                try self.app?.onResume()
+            } catch {
+                Self.logger.error("wallet resume failed: \(String(describing: error))")
+            }
+        }
+    }
+
+    // onNetworkChanged re-dials the node's peers after a host connectivity
+    // transition (WiFi<->cellular, loss->regain). Called by AppDelegate's
+    // NWPathMonitor callback, debounced there the same way Android's
+    // ConnectivityManager.NetworkCallback debounces onAvailable/onLost.
+    //
+    // Same threading contract as onResume: the Go-side call is a blocking node
+    // Stop+relaunch cycle, so it always hops onto stateQueue rather than
+    // running on the caller's thread, and self.app?.onNetworkChanged() is a
+    // documented no-op before Start/after Stop.
+    func onNetworkChanged() {
+        stateQueue.async { [weak self] in
+            guard let self = self, !self.stopping else { return }
+            do {
+                try self.app?.onNetworkChanged()
+            } catch {
+                Self.logger.error("wallet network-changed failed: \(String(describing: error))")
+            }
+        }
+    }
+
+    // stopWallet tears the wallet down cleanly. Called by AppDelegate on
+    // applicationWillTerminate. deinit handles the normal destroy path.
+    func stopWallet() {
+        stopWalletLogged()
+    }
+
+    private func stopWalletLogged() {
+        let currentApp = syncState { () -> MobileApp? in
+            stopping = true
+            let current = app
+            app = nil
+            return current
+        }
+        Self.stopApp(currentApp)
+    }
+
+    private static func stopApp(_ app: MobileApp?) {
+        do {
+            try app?.stop()
+        } catch {
+            logger.error("wallet stop failed: \(String(describing: error))")
+        }
+    }
+
+    private func syncState<T>(_ work: () -> T) -> T {
+        if DispatchQueue.getSpecific(key: Self.stateQueueKey) != nil {
+            return work()
+        }
+        return stateQueue.sync {
+            work()
+        }
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.cancel)
+            return
+        }
+        if isWalletURL(url) || url.scheme == "about" {
+            decisionHandler(.allow)
+            return
+        }
+
+        decisionHandler(.cancel)
+        if navigationAction.targetFrame?.isMainFrame ?? true {
+            showError("Blocked navigation", detail: "The wallet blocked navigation to \(url.absoluteString).")
+        }
+    }
+
+    private func isWalletURL(_ url: URL) -> Bool {
+        guard url.scheme == "http", walletPort > 0, url.port == walletPort else {
+            return false
+        }
+        guard let host = url.host?.lowercased() else {
+            return false
+        }
+        return host == "127.0.0.1" || host == "localhost" || host == "::1" || host == "[::1]"
+    }
+
+    // showError renders a minimal inline error page when the wallet fails to
+    // boot, replacing the blank WebView the user would otherwise see.
+    private func showError(_ title: String, detail: String) {
+        let escaped = detail
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+        let html = """
+        <!doctype html>
+        <html>
+        <head>
+          <meta name="viewport" content="width=device-width,initial-scale=1">
+          <style>
+            body{font-family:sans-serif;margin:0;padding:24px;background:#111;color:#eee;
+                 display:flex;flex-direction:column;justify-content:center;min-height:100vh}
+            h1{font-size:1.25rem;margin:0 0 12px}
+            p{margin:0;color:#bbb;line-height:1.5;word-break:break-word}
+          </style>
+        </head>
+        <body>
+          <h1>\(title)</h1>
+          <p>\(escaped)</p>
+        </body>
+        </html>
+        """
+        webView.loadHTMLString(html, baseURL: nil)
+    }
+
+    deinit {
+        // Tear the wallet down: drains the control surface and winds down the
+        // in-process node.
+        stopWalletLogged()
+    }
+}

--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -1,0 +1,40 @@
+# Copyright 2026 Blink Labs Software
+# Licensed under the Apache License, Version 2.0.
+#
+# xcodegen project spec for the Bursa iOS app. Generate the .xcodeproj with:
+#   cd mobile/ios && xcodegen generate
+# then build with:
+#   xcodebuild -project Bursa.xcodeproj -scheme Bursa \
+#       -sdk iphonesimulator -configuration Debug build
+#
+# The Go wallet core is the Bursa.xcframework produced by `gomobile bind
+# -target=ios ... ./mobile` (see ../README.md / the CI `ios` job). It is expected
+# at mobile/ios/Bursa.xcframework and embedded into the app below.
+
+name: Bursa
+options:
+  bundleIdPrefix: io.blinklabs
+  deploymentTarget:
+    iOS: "15.0"
+
+targets:
+  Bursa:
+    type: application
+    platform: iOS
+    sources:
+      - path: Bursa
+    info:
+      path: Bursa/Info.plist
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: io.blinklabs.bursa
+        PRODUCT_NAME: Bursa
+        GENERATE_INFOPLIST_FILE: NO
+        # Allow building without a signing identity in CI (simulator/unsigned).
+        CODE_SIGNING_ALLOWED: NO
+        CODE_SIGNING_REQUIRED: NO
+    dependencies:
+      # The gomobile-generated wallet core. embed: true copies it into the .app;
+      # gomobile xcframeworks are dynamic and must be embedded + signed.
+      - framework: Bursa.xcframework
+        embed: true

--- a/ui/cmd/bursa-wallet/main.go
+++ b/ui/cmd/bursa-wallet/main.go
@@ -18,52 +18,22 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
-	"time"
 
-	"github.com/blinklabs-io/apollo/v2/backend/utxorpc"
-	"github.com/blinklabs-io/bursa/ui/internal/api"
-	"github.com/blinklabs-io/bursa/ui/internal/cardanonet"
-	"github.com/blinklabs-io/bursa/ui/internal/chain"
-	"github.com/blinklabs-io/bursa/ui/internal/keystore"
-	"github.com/blinklabs-io/bursa/ui/internal/poolops"
-	"github.com/blinklabs-io/bursa/ui/internal/settings"
-	"github.com/blinklabs-io/bursa/ui/internal/spend"
-	"github.com/blinklabs-io/bursa/ui/internal/supervisor"
-	"github.com/blinklabs-io/bursa/ui/internal/vault"
-	"github.com/blinklabs-io/bursa/ui/internal/wallet"
-	"github.com/blinklabs-io/bursa/ui/internal/webui"
+	"github.com/blinklabs-io/bursa/ui/internal/boot"
 )
 
-// vaultKeystore adapts the encrypted vault to the spend service's Keystore
-// interface. The vault owns seed encryption and the active-wallet selection, so
-// Unlock decrypts the ACTIVE wallet's seed under the supplied spending password;
-// Create is unsupported (wallets are added via the vault) and Exists is true
-// whenever a wallet is active.
-type vaultKeystore struct{ v *vault.Vault }
-
-func (k vaultKeystore) Exists() bool { return k.v.ActiveID() != "" }
-
-func (k vaultKeystore) Create(string, string) error {
-	return errors.New("wallets are added through the vault, not the keystore")
-}
-
-func (k vaultKeystore) Unlock(password string) ([]byte, error) {
-	return k.v.UnlockSeed(password)
-}
-
-func (k vaultKeystore) UnlockFor(walletID, password string) ([]byte, error) {
-	return k.v.UnlockSeedFor(walletID, password)
-}
+// desktopAddr is the fixed loopback control-surface address the desktop binary
+// serves on (a browser or the embedded webview navigates here). Mobile instead
+// uses an OS-assigned port (boot.Config.Addr "127.0.0.1:0").
+const desktopAddr = "127.0.0.1:8090"
 
 func main() {
 	if err := run(); err != nil {
@@ -80,122 +50,36 @@ func run() error {
 		return err
 	}
 	network := envOr("BURSA_NETWORK", "preview")
-	netID, err := cardanonet.AddressNetworkID(network)
-	if err != nil {
-		return fmt.Errorf("invalid BURSA_NETWORK %q: must be one of %s", network, cardanonet.SupportedNetworks())
-	}
 	dataDir := filepath.Join(home, ".bursa-wallet", network)
-	if err := os.MkdirAll(dataDir, 0o700); err != nil {
-		return err
-	}
 
-	const (
-		utxorpcPort    uint = 5555
-		blockfrostPort uint = 5556
-	)
 	// Mithril fast-sync is on by default; BURSA_SYNC=genesis opts out.
 	mithrilEnabled := !strings.EqualFold(envOr("BURSA_SYNC", "mithril"), "genesis")
-
-	// The lean-node (history-expiry) profile is now a persisted, user-facing app
-	// setting (the source of truth) rather than an env-only control. BURSA_LEAN
-	// only SEEDS the first-run default — once a value is persisted (default off,
-	// or whatever the user later sets in the Settings screen), the env is ignored.
-	// This keeps the env as the initial-default seed for mobile builds.
-	settingsStore, err := settings.Load(filepath.Join(dataDir, "settings.json"))
-	if err != nil {
-		return fmt.Errorf("load settings: %w", err)
-	}
-	if err := settingsStore.SeedDefault(envBool("BURSA_LEAN", false)); err != nil {
-		return fmt.Errorf("seed lean-node default: %w", err)
-	}
-
-	nodeDataDir := filepath.Join(dataDir, "db")
-	sup := supervisor.New(supervisor.Config{
-		Network:        network,
-		DataDir:        nodeDataDir,
-		SocketPath:     filepath.Join(dataDir, "node.socket"),
-		UtxorpcPort:    utxorpcPort,
-		BlockfrostPort: blockfrostPort,
-		Logger:         logger,
-		MithrilEnabled: mithrilEnabled,
-		// Read the persisted setting fresh at each node construction, so a toggle
-		// in the Settings screen takes effect on the next node restart. This is
-		// deliberately a provider because Mithril bootstrap defers construction
-		// until after the snapshot import completes.
-		HistoryExpiry: settingsStore.HistoryExpiry,
-	})
-
-	// The wallet queries the node's own loopback Blockfrost endpoint. The same
-	// client also verifies pasted pool/DRep IDs and reads protocol params for the
-	// staking flow (consent law: the embedded node is the only network contact).
-	chainClient := chain.NewClient(blockfrostPort, chain.WithDingoDataDir(nodeDataDir))
-	walletSvc := wallet.NewService(chainClient)
-
-	// The vault is the encrypted multi-wallet store: a single file under the data
-	// dir holding the wallet index (encrypted under the vault password) and each
-	// wallet's seed (encrypted under its own spending password). It replaces the
-	// old single plaintext/keystore model — no plaintext seeds at rest.
-	vlt := vault.New(filepath.Join(dataDir, "vault.json"))
-	legacyKeyStore := keystore.New(filepath.Join(dataDir, "keystore.json"))
-
-	// Spending builds/signs/submits through the node's loopback UTxO-RPC
-	// endpoint; the active wallet's seed is decrypted from the vault on demand.
-	// Delegation txs additionally query pool/DRep/account state + protocol params
-	// through the Blockfrost client.
-	chainCtx := utxorpc.NewUtxoRpcChainContext(
-		fmt.Sprintf("http://127.0.0.1:%d", utxorpcPort), netID, nil,
-	)
-	spendSvc := spend.NewService(chainCtx, vaultKeystore{v: vlt}, nil)
-	spendSvc.SetChainQuerier(chainClient)
-
-	// Stake Pool Operations: derives cold/VRF/KES credentials and builds/submits
-	// pool certificates on the active wallet, sharing the spend chain context for
-	// submission. Genesis (for KES-period math) comes from the node's loopback
-	// Blockfrost endpoint; the tip comes from the supervisor — no external call.
-	poolGenesis := chain.NewClient(blockfrostPort)
-	poolSvc := poolops.NewService(
-		chainCtx, vaultKeystore{v: vlt},
-		genesisAdapter{c: poolGenesis},
-		tipAdapter{sup: sup},
-	)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	if err := sup.Start(ctx); err != nil {
-		return fmt.Errorf("start node: %w", err)
+	// Boot the shared wallet stack (supervisor + node + chain + api + embedded
+	// SPA) on the fixed desktop loopback port. This is the same wiring the mobile
+	// binding (ui/mobile) drives — see internal/boot.
+	app, err := boot.Boot(ctx, boot.Config{
+		Network:        network,
+		DataDir:        dataDir,
+		Addr:           desktopAddr,
+		Logger:         logger,
+		MithrilEnabled: mithrilEnabled,
+		// BURSA_LEAN seeds the first-run lean-node default; the persisted setting
+		// (default off) is the source of truth thereafter.
+		LeanDefault: envBool("BURSA_LEAN", false),
+	})
+	if err != nil {
+		return err
 	}
-	defer sup.Stop()
-
-	srv := &http.Server{
-		Addr: "127.0.0.1:8090", // loopback only
-		Handler: api.NewHandler(
-			sup, vlt, walletSvc, spendSvc,
-			&settingsController{store: settingsStore, sup: sup},
-			chainClient,
-			poolSvc,
-			network, webui.Handler(),
-			api.WithLegacyKeystore(legacyKeyStore),
-		),
-		ReadHeaderTimeout: 5 * time.Second,
-	}
-	srvErr := make(chan error, 1)
-	go func() {
-		logger.Info("control surface listening", "addr", srv.Addr)
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			srvErr <- err
-		}
-	}()
+	defer func() { _ = app.Stop() }()
 
 	// Block until it's time to shut down. The default (headless) build waits for a
 	// signal and serves the UI over loopback for a browser; the `webview` build
 	// opens a native window onto the same loopback UI and waits for it to close.
-	uiErr := awaitUI(ctx, "http://"+srv.Addr, logger, srvErr)
-
-	logger.Info("shutting down")
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	_ = srv.Shutdown(shutdownCtx)
+	uiErr := awaitUI(ctx, app.URL(), logger, app.Err())
 	return uiErr
 }
 
@@ -218,61 +102,4 @@ func envBool(key string, def bool) bool {
 		return def
 	}
 	return b
-}
-
-// settingsController adapts the persisted settings store + the supervisor to the
-// api.SettingsController surface. The store is the source of truth for the
-// lean-node profile; the supervisor reports what the running node was actually
-// built with, so a change can be flagged as needing a node restart.
-type settingsController struct {
-	store *settings.Store
-	sup   *supervisor.Supervisor
-}
-
-func (c *settingsController) HistoryExpiry() bool { return c.store.HistoryExpiry() }
-
-func (c *settingsController) SetHistoryExpiry(enabled bool) error {
-	return c.store.SetHistoryExpiry(enabled)
-}
-
-// HistoryExpiryRestartRequired reports whether the persisted value differs from
-// what the running node was launched with. History expiry is a node-construction
-// option, so it only takes effect on the next node start: if no node has been
-// launched yet (ran=false), there is nothing to restart, and any pending launch
-// will read the latest persisted value when it constructs the node.
-func (c *settingsController) HistoryExpiryRestartRequired() bool {
-	applied, ran := c.sup.AppliedHistoryExpiry()
-	if !ran {
-		return false
-	}
-	return applied != c.store.HistoryExpiry()
-}
-
-// genesisAdapter adapts the loopback Blockfrost chain client to the genesis
-// subset the SPO toolkit's KES-period math needs.
-type genesisAdapter struct{ c *chain.Client }
-
-func (g genesisAdapter) Genesis(ctx context.Context) (poolops.Genesis, error) {
-	gen, err := g.c.Genesis(ctx)
-	if err != nil {
-		return poolops.Genesis{}, err
-	}
-	return poolops.Genesis{
-		SlotsPerKESPeriod: gen.SlotsPerKESPeriod,
-		MaxKESEvolutions:  gen.MaxKESEvolutions,
-		EpochLength:       gen.EpochLength,
-	}, nil
-}
-
-// tipAdapter exposes the supervisor's current tip slot to the SPO toolkit.
-// TipSlot returns an error when the node has not yet caught up to the chain
-// tip so that KES-period calculations do not silently use a stale slot.
-type tipAdapter struct{ sup *supervisor.Supervisor }
-
-func (t tipAdapter) TipSlot() (uint64, error) {
-	st := t.sup.Status()
-	if st.State != supervisor.StateReady {
-		return 0, fmt.Errorf("node is not synced (state: %s); wait for it to reach 'ready' before issuing opcerts", st.State)
-	}
-	return st.Tip, nil
 }

--- a/ui/go.mod
+++ b/ui/go.mod
@@ -207,6 +207,8 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/mobile v0.0.0-20260611195102-4dd8f1dbf5d2 // indirect
+	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
@@ -214,6 +216,7 @@ require (
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
+	golang.org/x/tools v0.46.0 // indirect
 	google.golang.org/api v0.286.0 // indirect
 	google.golang.org/genproto v0.0.0-20260427160629-7cedc36a6bc4 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
@@ -233,3 +236,5 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 	modernc.org/sqlite v1.53.0 // indirect
 )
+
+tool golang.org/x/mobile/cmd/gobind

--- a/ui/go.sum
+++ b/ui/go.sum
@@ -889,11 +889,15 @@ golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df/go.mod h1:FXUEEKJgO7OQYeo8N0
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/mobile v0.0.0-20260611195102-4dd8f1dbf5d2 h1:zoM1gIKhVkcQNm43kad8OHLgPNoJ12xIqmxHtKr8Mug=
+golang.org/x/mobile v0.0.0-20260611195102-4dd8f1dbf5d2/go.mod h1:QGMqsqLn6orFQ/ksqYMf+Fa33Soa1vPoHEd0Pj7N+lQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
 golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
+golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
+golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -962,6 +966,8 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.45.0 h1:18qN3FAooORvApf5XjCXgsuayZOEtXf6JK18I3+ONa8=
 golang.org/x/tools v0.45.0/go.mod h1:LuUGqqaXcXMEFEruIVJVm5mgDD8vww/z/SR1gQ4uE/0=
+golang.org/x/tools v0.46.0 h1:7jTurBkPZu4moS/Uy4OQT1M+QBlsj3wejyZwsT8Z7rk=
+golang.org/x/tools v0.46.0/go.mod h1:FrD85F8l+NWL+9XWBSyVSHO6Ne4jutsfIFba7AWQ5Ys=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/ui/internal/boot/boot.go
+++ b/ui/internal/boot/boot.go
@@ -1,0 +1,423 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package boot wires the Bursa full-node wallet stack — the supervised embedded
+// Dingo node, the loopback Blockfrost-backed wallet/spend services, the
+// persisted app settings, and the HTTP control surface that serves the API plus
+// the embedded SPA. It is the single source of truth for "how the wallet boots"
+// so every front end (the desktop binary in cmd/bursa-wallet and the gomobile
+// binding in ui/mobile) brings up an identical stack on a loopback listener.
+package boot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	"github.com/blinklabs-io/apollo/v2/backend/utxorpc"
+	"github.com/blinklabs-io/bursa/ui/internal/api"
+	"github.com/blinklabs-io/bursa/ui/internal/cardanonet"
+	"github.com/blinklabs-io/bursa/ui/internal/chain"
+	"github.com/blinklabs-io/bursa/ui/internal/keystore"
+	"github.com/blinklabs-io/bursa/ui/internal/poolops"
+	"github.com/blinklabs-io/bursa/ui/internal/settings"
+	"github.com/blinklabs-io/bursa/ui/internal/spend"
+	"github.com/blinklabs-io/bursa/ui/internal/supervisor"
+	"github.com/blinklabs-io/bursa/ui/internal/vault"
+	"github.com/blinklabs-io/bursa/ui/internal/wallet"
+	"github.com/blinklabs-io/bursa/ui/internal/webui"
+)
+
+// vaultKeystore adapts the encrypted vault to the spend service's Keystore
+// interface. The vault owns seed encryption and the active-wallet selection, so
+// Unlock decrypts the ACTIVE wallet's seed under the supplied spending password;
+// Create is unsupported (wallets are added via the vault) and Exists is true
+// whenever a wallet is active.
+type vaultKeystore struct{ v *vault.Vault }
+
+func (k vaultKeystore) Exists() bool { return k.v.ActiveID() != "" }
+
+func (k vaultKeystore) Create(string, string) error {
+	return errors.New("wallets are added through the vault, not the keystore")
+}
+
+func (k vaultKeystore) Unlock(password string) ([]byte, error) {
+	return k.v.UnlockSeed(password)
+}
+
+func (k vaultKeystore) UnlockFor(walletID, password string) ([]byte, error) {
+	return k.v.UnlockSeedFor(walletID, password)
+}
+
+// Loopback node ports. These are fixed loopback ports the embedded node binds
+// for its UTxO-RPC and Blockfrost endpoints; the wallet/spend services and the
+// supervisor's tip poller reach the node over these. Only the control surface
+// (the HTTP API + SPA) uses an OS-assigned port (see Config.Addr).
+const (
+	utxorpcPort    uint = 5555
+	blockfrostPort uint = 5556
+)
+
+// Config controls a wallet boot. The zero value is not usable: Network and
+// DataDir are required.
+type Config struct {
+	// Network is the Cardano network the embedded node runs on
+	// ("preview" | "preprod" | "mainnet").
+	Network string
+	// DataDir is the per-network data directory (db, node socket, settings,
+	// keystore). It is created (0700) if missing.
+	DataDir string
+	// Addr is the control-surface listen address. Use "127.0.0.1:8090" for the
+	// fixed desktop port or "127.0.0.1:0" to let the OS assign a free loopback
+	// port (mobile); the bound port is reported by App.Addr after Start.
+	Addr string
+	// Logger receives node + control-surface logs. Defaults to a stderr text
+	// logger when nil.
+	Logger *slog.Logger
+	// MithrilEnabled bootstraps a fresh node DB from a Mithril snapshot before
+	// serving (faster first sync). The zero value is false (genesis sync).
+	MithrilEnabled bool
+	// LeanDefault seeds the first-run default for the lean-node (history-expiry)
+	// profile. It only takes effect when no value has been persisted yet; once a
+	// user toggles the Settings screen, the persisted value is the source of
+	// truth and this seed is ignored. Mobile builds pass true.
+	LeanDefault bool
+}
+
+// App is a booted wallet stack: a running supervised node and an HTTP control
+// surface listening on a loopback port. It is returned by Boot and torn down by
+// Stop. It is the shared runtime both the desktop binary and the mobile binding
+// drive.
+type App struct {
+	srv      *http.Server
+	listener net.Listener
+	sup      *supervisor.Supervisor
+	logger   *slog.Logger
+
+	// ctx is the parent context supplied to Boot; it is forwarded to
+	// supervisor.Reconnect so the re-dial is cancelled if the app is torn down.
+	ctx context.Context
+	// stop cancels the node/supervisor context; srvErr surfaces a control-surface
+	// ListenAndServe failure to the caller (and to awaitUI on the desktop).
+	stop   context.CancelFunc
+	srvErr chan error
+	// stopped guards against concurrent Stop calls. 0 = running, 1 = stopped.
+	// Accessed via atomic load/store so Stop is safe under concurrent lifecycle
+	// calls (e.g. mobile deinit racing with an OS background-termination signal).
+	stopped atomic.Int32
+}
+
+// Boot brings up the full wallet stack described by cfg and starts serving on a
+// loopback listener. It returns once the node goroutine is launched and the
+// control surface is accepting connections (readiness — the node finishing sync
+// — is reported separately via the /status API). The caller owns the returned
+// App and must call Stop to tear it down.
+//
+// Boot is the single wiring path shared by cmd/bursa-wallet (desktop) and
+// ui/mobile (the gomobile binding) so both front ends boot an identical stack.
+//
+// ctx cancellation: every step Boot takes to get here is local, bounded work
+// (config validation, small file reads, in-process construction) — nothing
+// waits on the network or on node readiness, so Boot itself cannot hang. It is
+// still not ctx-aware by default (none of those steps consult ctx), so Boot
+// checks ctx.Err() at its two natural checkpoints — before doing any work, and
+// again right after the node/control surface are launched — and tears down
+// anything it already started rather than handing back a live App the caller
+// has already given up on (see ui/mobile's cleanupLateStart, which relies on
+// this to make its unconditional wait for Boot's result safe).
+func Boot(ctx context.Context, cfg Config) (*App, error) {
+	if cfg.Network == "" {
+		return nil, errors.New("boot: network is required")
+	}
+	if cfg.DataDir == "" {
+		return nil, errors.New("boot: data dir is required")
+	}
+	// A start superseded before Boot did any work (a rapid-fire supersede or a
+	// timeout that already fired) must not spend effort on — or spin up — a
+	// node the caller has already abandoned.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if cfg.Addr == "" {
+		cfg.Addr = "127.0.0.1:0"
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	netID, err := cardanonet.AddressNetworkID(cfg.Network)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"invalid network %q: must be one of %s",
+			cfg.Network, cardanonet.SupportedNetworks(),
+		)
+	}
+	if err := os.MkdirAll(cfg.DataDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create data dir %q: %w", cfg.DataDir, err)
+	}
+
+	// The lean-node (history-expiry) profile is a persisted, user-facing setting
+	// (the source of truth). LeanDefault only seeds the first-run default; once a
+	// value is persisted it is honored and the seed is ignored.
+	settingsStore, err := settings.Load(filepath.Join(cfg.DataDir, "settings.json"))
+	if err != nil {
+		return nil, fmt.Errorf("load settings: %w", err)
+	}
+	if err := settingsStore.SeedDefault(cfg.LeanDefault); err != nil {
+		return nil, fmt.Errorf("seed lean-node default: %w", err)
+	}
+
+	nodeDataDir := filepath.Join(cfg.DataDir, "db")
+	sup := supervisor.New(supervisor.Config{
+		Network:        cfg.Network,
+		DataDir:        nodeDataDir,
+		SocketPath:     filepath.Join(cfg.DataDir, "node.socket"),
+		UtxorpcPort:    utxorpcPort,
+		BlockfrostPort: blockfrostPort,
+		Logger:         logger,
+		MithrilEnabled: cfg.MithrilEnabled,
+		// Read the persisted setting fresh at each node Start, so a toggle in the
+		// Settings screen takes effect on the next node restart.
+		HistoryExpiry: settingsStore.HistoryExpiry,
+	})
+
+	// The wallet queries the node's own loopback Blockfrost endpoint. The same
+	// client also verifies pasted pool/DRep IDs and reads protocol params for the
+	// staking flow.
+	chainClient := chain.NewClient(blockfrostPort, chain.WithDingoDataDir(nodeDataDir))
+	walletSvc := wallet.NewService(chainClient)
+
+	// The vault is the encrypted multi-wallet store: a single file under the data
+	// dir holding the wallet index (encrypted under the vault password) and each
+	// wallet's seed (encrypted under its own spending password). It replaces the
+	// old single plaintext/keystore model — no plaintext seeds at rest. The legacy
+	// keystore is accepted only for explicit migration into the vault.
+	vlt := vault.New(filepath.Join(cfg.DataDir, "vault.json"))
+	legacyKeyStore := keystore.New(filepath.Join(cfg.DataDir, "keystore.json"))
+
+	// Spending builds/signs/submits through the node's loopback UTxO-RPC
+	// endpoint; the active wallet's seed is decrypted from the vault on demand.
+	chainCtx := utxorpc.NewUtxoRpcChainContext(
+		fmt.Sprintf("http://127.0.0.1:%d", utxorpcPort), netID, nil,
+	)
+	spendSvc := spend.NewService(chainCtx, vaultKeystore{v: vlt}, nil)
+	spendSvc.SetChainQuerier(chainClient)
+
+	// Stake Pool Operations derives cold/VRF/KES credentials and builds/submits
+	// pool certificates on the active wallet, sharing the spend chain context for
+	// submission. Genesis and tip data come from the node's loopback surfaces.
+	poolGenesis := chain.NewClient(blockfrostPort)
+	poolSvc := poolops.NewService(
+		chainCtx, vaultKeystore{v: vlt},
+		genesisAdapter{c: poolGenesis},
+		tipAdapter{sup: sup},
+	)
+
+	// Bind the control-surface listener BEFORE starting the node so an
+	// OS-assigned port (127.0.0.1:0) is known to the caller the moment Boot
+	// returns — the mobile WebView needs the concrete port to load the SPA.
+	listener, err := net.Listen("tcp", cfg.Addr)
+	if err != nil {
+		return nil, fmt.Errorf("bind control surface %q: %w", cfg.Addr, err)
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	if err := sup.Start(runCtx); err != nil {
+		cancel()
+		_ = listener.Close()
+		return nil, fmt.Errorf("start node: %w", err)
+	}
+	// sup.Start only launches the node/poll-loop goroutines; it does not wait
+	// on readiness, so it returns promptly and this check runs shortly after
+	// the node was launched. Re-checking ctx here catches a cancellation that
+	// landed anywhere in the synchronous setup above and tears the
+	// just-started node down (sup.Stop blocks until it has fully exited)
+	// instead of proceeding to build the control surface and return a live App
+	// nobody asked for anymore.
+	if err := ctx.Err(); err != nil {
+		sup.Stop()
+		cancel()
+		_ = listener.Close()
+		return nil, err
+	}
+
+	srv := &http.Server{
+		Handler: api.NewHandler(
+			sup, vlt, walletSvc, spendSvc,
+			&settingsController{store: settingsStore, sup: sup},
+			chainClient,
+			poolSvc,
+			cfg.Network, webui.Handler(),
+			api.WithLegacyKeystore(legacyKeyStore),
+		),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	srvErr := make(chan error, 1)
+	go func() {
+		logger.Info("control surface listening", "addr", listener.Addr().String())
+		if err := srv.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			srvErr <- err
+		}
+	}()
+
+	return &App{
+		srv:      srv,
+		listener: listener,
+		sup:      sup,
+		logger:   logger,
+		ctx:      ctx,
+		stop:     cancel,
+		srvErr:   srvErr,
+	}, nil
+}
+
+// Addr returns the control surface's bound listen address (host:port). With a
+// "127.0.0.1:0" config this is the concrete OS-assigned loopback port.
+func (a *App) Addr() string { return a.listener.Addr().String() }
+
+// URL returns the control surface base URL (http://host:port) for a WebView or
+// browser to load.
+func (a *App) URL() string { return "http://" + a.Addr() }
+
+// Port returns the control surface's bound TCP port.
+func (a *App) Port() int {
+	if tcp, ok := a.listener.Addr().(*net.TCPAddr); ok {
+		return tcp.Port
+	}
+	return 0
+}
+
+// Err returns the channel that surfaces a fatal control-surface error (a failed
+// Serve). It is buffered (size 1); a clean Stop never sends on it.
+func (a *App) Err() <-chan error { return a.srvErr }
+
+// Stop tears the stack down: it shuts the control surface down gracefully
+// (draining in-flight requests up to a timeout), then cancels the node context
+// so the embedded node and supervisor wind down. It is safe to call
+// concurrently; only the first caller performs the shutdown.
+func (a *App) Stop() error {
+	if !a.stopped.CompareAndSwap(0, 1) {
+		return nil
+	}
+	a.logger.Info("shutting down")
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err := a.srv.Shutdown(shutdownCtx)
+	// Cancel the node context AFTER the control surface drains so in-flight API
+	// calls don't see the node yanked out from under them mid-request.
+	a.stop()
+	a.sup.Stop()
+	return err
+}
+
+// OnNetworkChanged re-dials the embedded node's peers after a host network
+// change (e.g. WiFi↔cellular, loss→regain). It delegates to
+// supervisor.Reconnect which performs a Stop-then-relaunch cycle on the node,
+// re-establishing all peer connections while preserving the synced DataDir.
+//
+// It is a safe no-op when called before Boot or after Stop.
+func (a *App) OnNetworkChanged() error {
+	return a.reconnect()
+}
+
+// OnResume re-dials the embedded node's peers after the app returns from the
+// background. Peers go stale during suspension (the OS may have torn down TCP
+// connections), so a Reconnect cycle re-establishes them without data loss (the
+// synced DataDir is preserved; Mithril bootstrap is skipped).
+//
+// It is a safe no-op when called before Boot or after Stop.
+func (a *App) OnResume() error {
+	return a.reconnect()
+}
+
+func (a *App) reconnect() error {
+	if a.stopped.Load() != 0 {
+		return nil
+	}
+	if a.sup == nil {
+		return nil
+	}
+	ctx := a.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return a.sup.Reconnect(ctx)
+}
+
+// settingsController adapts the persisted settings store + the supervisor to the
+// api.SettingsController surface. The store is the source of truth for the
+// lean-node profile; the supervisor reports what the running node was actually
+// built with, so a change can be flagged as needing a node restart.
+type settingsController struct {
+	store *settings.Store
+	sup   *supervisor.Supervisor
+}
+
+func (c *settingsController) HistoryExpiry() bool { return c.store.HistoryExpiry() }
+
+func (c *settingsController) SetHistoryExpiry(enabled bool) error {
+	return c.store.SetHistoryExpiry(enabled)
+}
+
+// HistoryExpiryRestartRequired reports whether the persisted value differs from
+// what the running node was launched with. History expiry is a node-construction
+// option, so it only takes effect on the next node start: if no node has been
+// launched yet (ran=false), there is nothing to restart, so it is not required.
+func (c *settingsController) HistoryExpiryRestartRequired() bool {
+	applied, ran := c.sup.AppliedHistoryExpiry()
+	if !ran {
+		return false
+	}
+	return applied != c.store.HistoryExpiry()
+}
+
+// genesisAdapter adapts the loopback Blockfrost chain client to the genesis
+// subset the SPO toolkit's KES-period math needs.
+type genesisAdapter struct{ c *chain.Client }
+
+func (g genesisAdapter) Genesis(ctx context.Context) (poolops.Genesis, error) {
+	gen, err := g.c.Genesis(ctx)
+	if err != nil {
+		return poolops.Genesis{}, err
+	}
+	return poolops.Genesis{
+		SlotsPerKESPeriod: gen.SlotsPerKESPeriod,
+		MaxKESEvolutions:  gen.MaxKESEvolutions,
+		EpochLength:       gen.EpochLength,
+	}, nil
+}
+
+// tipAdapter exposes the supervisor's current tip slot to the SPO toolkit.
+// TipSlot returns an error when the node has not yet caught up to the chain
+// tip so that KES-period calculations do not silently use a stale slot.
+type tipAdapter struct{ sup *supervisor.Supervisor }
+
+func (t tipAdapter) TipSlot() (uint64, error) {
+	st := t.sup.Status()
+	if st.State != supervisor.StateReady {
+		return 0, fmt.Errorf("node is not synced (state: %s); wait for it to reach 'ready' before issuing opcerts", st.State)
+	}
+	return st.Tip, nil
+}

--- a/ui/internal/boot/boot_test.go
+++ b/ui/internal/boot/boot_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package boot
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestBootValidatesConfig covers the cheap, no-node validation paths so a
+// misconfiguration is reported synchronously by Boot (before any node is
+// launched) rather than failing later.
+func TestBootValidatesConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantSub string
+	}{
+		{
+			name:    "missing network",
+			cfg:     Config{DataDir: t.TempDir()},
+			wantSub: "network is required",
+		},
+		{
+			name:    "missing data dir",
+			cfg:     Config{Network: "preview"},
+			wantSub: "data dir is required",
+		},
+		{
+			name:    "invalid network",
+			cfg:     Config{Network: "bogus", DataDir: t.TempDir()},
+			wantSub: "invalid network",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			app, err := Boot(context.Background(), tc.cfg)
+			if app != nil {
+				_ = app.Stop()
+				t.Fatalf("expected nil App on error, got %v", app)
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestBootReturnsContextErrorWhenAlreadyCanceled covers the node-lifecycle
+// leak fix for ui/mobile's cleanupLateStart (PR #561 review): a start
+// superseded (or timed out) before Boot is even invoked must abort promptly
+// with a context error and must never spin up — or hand back — a live App.
+// This is what makes cleanupLateStart's unconditional wait for Boot's result
+// safe: Boot is bounded and ctx-aware, so the wait cannot leak the watcher
+// goroutine and cannot leave a node/socket running behind a caller that has
+// already moved on.
+func TestBootReturnsContextErrorWhenAlreadyCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	app, err := Boot(ctx, Config{
+		Network: "preview",
+		DataDir: t.TempDir(),
+		Addr:    "127.0.0.1:0",
+	})
+	elapsed := time.Since(start)
+
+	if app != nil {
+		_ = app.Stop()
+		t.Fatalf("expected nil App when ctx is already canceled, got %v", app)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Boot with an already-canceled ctx = %v, want context.Canceled", err)
+	}
+	// The guard must fire before any node/network work, so this must return
+	// almost instantly — a regression back to "ignore ctx" would still return
+	// (fast, since nothing in Boot's synchronous path blocks) but with a live
+	// App instead of this error, which the case above already catches; the
+	// bound here guards against a future step becoming a genuine, unbounded
+	// wait that ignores ctx.
+	if elapsed > 2*time.Second {
+		t.Fatalf("Boot with an already-canceled ctx took %s; want a prompt abort", elapsed)
+	}
+}

--- a/ui/internal/boot/network_test.go
+++ b/ui/internal/boot/network_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package boot
+
+import (
+	"testing"
+)
+
+// TestAppOnNetworkChangedNilApp: OnNetworkChanged on a nil (pre-Boot) App
+// must not panic and must return nil. Boot is heavyweight (real node); we test
+// OnNetworkChanged's nil-guard through the zero App value path directly.
+func TestAppOnNetworkChangedNilApp(t *testing.T) {
+	// A zero-value App has sup == nil. OnNetworkChanged must guard this
+	// just as Stop does (a.stopped check / nil-guard pattern).
+	a := &App{}
+	if err := a.OnNetworkChanged(); err != nil {
+		t.Fatalf("OnNetworkChanged on zero App = %v, want nil", err)
+	}
+}

--- a/ui/internal/boot/resume_test.go
+++ b/ui/internal/boot/resume_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package boot
+
+import "testing"
+
+// TestAppOnResumeNilApp: OnResume on a zero-value App (sup == nil) must return
+// nil and not panic. This is the pre-Boot / already-stopped safe no-op guard.
+func TestAppOnResumeNilApp(t *testing.T) {
+	a := &App{}
+	if err := a.OnResume(); err != nil {
+		t.Fatalf("OnResume on zero App = %v, want nil", err)
+	}
+}

--- a/ui/internal/supervisor/bootstrap_test.go
+++ b/ui/internal/supervisor/bootstrap_test.go
@@ -167,7 +167,7 @@ func TestBootstrapThenLaunchSuccess(t *testing.T) {
 	s := newTestSupervisor(t, fb)
 	launched := false
 	s.setState(StateBootstrapping)
-	s.bootstrapThenLaunch(context.Background(), s.runID, func() error { launched = true; return nil })
+	s.bootstrapThenLaunch(context.Background(), s.runID, func() error { launched = true; return nil }, func() {})
 
 	if !fb.called {
 		t.Fatal("bootstrapper not invoked")
@@ -191,7 +191,7 @@ func TestBootstrapThenLaunchFailureSetsError(t *testing.T) {
 	s := newTestSupervisor(t, fb)
 	launched := false
 	s.setState(StateBootstrapping)
-	s.bootstrapThenLaunch(context.Background(), s.runID, func() error { launched = true; return nil })
+	s.bootstrapThenLaunch(context.Background(), s.runID, func() error { launched = true; return nil }, func() {})
 
 	if launched {
 		t.Fatal("launch must NOT be called when bootstrap fails")
@@ -219,7 +219,7 @@ func TestBootstrapCancellationIsNotError(t *testing.T) {
 	s := newTestSupervisor(t, fb)
 	s.setState(StateBootstrapping)
 	launched := false
-	s.bootstrapThenLaunch(ctx, s.runID, func() error { launched = true; return nil })
+	s.bootstrapThenLaunch(ctx, s.runID, func() error { launched = true; return nil }, func() {})
 
 	if launched {
 		t.Fatal("launch must NOT be called when bootstrap is cancelled")
@@ -244,7 +244,7 @@ func TestBootstrapPostSuccessCancellationStopsBeforeLaunch(t *testing.T) {
 	s.bootstrapThenLaunch(ctx, s.runID, func() error {
 		launched = true
 		return errors.New("late launch failure")
-	})
+	}, func() {})
 
 	if launched {
 		t.Fatal("launch must NOT be called after cancellation")

--- a/ui/internal/supervisor/reconnect.go
+++ b/ui/internal/supervisor/reconnect.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package supervisor
+
+import (
+	"context"
+	"errors"
+)
+
+// Reconnect re-dials the node's peers after a host network change or app
+// resume. It performs a Stop-then-relaunch cycle via the existing
+// runID-versioned path, which tears down all peer connections and
+// re-establishes them. The already-synced DataDir is preserved and Mithril
+// bootstrap is skipped (the completion marker remains), so reconnect is fast
+// and involves no data loss.
+//
+// Reconnect is a safe no-op when the supervisor is not running (not started,
+// stopped, or mid-stop). It is concurrency-safe and may be called from the
+// Android NetworkCallback or onResume thread.
+//
+// If the supervisor is already running (Start returns ErrAlreadyStarted),
+// Reconnect folds that benign sentinel to nil — the desired post-reconnect
+// state is "node running", which is already true.
+func (s *Supervisor) Reconnect(ctx context.Context) error {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+
+	s.mu.RLock()
+	running := s.cancel != nil
+	s.mu.RUnlock()
+	if !running {
+		return nil
+	}
+	s.waitForRunExit(s.stop())
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := s.start(ctx); err != nil && !errors.Is(err, ErrAlreadyStarted) {
+		return err
+	}
+	return nil
+}

--- a/ui/internal/supervisor/reconnect_test.go
+++ b/ui/internal/supervisor/reconnect_test.go
@@ -1,0 +1,290 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package supervisor
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/dingo"
+)
+
+// fakeNodeRunner is a no-op NodeRunner for tests: Run blocks until ctx is
+// cancelled (simulating a long-lived node) so Start can complete its goroutine
+// launch without immediately returning an error.
+type fakeNodeRunner struct{}
+
+func (fakeNodeRunner) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// fakeNodeFactory creates fakeNodeRunners and never errors, allowing Start to
+// succeed in tests without a real Dingo configuration.
+type fakeNodeFactory struct{}
+
+func (fakeNodeFactory) New(_ dingo.Config) (NodeRunner, error) { return fakeNodeRunner{}, nil }
+
+type blockingNodeFactory struct {
+	newRunner chan *blockingNodeRunner
+}
+
+func newBlockingNodeFactory() *blockingNodeFactory {
+	return &blockingNodeFactory{newRunner: make(chan *blockingNodeRunner, 4)}
+}
+
+func (f *blockingNodeFactory) New(_ dingo.Config) (NodeRunner, error) {
+	r := &blockingNodeRunner{
+		canceled: make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	f.newRunner <- r
+	return r, nil
+}
+
+type blockingNodeRunner struct {
+	canceled chan struct{}
+	release  chan struct{}
+}
+
+func (r *blockingNodeRunner) Run(ctx context.Context) error {
+	<-ctx.Done()
+	close(r.canceled)
+	<-r.release
+	return ctx.Err()
+}
+
+// TestReconnectNoOpWhenNotRunning: Reconnect must be a safe no-op when the
+// supervisor has not been started (no active run). It must not panic or return
+// an error — the Android callback thread may call it before Start.
+func TestReconnectNoOpWhenNotRunning(t *testing.T) {
+	s := New(Config{Network: "preview", DataDir: t.TempDir()})
+	if err := s.Reconnect(context.Background()); err != nil {
+		t.Fatalf("Reconnect before Start = %v, want nil", err)
+	}
+	if got := s.Status().State; got != StateStopped {
+		t.Fatalf("state after no-op Reconnect = %q, want stopped", got)
+	}
+}
+
+// TestReconnectNoOpAfterStop: Reconnect is a no-op after an explicit Stop.
+func TestReconnectNoOpAfterStop(t *testing.T) {
+	s := newTestSupervisor(t, &fakeBootstrapper{})
+	s.setState(StateStarting)
+	s.Stop()
+	if err := s.Reconnect(context.Background()); err != nil {
+		t.Fatalf("Reconnect after Stop = %v, want nil", err)
+	}
+	if got := s.Status().State; got != StateStopped {
+		t.Fatalf("state after no-op Reconnect = %q, want stopped", got)
+	}
+}
+
+// TestReconnectWhileRunningIncreasesRunID: Reconnect while the supervisor is
+// running must perform a Stop-then-relaunch cycle, producing a strictly
+// greater runID (the observable signal that the node restarted) while keeping
+// the DataDir (no re-bootstrap).
+func TestReconnectWhileRunningIncreasesRunID(t *testing.T) {
+	s := newTestSupervisor(t, &fakeBootstrapper{})
+	s.nodeFactory = fakeNodeFactory{}
+	s.setState(StateStarting)
+	t.Cleanup(s.Stop)
+	beforeRunID := s.runID
+
+	// Reconnect replaces the current run with a new one.
+	if err := s.Reconnect(context.Background()); err != nil {
+		t.Fatalf("Reconnect while running = %v, want nil", err)
+	}
+
+	afterRunID := s.runID
+	if afterRunID <= beforeRunID {
+		t.Fatalf("runID did not increase: before=%d after=%d", beforeRunID, afterRunID)
+	}
+}
+
+func TestReconnectWaitsForPreviousRunToExit(t *testing.T) {
+	factory := newBlockingNodeFactory()
+	s := New(Config{Network: "preview", DataDir: t.TempDir()})
+	s.bootstrapper = &fakeBootstrapper{}
+	s.nodeFactory = factory
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start = %v", err)
+	}
+	first := waitForRunner(t, factory.newRunner)
+
+	reconnectErr := make(chan error, 1)
+	go func() {
+		reconnectErr <- s.Reconnect(context.Background())
+	}()
+
+	waitForClosed(t, first.canceled, "first runner cancellation")
+	select {
+	case <-factory.newRunner:
+		t.Fatal("Reconnect started a replacement node before the previous Run exited")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(first.release)
+	second := waitForRunner(t, factory.newRunner)
+	select {
+	case err := <-reconnectErr:
+		if err != nil {
+			t.Fatalf("Reconnect = %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Reconnect did not return after the previous Run exited")
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		s.Stop()
+		close(stopDone)
+	}()
+	waitForClosed(t, second.canceled, "second runner cancellation")
+	close(second.release)
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not return after the second Run exited")
+	}
+}
+
+func TestReconnectReturnsContextErrorIfCanceledBeforeRestart(t *testing.T) {
+	factory := newBlockingNodeFactory()
+	s := New(Config{Network: "preview", DataDir: t.TempDir()})
+	s.bootstrapper = &fakeBootstrapper{}
+	s.nodeFactory = factory
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start = %v", err)
+	}
+	first := waitForRunner(t, factory.newRunner)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	reconnectErr := make(chan error, 1)
+	go func() {
+		reconnectErr <- s.Reconnect(ctx)
+	}()
+
+	waitForClosed(t, first.canceled, "first runner cancellation")
+	cancel()
+	close(first.release)
+
+	select {
+	case err := <-reconnectErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Reconnect = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Reconnect did not return after the previous Run exited")
+	}
+
+	select {
+	case <-factory.newRunner:
+		t.Fatal("Reconnect started a replacement node with a canceled context")
+	default:
+	}
+	if got := s.Status().State; got != StateStopped {
+		t.Fatalf("state after canceled Reconnect = %q, want stopped", got)
+	}
+}
+
+// TestReconnectDoesNotReBootstrap: Reconnect must not trigger a Mithril
+// bootstrap. Even when MithrilEnabled is true, if shouldBootstrap returns false
+// (because the DataDir already has the completion marker), the relaunch must
+// skip the bootstrap path entirely — no re-download, no data loss.
+func TestReconnectDoesNotReBootstrap(t *testing.T) {
+	dir := t.TempDir()
+	// Write the bootstrap-done marker so shouldBootstrap returns false.
+	if err := markBootstrapDone(dir); err != nil {
+		t.Fatalf("markBootstrapDone: %v", err)
+	}
+
+	fb := &fakeBootstrapper{}
+	s := New(Config{
+		Network:        "preview",
+		DataDir:        dir,
+		MithrilEnabled: true,
+	})
+	s.bootstrapper = fb
+	s.nodeFactory = fakeNodeFactory{}
+	// Simulate an already-running node (reuse newTestSupervisor's pattern).
+	s.runID = 1
+	s.cancel = func() {}
+	s.status.State = StateStarting
+	t.Cleanup(s.Stop)
+
+	if err := s.Reconnect(context.Background()); err != nil {
+		t.Fatalf("Reconnect = %v, want nil", err)
+	}
+
+	if fb.called {
+		t.Fatal("Reconnect must not trigger a bootstrap (marker is present)")
+	}
+	if !bootstrapDone(dir) {
+		t.Fatal("bootstrap marker must be preserved after Reconnect")
+	}
+}
+
+// TestReconnectConcurrentStopWins: concurrent calls to Reconnect and Stop from
+// different goroutines must not panic/deadlock, and once the explicit Stop has
+// completed no racing reconnect may resurrect the node afterward.
+func TestReconnectConcurrentStopWins(t *testing.T) {
+	s := newTestSupervisor(t, &fakeBootstrapper{})
+	s.nodeFactory = fakeNodeFactory{}
+	s.setState(StateStarting)
+
+	var wg sync.WaitGroup
+	const goroutines = 10
+	ctx := context.Background()
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = s.Reconnect(ctx)
+		}()
+	}
+	// Also race Stop with the reconnects.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.Stop()
+	}()
+	wg.Wait()
+	if got := s.Status().State; got != StateStopped {
+		t.Fatalf("state after concurrent Reconnect/Stop = %q, want stopped", got)
+	}
+}
+
+func waitForRunner(t *testing.T, ch <-chan *blockingNodeRunner) *blockingNodeRunner {
+	t.Helper()
+	select {
+	case runner := <-ch:
+		return runner
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for node runner")
+		return nil
+	}
+}
+
+func waitForClosed(t *testing.T, ch <-chan struct{}, label string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", label)
+	}
+}

--- a/ui/internal/supervisor/resume_test.go
+++ b/ui/internal/supervisor/resume_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package supervisor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/dingo"
+)
+
+// countingNodeFactory records how many times New is called, so tests can
+// assert a node was never constructed (e.g. because Start bailed out on an
+// already-canceled ctx before reaching the node factory).
+type countingNodeFactory struct{ calls int }
+
+func (f *countingNodeFactory) New(_ dingo.Config) (NodeRunner, error) {
+	f.calls++
+	return fakeNodeRunner{}, nil
+}
+
+// TestStartReturnsContextErrorIfAlreadyCanceled covers the guard added for the
+// boot.Boot node-lifecycle leak fix (PR #561 review): a caller that races a
+// cancellation against Start (boot.Boot does this on a superseded/timed-out
+// mobile start) must get a prompt context error and must NOT have a node
+// constructed or launched — the whole point is that no node work happens for a
+// start the caller has already abandoned.
+func TestStartReturnsContextErrorIfAlreadyCanceled(t *testing.T) {
+	factory := &countingNodeFactory{}
+	s := New(Config{Network: "preview", DataDir: t.TempDir()})
+	s.bootstrapper = &fakeBootstrapper{}
+	s.nodeFactory = factory
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := s.Start(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Start with already-canceled ctx = %v, want context.Canceled", err)
+	}
+	if factory.calls != 0 {
+		t.Fatalf("Start constructed a node with an already-canceled context (New called %d times)", factory.calls)
+	}
+	if got := s.Status().State; got != StateStopped {
+		t.Fatalf("state after canceled Start = %q, want stopped", got)
+	}
+
+	// The guard must not consume the start reservation: a fresh, uncancelled
+	// Start must still succeed afterward.
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start after a canceled attempt = %v, want nil", err)
+	}
+	t.Cleanup(s.Stop)
+	if factory.calls != 1 {
+		t.Fatalf("Start after a canceled attempt: New called %d times, want 1", factory.calls)
+	}
+}
+
+// TestStartWhileRunningReturnsErrAlreadyStarted verifies the start guard: a
+// second Start must not overwrite the active node's cancel function and orphan
+// its goroutines.
+func TestStartWhileRunningReturnsErrAlreadyStarted(t *testing.T) {
+	s := New(Config{Network: "preview", DataDir: t.TempDir()})
+	s.nodeFactory = fakeNodeFactory{}
+
+	// Start the supervisor so the cancel guard is set.
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("first Start = %v, want nil", err)
+	}
+	t.Cleanup(s.Stop)
+
+	// Verify the cancel guard is occupied.
+	s.mu.Lock()
+	guard := s.cancel
+	s.mu.Unlock()
+	if guard == nil {
+		t.Fatal("expected cancel guard to be set after Start")
+	}
+
+	// A direct Start while running must return ErrAlreadyStarted — not nil
+	// (which would silently accept a double-start bug) and not some other error.
+	err := s.Start(context.Background())
+	if err == nil {
+		t.Fatal("Start while running returned nil; expected ErrAlreadyStarted")
+	}
+	if !errors.Is(err, ErrAlreadyStarted) {
+		t.Fatalf("Start while running = %v, want ErrAlreadyStarted", err)
+	}
+
+}

--- a/ui/internal/supervisor/supervisor.go
+++ b/ui/internal/supervisor/supervisor.go
@@ -57,14 +57,37 @@ type Config struct {
 	HistoryExpiry func() bool
 }
 
+// NodeRunner is the interface the supervisor uses to create and run the embedded
+// node. It is an interface (not a concrete dingo.Node) so the orchestration can
+// be unit-tested without network connectivity (the production implementation
+// calls dingo.New and then node.Run).
+type NodeRunner interface {
+	// Run starts the node and blocks until ctx is cancelled. An error from a
+	// graceful cancellation (ctx.Err() != nil) is treated as orderly shutdown.
+	Run(ctx context.Context) error
+}
+
+// NodeFactory creates a NodeRunner from a dingo config. It is injectable for
+// tests (the real factory calls dingo.New).
+type NodeFactory interface {
+	New(cfg dingo.Config) (NodeRunner, error)
+}
+
+// dingoNodeFactory is the production NodeFactory backed by dingo.New.
+type dingoNodeFactory struct{}
+
+func (dingoNodeFactory) New(cfg dingo.Config) (NodeRunner, error) { return dingo.New(cfg) }
+
 // Supervisor owns the embedded Dingo node's lifecycle and exposes its status.
 type Supervisor struct {
-	cfg    Config
-	cancel context.CancelFunc
-	runID  uint64
+	cfg     Config
+	cancel  context.CancelFunc
+	runDone chan struct{}
+	runID   uint64
 
-	mu     sync.RWMutex
-	status Status
+	lifecycleMu sync.Mutex
+	mu          sync.RWMutex
+	status      Status
 	// applied records the history-expiry value the currently-running node was
 	// built with, so the API can tell whether a changed setting still needs a
 	// restart to take effect. ran is false until the node has been launched at
@@ -76,7 +99,7 @@ type Supervisor struct {
 
 	now          func() time.Time // injectable clock for tests
 	bootstrapper Bootstrapper     // injectable for tests
-	newNode      func(dingo.Config) (nodeRunner, error)
+	nodeFactory  NodeFactory      // injectable for tests
 }
 
 func New(cfg Config) *Supervisor {
@@ -91,14 +114,8 @@ func New(cfg Config) *Supervisor {
 		status:       Status{State: StateStopped},
 		now:          time.Now,
 		bootstrapper: mithrilBootstrapper{logger: cfg.Logger},
-		newNode: func(cfg dingo.Config) (nodeRunner, error) {
-			return dingo.New(cfg)
-		},
+		nodeFactory:  dingoNodeFactory{},
 	}
-}
-
-type nodeRunner interface {
-	Run(context.Context) error
 }
 
 // historyExpiryEnabled resolves the lean-node profile from the (optional)
@@ -161,20 +178,47 @@ func (s *Supervisor) AppliedHistoryExpiry() (applied bool, ran bool) {
 	return s.applied.historyExpiry, s.applied.ran
 }
 
+// ErrAlreadyStarted is returned by Start when the supervisor is already running.
+// Reconnect folds this sentinel to nil (the node is running, which is the
+// desired post-reconnect state) so callers can use errors.Is to distinguish it
+// from real failures.
+var ErrAlreadyStarted = errors.New("supervisor already started")
+
 // Start constructs the node, launches it, and begins polling its tip. It
 // returns once the node goroutine is launched; readiness is reported via Status.
 func (s *Supervisor) Start(ctx context.Context) error {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	// Mirror Reconnect's guard: a caller that raced a cancellation against
+	// Start (e.g. boot.Boot, superseded by mobile's start-supersede/timeout
+	// path) must get a prompt error instead of a node it no longer wants —
+	// bail before touching any state or the node factory.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return s.start(ctx)
+}
+
+func (s *Supervisor) start(ctx context.Context) error {
 	// Guard against double-start: reserve s.cancel atomically so a second Start
 	// can't overwrite (and orphan) the first node and poll loop.
 	s.mu.Lock()
 	if s.cancel != nil {
 		s.mu.Unlock()
-		return errors.New("supervisor already started")
+		return ErrAlreadyStarted
 	}
 	runCtx, cancel := context.WithCancel(ctx)
+	runDone := make(chan struct{})
+	var completeOnce sync.Once
+	completeRun := func() {
+		completeOnce.Do(func() {
+			close(runDone)
+		})
+	}
 	s.runID++
 	runID := s.runID
 	s.cancel = cancel
+	s.runDone = runDone
 	s.mu.Unlock()
 
 	// fail releases the reservation so Start can be retried if we error out
@@ -183,9 +227,11 @@ func (s *Supervisor) Start(ctx context.Context) error {
 		s.mu.Lock()
 		if s.activeRunLocked(runID) {
 			s.cancel = nil
+			s.runDone = nil
 		}
 		s.mu.Unlock()
 		cancel()
+		completeRun()
 		return err
 	}
 
@@ -222,7 +268,7 @@ func (s *Supervisor) Start(ctx context.Context) error {
 		// before the first node exists.
 		historyExpiry := s.cfg.historyExpiryEnabled()
 		nodeCfg := dingo.NewConfig(nodeConfigOptions(s.cfg, historyExpiry, cardanoCfg, topologyCfg)...)
-		node, err := s.newNode(nodeCfg)
+		node, err := s.nodeFactory.New(nodeCfg)
 		if err != nil {
 			return err
 		}
@@ -232,6 +278,7 @@ func (s *Supervisor) Start(ctx context.Context) error {
 		s.mu.Unlock()
 		s.setStateForRun(runID, StateStarting)
 		go func() {
+			defer completeRun()
 			if err := node.Run(runCtx); err != nil && runCtx.Err() == nil {
 				s.setErrorForRun(runID, err)
 			}
@@ -251,13 +298,20 @@ func (s *Supervisor) Start(ctx context.Context) error {
 	// creation is deferred until the snapshot import finishes (mithril.Sync and
 	// the node cannot both hold the DB).
 	s.setStateForRun(runID, StateBootstrapping)
-	go s.bootstrapThenLaunch(runCtx, runID, launch)
+	go s.bootstrapThenLaunch(runCtx, runID, launch, completeRun)
 	return nil
 }
 
 // bootstrapThenLaunch runs the Mithril bootstrap and, on success, records the
 // completion marker and launches the node. Any failure → StateError (no fallback).
-func (s *Supervisor) bootstrapThenLaunch(ctx context.Context, runID uint64, launch func() error) {
+func (s *Supervisor) bootstrapThenLaunch(ctx context.Context, runID uint64, launch func() error, completeRun func()) {
+	launched := false
+	defer func() {
+		if !launched {
+			completeRun()
+		}
+	}()
+
 	err := s.bootstrapper.Bootstrap(ctx, BootstrapParams{
 		Network: s.cfg.Network,
 		DataDir: s.cfg.DataDir,
@@ -294,7 +348,9 @@ func (s *Supervisor) bootstrapThenLaunch(ctx context.Context, runID uint64, laun
 		if ctx.Err() == nil {
 			s.setErrorForRun(runID, fmt.Errorf("create node: %w", err))
 		}
+		return
 	}
+	launched = true
 }
 
 // onProgress stores the latest bootstrap progress on the status snapshot.
@@ -314,19 +370,35 @@ func (s *Supervisor) onProgressForRun(runID uint64, bp BootstrapProgress) {
 	s.status.Bootstrap = &bp
 }
 
-// Stop cancels the node's context and marks the supervisor stopped.
+// Stop cancels the node's context, waits for the active run to exit, and marks
+// the supervisor stopped.
 func (s *Supervisor) Stop() {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	s.waitForRunExit(s.stop())
+}
+
+func (s *Supervisor) stop() <-chan struct{} {
 	s.mu.Lock()
 	cancel := s.cancel
+	runDone := s.runDone
 	// Clear the start guard so the supervisor can be started again after being
 	// stopped, and record the terminal state under the same lock so a late poll
 	// can't race between the unlock and the state write.
 	s.cancel = nil
+	s.runDone = nil
 	s.status.State = StateStopped
 	s.status.Bootstrap = nil // a clean shutdown is not a diagnostic failure
 	s.mu.Unlock()
 	if cancel != nil {
 		cancel()
+	}
+	return runDone
+}
+
+func (s *Supervisor) waitForRunExit(runDone <-chan struct{}) {
+	if runDone != nil {
+		<-runDone
 	}
 }
 
@@ -371,6 +443,7 @@ func (s *Supervisor) setErrorForRun(runID uint64, err error) {
 	}
 	cancel := s.cancel
 	s.cancel = nil
+	s.runDone = nil
 	s.status.State = StateError
 	// Status.Bootstrap is intentionally retained on error so /status shows how
 	// far a bootstrap got before failing (diagnostics).

--- a/ui/internal/supervisor/supervisor_test.go
+++ b/ui/internal/supervisor/supervisor_test.go
@@ -119,6 +119,10 @@ type nodeRunnerFunc func(context.Context) error
 
 func (f nodeRunnerFunc) Run(ctx context.Context) error { return f(ctx) }
 
+type nodeFactoryFunc func(dingo.Config) (NodeRunner, error)
+
+func (f nodeFactoryFunc) New(cfg dingo.Config) (NodeRunner, error) { return f(cfg) }
+
 func TestStartReadsHistoryExpiryAtDeferredBootstrapLaunch(t *testing.T) {
 	enabled := false
 	cfg := baseConfig()
@@ -135,13 +139,13 @@ func TestStartReadsHistoryExpiryAtDeferredBootstrapLaunch(t *testing.T) {
 	}
 	s.bootstrapper = fb
 	nodeStarted := make(chan struct{})
-	s.newNode = func(dingo.Config) (nodeRunner, error) {
+	s.nodeFactory = nodeFactoryFunc(func(dingo.Config) (NodeRunner, error) {
 		return nodeRunnerFunc(func(ctx context.Context) error {
 			close(nodeStarted)
 			<-ctx.Done()
 			return ctx.Err()
 		}), nil
-	}
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/ui/mobile/mobile.go
+++ b/ui/mobile/mobile.go
@@ -1,0 +1,330 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mobile is the gomobile binding for the Bursa full-node wallet. It is
+// compiled to a native library (an Android AAR via `gomobile bind
+// -target=android`, an Apple xcframework via `-target=ios`) and consumed by the
+// Android/iOS shells in ../../mobile. Each shell boots the wallet in-process and
+// points a system WebView at the loopback URL the wallet serves the embedded SPA
+// on.
+//
+// gomobile constraint: only a fixed set of types cross the language boundary —
+// bool, int/int64, float, string, []byte, error, and exported structs/methods.
+// NO maps, slices-of-structs, channels, or other Go types may appear in any
+// EXPORTED signature here. App keeps all its fields unexported (so the struct
+// crosses as an opaque handle) and every exported method uses only the supported
+// scalar/error types.
+package mobile
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/blinklabs-io/bursa/ui/internal/boot"
+)
+
+const defaultStartTimeout = 2 * time.Minute
+
+var (
+	errStartTimeout = errors.New("mobile: start timed out")
+	bootWallet      = boot.Boot
+)
+
+// App is an opaque handle to a booted in-process wallet. It is returned by New
+// and driven by the Android/iOS shells: Start boots the stack, Port reports the
+// loopback port the WebView should load, and Stop tears it down. All fields are
+// unexported so gomobile treats it as an opaque reference type.
+type App struct {
+	mu          sync.Mutex
+	app         *boot.App
+	starting    bool
+	startCancel context.CancelFunc
+	// startDone is created before each boot goroutine launches and is closed
+	// only after that boot has either completed normally or its canceled result
+	// has been collected and stopped. Stop publishes this channel as draining
+	// before it cancels, so an immediate retry waits even if the canceled
+	// StartWithTimeout goroutine has not observed ctx.Done yet.
+	startDone chan struct{}
+	startID   uint64
+	// draining is the done-channel of an in-flight (or already-finished)
+	// cleanupLateStart watching a superseded/canceled start. StartWithTimeout
+	// waits on it before rebinding boot's fixed node ports (5555/5556), so a
+	// rapid Stop-then-retry can't race a still-unwinding canceled boot for those
+	// ports. The channel is registered before boot launch (startDone) and
+	// published when the start is canceled, not after the canceled start notices
+	// cancellation. Reading an already-closed channel never blocks, so once
+	// cleanup finishes this becomes a no-op wait; it is never reset to nil.
+	draining <-chan struct{}
+}
+
+// New constructs an unstarted App handle. Call Start to boot the wallet.
+func New() *App { return &App{} }
+
+// Start boots the wallet stack in-process and begins serving the embedded SPA +
+// API on an OS-assigned loopback port (127.0.0.1:0). It returns once the node
+// goroutine is launched and the control surface is accepting connections; node
+// sync progress is reported via the /status API the WebView polls. After Start
+// returns nil, call Port to learn the loopback port to load in the WebView.
+//
+// dataDir is the per-app writable directory (Android filesDir, iOS Documents);
+// network is "preview" | "preprod" | "mainnet"; lean seeds the first-run
+// lean-node (history-expiry) profile (mobile passes true for a small on-disk
+// footprint). Calling Start on an already-started App returns an error.
+func (a *App) Start(dataDir, network string, lean bool) error {
+	return a.StartWithTimeout(dataDir, network, lean, defaultStartTimeout.Milliseconds())
+}
+
+// StartWithTimeout is Start with a caller-supplied boot timeout in milliseconds.
+// A non-positive timeout uses the default. The boot work runs outside a.mu so
+// Port, Stop, and lifecycle kicks are not blocked while startup waits on I/O.
+func (a *App) StartWithTimeout(dataDir, network string, lean bool, timeoutMs int64) error {
+	timeout := startTimeout(timeoutMs)
+
+	var (
+		ctx       context.Context
+		cancel    context.CancelFunc
+		startDone chan struct{}
+		startID   uint64
+		waited    <-chan struct{}
+	)
+	for {
+		a.mu.Lock()
+		// Wait for a previous canceled/timed-out start's cleanup to finish
+		// releasing the fixed node ports before attempting to rebind them here.
+		// This check shares the admission lock with Stop/cancelStart so a retry
+		// cannot slip between a canceled start being cleared and its drain being
+		// published.
+		if a.draining != nil && a.draining != waited {
+			draining := a.draining
+			a.mu.Unlock()
+			<-draining
+			waited = draining
+			continue
+		}
+		if a.app != nil {
+			a.mu.Unlock()
+			return errors.New("mobile: already started")
+		}
+		if a.starting {
+			a.mu.Unlock()
+			return errors.New("mobile: start already in progress")
+		}
+		ctx, cancel = context.WithCancel(context.Background())
+		startDone = make(chan struct{})
+		a.starting = true
+		a.startCancel = cancel
+		a.startDone = startDone
+		a.startID++
+		startID = a.startID
+		a.mu.Unlock()
+		break
+	}
+
+	// Mithril fast-sync keeps the first sync (and the on-disk footprint, paired
+	// with the lean profile) practical on a mobile device.
+	result := make(chan startResult, 1)
+	go func() {
+		app, err := bootWallet(ctx, boot.Config{
+			Network:        network,
+			DataDir:        dataDir,
+			Addr:           "127.0.0.1:0", // OS-assigned loopback port for the WebView
+			MithrilEnabled: true,
+			LeanDefault:    lean,
+		})
+		result <- startResult{app: app, err: err}
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case res := <-result:
+		return a.finishStart(startID, cancel, startDone, res)
+	case <-timer.C:
+		cancel()
+		a.cancelStart(startID, startDone)
+		cleanupStartResult(result, startDone)
+		return fmt.Errorf("%w after %s", errStartTimeout, timeout)
+	case <-ctx.Done():
+		a.cancelStart(startID, startDone)
+		cleanupStartResult(result, startDone)
+		return ctx.Err()
+	}
+}
+
+type startResult struct {
+	app *boot.App
+	err error
+}
+
+func startTimeout(timeoutMs int64) time.Duration {
+	if timeoutMs <= 0 {
+		return defaultStartTimeout
+	}
+	return time.Duration(timeoutMs) * time.Millisecond
+}
+
+func (a *App) finishStart(startID uint64, cancel context.CancelFunc, done chan struct{}, res startResult) error {
+	defer close(done)
+
+	a.mu.Lock()
+	if a.startID != startID || !a.starting {
+		a.mu.Unlock()
+		cancel()
+		if res.app != nil {
+			_ = res.app.Stop()
+		}
+		if res.err != nil {
+			return res.err
+		}
+		return context.Canceled
+	}
+	a.starting = false
+	a.startCancel = nil
+	a.startDone = nil
+	if res.err != nil {
+		a.mu.Unlock()
+		cancel()
+		return res.err
+	}
+	a.app = res.app
+	a.mu.Unlock()
+	return nil
+}
+
+func (a *App) cancelStart(startID uint64, done <-chan struct{}) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.startID != startID || !a.starting {
+		return
+	}
+	a.starting = false
+	a.startCancel = nil
+	a.startDone = nil
+	a.startID++
+	a.draining = done
+}
+
+// cleanupLateStart waits for a superseded/canceled start's boot result and, if
+// bootWallet went on to return a live *boot.App despite the supersede, stops it
+// so the abandoned start doesn't leak a running node or its sockets.
+//
+// The wait is unconditional — it does NOT select on ctx.Done(). Callers invoke
+// this only after cancel() has already fired, so ctx.Done() is already closed
+// by the time this runs: a `case <-ctx.Done(): return` would fire immediately
+// and abandon the watch right when a live, fully-booted App could still be in
+// flight — the exact node/socket leak this function exists to prevent (see
+// boot.Boot returning a live App promptly after cancellation, e.g. via the
+// timeout path).
+//
+// The unconditional wait is safe because bootWallet (boot.Boot) is itself
+// ctx-aware: it checks ctx.Err() before doing any work and again right after
+// the node/control surface are launched, tearing down and returning an error
+// instead of a live App whenever it observes cancellation. Every step in
+// between is local, bounded work (no network/readiness waits), so bootWallet's
+// return is guaranteed to happen in bounded time — which is what makes this
+// goroutine guaranteed to terminate rather than leak.
+//
+// It returns a channel that is closed once the goroutine has finished (Stop
+// called, if applicable). Tests use the channel to deterministically observe
+// completion instead of polling.
+func cleanupLateStart(result <-chan startResult) <-chan struct{} {
+	done := make(chan struct{})
+	cleanupStartResult(result, done)
+	return done
+}
+
+func cleanupStartResult(result <-chan startResult, done chan struct{}) {
+	go func() {
+		defer close(done)
+		res := <-result
+		if res.app != nil {
+			_ = res.app.Stop()
+		}
+	}()
+}
+
+// Port returns the OS-assigned loopback TCP port the control surface is serving
+// on, for the WebView to load (http://127.0.0.1:<port>/). It returns 0 before a
+// successful Start.
+func (a *App) Port() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.app == nil {
+		return 0
+	}
+	return a.app.Port()
+}
+
+// OnNetworkChanged re-dials the embedded node's peers after the host network
+// changes (WiFi↔cellular, loss→regain). It is called from the Android
+// ConnectivityManager.NetworkCallback and must be safe to call from any thread.
+// It is a safe no-op before Start.
+func (a *App) OnNetworkChanged() error {
+	a.mu.Lock()
+	app := a.app
+	a.mu.Unlock()
+	if app == nil {
+		return nil
+	}
+	return app.OnNetworkChanged()
+}
+
+// OnResume re-dials the embedded node's peers after the app returns from the
+// background. It is called from the Android Activity.onResume and must be safe
+// to call from any thread. Peers go stale during suspension so a re-dial cycle
+// re-establishes them without data loss. It is a safe no-op before Start.
+func (a *App) OnResume() error {
+	a.mu.Lock()
+	app := a.app
+	a.mu.Unlock()
+	if app == nil {
+		return nil
+	}
+	return app.OnResume()
+}
+
+// Stop tears the wallet down cleanly: it drains the control surface and winds
+// down the in-process node. It is safe to call more than once; calling it before
+// Start is a no-op.
+func (a *App) Stop() error {
+	a.mu.Lock()
+	if a.starting {
+		cancel := a.startCancel
+		done := a.startDone
+		a.starting = false
+		a.startCancel = nil
+		a.startDone = nil
+		a.startID++
+		if done != nil {
+			a.draining = done
+		}
+		a.mu.Unlock()
+		if cancel != nil {
+			cancel()
+		}
+		return nil
+	}
+	if a.app == nil {
+		a.mu.Unlock()
+		return nil
+	}
+	app := a.app
+	a.app = nil
+	a.mu.Unlock()
+	return app.Stop()
+}

--- a/ui/mobile/mobile_test.go
+++ b/ui/mobile/mobile_test.go
@@ -1,0 +1,435 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package mobile
+
+import (
+	"context"
+	"errors"
+	"net"
+	"reflect"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/bursa/ui/internal/boot"
+)
+
+// TestNewHandleLifecycleBeforeStart verifies the pre-Start contract the
+// Android/iOS shells rely on: a fresh handle reports port 0, and Stop is a
+// harmless no-op before a successful Start (so a shell that tears down after a
+// failed Start does not panic). This exercises the binding without spinning up a
+// real node.
+func TestNewHandleLifecycleBeforeStart(t *testing.T) {
+	a := New()
+	if a == nil {
+		t.Fatal("New returned nil")
+	}
+	if got := a.Port(); got != 0 {
+		t.Fatalf("Port before Start = %d, want 0", got)
+	}
+	if err := a.Stop(); err != nil {
+		t.Fatalf("Stop before Start = %v, want nil", err)
+	}
+}
+
+// gomobileSupported is true only for the value types gomobile can marshal
+// across the language boundary, plus exported struct pointers (treated as
+// opaque handles).
+func gomobileSupported(kind string) bool {
+	switch kind {
+	case "bool", "int", "int64", "float32", "float64", "string", "[]byte", "error",
+		"*mobile.App": // exported struct pointer — crosses as an opaque handle
+		return true
+	}
+	return false
+}
+
+func gomobileTypeName(typ reflect.Type) string {
+	if typ.Kind() == reflect.Slice && typ.Elem().Kind() == reflect.Uint8 {
+		return "[]byte"
+	}
+	return typ.String()
+}
+
+func assertGomobileInputs(t *testing.T, name string, typ reflect.Type, offset int, params []string) {
+	t.Helper()
+	if typ.NumIn()-offset != len(params) {
+		t.Fatalf("%s param count = %d, want %d", name, typ.NumIn()-offset, len(params))
+	}
+	for i, want := range params {
+		got := gomobileTypeName(typ.In(i + offset))
+		if got != want {
+			t.Fatalf("%s param %d = %q, want %q", name, i, got, want)
+		}
+		if !gomobileSupported(got) {
+			t.Fatalf("%s param %d type %q is not gomobile-compatible", name, i, got)
+		}
+	}
+}
+
+func assertGomobileResults(t *testing.T, name string, typ reflect.Type, results []string) {
+	t.Helper()
+	if typ.NumOut() != len(results) {
+		t.Fatalf("%s result count = %d, want %d", name, typ.NumOut(), len(results))
+	}
+	for i, want := range results {
+		got := gomobileTypeName(typ.Out(i))
+		if got != want {
+			t.Fatalf("%s result %d = %q, want %q", name, i, got, want)
+		}
+		if !gomobileSupported(got) {
+			t.Fatalf("%s result %d type %q is not gomobile-compatible", name, i, got)
+		}
+	}
+}
+
+func assertGomobileFunc(t *testing.T, name string, typ reflect.Type, params, results []string) {
+	t.Helper()
+	assertGomobileInputs(t, name, typ, 0, params)
+	assertGomobileResults(t, name, typ, results)
+}
+
+func assertGomobileMethod(t *testing.T, appType reflect.Type, name string, params, results []string) {
+	t.Helper()
+	method, ok := appType.MethodByName(name)
+	if !ok {
+		t.Fatalf("missing exported method %s", name)
+	}
+	typ := method.Type
+	if typ.NumIn() == 0 || typ.In(0) != appType {
+		t.Fatalf("%s has unexpected receiver signature %s", name, typ)
+	}
+	assertGomobileInputs(t, name, typ, 1, params)
+	assertGomobileResults(t, name, typ, results)
+}
+
+// TestBindingSignaturesAreGomobileCompatible is a guard against accidentally
+// adding an exported binding method (or a New return) whose parameter/return
+// types gomobile cannot marshal. It reflects on the actual exported functions
+// and methods so signature drift fails in plain `go test`, before CI reaches
+// `gomobile bind`.
+func TestBindingSignaturesAreGomobileCompatible(t *testing.T) {
+	assertGomobileFunc(t, "New", reflect.TypeOf(New), nil, []string{"*mobile.App"})
+
+	type sig struct {
+		method string
+		params []string
+		result []string
+	}
+	sigs := []sig{
+		{"Start", []string{"string", "string", "bool"}, []string{"error"}},
+		{"StartWithTimeout", []string{"string", "string", "bool", "int64"}, []string{"error"}},
+		{"Port", nil, []string{"int"}},
+		{"Stop", nil, []string{"error"}},
+		{"OnNetworkChanged", nil, []string{"error"}},
+		{"OnResume", nil, []string{"error"}},
+	}
+	appType := reflect.TypeOf((*App)(nil))
+	expected := make(map[string]struct{}, len(sigs))
+	for _, s := range sigs {
+		expected[s.method] = struct{}{}
+	}
+	for i := 0; i < appType.NumMethod(); i++ {
+		method := appType.Method(i)
+		if _, ok := expected[method.Name]; !ok {
+			t.Fatalf("unexpected exported App method %s; add it to the gomobile signature guard or unexport it", method.Name)
+		}
+	}
+	for _, s := range sigs {
+		assertGomobileMethod(t, appType, s.method, s.params, s.result)
+	}
+}
+
+func TestStartWithTimeoutReturnsOnStalledBoot(t *testing.T) {
+	orig := bootWallet
+	defer func() { bootWallet = orig }()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	bootWallet = func(context.Context, boot.Config) (*boot.App, error) {
+		close(started)
+		<-release
+		return nil, context.Canceled
+	}
+	defer close(release)
+
+	a := New()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- a.StartWithTimeout(t.TempDir(), "preview", true, 25)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("boot did not start")
+	}
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, errStartTimeout) {
+			t.Fatalf("StartWithTimeout = %v, want errStartTimeout", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("StartWithTimeout did not return after timeout")
+	}
+}
+
+func TestStopCancelsStartInProgress(t *testing.T) {
+	orig := bootWallet
+	defer func() { bootWallet = orig }()
+
+	started := make(chan struct{})
+	bootWallet = func(ctx context.Context, _ boot.Config) (*boot.App, error) {
+		close(started)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	a := New()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- a.StartWithTimeout(t.TempDir(), "preview", true, 60_000)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("boot did not start")
+	}
+	if err := a.Stop(); err != nil {
+		t.Fatalf("Stop during Start = %v, want nil", err)
+	}
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Start after Stop = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not cancel Start")
+	}
+	if got := a.Port(); got != 0 {
+		t.Fatalf("Port after canceled Start = %d, want 0", got)
+	}
+}
+
+// TestStartWithTimeoutWaitsForPriorCleanup proves the fix for a race flagged
+// in PR #561 review: Stop() clears starting and returns as soon as it calls
+// cancel(), without waiting for the canceled boot to actually unwind. Since
+// boot.Boot binds fixed node ports (5555/5556) deep inside node startup —
+// past the point where it notices cancellation — an immediate retry could
+// previously race the old boot's teardown for those ports. StartWithTimeout
+// must now block a retry on the prior cleanup (the draining field) before
+// spawning a new boot attempt.
+func TestStartWithTimeoutWaitsForPriorCleanup(t *testing.T) {
+	orig := bootWallet
+	defer func() { bootWallet = orig }()
+
+	firstStarted := make(chan struct{})
+	release := make(chan struct{})
+	secondStarted := make(chan struct{})
+	var calls atomic.Int32
+
+	bootWallet = func(ctx context.Context, _ boot.Config) (*boot.App, error) {
+		if calls.Add(1) == 1 {
+			close(firstStarted)
+			<-ctx.Done()
+			// Simulate the real teardown window (dingo's node.Run only checks
+			// ctx after it has already bound its listeners): the canceled
+			// boot does not release anything until this call returns.
+			<-release
+			return nil, ctx.Err()
+		}
+		close(secondStarted)
+		return nil, nil
+	}
+
+	a := New()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- a.StartWithTimeout(t.TempDir(), "preview", true, 60_000)
+	}()
+
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first boot did not start")
+	}
+	if err := a.Stop(); err != nil {
+		t.Fatalf("Stop during Start = %v, want nil", err)
+	}
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("first Start = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not cancel first Start")
+	}
+
+	// Fire the retry right away, while the first boot is still stuck
+	// "unwinding" behind release. It must not touch bootWallet yet.
+	retryErrCh := make(chan error, 1)
+	go func() {
+		retryErrCh <- a.StartWithTimeout(t.TempDir(), "preview", true, 60_000)
+	}()
+
+	select {
+	case <-secondStarted:
+		t.Fatal("retry started a new boot before the prior canceled boot's cleanup finished")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("retry did not start once the prior cleanup finished")
+	}
+	select {
+	case err := <-retryErrCh:
+		if err != nil {
+			t.Fatalf("retry StartWithTimeout = %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("retry did not complete")
+	}
+}
+
+func TestStopPublishesDrainBeforeCanceledStartObservesCancellation(t *testing.T) {
+	orig := bootWallet
+	defer func() { bootWallet = orig }()
+	oldProcs := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(oldProcs)
+
+	firstStarted := make(chan struct{})
+	release := make(chan struct{})
+	releaseClosed := make(chan struct{})
+	var releaseOnce sync.Once
+	closeRelease := func() {
+		releaseOnce.Do(func() {
+			close(release)
+			close(releaseClosed)
+		})
+	}
+	defer closeRelease()
+
+	var calls atomic.Int32
+	bootWallet = func(ctx context.Context, _ boot.Config) (*boot.App, error) {
+		if calls.Add(1) == 1 {
+			close(firstStarted)
+			<-ctx.Done()
+			<-release
+			return nil, ctx.Err()
+		}
+		return nil, nil
+	}
+
+	a := New()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- a.StartWithTimeout(t.TempDir(), "preview", true, 60_000)
+	}()
+
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first boot did not start")
+	}
+	if err := a.Stop(); err != nil {
+		t.Fatalf("Stop during Start = %v, want nil", err)
+	}
+
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		closeRelease()
+	}()
+
+	// Invoke the retry synchronously before the canceled StartWithTimeout
+	// goroutine gets scheduled. Stop must already have published the first
+	// start's drain channel, so this call cannot complete before release closes.
+	retryErr := a.StartWithTimeout(t.TempDir(), "preview", true, 60_000)
+	releasedBeforeRetryReturned := false
+	select {
+	case <-releaseClosed:
+		releasedBeforeRetryReturned = true
+	default:
+	}
+	closeRelease()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("first Start = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first Start did not finish after release")
+	}
+	if !releasedBeforeRetryReturned {
+		t.Fatal("retry completed before Stop-published cleanup finished")
+	}
+	if retryErr != nil {
+		t.Fatalf("retry StartWithTimeout = %v, want nil", retryErr)
+	}
+}
+
+// TestCleanupLateStartStopsLiveAppAndTerminates proves the fix for the
+// node-lifecycle leak in cleanupLateStart (PR #561 review): when a superseded
+// start's slow bootWallet call eventually delivers a live *boot.App anyway —
+// the scenario the reviewer's rejected `case <-ctx.Done(): return` patch would
+// have abandoned mid-watch — cleanupLateStart must Stop() it (releasing the
+// node and its control-surface socket) AND its goroutine must terminate
+// promptly rather than leak.
+//
+// It exercises the real boot.Boot/App.Stop pair (not a fake), so the
+// assertions cover the actual lifecycle contract: a real bound listener that
+// must stop accepting connections once cleanup runs.
+func TestCleanupLateStartStopsLiveAppAndTerminates(t *testing.T) {
+	app, err := boot.Boot(context.Background(), boot.Config{
+		Network: "preview",
+		DataDir: t.TempDir(),
+		Addr:    "127.0.0.1:0",
+	})
+	if err != nil {
+		t.Fatalf("boot.Boot: %v", err)
+	}
+	addr := app.Addr()
+
+	if conn, dialErr := net.DialTimeout("tcp", addr, time.Second); dialErr != nil {
+		t.Fatalf("control surface not reachable before cleanup: %v", dialErr)
+	} else {
+		_ = conn.Close()
+	}
+
+	result := make(chan startResult, 1)
+	result <- startResult{app: app, err: nil}
+
+	done := cleanupLateStart(result)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("cleanupLateStart did not terminate; goroutine leaked")
+	}
+
+	// done only closes after res.app.Stop() has returned (deferred close runs
+	// last), so the control surface listener must already be torn down —
+	// proving cleanupLateStart genuinely stopped the live node/socket rather
+	// than merely that Stop is idempotent.
+	if conn, dialErr := net.DialTimeout("tcp", addr, time.Second); dialErr == nil {
+		_ = conn.Close()
+		t.Fatal("control surface still reachable after cleanupLateStart; Stop was not performed")
+	}
+}

--- a/ui/mobile/reconnect_test.go
+++ b/ui/mobile/reconnect_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package mobile
+
+import "testing"
+
+// TestOnNetworkChangedNoOpBeforeStart: OnNetworkChanged on a fresh (unstarted)
+// App must return nil and must not panic. This mirrors Stop's nil-guard pattern.
+func TestOnNetworkChangedNoOpBeforeStart(t *testing.T) {
+	a := New()
+	if err := a.OnNetworkChanged(); err != nil {
+		t.Fatalf("OnNetworkChanged before Start = %v, want nil", err)
+	}
+}
+
+// TestOnNetworkChangedSignatureIsGomobileCompatible: the OnNetworkChanged
+// method takes no parameters and returns only error — both gomobile-supported.
+func TestOnNetworkChangedSignatureIsGomobileCompatible(t *testing.T) {
+	// params: none
+	// result: error
+	if !gomobileSupported("error") {
+		t.Fatal("OnNetworkChanged result type error is not gomobile-compatible")
+	}
+}

--- a/ui/mobile/resume_test.go
+++ b/ui/mobile/resume_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package mobile
+
+import "testing"
+
+// TestOnResumeNoOpBeforeStart: OnResume on a fresh (unstarted) App must return
+// nil and must not panic. This mirrors the nil-guard pattern of OnNetworkChanged
+// and Stop.
+func TestOnResumeNoOpBeforeStart(t *testing.T) {
+	a := New()
+	if err := a.OnResume(); err != nil {
+		t.Fatalf("OnResume before Start = %v, want nil", err)
+	}
+}
+
+// TestOnResumeSignatureIsGomobileCompatible: OnResume takes no parameters and
+// returns only error — both gomobile-supported types.
+func TestOnResumeSignatureIsGomobileCompatible(t *testing.T) {
+	// params: none
+	// result: error
+	if !gomobileSupported("error") {
+		t.Fatal("OnResume result type error is not gomobile-compatible")
+	}
+}

--- a/ui/web/src/api/client.test.ts
+++ b/ui/web/src/api/client.test.ts
@@ -1,4 +1,4 @@
-import { apiGet, ApiError } from "./client";
+import { apiDelete, apiGet, ApiError } from "./client";
 
 function mockFetch(status: number, body: unknown) {
   globalThis.fetch = vi.fn().mockResolvedValue({
@@ -18,4 +18,61 @@ test("apiGet throws ApiError with the server message + status on failure", async
   mockFetch(409, { error: "no wallet set" });
   await expect(apiGet("/wallet/balance")).rejects.toMatchObject({ status: 409, message: "no wallet set" });
   await expect(apiGet("/wallet/balance")).rejects.toBeInstanceOf(ApiError);
+});
+
+// --- Retry / backoff tests ---------------------------------------------------
+
+test("a flaky fetch (rejects once with TypeError then resolves) is retried and succeeds", async () => {
+  let calls = 0;
+  globalThis.fetch = vi.fn().mockImplementation(async () => {
+    calls++;
+    if (calls === 1) throw new TypeError("Failed to fetch");
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ lovelace: "1000000", assets: [] }),
+    };
+  }) as unknown as typeof fetch;
+
+  const result = await apiGet("/wallet/balance");
+  expect(result).toEqual({ lovelace: "1000000", assets: [] });
+  expect(calls).toBe(2);
+});
+
+test("a fetch returning HTTP 500 is NOT retried — one call, error surfaced immediately", async () => {
+  let calls = 0;
+  globalThis.fetch = vi.fn().mockImplementation(async () => {
+    calls++;
+    return {
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "internal server error" }),
+    };
+  }) as unknown as typeof fetch;
+
+  await expect(apiGet("/wallet/balance")).rejects.toMatchObject({ status: 500 });
+  expect(calls).toBe(1);
+});
+
+test("a persistent network error (TypeError every attempt) exhausts retries and throws", async () => {
+  let calls = 0;
+  globalThis.fetch = vi.fn().mockImplementation(async () => {
+    calls++;
+    throw new TypeError("Failed to fetch");
+  }) as unknown as typeof fetch;
+
+  await expect(apiGet("/wallet/balance")).rejects.toBeInstanceOf(ApiError);
+  // RETRY_ATTEMPTS=3: 1 initial + 2 retries = 3 total calls.
+  expect(calls).toBe(3);
+});
+
+test("apiDelete is not retried after a network error", async () => {
+  let calls = 0;
+  globalThis.fetch = vi.fn().mockImplementation(async () => {
+    calls++;
+    throw new TypeError("Failed to fetch");
+  }) as unknown as typeof fetch;
+
+  await expect(apiDelete("/wallet/test-wallet")).rejects.toBeInstanceOf(ApiError);
+  expect(calls).toBe(1);
 });

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -51,39 +51,65 @@ export class ApiError extends Error {
 }
 
 const REQUEST_TIMEOUT_MS = 30_000;
+// Retry only on network failures (TypeError/"Failed to fetch"), not HTTP errors.
+const RETRY_ATTEMPTS = 3; // total attempts (1 initial + 2 retries)
+const RETRY_BACKOFF_BASE_MS = 250;
+const RETRY_BACKOFF_CAP_MS = 1_000;
+
+// Only retry read-only methods. Replaying DELETE can surface a false failure if
+// the first request succeeded server-side but the response was lost.
+const RETRYABLE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 
 async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-  let res: Response;
-  try {
-    res = await fetch(path, {
-      method,
-      headers: body ? { "Content-Type": "application/json" } : undefined,
-      body: body ? JSON.stringify(body) : undefined,
-      signal: controller.signal,
-    });
-  } catch (e) {
-    // Normalize transport failures (network down, timeout/abort) into ApiError
-    // so callers handle them uniformly; status 0 means no HTTP response.
-    const msg =
-      e instanceof DOMException && e.name === "AbortError" ? "request timed out" : "network error";
-    throw new ApiError(0, msg);
-  } finally {
-    clearTimeout(timer);
-  }
-  if (!res.ok) {
-    let message = `request failed (${res.status})`;
-    try {
-      const j = await res.json();
-      if (j && typeof j.error === "string") message = j.error;
-    } catch {
-      /* non-JSON */
+  let lastNetworkError: ApiError | null = null;
+  const maxAttempts = RETRYABLE_METHODS.has(method.toUpperCase()) ? RETRY_ATTEMPTS : 1;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (attempt > 0) {
+      // Capped exponential backoff: 250ms, 500ms, ... capped at 1000ms
+      const delay = Math.min(RETRY_BACKOFF_BASE_MS * Math.pow(2, attempt - 1), RETRY_BACKOFF_CAP_MS);
+      await new Promise<void>((resolve) => setTimeout(resolve, delay));
     }
-    throw new ApiError(res.status, message);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    let res: Response;
+    try {
+      res = await fetch(path, {
+        method,
+        headers: body ? { "Content-Type": "application/json" } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+    } catch (e) {
+      clearTimeout(timer);
+      // Only retry on network failures (TypeError). AbortError (timeout) is not retried.
+      if (e instanceof TypeError) {
+        lastNetworkError = new ApiError(0, "network error");
+        continue;
+      }
+      // Timeout / abort — treat as a terminal error, don't retry.
+      throw new ApiError(0, "request timed out");
+    }
+    clearTimeout(timer);
+
+    if (!res.ok) {
+      let message = `request failed (${res.status})`;
+      try {
+        const j = await res.json();
+        if (j && typeof j.error === "string") message = j.error;
+      } catch {
+        /* non-JSON */
+      }
+      // HTTP error responses are real responses — do not retry.
+      throw new ApiError(res.status, message);
+    }
+    // All our endpoints return JSON.
+    return (await res.json()) as T;
   }
-  // All our endpoints return JSON.
-  return (await res.json()) as T;
+
+  // Exhausted all retry attempts for network failures.
+  throw lastNetworkError ?? new ApiError(0, "network error");
 }
 
 export const apiGet = <T>(path: string) => request<T>("GET", path);

--- a/ui/web/src/api/hooks.test.tsx
+++ b/ui/web/src/api/hooks.test.tsx
@@ -1,10 +1,13 @@
 import { renderHook, waitFor, act } from "@testing-library/react";
-import { useStatus } from "./hooks";
+import { useStatus, useAsync } from "./hooks";
 import * as client from "./client";
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.useRealTimers();
+  // Restore navigator.onLine and document.hidden defaults
+  Object.defineProperty(navigator, "onLine", { value: true, configurable: true, writable: true });
+  Object.defineProperty(document, "hidden", { value: false, configurable: true, writable: true });
 });
 
 test("useStatus loads then polls", async () => {
@@ -17,4 +20,150 @@ test("useStatus loads then polls", async () => {
   await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
   await waitFor(() => expect(result.current.data?.state).toBe("ready"));
   expect(spy).toHaveBeenCalledTimes(2);
+});
+
+// --- Online-aware polling tests ----------------------------------------------
+
+test("poll is suspended when navigator.onLine is false — interval fires but fetch is skipped", async () => {
+  Object.defineProperty(navigator, "onLine", { value: false, configurable: true, writable: true });
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+
+  let calls = 0;
+  const fn = vi.fn(async () => {
+    calls++;
+    return { state: "ready", tip: calls, caughtUp: true } as never;
+  });
+
+  const { result } = renderHook(() => useAsync(fn, { pollMs: 500 }));
+  // Initial fetch fires regardless of online state
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  const callsAfterInit = calls;
+
+  // Advance time — poll should NOT fire extra calls while offline
+  await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+  expect(calls).toBe(callsAfterInit);
+});
+
+test("poll is suspended when document.hidden is true — fetch is skipped while hidden", async () => {
+  Object.defineProperty(document, "hidden", { value: true, configurable: true, writable: true });
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+
+  let calls = 0;
+  const fn = vi.fn(async () => {
+    calls++;
+    return { state: "syncing", tip: calls, caughtUp: false } as never;
+  });
+
+  const { result } = renderHook(() => useAsync(fn, { pollMs: 500 }));
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  const callsAfterInit = calls;
+
+  await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+  expect(calls).toBe(callsAfterInit);
+});
+
+// --- Visibility-change (resume) refetch tests --------------------------------
+// These tests use shouldAdvanceTime: true but a very long poll interval (10 s)
+// so only the visibilitychange event itself can trigger the extra refetch
+// within the tight timing window we measure.
+
+test("a visibilitychange to visible triggers an immediate refetch", async () => {
+  // Start hidden; poll is long so the timer alone cannot fire the extra call.
+  Object.defineProperty(document, "hidden", { value: true, configurable: true, writable: true });
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+
+  let calls = 0;
+  const fn = vi.fn(async () => {
+    calls++;
+    return { state: "ready", tip: calls, caughtUp: true } as never;
+  });
+
+  const { result } = renderHook(() => useAsync(fn, { pollMs: 10000 }));
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  const callsAfterInit = calls; // == 1
+
+  // Become visible and dispatch — only the visibilitychange listener can
+  // produce the extra call within this 20 ms window (interval is 10 000 ms).
+  Object.defineProperty(document, "hidden", { value: false, configurable: true, writable: true });
+  await act(async () => {
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.advanceTimersByTimeAsync(20);
+  });
+
+  expect(calls).toBeGreaterThan(callsAfterInit);
+});
+
+test("a visibilitychange to hidden does NOT trigger a refetch", async () => {
+  Object.defineProperty(document, "hidden", { value: false, configurable: true, writable: true });
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+
+  let calls = 0;
+  const fn = vi.fn(async () => {
+    calls++;
+    return { state: "ready", tip: calls, caughtUp: true } as never;
+  });
+
+  const { result } = renderHook(() => useAsync(fn, { pollMs: 10000 }));
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  const callsAfterInit = calls;
+
+  // Go hidden — must NOT fire an extra refetch.
+  Object.defineProperty(document, "hidden", { value: true, configurable: true, writable: true });
+  await act(async () => {
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.advanceTimersByTimeAsync(20);
+  });
+
+  expect(calls).toBe(callsAfterInit);
+});
+
+test("visibilitychange listener is removed on unmount (no refetch after cleanup)", async () => {
+  Object.defineProperty(document, "hidden", { value: true, configurable: true, writable: true });
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+
+  let calls = 0;
+  const fn = vi.fn(async () => {
+    calls++;
+    return { state: "ready", tip: calls, caughtUp: true } as never;
+  });
+
+  const { result, unmount } = renderHook(() => useAsync(fn, { pollMs: 10000 }));
+  await waitFor(() => expect(result.current.loading).toBe(false));
+
+  unmount();
+  const callsAtUnmount = calls;
+
+  // Become visible after unmount — removed listener must not fire.
+  Object.defineProperty(document, "hidden", { value: false, configurable: true, writable: true });
+  await act(async () => {
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.advanceTimersByTimeAsync(20);
+  });
+
+  expect(calls).toBe(callsAtUnmount);
+});
+
+test("an 'online' window event triggers an immediate refetch", async () => {
+  Object.defineProperty(navigator, "onLine", { value: false, configurable: true, writable: true });
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+
+  let calls = 0;
+  const fn = vi.fn(async () => {
+    calls++;
+    return { state: "ready", tip: calls, caughtUp: true } as never;
+  });
+
+  const { result } = renderHook(() => useAsync(fn, { pollMs: 500 }));
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  const callsAfterInit = calls;
+
+  // Come back online — fire the 'online' event
+  Object.defineProperty(navigator, "onLine", { value: true, configurable: true, writable: true });
+  await act(async () => {
+    window.dispatchEvent(new Event("online"));
+    // Small tick for the async refetch to settle
+    await vi.advanceTimersByTimeAsync(50);
+  });
+
+  await waitFor(() => expect(calls).toBeGreaterThan(callsAfterInit));
 });

--- a/ui/web/src/api/hooks.ts
+++ b/ui/web/src/api/hooks.ts
@@ -44,6 +44,9 @@ export function useAsync<T>(fn: () => Promise<T>, opts?: { pollMs?: number }): A
     let inFlight = false;
 
     const run = (isInitial: boolean) => {
+      // Suspend polling when the network is down or the page is hidden — avoid
+      // firing requests into a dead network or a backgrounded tab.
+      if (!isInitial && (!navigator.onLine || document.hidden)) return;
       // Skip if a request is still pending: prevents overlapping polls and
       // out-of-order responses from overwriting fresher data.
       if (inFlight) return;
@@ -73,9 +76,23 @@ export function useAsync<T>(fn: () => Promise<T>, opts?: { pollMs?: number }): A
       id = setInterval(() => run(false), opts.pollMs);
     }
 
+    // When the network comes back, trigger an immediate refetch so the UI
+    // recovers without waiting for the next poll interval.
+    const onOnline = () => run(false);
+    window.addEventListener("online", onOnline);
+
+    // When the app returns from the background (tab/app becomes visible),
+    // trigger an immediate refetch so the UI reflects any state changes that
+    // occurred while it was suspended. The run() guard already skips the call
+    // when document.hidden is true, so a hidden→hidden transition is a no-op.
+    const onVisibilityChange = () => run(false);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
     return () => {
       cancelled = true;
       if (id !== undefined) clearInterval(id);
+      window.removeEventListener("online", onOnline);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tick]);

--- a/ui/web/src/app.test.tsx
+++ b/ui/web/src/app.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
 import { App } from "./app";
 import * as hooks from "./api/hooks";
 import * as client from "./api/client";
@@ -266,4 +266,56 @@ test("Add wallet action opens the add-wallet form", async () => {
   fireEvent.click(screen.getByRole("button", { name: /add wallet/i }));
   // The add-wallet form (with a recovery-phrase field) appears.
   await waitFor(() => expect(screen.getByLabelText(/recovery phrase/i)).toBeInTheDocument());
+});
+
+// --- Offline banner tests ----------------------------------------------------
+
+test("offline banner appears when an 'offline' event is fired", async () => {
+  stubStatus("ready");
+  stubVault({ exists: false, locked: true, wallet_count: 0 });
+
+  render(<App />);
+  await waitFor(() => expect(screen.getByRole("button", { name: /create vault/i })).toBeInTheDocument());
+
+  expect(screen.queryByRole("alert", { name: /offline/i })).not.toBeInTheDocument();
+
+  act(() => {
+    window.dispatchEvent(new Event("offline"));
+  });
+
+  await waitFor(() => expect(screen.getByRole("alert", { name: /offline/i })).toBeInTheDocument());
+});
+
+test("offline banner hides when an 'online' event fires after going offline", async () => {
+  stubStatus("ready");
+  stubVault({ exists: false, locked: true, wallet_count: 0 });
+
+  render(<App />);
+  await waitFor(() => expect(screen.getByRole("button", { name: /create vault/i })).toBeInTheDocument());
+
+  act(() => {
+    window.dispatchEvent(new Event("offline"));
+  });
+  await waitFor(() => expect(screen.getByRole("alert", { name: /offline/i })).toBeInTheDocument());
+
+  act(() => {
+    window.dispatchEvent(new Event("online"));
+  });
+  await waitFor(() => expect(screen.queryByRole("alert", { name: /offline/i })).not.toBeInTheDocument());
+});
+
+test("offline banner can be dismissed by the user", async () => {
+  stubStatus("ready");
+  stubVault({ exists: false, locked: true, wallet_count: 0 });
+
+  render(<App />);
+  await waitFor(() => expect(screen.getByRole("button", { name: /create vault/i })).toBeInTheDocument());
+
+  act(() => {
+    window.dispatchEvent(new Event("offline"));
+  });
+  await waitFor(() => expect(screen.getByRole("alert", { name: /offline/i })).toBeInTheDocument());
+
+  fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+  expect(screen.queryByRole("alert", { name: /offline/i })).not.toBeInTheDocument();
 });

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { ReactElement } from "react";
 import type { Account, WalletView } from "./api/types";
 import { useStatus, useVaultStatus } from "./api/hooks";
@@ -156,6 +156,7 @@ export function App() {
   if (!unlocked && !loadAnyway && status.data && status.data.state !== "ready") {
     return (
       <div className="app">
+        <OfflineBanner />
         <SyncBanner status={status.data} />
         <main className="content content-boot">
           <Syncing status={status.data} onLoadAnyway={() => setLoadAnyway(true)} />
@@ -263,6 +264,7 @@ export function App() {
 
   return (
     <div className="app">
+      <OfflineBanner />
       {status.data && <SyncBanner status={status.data} />}
       <div className="layout">
         <nav className="sidebar">
@@ -322,6 +324,7 @@ function FullScreen({
 }) {
   return (
     <div className="app">
+      <OfflineBanner />
       {status && <SyncBanner status={status} />}
       <main className="content content-centered">{children}</main>
     </div>
@@ -343,5 +346,41 @@ function VaultStatusUnavailable({
       </p>
       <Button onClick={onRetry}>Retry</Button>
     </section>
+  );
+}
+
+// Small dismissible banner that appears when the browser reports no network.
+function OfflineBanner() {
+  const [offline, setOffline] = useState(!navigator.onLine);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    const onOffline = () => { setOffline(true); setDismissed(false); };
+    const onOnline = () => { setOffline(false); setDismissed(false); };
+    window.addEventListener("offline", onOffline);
+    window.addEventListener("online", onOnline);
+    return () => {
+      window.removeEventListener("offline", onOffline);
+      window.removeEventListener("online", onOnline);
+    };
+  }, []);
+
+  if (!offline || dismissed) return null;
+
+  return (
+    <div
+      role="alert"
+      aria-label="offline"
+      className="offline-banner"
+    >
+      <span>You are offline. Some features may be unavailable.</span>
+      <button
+        className="offline-banner-dismiss"
+        aria-label="dismiss"
+        onClick={() => setDismissed(true)}
+      >
+        ✕
+      </button>
+    </div>
   );
 }

--- a/ui/web/src/screens/Settings.test.tsx
+++ b/ui/web/src/screens/Settings.test.tsx
@@ -162,7 +162,11 @@ test("(l) toggling lean storage PUTs the new value and shows restart note", asyn
   await waitFor(() => expect(spy).toHaveBeenCalledWith(true));
   await waitFor(() => expect(toggle).not.toBeDisabled());
   expect(toggle).toBeChecked();
-  expect(screen.getByRole("status")).toHaveTextContent(/takes effect after a node restart/i);
+  // The live restart note (role=status) must appear after a save that returns
+  // restart_required=true. findByRole is used here because the static copy
+  // section also contains the same text ("Takes effect after a node restart."),
+  // and findByText would match both elements.
+  expect(await screen.findByRole("status")).toHaveTextContent(/takes effect after a node restart/i);
 });
 
 test("(m) failed lean storage update rolls back and surfaces the error", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Android and iOS shells and hardens network/wake behavior so the wallet stays in sync in the background and recovers cleanly after network changes or app resume. Unifies boot across desktop/mobile and ships an offline-aware web UI with safe retries and an offline banner.

- **New Features**
  - `ui/mobile`: `gomobile` binding (`App.Start/Stop/Port/OnNetworkChanged/OnResume`) that boots the wallet and serves the SPA on `127.0.0.1`.
  - Android/iOS shells: WebView apps loading the embedded SPA. Android runs a foreground `WalletService` (`dataSync`), shows a notification, listens for connectivity changes, and allows loopback cleartext via a strict `network_security_config`. iOS uses `WKWebView`, monitors reachability (`NWPathMonitor`), and links a generated xcframework via `xcodegen`.
  - Network/wake resilience: `supervisor.Reconnect` stop-then-relaunch, `boot.App` hooks for resume/network-change, plus unit tests around cancellation and relaunch.
  - Web UI robustness: read-only request retries (GET/HEAD/OPTIONS only) on network failures with capped backoff; polling pauses when offline/hidden and immediately refetches on online/visibilitychange/resume; adds an offline banner.
  - Unified boot: `ui/internal/boot` centralizes node/services/settings and binds an OS-assigned loopback port; desktop now calls `boot.Boot`. CI adds a `mobile` workflow that builds Android (canonical Docker image/script) and iOS (macOS runner) on tags or manual runs.

- **Migration**
  - Android: declare `FOREGROUND_SERVICE` with `foregroundServiceType="dataSync"` and add `FOREGROUND_SERVICE_DATA_SYNC` on API 34+.
  - Builds: add `golang.org/x/mobile` and the tool `golang.org/x/mobile/cmd/gobind`; Android bind targets `android/arm64`. Use the provided Docker image/script for Android or the CI workflow.

<sup>Written for commit dc397a75744dc9a373ddaaa4ddaa31560787647c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile app build and CI support for Android and iOS, including packaged artifacts for both platforms.
  * Introduced mobile app shells that keep the wallet available in the background and recover after network/app resume events.
  * Added offline-aware UI behavior, including an offline banner and immediate refetch on reconnect.

* **Bug Fixes**
  * Improved request handling with retries for transient network issues.
  * Added safer startup, shutdown, and resume behavior across mobile and web flows.

* **Documentation**
  * Added mobile build and architecture guidance for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->