### PR TITLE
feat(ui): ADA Handle resolution in Send

### DIFF
--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -25,6 +25,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/blinklabs-io/bursa/ui/internal/chain"
+	"github.com/blinklabs-io/bursa/ui/internal/handle"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/poolops"
 	"github.com/blinklabs-io/bursa/ui/internal/spend"
@@ -70,12 +71,15 @@ type Spender interface {
 	BuildDelegation(ctx context.Context, req spend.DelegationRequest) (spend.DelegationPreview, error)
 }
 
-// PoolDRepLookup is the node-backed verification surface the staking screen uses
-// to confirm a pasted pool or DRep ID exists (consent law: the embedded node is
-// the only thing that touches the network). *chain.Client satisfies it.
-type PoolDRepLookup interface {
+// NodeLookup is the node-backed verification surface the staking and send
+// screens use: confirming a pasted pool or DRep ID exists, and resolving an
+// ADA Handle ($name) to its current holding address (consent law: the
+// embedded node is the only thing that touches the network). *chain.Client
+// satisfies it.
+type NodeLookup interface {
 	Pool(ctx context.Context, poolID string) (chain.PoolInfo, error)
 	DRep(ctx context.Context, drepID string) (chain.DRepInfo, error)
+	AssetAddresses(ctx context.Context, asset string) ([]chain.AssetAddress, error)
 }
 
 // Vault is the encrypted multi-wallet store the API drives. It owns the wallet
@@ -243,6 +247,14 @@ type poolRegistrationAirGapRequest struct {
 	VRFKeyHashHex string `json:"vrf_key_hash_hex"`
 }
 
+// handleInfo mirrors GET /wallet/handle/{name}: a node-verified ADA Handle
+// resolution. Handle is the bare name (no leading '$'); Address is the
+// bech32 payment address currently holding the handle NFT.
+type handleInfo struct {
+	Handle  string `json:"handle"`
+	Address string `json:"address"`
+}
+
 const defaultWindow = 20
 
 // vaultStatus is the GET /vault/status response.
@@ -282,11 +294,12 @@ func toWalletView(w vault.WalletMeta, activeID string) walletView {
 // the embedded node runs on; wallet requests must match it (or omit it). vlt is
 // the encrypted multi-wallet store; the API pushes the active wallet onto wl/sp
 // whenever the selection changes. settings exposes user-facing app settings
-// (the lean-node profile). lookup verifies pasted pool/DRep IDs through the
-// node (may be nil, in which case those endpoints report unavailable). po is
-// the Stake Pool Operations surface. spa is the embedded SPA, registered as
-// the catch-all so the specific API routes take precedence on the mux.
-func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings SettingsController, lookup PoolDRepLookup, po PoolOps, network string, spa http.Handler, opts ...HandlerOption) http.Handler {
+// (the lean-node profile). lookup verifies pasted pool/DRep IDs and resolves
+// ADA Handles through the node (may be nil, in which case those endpoints
+// report unavailable). po is the Stake Pool Operations surface. spa is the
+// embedded SPA, registered as the catch-all so the specific API routes take
+// precedence on the mux.
+func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings SettingsController, lookup NodeLookup, po PoolOps, network string, spa http.Handler, opts ...HandlerOption) http.Handler {
 	cfg := handlerOptions{}
 	for _, opt := range opts {
 		opt(&cfg)
@@ -729,6 +742,21 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 		}
 		info, err := lookup.DRep(r.Context(), r.PathValue("id"))
 		serveLookup(w, info, err)
+	}))
+
+	// ADA Handle ($name) resolution for the Send screen: resolve the on-chain
+	// NFT to its current holding address through the node (never an external
+	// service). A leading '$' is optional; handle.Resolve normalizes it. A
+	// name with no Handle policy on this network (anything but mainnet, today)
+	// or with no on-chain holder reports as a clean not-found (404), never a
+	// hard error.
+	mux.HandleFunc("GET /wallet/handle/{name}", gated(st, func(w http.ResponseWriter, r *http.Request) {
+		if lookup == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "handle lookup unavailable"})
+			return
+		}
+		bare, addr, err := handle.Resolve(r.Context(), lookup, network, r.PathValue("name"))
+		serveLookup(w, handleInfo{Handle: bare, Address: addr}, err)
 	}))
 
 	mux.HandleFunc("POST /wallet/delegation", readyGate(st, func(w http.ResponseWriter, r *http.Request) {

--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -747,9 +747,8 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 	// ADA Handle ($name) resolution for the Send screen: resolve the on-chain
 	// NFT to its current holding address through the node (never an external
 	// service). A leading '$' is optional; handle.Resolve normalizes it. A
-	// name with no Handle policy on this network (anything but mainnet, today)
-	// or with no on-chain holder reports as a clean not-found (404), never a
-	// hard error.
+	// name on an unsupported network or with no on-chain holder reports as a
+	// clean not-found (404), never a hard error.
 	mux.HandleFunc("GET /wallet/handle/{name}", gated(st, func(w http.ResponseWriter, r *http.Request) {
 		if lookup == nil {
 			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "handle lookup unavailable"})

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -2003,6 +2003,27 @@ func TestHandleLookupResolvesOnMainnet(t *testing.T) {
 	}
 }
 
+func TestHandleLookupResolvesOnPreview(t *testing.T) {
+	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr_test1abc", Quantity: "1"}}}
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, lk, &fakePoolOps{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /wallet/handle/$chris on preview = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var got handleInfo
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Handle != "chris" || got.Address != "addr_test1abc" {
+		t.Fatalf("unexpected handle info: %+v", got)
+	}
+	wantUnit := "f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a" + "6368726973"
+	if len(lk.gotAssetUnits) != 1 || lk.gotAssetUnits[0] != wantUnit {
+		t.Fatalf("queried asset unit = %v, want [%s]", lk.gotAssetUnits, wantUnit)
+	}
+}
+
 func TestHandleLookupWithoutDollarSign(t *testing.T) {
 	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr1abc"}}}
 	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, lk, &fakePoolOps{}, "mainnet", http.NotFoundHandler())
@@ -2013,16 +2034,16 @@ func TestHandleLookupWithoutDollarSign(t *testing.T) {
 	}
 }
 
-func TestHandleLookupNotFoundOnPreview(t *testing.T) {
+func TestHandleLookupNotFoundOnInvalidNetwork(t *testing.T) {
 	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr1abc"}}}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, lk, &fakePoolOps{}, "preview", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, lk, &fakePoolOps{}, "mainnte", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusNotFound {
-		t.Fatalf("GET /wallet/handle/$chris on preview = %d, want 404: %s", rec.Code, rec.Body.String())
+		t.Fatalf("GET /wallet/handle/$chris on invalid network = %d, want 404: %s", rec.Code, rec.Body.String())
 	}
 	if len(lk.gotAssetUnits) != 0 {
-		t.Fatalf("preview lookup should not query the node, got %v", lk.gotAssetUnits)
+		t.Fatalf("invalid-network lookup should not query the node, got %v", lk.gotAssetUnits)
 	}
 }
 

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/blinklabs-io/bursa/ui/internal/chain"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/poolops"
 	"github.com/blinklabs-io/bursa/ui/internal/spend"
@@ -1943,5 +1944,115 @@ func TestTPMRoutesRejectTrailingJSON(t *testing.T) {
 		if fv.enableTPMCalled || fv.disableTPMCalled {
 			t.Fatalf("POST %s with trailing JSON must not touch the vault", route)
 		}
+	}
+}
+
+// fakeNodeLookup implements NodeLookup for the pool/DRep/handle lookup
+// endpoint tests.
+type fakeNodeLookup struct {
+	pool    chain.PoolInfo
+	poolErr error
+	drep    chain.DRepInfo
+	drepErr error
+
+	assetAddrs    []chain.AssetAddress
+	assetErr      error
+	gotAssetUnits []string
+}
+
+func (f *fakeNodeLookup) Pool(_ context.Context, _ string) (chain.PoolInfo, error) {
+	return f.pool, f.poolErr
+}
+
+func (f *fakeNodeLookup) DRep(_ context.Context, _ string) (chain.DRepInfo, error) {
+	return f.drep, f.drepErr
+}
+
+func (f *fakeNodeLookup) AssetAddresses(_ context.Context, asset string) ([]chain.AssetAddress, error) {
+	f.gotAssetUnits = append(f.gotAssetUnits, asset)
+	return f.assetAddrs, f.assetErr
+}
+
+func TestHandleLookupUnavailableWithoutLookup(t *testing.T) {
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "mainnet", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/chris", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /wallet/handle/chris with no lookup = %d, want 503", rec.Code)
+	}
+}
+
+func TestHandleLookupResolvesOnMainnet(t *testing.T) {
+	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr1abc", Quantity: "1"}}}
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, lk, &fakePoolOps{}, "mainnet", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /wallet/handle/$chris = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var got handleInfo
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Handle != "chris" || got.Address != "addr1abc" {
+		t.Fatalf("unexpected handle info: %+v", got)
+	}
+	wantUnit := "f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a" + "6368726973"
+	if len(lk.gotAssetUnits) != 1 || lk.gotAssetUnits[0] != wantUnit {
+		t.Fatalf("queried asset unit = %v, want [%s]", lk.gotAssetUnits, wantUnit)
+	}
+}
+
+func TestHandleLookupWithoutDollarSign(t *testing.T) {
+	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr1abc"}}}
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, lk, &fakePoolOps{}, "mainnet", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/chris", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /wallet/handle/chris = %d, want 200", rec.Code)
+	}
+}
+
+func TestHandleLookupNotFoundOnPreview(t *testing.T) {
+	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr1abc"}}}
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, lk, &fakePoolOps{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("GET /wallet/handle/$chris on preview = %d, want 404: %s", rec.Code, rec.Body.String())
+	}
+	if len(lk.gotAssetUnits) != 0 {
+		t.Fatalf("preview lookup should not query the node, got %v", lk.gotAssetUnits)
+	}
+}
+
+func TestHandleLookupNotFoundWhenNodeHasNotSeenAsset(t *testing.T) {
+	lk := &fakeNodeLookup{assetErr: chain.ErrNotFound}
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, lk, &fakePoolOps{}, "mainnet", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("GET /wallet/handle/$chris unseen asset = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandleLookupBadGatewayOnHardError(t *testing.T) {
+	lk := &fakeNodeLookup{assetErr: errors.New("node exploded")}
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, lk, &fakePoolOps{}, "mainnet", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("GET /wallet/handle/$chris hard error = %d, want 502", rec.Code)
+	}
+}
+
+func TestHandleLookupGatedWhileStarting(t *testing.T) {
+	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr1abc"}}}
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, lk, &fakePoolOps{}, "mainnet", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /wallet/handle/$chris while starting = %d, want 503", rec.Code)
 	}
 }

