### PR TITLE
feat(ui): QR codes on Receive screen

### DIFF
--- a/ui/web/package-lock.json
+++ b/ui/web/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "bursa-wallet-ui",
       "dependencies": {
+        "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -3858,6 +3859,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react": {

--- a/ui/web/package.json
+++ b/ui/web/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/ui/web/src/screens/Receive.qr.test.tsx
+++ b/ui/web/src/screens/Receive.qr.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// Stub the QR encoder so we can assert on exactly what value it was asked to
+// encode, independent of the real qrcode.react rendering pipeline (which is
+// exercised for real — unmocked — in Receive.test.tsx).
+vi.mock("qrcode.react", () => ({
+  QRCodeSVG: ({ value, title }: { value: string; title?: string }) => (
+    <svg data-testid="qr-mock" data-qr-value={value} role="img">
+      {title && <title>{title}</title>}
+    </svg>
+  ),
+}));
+
+import { Receive } from "./Receive";
+import * as hooks from "../api/hooks";
+
+const ADDR_A = "addr_test1qpfqpgxzsq8d6l5n5qxkdqqvxqqtd2syvxsw0mkzmq2dzn7y2y5a3uqquasklznf6xvxn0tmxy2cjaslt9yq5ygz4dqsv9r4pk";
+const ADDR_B = "addr_test1qqy2j78ks2htj6x5p2xztqpvqxqqtd2syvxsw0mkzmq2dzny0cjaslt9yq5ygz4dqsv9r4pkzuqquasklznf6xvxn0tmxwtest2";
+
+function mockAddresses() {
+  vi.spyOn(hooks, "useAddresses").mockReturnValue({
+    data: {
+      receive: [ADDR_A, ADDR_B],
+      used: [ADDR_A],
+      next_unused: ADDR_B,
+    },
+    error: null,
+    loading: false,
+    refresh: vi.fn(),
+    setData: vi.fn(),
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("hero QR encodes the exact next-unused address, not the truncated display string", () => {
+  mockAddresses();
+  render(<Receive />);
+
+  // No row QR is expanded yet, so the hero's is the only QR mock rendered —
+  // asserting the count keeps this from silently depending on render order.
+  const qrCodes = screen.getAllByTestId("qr-mock");
+  expect(qrCodes).toHaveLength(1);
+  expect(qrCodes[0]).toHaveAttribute("data-qr-value", ADDR_B);
+});
+
+test("per-row QR toggle reveals a code encoding the exact full row address", () => {
+  mockAddresses();
+  render(<Receive />);
+
+  // No row QR is shown until requested.
+  expect(
+    screen.queryAllByTestId("qr-mock").some((el) => el.getAttribute("data-qr-value") === ADDR_A),
+  ).toBe(false);
+
+  fireEvent.click(screen.getByRole("button", { name: `Show QR code for ${ADDR_A}` }));
+
+  const rowQr = screen
+    .getAllByTestId("qr-mock")
+    .find((el) => el.getAttribute("data-qr-value") === ADDR_A);
+  expect(rowQr).toBeDefined();
+
+  // Toggling again hides it.
+  fireEvent.click(screen.getByRole("button", { name: `Hide QR code for ${ADDR_A}` }));
+  expect(
+    screen.queryAllByTestId("qr-mock").some((el) => el.getAttribute("data-qr-value") === ADDR_A),
+  ).toBe(false);
+});
+
+test("QR regenerates when the next-unused address changes", () => {
+  mockAddresses();
+  const { rerender } = render(<Receive />);
+  let qrCodes = screen.getAllByTestId("qr-mock");
+  expect(qrCodes).toHaveLength(1);
+  expect(qrCodes[0]).toHaveAttribute("data-qr-value", ADDR_B);
+
+  vi.spyOn(hooks, "useAddresses").mockReturnValue({
+    data: { receive: [ADDR_A, ADDR_B], used: [ADDR_A, ADDR_B], next_unused: ADDR_A },
+    error: null,
+    loading: false,
+    refresh: vi.fn(),
+    setData: vi.fn(),
+  });
+  rerender(<Receive />);
+
+  qrCodes = screen.getAllByTestId("qr-mock");
+  expect(qrCodes).toHaveLength(1);
+  expect(qrCodes[0]).toHaveAttribute("data-qr-value", ADDR_A);
+});

--- a/ui/web/src/screens/Receive.tsx
+++ b/ui/web/src/screens/Receive.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
 import { useAddresses } from "../api/hooks";
 import { Card } from "../components/Card";
 import { Table } from "../components/Table";
@@ -9,8 +11,27 @@ function truncateAddr(addr: string): string {
   return addr.slice(0, 12) + "…" + addr.slice(-8);
 }
 
+// QR codes are rendered entirely client-side (bundled `qrcode.react`, no
+// network round-trip) into an inline SVG. A high, near-white/near-black
+// contrast pair is used regardless of the surrounding dark theme so the code
+// stays reliably scannable by phone cameras.
+const QR_BG = "#ffffff";
+const QR_FG = "#0c0f15";
+const QR_SIZE_HERO = 176;
+const QR_SIZE_ROW = 112;
+
+/** A QR code framed in a light chip so it stays scannable on the dark panel. */
+function AddressQR({ address, size, title }: { address: string; size: number; title: string }) {
+  return (
+    <div className="receive-qr-frame">
+      <QRCodeSVG value={address} size={size} bgColor={QR_BG} fgColor={QR_FG} level="M" marginSize={2} title={title} />
+    </div>
+  );
+}
+
 export function Receive() {
   const addresses = useAddresses();
+  const [expandedQr, setExpandedQr] = useState<string | null>(null);
 
   if (addresses.loading) {
     return <p>Loading…</p>;
@@ -32,20 +53,47 @@ export function Receive() {
   const columns = [
     { key: "address", label: "Address" },
     { key: "status", label: "Status" },
+    { key: "qr", label: "QR" },
     { key: "copy", label: "" },
   ];
 
-  const rows = receive.map((addr) => ({
-    address: truncateAddr(addr),
-    status: usedSet.has(addr) ? "Used" : "Unused",
-    copy: <CopyButton value={addr} />,
-  }));
+  const rows = receive.map((addr) => {
+    const isExpanded = expandedQr === addr;
+    return {
+      address: truncateAddr(addr),
+      status: usedSet.has(addr) ? "Used" : "Unused",
+      qr: (
+        <div className="receive-qr-cell">
+          <button
+            type="button"
+            className="btn ghost"
+            aria-expanded={isExpanded}
+            aria-label={`${isExpanded ? "Hide" : "Show"} QR code for ${addr}`}
+            onClick={() => setExpandedQr(isExpanded ? null : addr)}
+          >
+            {isExpanded ? "Hide QR" : "QR"}
+          </button>
+          {isExpanded && (
+            <AddressQR address={addr} size={QR_SIZE_ROW} title={`QR code for ${addr}`} />
+          )}
+        </div>
+      ),
+      copy: <CopyButton value={addr} />,
+    };
+  });
 
   return (
     <div className="receive">
       <Card title="Next Unused Address">
-        <p className="mono address-full">{nextUnused}</p>
-        <CopyButton value={nextUnused} />
+        <div className="receive-next">
+          {nextUnused && (
+            <AddressQR address={nextUnused} size={QR_SIZE_HERO} title={`QR code for ${nextUnused}`} />
+          )}
+          <div className="receive-next-details">
+            <p className="mono address-full">{nextUnused}</p>
+            <CopyButton value={nextUnused} />
+          </div>
+        </div>
       </Card>
 
       <Card title="Receive Addresses">

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -435,6 +435,37 @@ a:hover {
   color: var(--text);
 }
 
+/* Receive screen — QR codes framed in a light chip so they stay reliably
+   scannable regardless of the surrounding dark theme. */
+.receive-next {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-4);
+}
+.receive-next-details {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  align-items: flex-start;
+  min-width: 0;
+}
+.receive-qr-frame {
+  display: inline-flex;
+  padding: var(--space-2);
+  background: #ffffff;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  line-height: 0;
+  flex-shrink: 0;
+}
+.receive-qr-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-2);
+}
+
 /* Labeled readout rows (delegation, tx preview summary, settings stats). */
 .dl-row,
 .stat-list > div {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add QR codes to the Receive screen for easier address sharing and scanning. Includes a hero QR for the next-unused address and toggleable QRs in the address list.

- **New Features**
  - Hero QR for `next_unused` rendered as inline SVG via `qrcode.react`.
  - New QR column with a per-row toggle using `aria-label` and `aria-expanded`, encoding the full address.
  - High-contrast QR colors with a light frame for reliable scanning on dark theme; titles set for screen readers.
  - Receive layout updated to show the hero QR alongside address details; tests cover hero encoding, row toggle, and regeneration when `next_unused` changes.

- **Dependencies**
  - Add `qrcode.react` ^4.2.0.

<sup>Written for commit 5fac848b88170f458346e4c806750993f42f60e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added QR codes to the Receive screen for the next unused address and individual addresses in the list.
  * Added a toggle to show or hide each row’s QR code for easier sharing and scanning.
  * Improved the Receive layout to better display address details alongside the QR code.

* **Bug Fixes**
  * Ensured QR codes use the full address value rather than a shortened display version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->