--- a/ui/internal/chain/blockfrost.go
+++ b/ui/internal/chain/blockfrost.go
@@ -177,6 +177,14 @@ type EpochInfo struct {
 	EndTime   int64  `json:"end_time"`
 }
 
+// AssetAddress mirrors one entry of GET /api/v0/assets/{asset}/addresses: an
+// address currently holding some quantity of the asset. Used to resolve an
+// ADA Handle NFT to its current holder (see internal/handle).
+type AssetAddress struct {
+	Address  string `json:"address"`
+	Quantity string `json:"quantity"`
+}
+
 type accountAddress struct {
 	Address string `json:"address"`
 }
@@ -513,4 +521,11 @@ func (c *Client) LatestEpoch(ctx context.Context) (EpochInfo, error) {
 	var out EpochInfo
 	err := c.get(ctx, "/api/v0/epochs/latest", &out)
 	return out, err
+}
+
+// AssetAddresses returns every address currently holding some quantity of
+// asset — a Blockfrost-style unit (policy ID concatenated with the hex asset
+// name). An asset the node has not seen yields ErrNotFound.
+func (c *Client) AssetAddresses(ctx context.Context, asset string) ([]AssetAddress, error) {
+	return getAllPages[AssetAddress](ctx, c, "/api/v0/assets/"+asset+"/addresses")
 }

--- a/ui/internal/chain/blockfrost_test.go
+++ b/ui/internal/chain/blockfrost_test.go
@@ -539,3 +539,76 @@ func TestLatestEpoch(t *testing.T) {
 		t.Fatalf("epoch times: got StartTime=%d EndTime=%d, want 1700000000/1700432000", got.StartTime, got.EndTime)
 	}
 }
+
+func TestAssetAddresses(t *testing.T) {
+	const asset = "f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a6368726973"
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/assets/"+asset+"/addresses" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"address":"addr1abc","quantity":"1"}]`))
+	})
+	got, err := c.AssetAddresses(context.Background(), asset)
+	if err != nil {
+		t.Fatalf("AssetAddresses: %v", err)
+	}
+	if len(got) != 1 || got[0].Address != "addr1abc" || got[0].Quantity != "1" {
+		t.Fatalf("unexpected asset addresses: %+v", got)
+	}
+}
+
+func TestAssetAddressesNotFound(t *testing.T) {
+	t.Parallel()
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v0/assets/deadbeef/addresses" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(blockfrostNotFoundJSON))
+	})
+	_, err := c.AssetAddresses(context.Background(), "deadbeef")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("404 should map to ErrNotFound, got %v", err)
+	}
+}
+
+func TestAssetAddressesPaginated(t *testing.T) {
+	const asset = "deadbeef"
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/assets/"+asset+"/addresses" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("count") != "100" {
+			t.Errorf("count = %q", q.Get("count"))
+		}
+		var rows []string
+		switch q.Get("page") {
+		case "1":
+			for i := range pageSize {
+				rows = append(rows, fmt.Sprintf(`{"address":"addr1_%03d","quantity":"1"}`, i))
+			}
+		case "2":
+			rows = append(rows, `{"address":"addr1_100","quantity":"1"}`)
+		default:
+			t.Errorf("page = %q", q.Get("page"))
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_, _ = w.Write([]byte("[" + strings.Join(rows, ",") + "]"))
+	})
+	got, err := c.AssetAddresses(context.Background(), asset)
+	if err != nil {
+		t.Fatalf("AssetAddresses: %v", err)
+	}
+	if len(got) != pageSize+1 {
+		t.Fatalf("len = %d, want %d", len(got), pageSize+1)
+	}
+}

--- a/ui/internal/handle/handle.go
+++ b/ui/internal/handle/handle.go
@@ -23,11 +23,15 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/blinklabs-io/bursa/ui/internal/cardanonet"
 	"github.com/blinklabs-io/bursa/ui/internal/chain"
 )
 
-// MainnetPolicyID is the canonical ADA Handle root policy on Cardano mainnet.
-const MainnetPolicyID = "f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a"
+// PolicyID is the ADA Handle root policy used on mainnet and supported testnets.
+const PolicyID = "f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a"
+
+// MainnetPolicyID is kept as a compatibility alias for PolicyID.
+const MainnetPolicyID = PolicyID
 
 // ErrInvalidName is returned when a handle input has no name left after
 // stripping its optional leading '$' and surrounding whitespace.
@@ -55,20 +59,18 @@ func AssetNameHex(name string) string {
 	return hex.EncodeToString([]byte(name))
 }
 
-// PolicyForNetwork returns the ADA Handle policy ID for network and whether
-// handle resolution is available there. Only mainnet has a canonical Handle
-// policy today; other networks (preview, preprod, ...) report unavailable
-// rather than guessing at a policy or erroring.
+// PolicyForNetwork returns the ADA Handle policy ID for a supported Cardano
+// network and whether handle resolution is available there.
 func PolicyForNetwork(network string) (policyID string, ok bool) {
-	if network == "mainnet" {
-		return MainnetPolicyID, true
+	if cardanonet.ValidNetwork(network) {
+		return PolicyID, true
 	}
 	return "", false
 }
 
 // AssetUnit returns the Blockfrost-style asset unit (policy ID concatenated
 // with the hex-encoded asset name) identifying handle name on network, or
-// ok=false when network has no known Handle policy.
+// ok=false when network is unsupported.
 func AssetUnit(network, name string) (unit string, ok bool) {
 	policy, ok := PolicyForNetwork(network)
 	if !ok {
@@ -90,9 +92,9 @@ type AssetLookup interface {
 // returns the normalized (lowercased, '$'-stripped) name alongside the
 // address, so callers don't need to normalize the input a second time. It
 // returns chain.ErrNotFound — never a hard error — for every "not found"
-// case: an empty/invalid name, a network with no Handle policy
-// (preview/preprod today), the node not having seen the asset, or the asset
-// having no current holder. Any other lookup error is returned as-is.
+// case: an empty/invalid name, an unsupported network, the node not having
+// seen the asset, or the asset having no current holder. Any other lookup
+// error is returned as-is.
 func Resolve(ctx context.Context, lookup AssetLookup, network, input string) (name, address string, err error) {
 	name, err = Normalize(input)
 	if err != nil {

--- a/ui/internal/handle/handle.go
+++ b/ui/internal/handle/handle.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package handle resolves an ADA Handle ($name) — an on-chain NFT — to the
+// address currently holding it. Resolution is a chain query through the
+// embedded node only (consent law: no external service is ever contacted).
+package handle
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"strings"
+
+	"github.com/blinklabs-io/bursa/ui/internal/chain"
+)
+
+// MainnetPolicyID is the canonical ADA Handle root policy on Cardano mainnet.
+const MainnetPolicyID = "f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a"
+
+// ErrInvalidName is returned when a handle input has no name left after
+// stripping its optional leading '$' and surrounding whitespace.
+var ErrInvalidName = errors.New("handle: empty name")
+
+// Normalize strips an optional leading '$' (and surrounding whitespace) from
+// a handle input and case-folds it to lowercase — "$Chris", "CHRIS", and
+// "chris" all normalize to "chris" — and rejects an empty result. Case
+// folding matters because the Handle minting policy restricts base-handle
+// names to lowercase a-z, digits, and "._-", so resolution must be
+// case-insensitive to match how every mainstream wallet treats handle input.
+func Normalize(input string) (string, error) {
+	name := strings.TrimPrefix(strings.TrimSpace(input), "$")
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		return "", ErrInvalidName
+	}
+	return name, nil
+}
+
+// AssetNameHex returns the base-handle on-chain asset name: the hex encoding
+// of the handle's UTF-8 bytes (assetName = hex(utf8(name))). It does not
+// handle CIP-113 virtual sub-handles ("$a@b"), only the base handle.
+func AssetNameHex(name string) string {
+	return hex.EncodeToString([]byte(name))
+}
+
+// PolicyForNetwork returns the ADA Handle policy ID for network and whether
+// handle resolution is available there. Only mainnet has a canonical Handle
+// policy today; other networks (preview, preprod, ...) report unavailable
+// rather than guessing at a policy or erroring.
+func PolicyForNetwork(network string) (policyID string, ok bool) {
+	if network == "mainnet" {
+		return MainnetPolicyID, true
+	}
+	return "", false
+}
+
+// AssetUnit returns the Blockfrost-style asset unit (policy ID concatenated
+// with the hex-encoded asset name) identifying handle name on network, or
+// ok=false when network has no known Handle policy.
+func AssetUnit(network, name string) (unit string, ok bool) {
+	policy, ok := PolicyForNetwork(network)
+	if !ok {
+		return "", false
+	}
+	return policy + AssetNameHex(name), true
+}
+
+// AssetLookup is the node-backed surface Resolve needs: the current holder
+// addresses for an on-chain asset unit. *chain.Client satisfies it via
+// AssetAddresses (GET /api/v0/assets/{asset}/addresses on the embedded node).
+type AssetLookup interface {
+	AssetAddresses(ctx context.Context, asset string) ([]chain.AssetAddress, error)
+}
+
+// Resolve resolves an ADA Handle (input may or may not carry a leading '$',
+// and is matched case-insensitively — see Normalize) to its current holding
+// address by querying lookup for the handle NFT's holder on network. It
+// returns the normalized (lowercased, '$'-stripped) name alongside the
+// address, so callers don't need to normalize the input a second time. It
+// returns chain.ErrNotFound — never a hard error — for every "not found"
+// case: an empty/invalid name, a network with no Handle policy
+// (preview/preprod today), the node not having seen the asset, or the asset
+// having no current holder. Any other lookup error is returned as-is.
+func Resolve(ctx context.Context, lookup AssetLookup, network, input string) (name, address string, err error) {
+	name, err = Normalize(input)
+	if err != nil {
+		return "", "", chain.ErrNotFound
+	}
+	unit, ok := AssetUnit(network, name)
+	if !ok {
+		return name, "", chain.ErrNotFound
+	}
+	if lookup == nil {
+		return name, "", chain.ErrNotFound
+	}
+	addrs, err := lookup.AssetAddresses(ctx, unit)
+	if err != nil {
+		return name, "", err
+	}
+	if len(addrs) == 0 {
+		return name, "", chain.ErrNotFound
+	}
+	// An ADA Handle is a non-fungible token: exactly one address holds it. If
+	// the node ever reports more than one (e.g. transient reorg view), the
+	// current holder is still the most informative single answer.
+	return name, addrs[0].Address, nil
+}

--- a/ui/internal/handle/handle_test.go
+++ b/ui/internal/handle/handle_test.go
@@ -72,15 +72,17 @@ func TestAssetNameHex(t *testing.T) {
 	}
 }
 
-func TestPolicyForNetworkMainnetOnly(t *testing.T) {
-	policy, ok := PolicyForNetwork("mainnet")
-	if !ok {
-		t.Fatal("PolicyForNetwork(mainnet) ok = false, want true")
+func TestPolicyForNetworkUsesSamePolicyOnSupportedNetworks(t *testing.T) {
+	for _, network := range []string{"mainnet", "preview", "preprod"} {
+		policy, ok := PolicyForNetwork(network)
+		if !ok {
+			t.Fatalf("PolicyForNetwork(%q) ok = false, want true", network)
+		}
+		if policy != PolicyID {
+			t.Fatalf("PolicyForNetwork(%q) = %q, want %q", network, policy, PolicyID)
+		}
 	}
-	if policy != MainnetPolicyID {
-		t.Fatalf("PolicyForNetwork(mainnet) = %q, want %q", policy, MainnetPolicyID)
-	}
-	for _, net := range []string{"preview", "preprod", "testnet", "", "MAINNET"} {
+	for _, net := range []string{"testnet", "", "MAINNET", "mainnte"} {
 		if _, ok := PolicyForNetwork(net); ok {
 			t.Errorf("PolicyForNetwork(%q) ok = true, want false", net)
 		}
@@ -92,17 +94,26 @@ func TestAssetUnit(t *testing.T) {
 	if !ok {
 		t.Fatal("AssetUnit(mainnet, chris) ok = false, want true")
 	}
-	want := MainnetPolicyID + "6368726973"
+	want := PolicyID + "6368726973"
 	if unit != want {
 		t.Fatalf("AssetUnit(mainnet, chris) = %q, want %q", unit, want)
 	}
-	if _, ok := AssetUnit("preview", "chris"); ok {
-		t.Fatal("AssetUnit(preview, chris) ok = true, want false")
+	for _, network := range []string{"preview", "preprod"} {
+		unit, ok := AssetUnit(network, "chris")
+		if !ok {
+			t.Fatalf("AssetUnit(%s, chris) ok = false, want true", network)
+		}
+		if unit != want {
+			t.Fatalf("AssetUnit(%s, chris) = %q, want %q", network, unit, want)
+		}
+	}
+	if _, ok := AssetUnit("mainnte", "chris"); ok {
+		t.Fatal("AssetUnit(mainnte, chris) ok = true, want false")
 	}
 }
 
 // fakeAssetLookup is a test double for AssetLookup; it records whether it was
-// called (so tests can assert Resolve short-circuits on unsupported networks
+// called (so tests can assert Resolve short-circuits on invalid networks
 // without touching the node) and which asset unit it was called with (so
 // tests can assert Resolve queries the case-folded unit).
 type fakeAssetLookup struct {
@@ -135,14 +146,32 @@ func TestResolveFound(t *testing.T) {
 	}
 }
 
-func TestResolveNotFoundOnUnsupportedNetworkSkipsNodeQuery(t *testing.T) {
+func TestResolveOnTestnetUsesSharedPolicy(t *testing.T) {
 	lk := &fakeAssetLookup{addrs: []chain.AssetAddress{{Address: "addr1abc"}}}
-	_, _, err := Resolve(context.Background(), lk, "preview", "$chris")
+	name, addr, err := Resolve(context.Background(), lk, "preview", "$chris")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if name != "chris" {
+		t.Fatalf("Resolve name = %q, want chris", name)
+	}
+	if addr != "addr1abc" {
+		t.Fatalf("Resolve address = %q, want addr1abc", addr)
+	}
+	wantUnit := PolicyID + "6368726973"
+	if lk.gotAsset != wantUnit {
+		t.Fatalf("Resolve queried asset %q, want %q", lk.gotAsset, wantUnit)
+	}
+}
+
+func TestResolveNotFoundOnInvalidNetworkSkipsNodeQuery(t *testing.T) {
+	lk := &fakeAssetLookup{addrs: []chain.AssetAddress{{Address: "addr1abc"}}}
+	_, _, err := Resolve(context.Background(), lk, "mainnte", "$chris")
 	if !errors.Is(err, chain.ErrNotFound) {
 		t.Fatalf("Resolve err = %v, want chain.ErrNotFound", err)
 	}
 	if lk.called {
-		t.Fatal("Resolve queried the node for a network with no Handle policy")
+		t.Fatal("Resolve queried the node for an invalid network")
 	}
 }
 

--- a/ui/internal/handle/handle_test.go
+++ b/ui/internal/handle/handle_test.go
@@ -1,0 +1,251 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package handle
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/bursa/ui/internal/chain"
+)
+
+func TestNormalizeStripsLeadingDollar(t *testing.T) {
+	got, err := Normalize("$chris")
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if got != "chris" {
+		t.Fatalf("Normalize($chris) = %q, want %q", got, "chris")
+	}
+}
+
+func TestNormalizeWithoutDollar(t *testing.T) {
+	got, err := Normalize("chris")
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if got != "chris" {
+		t.Fatalf("Normalize(chris) = %q, want %q", got, "chris")
+	}
+}
+
+func TestNormalizeTrimsWhitespace(t *testing.T) {
+	got, err := Normalize("  $chris  ")
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if got != "chris" {
+		t.Fatalf("Normalize = %q, want %q", got, "chris")
+	}
+}
+
+func TestNormalizeRejectsEmpty(t *testing.T) {
+	for _, in := range []string{"", "$", "   ", "  $  "} {
+		if _, err := Normalize(in); !errors.Is(err, ErrInvalidName) {
+			t.Fatalf("Normalize(%q) err = %v, want ErrInvalidName", in, err)
+		}
+	}
+}
+
+func TestAssetNameHex(t *testing.T) {
+	cases := map[string]string{
+		"chris": "6368726973",
+		"ape":   "617065",
+		"a":     "61",
+	}
+	for name, want := range cases {
+		if got := AssetNameHex(name); got != want {
+			t.Errorf("AssetNameHex(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestPolicyForNetworkMainnetOnly(t *testing.T) {
+	policy, ok := PolicyForNetwork("mainnet")
+	if !ok {
+		t.Fatal("PolicyForNetwork(mainnet) ok = false, want true")
+	}
+	if policy != MainnetPolicyID {
+		t.Fatalf("PolicyForNetwork(mainnet) = %q, want %q", policy, MainnetPolicyID)
+	}
+	for _, net := range []string{"preview", "preprod", "testnet", "", "MAINNET"} {
+		if _, ok := PolicyForNetwork(net); ok {
+			t.Errorf("PolicyForNetwork(%q) ok = true, want false", net)
+		}
+	}
+}
+
+func TestAssetUnit(t *testing.T) {
+	unit, ok := AssetUnit("mainnet", "chris")
+	if !ok {
+		t.Fatal("AssetUnit(mainnet, chris) ok = false, want true")
+	}
+	want := MainnetPolicyID + "6368726973"
+	if unit != want {
+		t.Fatalf("AssetUnit(mainnet, chris) = %q, want %q", unit, want)
+	}
+	if _, ok := AssetUnit("preview", "chris"); ok {
+		t.Fatal("AssetUnit(preview, chris) ok = true, want false")
+	}
+}
+
+// fakeAssetLookup is a test double for AssetLookup; it records whether it was
+// called (so tests can assert Resolve short-circuits on unsupported networks
+// without touching the node) and which asset unit it was called with (so
+// tests can assert Resolve queries the case-folded unit).
+type fakeAssetLookup struct {
+	called   bool
+	gotAsset string
+	addrs    []chain.AssetAddress
+	err      error
+}
+
+func (f *fakeAssetLookup) AssetAddresses(_ context.Context, asset string) ([]chain.AssetAddress, error) {
+	f.called = true
+	f.gotAsset = asset
+	return f.addrs, f.err
+}
+
+func TestResolveFound(t *testing.T) {
+	lk := &fakeAssetLookup{addrs: []chain.AssetAddress{{Address: "addr1abc", Quantity: "1"}}}
+	name, addr, err := Resolve(context.Background(), lk, "mainnet", "$chris")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if name != "chris" {
+		t.Fatalf("Resolve name = %q, want chris", name)
+	}
+	if addr != "addr1abc" {
+		t.Fatalf("Resolve address = %q, want addr1abc", addr)
+	}
+	if !lk.called {
+		t.Fatal("Resolve did not query the node")
+	}
+}
+
+func TestResolveNotFoundOnUnsupportedNetworkSkipsNodeQuery(t *testing.T) {
+	lk := &fakeAssetLookup{addrs: []chain.AssetAddress{{Address: "addr1abc"}}}
+	_, _, err := Resolve(context.Background(), lk, "preview", "$chris")
+	if !errors.Is(err, chain.ErrNotFound) {
+		t.Fatalf("Resolve err = %v, want chain.ErrNotFound", err)
+	}
+	if lk.called {
+		t.Fatal("Resolve queried the node for a network with no Handle policy")
+	}
+}
+
+func TestResolveNotFoundWhenNodeHasNotSeenAsset(t *testing.T) {
+	lk := &fakeAssetLookup{err: chain.ErrNotFound}
+	_, _, err := Resolve(context.Background(), lk, "mainnet", "chris")
+	if !errors.Is(err, chain.ErrNotFound) {
+		t.Fatalf("Resolve err = %v, want chain.ErrNotFound", err)
+	}
+}
+
+func TestResolveNotFoundWhenNoHolders(t *testing.T) {
+	lk := &fakeAssetLookup{addrs: nil}
+	_, _, err := Resolve(context.Background(), lk, "mainnet", "chris")
+	if !errors.Is(err, chain.ErrNotFound) {
+		t.Fatalf("Resolve err = %v, want chain.ErrNotFound", err)
+	}
+}
+
+func TestResolveInvalidNameNotFound(t *testing.T) {
+	lk := &fakeAssetLookup{}
+	_, _, err := Resolve(context.Background(), lk, "mainnet", "$")
+	if !errors.Is(err, chain.ErrNotFound) {
+		t.Fatalf("Resolve err = %v, want chain.ErrNotFound", err)
+	}
+	if lk.called {
+		t.Fatal("Resolve queried the node for an invalid handle name")
+	}
+}
+
+func TestResolvePropagatesHardErrors(t *testing.T) {
+	wantErr := errors.New("boom")
+	lk := &fakeAssetLookup{err: wantErr}
+	_, _, err := Resolve(context.Background(), lk, "mainnet", "chris")
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Resolve err = %v, want %v", err, wantErr)
+	}
+}
+
+func TestNormalizeCaseFolds(t *testing.T) {
+	for _, in := range []string{"chris", "Chris", "CHRIS", "$chris", "$Chris", "$CHRIS"} {
+		got, err := Normalize(in)
+		if err != nil {
+			t.Fatalf("Normalize(%q): %v", in, err)
+		}
+		if got != "chris" {
+			t.Fatalf("Normalize(%q) = %q, want %q", in, got, "chris")
+		}
+	}
+}
+
+func TestAssetNameHexCaseInsensitive(t *testing.T) {
+	want := AssetNameHex("chris")
+	for _, in := range []string{"Chris", "CHRIS", "$Chris", "$CHRIS"} {
+		norm, err := Normalize(in)
+		if err != nil {
+			t.Fatalf("Normalize(%q): %v", in, err)
+		}
+		if got := AssetNameHex(norm); got != want {
+			t.Errorf("AssetNameHex(Normalize(%q)) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestAssetUnitCaseInsensitive(t *testing.T) {
+	want, ok := AssetUnit("mainnet", "chris")
+	if !ok {
+		t.Fatal("AssetUnit(mainnet, chris) ok = false, want true")
+	}
+	for _, in := range []string{"Chris", "CHRIS", "$Chris", "$CHRIS"} {
+		norm, err := Normalize(in)
+		if err != nil {
+			t.Fatalf("Normalize(%q): %v", in, err)
+		}
+		got, ok := AssetUnit("mainnet", norm)
+		if !ok || got != want {
+			t.Errorf("AssetUnit(mainnet, Normalize(%q)) = (%q, %v), want (%q, true)", in, got, ok, want)
+		}
+	}
+}
+
+// TestResolveCaseInsensitive asserts that mixed-case handle input resolves
+// identically to lowercase input: same normalized name, same node query (the
+// lowercased asset unit), same resolved address.
+func TestResolveCaseInsensitive(t *testing.T) {
+	wantUnit, ok := AssetUnit("mainnet", "chris")
+	if !ok {
+		t.Fatal("AssetUnit(mainnet, chris) ok = false, want true")
+	}
+	for _, in := range []string{"chris", "Chris", "CHRIS", "$Chris", "$CHRIS"} {
+		lk := &fakeAssetLookup{addrs: []chain.AssetAddress{{Address: "addr1abc", Quantity: "1"}}}
+		name, addr, err := Resolve(context.Background(), lk, "mainnet", in)
+		if err != nil {
+			t.Fatalf("Resolve(%q): %v", in, err)
+		}
+		if name != "chris" {
+			t.Errorf("Resolve(%q) name = %q, want chris", in, name)
+		}
+		if addr != "addr1abc" {
+			t.Errorf("Resolve(%q) address = %q, want addr1abc", in, addr)
+		}
+		if lk.gotAsset != wantUnit {
+			t.Errorf("Resolve(%q) queried asset %q, want %q", in, lk.gotAsset, wantUnit)
+		}
+	}
+}

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -26,6 +26,7 @@ import type {
   DRepInfo,
   DelegationRequest,
   DelegationPreview,
+  HandleInfo,
   PoolCredentials,
   KESPeriodInfo,
   OpCert,
@@ -128,6 +129,12 @@ export const exportUnsigned = (id: string) =>
 export const signTx = (req: SignTxRequest) => apiPost<WitnessResult>("/wallet/sign-tx", req);
 export const submitSigned = (req: SubmitSignedRequest) =>
   apiPost<TxResult>("/wallet/submit-signed", req);
+
+// ADA Handle ($name) resolution for the Send screen: resolves the handle NFT
+// to its current holding address through the node. name may carry a leading
+// '$' or not — the server strips it either way.
+export const resolveHandle = (name: string) =>
+  apiGet<HandleInfo>(`/wallet/handle/${encodeURIComponent(name)}`);
 
 // Staking & governance. Pool/DRep lookups verify a pasted ID through the node;
 // buildDelegation returns an itemized preview; confirmDelegation signs + submits

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -95,6 +95,14 @@ export interface TxResult {
   tx_hash: string;
 }
 
+// ADA Handle ($name) resolution: GET /wallet/handle/{name} resolves the
+// on-chain handle NFT to its current holding (payment) address through the
+// node. Handle is the bare name (no leading '$').
+export interface HandleInfo {
+  handle: string;
+  address: string;
+}
+
 // CIP-8/CIP-30 signData: sign an arbitrary message with a wallet address's key.
 export interface SignDataRequest {
   address: string;

--- a/ui/web/src/screens/Send.test.tsx
+++ b/ui/web/src/screens/Send.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { Send } from "./Send";
 import * as client from "../api/client";
-import type { Preview, TxResult } from "../api/types";
+import type { Preview, TxResult, HandleInfo } from "../api/types";
 
 const MOCK_PREVIEW: Preview = {
   pending_id: "pending-abc-123",
@@ -348,4 +348,99 @@ test("(g) buildSend error shown inline on compose phase", async () => {
 
   // Still on compose
   expect(screen.getByRole("button", { name: /review/i })).toBeInTheDocument();
+});
+
+// --- ADA Handle resolution ---
+
+const MOCK_HANDLE: HandleInfo = { handle: "chris", address: "addr1resolvedhandle" };
+
+test("(k) $handle recipient resolves and buildSend uses the resolved address", async () => {
+  const resolveHandle = vi.spyOn(client, "resolveHandle").mockResolvedValue(MOCK_HANDLE);
+  const buildSend = vi.spyOn(client, "buildSend").mockResolvedValue(MOCK_PREVIEW);
+
+  render(<Send />);
+
+  const inputs = screen.getAllByRole("textbox");
+  fireEvent.change(inputs[0], { target: { value: "$chris" } });
+  fireEvent.change(inputs[1], { target: { value: "5" } });
+
+  await waitFor(() => {
+    expect(resolveHandle).toHaveBeenCalledWith("$chris");
+  });
+
+  await waitFor(() => {
+    expect(screen.getByText(/resolved by your node/i)).toBeInTheDocument();
+  });
+  expect(screen.getByText(/addr1resolvedhandle/)).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("button", { name: /review/i }));
+
+  await waitFor(() => {
+    expect(buildSend).toHaveBeenCalledWith({
+      to: "addr1resolvedhandle",
+      lovelace: "5000000",
+    });
+  });
+});
+
+test("(l) unresolved $handle shows 'Handle not found' and disables Review", async () => {
+  vi.spyOn(client, "resolveHandle").mockRejectedValue(new client.ApiError(404, "not found by your node"));
+  const buildSend = vi.spyOn(client, "buildSend");
+
+  render(<Send />);
+
+  const inputs = screen.getAllByRole("textbox");
+  fireEvent.change(inputs[0], { target: { value: "$nosuchhandle" } });
+  fireEvent.change(inputs[1], { target: { value: "5" } });
+
+  await waitFor(() => {
+    expect(screen.getByText(/handle not found/i)).toBeInTheDocument();
+  });
+
+  expect(screen.getByRole("button", { name: /review/i })).toBeDisabled();
+
+  fireEvent.click(screen.getByRole("button", { name: /review/i }));
+  expect(buildSend).not.toHaveBeenCalled();
+});
+
+test("(m) Review is disabled while a $handle is still resolving", async () => {
+  let resolveLookup: (info: HandleInfo) => void = () => {};
+  vi.spyOn(client, "resolveHandle").mockReturnValue(
+    new Promise<HandleInfo>((resolve) => {
+      resolveLookup = resolve;
+    })
+  );
+
+  render(<Send />);
+
+  const inputs = screen.getAllByRole("textbox");
+  fireEvent.change(inputs[0], { target: { value: "$chris" } });
+  fireEvent.change(inputs[1], { target: { value: "5" } });
+
+  await waitFor(() => {
+    expect(screen.getByText(/resolving handle/i)).toBeInTheDocument();
+  });
+  expect(screen.getByRole("button", { name: /review/i })).toBeDisabled();
+
+  resolveLookup(MOCK_HANDLE);
+  await waitFor(() => {
+    expect(screen.getByRole("button", { name: /review/i })).toBeEnabled();
+  });
+});
+
+test("(n) a plain address recipient never calls resolveHandle", async () => {
+  const resolveHandle = vi.spyOn(client, "resolveHandle");
+  vi.spyOn(client, "buildSend").mockResolvedValue(MOCK_PREVIEW);
+
+  render(<Send />);
+
+  const inputs = screen.getAllByRole("textbox");
+  fireEvent.change(inputs[0], { target: { value: "addr_test1recipient" } });
+  fireEvent.change(inputs[1], { target: { value: "5" } });
+  fireEvent.click(screen.getByRole("button", { name: /review/i }));
+
+  await waitFor(() => {
+    expect(screen.getByText(/2 inputs/i)).toBeInTheDocument();
+  });
+  expect(resolveHandle).not.toHaveBeenCalled();
 });

--- a/ui/web/src/screens/Send.tsx
+++ b/ui/web/src/screens/Send.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
-import type { Preview, TxResult, SendAsset, UnsignedTx } from "../api/types";
-import { buildSend, confirmSend, exportUnsigned, ApiError } from "../api/client";
+import type { Preview, TxResult, SendAsset, UnsignedTx, HandleInfo } from "../api/types";
+import { buildSend, confirmSend, exportUnsigned, resolveHandle, ApiError } from "../api/client";
 import { Card } from "../components/Card";
 import { Input } from "../components/Input";
 import { Button } from "../components/Button";
@@ -23,6 +23,16 @@ function errorMessage(err: unknown): string {
   return String(err);
 }
 
+// How long to wait after the user stops typing a "$handle" before querying
+// the node to resolve it — avoids firing a lookup on every keystroke.
+const HANDLE_RESOLVE_DEBOUNCE_MS = 400;
+
+// isHandleInput reports whether a recipient input names an ADA Handle (a
+// leading '$') rather than a raw address.
+function isHandleInput(value: string): boolean {
+  return value.trim().startsWith("$");
+}
+
 // --- Compose phase ---
 
 interface ComposeProps {
@@ -42,6 +52,46 @@ function Compose({ to, setTo, adaAmount, setAdaAmount, assetRows, setAssetRows, 
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
+  // ADA Handle resolution: when `to` names a handle ($name), debounce a
+  // lookup through the node and show the resolved address (or a clean
+  // not-found). resolvedHandle.handle is only trusted when it still matches
+  // the current input — see the effect below.
+  const [resolvedHandle, setResolvedHandle] = useState<HandleInfo | null>(null);
+  const [handleError, setHandleError] = useState<string | null>(null);
+  const [resolvingHandle, setResolvingHandle] = useState(false);
+  const handleInput = isHandleInput(to);
+  const trimmedTo = to.trim();
+
+  useEffect(() => {
+    setResolvedHandle(null);
+    setHandleError(null);
+    if (!handleInput) {
+      setResolvingHandle(false);
+      return;
+    }
+    let cancelled = false;
+    setResolvingHandle(true);
+    const timer = setTimeout(() => {
+      resolveHandle(trimmedTo)
+        .then((info) => {
+          if (!cancelled) setResolvedHandle(info);
+        })
+        .catch((e: unknown) => {
+          if (cancelled) return;
+          setHandleError(
+            e instanceof ApiError && e.status === 404 ? "Handle not found" : errorMessage(e),
+          );
+        })
+        .finally(() => {
+          if (!cancelled) setResolvingHandle(false);
+        });
+    }, HANDLE_RESOLVE_DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [trimmedTo, handleInput]);
+
   function addAssetRow() {
     setAssetRows((prev) => [...prev, { unit: "", quantity: "" }]);
   }
@@ -58,6 +108,29 @@ function Compose({ to, setTo, adaAmount, setAdaAmount, assetRows, setAssetRows, 
 
   async function handleReview() {
     setError(null);
+
+    // A "$handle" recipient must resolve to an address before building the
+    // send; use the node-verified address, never the raw handle text.
+    let resolvedTo = trimmedTo;
+    if (handleInput) {
+      if (resolvingHandle) {
+        setError("Still resolving the handle — try again in a moment.");
+        return;
+      }
+      if (!resolvedHandle) {
+        setError(handleError ?? "Enter a valid, resolvable ADA Handle.");
+        return;
+      }
+      // Guard against a fast edit from one $handle to another landing here
+      // with the previous handle's resolved address still in state: only
+      // trust resolvedHandle when it matches the current input.
+      const normalizedHandle = trimmedTo.replace(/^\$/, "").trim().toLowerCase();
+      if (resolvedHandle.handle.toLowerCase() !== normalizedHandle) {
+        setError("Still resolving the handle — try again in a moment.");
+        return;
+      }
+      resolvedTo = resolvedHandle.address;
+    }
 
     // Validate ADA amount (parseAda returns a decimal lovelace string)
     let lovelace: string;
@@ -89,7 +162,7 @@ function Compose({ to, setTo, adaAmount, setAdaAmount, assetRows, setAssetRows, 
     setLoading(true);
     try {
       const preview = await buildSend({
-        to: to.trim(),
+        to: resolvedTo,
         lovelace,
         ...(assets.length > 0 ? { assets } : {}),
       });
@@ -104,15 +177,29 @@ function Compose({ to, setTo, adaAmount, setAdaAmount, assetRows, setAssetRows, 
   return (
     <Card title="Send ADA">
       <div className="send-form">
-        <label htmlFor="send-to">Recipient address</label>
+        <label htmlFor="send-to">Recipient address or $handle</label>
         <Input
           id="send-to"
           type="text"
-          placeholder="addr1..."
+          placeholder="addr1... or $handle"
           value={to}
           onChange={(e) => setTo(e.target.value)}
           disabled={loading}
         />
+        {handleInput && resolvingHandle && (
+          <p className="helper-text">Resolving handle…</p>
+        )}
+        {handleInput && resolvedHandle && (
+          <p className="verified-readout">
+            <span className="verified-tick">✓ Resolved by your node</span>
+            {" · "}${resolvedHandle.handle} → {resolvedHandle.address}
+          </p>
+        )}
+        {handleInput && handleError && (
+          <p role="alert" className="error-text">
+            {handleError}
+          </p>
+        )}
 
         <label htmlFor="send-amount">Amount (ADA)</label>
         <Input
@@ -161,7 +248,15 @@ function Compose({ to, setTo, adaAmount, setAdaAmount, assetRows, setAssetRows, 
           </p>
         )}
 
-        <Button onClick={handleReview} disabled={loading || !to.trim() || !adaAmount.trim()}>
+        <Button
+          onClick={handleReview}
+          disabled={
+            loading ||
+            !to.trim() ||
+            !adaAmount.trim() ||
+            (handleInput && (resolvingHandle || !resolvedHandle))
+          }
+        >
           {loading ? "Building…" : "Review"}
         </Button>
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds ADA Handle ($name) resolution to the Send flow using the embedded node. Users can enter a $handle and it resolves to the current holder’s address on supported networks with clear UI feedback.

- **New Features**
  - Send: recipient input accepts $handles; lookup is debounced, shows “Resolving/Resolved by your node/Handle not found”, disables Review until resolved, and builds the tx with the resolved address.
  - API: added GET /wallet/handle/{name} returning {handle, address}; case-insensitive, optional ‘$’; supports mainnet/preview/preprod (shared policy); 404 when not found or unsupported network, 503 when node unavailable or starting, 502 on node errors.

- **Refactors**
  - Added `ui/internal/handle` with normalization and `Resolve` (node-only lookup).
  - Extended `ui/internal/chain.Client` with `AssetAddresses` and `AssetAddress`.
  - Replaced `PoolDRepLookup` with `NodeLookup` in the API to support handle resolution.

<sup>Written for commit 39a51e0f45fe7be1590c313422ec9a9eec42c7e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

