### PR TITLE
feat(ui): transaction-history depth

### DIFF
--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -47,6 +47,10 @@ type Wallet interface {
 	Balance(ctx context.Context) (wallet.Balance, error)
 	Addresses(ctx context.Context) (wallet.AddressView, error)
 	Transactions(ctx context.Context) ([]wallet.Tx, error)
+	// TransactionDetail returns the drill-down view (inputs/outputs, every
+	// asset delta) of one transaction in the history; chain.ErrNotFound when
+	// the node has no record of hash.
+	TransactionDetail(ctx context.Context, hash string) (wallet.TxDetail, error)
 	Delegation(ctx context.Context) (wallet.DelegationView, error)
 }
 
@@ -574,6 +578,13 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 		v, err := wl.Transactions(r.Context())
 		serve(w, v, err)
 	}))
+	// Drill-down for one transaction in the history: full input/output
+	// breakdown. Gated like the list above — it only needs the node serving
+	// queries, not a full sync.
+	mux.HandleFunc("GET /wallet/transactions/{hash}", gated(st, func(w http.ResponseWriter, r *http.Request) {
+		v, err := wl.TransactionDetail(r.Context(), r.PathValue("hash"))
+		serve(w, v, err)
+	}))
 	mux.HandleFunc("GET /wallet/delegation", gated(st, func(w http.ResponseWriter, r *http.Request) {
 		v, err := wl.Delegation(r.Context())
 		serve(w, v, err)
@@ -1032,6 +1043,8 @@ func serve[T any](w http.ResponseWriter, v T, err error) {
 	switch {
 	case err == nil:
 		writeJSON(w, http.StatusOK, v)
+	case errors.Is(err, chain.ErrNotFound):
+		writeJSON(w, http.StatusNotFound, errBody(err)) // 404: node has no record of this transaction
 	case errors.Is(err, vault.ErrNoVault):
 		writeJSON(w, http.StatusNotFound, errBody(err)) // 404: no vault yet
 	case errors.Is(err, vault.ErrVaultExists):

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/blinklabs-io/bursa/ui/internal/chain"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/poolops"
 	"github.com/blinklabs-io/bursa/ui/internal/spend"
@@ -281,6 +282,8 @@ type fakeWallet struct {
 	set              bool
 	setAccountCalled bool
 	gotNetwork       string
+	txDetail         wallet.TxDetail
+	txDetailErr      error
 }
 
 func (f *fakeWallet) SetAccount(acct *wallet.Account) error {
@@ -315,6 +318,19 @@ func (f *fakeWallet) Transactions(_ context.Context) ([]wallet.Tx, error) {
 		return nil, wallet.ErrNoWallet
 	}
 	return nil, nil
+}
+
+func (f *fakeWallet) TransactionDetail(_ context.Context, hash string) (wallet.TxDetail, error) {
+	if !f.set {
+		return wallet.TxDetail{}, wallet.ErrNoWallet
+	}
+	if f.txDetailErr != nil {
+		return wallet.TxDetail{}, f.txDetailErr
+	}
+	if f.txDetail.TxHash != "" {
+		return f.txDetail, nil
+	}
+	return wallet.TxDetail{Tx: wallet.Tx{TxHash: hash}}, nil
 }
 
 func (f *fakeWallet) Delegation(_ context.Context) (wallet.DelegationView, error) {
@@ -736,7 +752,7 @@ func TestWalletGatedWhileBootstrapping(t *testing.T) {
 func TestWalletNoActiveWalletConflict(t *testing.T) {
 	// No active wallet bound: reads must yield 409 (the read service has no account).
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
-	for _, path := range []string{"/wallet/balance", "/wallet/addresses", "/wallet/transactions", "/wallet/delegation"} {
+	for _, path := range []string{"/wallet/balance", "/wallet/addresses", "/wallet/transactions", "/wallet/transactions/tx1", "/wallet/delegation"} {
 		t.Run(path, func(t *testing.T) {
 			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
@@ -745,6 +761,52 @@ func TestWalletNoActiveWalletConflict(t *testing.T) {
 				t.Fatalf("GET %s with no active wallet = %d, want 409", path, rec.Code)
 			}
 		})
+	}
+}
+
+func TestGetTransactionDetailOK(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	fw := &fakeWallet{
+		set: true,
+		txDetail: wallet.TxDetail{
+			Tx: wallet.Tx{
+				TxHash:      "tx1",
+				Direction:   wallet.TxDirectionSent,
+				NetLovelace: "-3170000",
+				Fee:         "170000",
+			},
+			Inputs:  []wallet.TxIO{{Address: "addr_mine", Lovelace: "5000000", IsMine: true}},
+			Outputs: []wallet.TxIO{{Address: "addr_other", Lovelace: "3000000"}},
+		},
+	}
+	h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/transactions/tx1", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /wallet/transactions/tx1 = %d, want 200", rec.Code)
+	}
+	var got wallet.TxDetail
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.TxHash != "tx1" || got.Direction != wallet.TxDirectionSent || got.Fee != "170000" {
+		t.Fatalf("detail = %+v, want tx1/sent/170000 fee", got)
+	}
+	if len(got.Inputs) != 1 || !got.Inputs[0].IsMine || len(got.Outputs) != 1 {
+		t.Fatalf("inputs/outputs = %+v / %+v", got.Inputs, got.Outputs)
+	}
+}
+
+func TestGetTransactionDetailNotFound(t *testing.T) {
+	// The node has no record of the hash: surfaced as 404, matching the
+	// pool/DRep lookup convention ("not found by your node").
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	fw := &fakeWallet{set: true, txDetailErr: chain.ErrNotFound}
+	h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/transactions/unknown", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("GET /wallet/transactions/unknown = %d, want 404", rec.Code)
 	}
 }
 

--- a/ui/internal/chain/blockfrost.go
+++ b/ui/internal/chain/blockfrost.go
@@ -405,6 +405,67 @@ func (c *Client) AddressTransactions(ctx context.Context, addr string) ([]Addres
 	return getAllPages[AddressTx](ctx, c, "/api/v0/addresses/"+addr+"/transactions")
 }
 
+// TxInfo mirrors the subset of GET /api/v0/txs/{hash} the wallet's transaction
+// history needs: the authoritative fee and the transaction's block placement.
+// An unknown hash yields ErrNotFound.
+type TxInfo struct {
+	Hash        string `json:"hash"`
+	Block       string `json:"block"`
+	BlockHeight uint64 `json:"block_height"`
+	BlockTime   int64  `json:"block_time"`
+	Index       int    `json:"index"`
+	Fees        string `json:"fees"`
+}
+
+// Transaction fetches a transaction's summary (fee, block placement) from
+// GET /api/v0/txs/{hash}.
+func (c *Client) Transaction(ctx context.Context, hash string) (TxInfo, error) {
+	var out TxInfo
+	err := c.get(ctx, "/api/v0/txs/"+url.PathEscape(hash), &out)
+	return out, err
+}
+
+// TxIO is one input or output of a transaction, as returned by
+// GET /api/v0/txs/{hash}/utxos: the address it belongs to and its per-asset
+// amounts (unit "lovelace" or policy+hexname, same shape as UTxO.Amount).
+type TxIO struct {
+	Address     string   `json:"address"`
+	Amount      []Amount `json:"amount"`
+	TxHash      string   `json:"tx_hash,omitempty"`
+	OutputIndex int      `json:"output_index"`
+}
+
+// TxUTxOs mirrors GET /api/v0/txs/{hash}/utxos: a transaction's full set of
+// inputs and outputs. The wallet diffs these against its own addresses to
+// compute a transaction's direction and net amount, entirely from node data.
+type TxUTxOs struct {
+	Hash    string `json:"hash"`
+	Inputs  []TxIO `json:"inputs"`
+	Outputs []TxIO `json:"outputs"`
+}
+
+// TransactionUTxOs fetches a transaction's inputs and outputs from
+// GET /api/v0/txs/{hash}/utxos.
+func (c *Client) TransactionUTxOs(ctx context.Context, hash string) (TxUTxOs, error) {
+	var out TxUTxOs
+	err := c.get(ctx, "/api/v0/txs/"+url.PathEscape(hash)+"/utxos", &out)
+	return out, err
+}
+
+// BlockTip is the subset of GET /api/v0/blocks/latest the wallet needs: the
+// chain's current block height, used to compute a transaction's confirmation
+// count (tip height minus the transaction's own block height).
+type BlockTip struct {
+	Height uint64 `json:"height"`
+}
+
+// LatestBlock fetches the chain tip from GET /api/v0/blocks/latest.
+func (c *Client) LatestBlock(ctx context.Context) (BlockTip, error) {
+	var out BlockTip
+	err := c.get(ctx, "/api/v0/blocks/latest", &out)
+	return out, err
+}
+
 func (c *Client) AccountDelegations(ctx context.Context, stakeAddr string) ([]Delegation, error) {
 	return getAllPages[Delegation](ctx, c, "/api/v0/accounts/"+stakeAddr+"/delegations")
 }

--- a/ui/internal/wallet/aggregate.go
+++ b/ui/internal/wallet/aggregate.go
@@ -25,12 +25,68 @@ type Balance struct {
 	Assets   []AssetBalance `json:"assets"`
 }
 
-// Tx is one entry of the merged transaction history.
+// TxDirection classifies a transaction relative to the wallet's own addresses.
+type TxDirection string
+
+const (
+	// TxDirectionReceived is a transaction that pays the wallet without
+	// spending any of its own inputs.
+	TxDirectionReceived TxDirection = "received"
+	// TxDirectionSent is a transaction that spends at least one of the
+	// wallet's own inputs to pay an outside address; change returned to the
+	// wallet does not change this classification.
+	TxDirectionSent TxDirection = "sent"
+	// TxDirectionSelf is a transaction whose every input and output belongs
+	// to the wallet's own addresses (e.g. UTxO consolidation between the
+	// wallet's own addresses).
+	TxDirectionSelf TxDirection = "self"
+)
+
+// AssetDelta is a signed per-native-asset quantity change (decimal string;
+// negative means the wallet's holdings of that asset decreased).
+type AssetDelta struct {
+	Unit     string `json:"unit"`
+	Quantity string `json:"quantity"`
+}
+
+// Tx is one entry of the merged transaction history, enriched with its
+// direction, net ADA/asset deltas, fee, and confirmation count relative to
+// the active wallet's own addresses.
 type Tx struct {
 	TxHash      string `json:"tx_hash"`
 	TxIndex     int    `json:"tx_index"`
 	BlockHeight uint64 `json:"block_height"`
 	BlockTime   int64  `json:"block_time"`
+	// Direction, NetLovelace, AssetDeltas, and Fee are populated by
+	// enrichment (see Service.Transactions / Service.TransactionDetail); a Tx
+	// built by MergeTransactions alone leaves them zero-valued.
+	Direction   TxDirection  `json:"direction"`
+	NetLovelace string       `json:"net_lovelace"`
+	AssetDeltas []AssetDelta `json:"asset_deltas"`
+	Fee         string       `json:"fee"`
+	// Confirmations is the node's chain-tip height minus this transaction's
+	// block height. Pending is true (and Confirmations 0) when the
+	// transaction has not yet been included in a block.
+	Confirmations uint64 `json:"confirmations"`
+	Pending       bool   `json:"pending"`
+}
+
+// TxIO is one input or output of a transaction detail view: the address, its
+// lovelace + native-asset amounts, and whether the address belongs to the
+// active wallet.
+type TxIO struct {
+	Address  string         `json:"address"`
+	Lovelace string         `json:"lovelace"`
+	Assets   []AssetBalance `json:"assets"`
+	IsMine   bool           `json:"is_mine"`
+}
+
+// TxDetail is the drill-down view of a single transaction: its enriched
+// summary (Tx) plus the full input/output breakdown.
+type TxDetail struct {
+	Tx
+	Inputs  []TxIO `json:"inputs"`
+	Outputs []TxIO `json:"outputs"`
 }
 
 // AggregateBalance sums all UTxO amounts by unit, separating lovelace from
@@ -92,4 +148,166 @@ func MergeTransactions(perAddress [][]chain.AddressTx) []Tx {
 		return out[i].TxHash > out[j].TxHash
 	})
 	return out
+}
+
+// ownedBalance sums the side (inputs or outputs) of a transaction that
+// belongs to the wallet's own addresses (mine), reusing AggregateBalance's
+// summation. It also reports whether any entry on that side is the wallet's
+// own (hasOwn) and whether any belongs to an outside address (hasExternal) —
+// together these classify a transaction's direction.
+func ownedBalance(ios []chain.TxIO, mine map[string]bool) (bal Balance, hasOwn, hasExternal bool, err error) {
+	owned := make([]chain.UTxO, 0, len(ios))
+	for _, io := range ios {
+		if mine[io.Address] {
+			hasOwn = true
+			owned = append(owned, chain.UTxO{Amount: io.Amount})
+		} else {
+			hasExternal = true
+		}
+	}
+	bal, err = AggregateBalance(owned)
+	return bal, hasOwn, hasExternal, err
+}
+
+// computeTxDelta diffs a transaction's inputs and outputs against the
+// wallet's own addresses (mine): the direction relative to the wallet, the
+// net lovelace change (signed decimal string), and the per-native-asset
+// deltas (zero-net units omitted).
+func computeTxDelta(inputs, outputs []chain.TxIO, mine map[string]bool) (TxDirection, string, []AssetDelta, error) {
+	inBal, hasOwnIn, hasExternalIn, err := ownedBalance(inputs, mine)
+	if err != nil {
+		return "", "", nil, err
+	}
+	outBal, hasOwnOut, hasExternalOut, err := ownedBalance(outputs, mine)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	direction := TxDirectionReceived
+	switch {
+	case hasOwnIn && !hasExternalIn && !hasExternalOut:
+		// Every input and output touching this transaction is the wallet's
+		// own: an internal reorganization (e.g. UTxO consolidation), not a
+		// payment to or from an outside party.
+		direction = TxDirectionSelf
+	case hasOwnIn && hasExternalOut:
+		// The wallet funded the transaction and paid an outside address;
+		// change coming back to it does not make this a "received"
+		// transaction. Requiring hasExternalOut (rather than just hasOwnIn)
+		// matters for a mixed-input transaction where the wallet contributed
+		// one input alongside an outside party's but every output still
+		// comes back to the wallet's own addresses — that is a receipt, not
+		// a send.
+		direction = TxDirectionSent
+	case hasOwnOut:
+		direction = TxDirectionReceived
+	}
+
+	netLovelace, err := subtractDecimal(outBal.Lovelace, inBal.Lovelace)
+	if err != nil {
+		return "", "", nil, err
+	}
+	deltas, err := diffAssetBalances(outBal.Assets, inBal.Assets)
+	if err != nil {
+		return "", "", nil, err
+	}
+	return direction, netLovelace, deltas, nil
+}
+
+// subtractDecimal returns a-b as a decimal string. a and b are always
+// produced by AggregateBalance (validated non-negative decimal digit
+// strings), so a parse failure here indicates a caller bug rather than bad
+// chain data.
+func subtractDecimal(a, b string) (string, error) {
+	av, ok := new(big.Int).SetString(a, 10)
+	if !ok {
+		return "", fmt.Errorf("%w: %q", ErrInvalidAmountQuantity, a)
+	}
+	bv, ok := new(big.Int).SetString(b, 10)
+	if !ok {
+		return "", fmt.Errorf("%w: %q", ErrInvalidAmountQuantity, b)
+	}
+	return new(big.Int).Sub(av, bv).String(), nil
+}
+
+// diffAssetBalances returns the per-unit delta (out minus in) across two
+// asset-balance lists, sorted by unit, omitting units whose net delta is
+// zero (a pass-through asset the transaction didn't actually move for the
+// wallet).
+func diffAssetBalances(out, in []AssetBalance) ([]AssetDelta, error) {
+	outQty := make(map[string]string, len(out))
+	for _, a := range out {
+		outQty[a.Unit] = a.Quantity
+	}
+	inQty := make(map[string]string, len(in))
+	for _, a := range in {
+		inQty[a.Unit] = a.Quantity
+	}
+	unitSet := make(map[string]bool, len(outQty)+len(inQty))
+	for u := range outQty {
+		unitSet[u] = true
+	}
+	for u := range inQty {
+		unitSet[u] = true
+	}
+	units := make([]string, 0, len(unitSet))
+	for u := range unitSet {
+		units = append(units, u)
+	}
+	sort.Strings(units)
+
+	deltas := make([]AssetDelta, 0, len(units))
+	for _, u := range units {
+		o, ok := outQty[u]
+		if !ok {
+			o = "0"
+		}
+		i, ok := inQty[u]
+		if !ok {
+			i = "0"
+		}
+		d, err := subtractDecimal(o, i)
+		if err != nil {
+			return nil, err
+		}
+		if d == "0" {
+			continue
+		}
+		deltas = append(deltas, AssetDelta{Unit: u, Quantity: d})
+	}
+	return deltas, nil
+}
+
+// txConfirmations reports a transaction's confirmation count and whether it
+// is still pending (not yet included in a block, blockHeight == 0). It
+// mirrors dingo's own block-confirmation convention: confirmations = tip
+// height minus the transaction's block height (0 if the tip has not yet
+// caught up to it, which can happen transiently against a syncing node).
+func txConfirmations(tipHeight, blockHeight uint64) (confirmations uint64, pending bool) {
+	if blockHeight == 0 {
+		return 0, true
+	}
+	if tipHeight < blockHeight {
+		return 0, false
+	}
+	return tipHeight - blockHeight, false
+}
+
+// toTxIOs converts a transaction's raw inputs/outputs into the detail view,
+// marking which belong to the wallet's own addresses (mine).
+func toTxIOs(ios []chain.TxIO, mine map[string]bool) ([]TxIO, error) {
+	out := make([]TxIO, 0, len(ios))
+	for _, io := range ios {
+		bal, err := AggregateBalance([]chain.UTxO{{Amount: io.Amount}})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, TxIO{
+			Address:  io.Address,
+			Lovelace: bal.Lovelace,
+			Assets:   bal.Assets,
+			IsMine:   mine[io.Address],
+		})
+	}
+	return out, nil
 }

--- a/ui/internal/wallet/aggregate_test.go
+++ b/ui/internal/wallet/aggregate_test.go
@@ -71,3 +71,167 @@ func TestMergeTransactions(t *testing.T) {
 		t.Fatalf("order = %v, want t3,t2,z-same-block-lower-index,t1", []string{got[0].TxHash, got[1].TxHash, got[2].TxHash, got[3].TxHash})
 	}
 }
+
+func TestComputeTxDeltaReceived(t *testing.T) {
+	mine := map[string]bool{"addr_mine": true}
+	inputs := []chain.TxIO{{Address: "addr_other", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "5000000"}}}}
+	outputs := []chain.TxIO{
+		{Address: "addr_mine", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "3000000"}}},
+		{Address: "addr_other", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "1800000"}}},
+	}
+	dir, net, deltas, err := computeTxDelta(inputs, outputs, mine)
+	if err != nil {
+		t.Fatalf("computeTxDelta: %v", err)
+	}
+	if dir != TxDirectionReceived {
+		t.Fatalf("direction = %v, want received", dir)
+	}
+	if net != "3000000" {
+		t.Fatalf("net = %v, want 3000000", net)
+	}
+	if len(deltas) != 0 {
+		t.Fatalf("deltas = %v, want none", deltas)
+	}
+}
+
+func TestComputeTxDeltaSent(t *testing.T) {
+	mine := map[string]bool{"addr_mine": true}
+	inputs := []chain.TxIO{{Address: "addr_mine", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "5000000"}}}}
+	outputs := []chain.TxIO{
+		{Address: "addr_other", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "3000000"}}},
+		{Address: "addr_mine", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "1800000"}}}, // change
+	}
+	dir, net, _, err := computeTxDelta(inputs, outputs, mine)
+	if err != nil {
+		t.Fatalf("computeTxDelta: %v", err)
+	}
+	if dir != TxDirectionSent {
+		t.Fatalf("direction = %v, want sent", dir)
+	}
+	if net != "-3200000" {
+		t.Fatalf("net = %v, want -3200000", net)
+	}
+}
+
+// TestComputeTxDeltaMixedInputNoExternalOutIsReceived covers a
+// mixed-input transaction where the wallet contributes one input alongside
+// an outside party's input, but every output still lands on the wallet's own
+// addresses. hasOwnIn is true here, but classifying this as "sent" would be
+// wrong since nothing left the wallet to an outside party; it should be
+// treated as a receipt instead.
+func TestComputeTxDeltaMixedInputNoExternalOutIsReceived(t *testing.T) {
+	mine := map[string]bool{"addr_mine": true}
+	inputs := []chain.TxIO{
+		{Address: "addr_mine", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "5000000"}}},
+		{Address: "addr_other", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "2000000"}}},
+	}
+	outputs := []chain.TxIO{
+		{Address: "addr_mine", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "6800000"}}},
+	}
+	dir, _, _, err := computeTxDelta(inputs, outputs, mine)
+	if err != nil {
+		t.Fatalf("computeTxDelta: %v", err)
+	}
+	if dir != TxDirectionReceived {
+		t.Fatalf("direction = %v, want received", dir)
+	}
+}
+
+func TestComputeTxDeltaSelf(t *testing.T) {
+	mine := map[string]bool{"addr_a": true, "addr_b": true}
+	inputs := []chain.TxIO{{Address: "addr_a", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "5000000"}}}}
+	outputs := []chain.TxIO{{Address: "addr_b", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "4800000"}}}}
+	dir, net, _, err := computeTxDelta(inputs, outputs, mine)
+	if err != nil {
+		t.Fatalf("computeTxDelta: %v", err)
+	}
+	if dir != TxDirectionSelf {
+		t.Fatalf("direction = %v, want self", dir)
+	}
+	if net != "-200000" {
+		t.Fatalf("net = %v, want -200000 (fee only)", net)
+	}
+}
+
+func TestComputeTxDeltaAssetDeltas(t *testing.T) {
+	mine := map[string]bool{"addr_mine": true}
+	inputs := []chain.TxIO{{Address: "addr_mine", Amount: []chain.Amount{
+		{Unit: "lovelace", Quantity: "5000000"},
+		{Unit: "tokenA", Quantity: "10"},
+	}}}
+	outputs := []chain.TxIO{
+		{Address: "addr_other", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "3000000"}, {Unit: "tokenA", Quantity: "4"}}},
+		{Address: "addr_mine", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "1800000"}, {Unit: "tokenA", Quantity: "6"}}},
+	}
+	dir, _, deltas, err := computeTxDelta(inputs, outputs, mine)
+	if err != nil {
+		t.Fatalf("computeTxDelta: %v", err)
+	}
+	if dir != TxDirectionSent {
+		t.Fatalf("direction = %v, want sent", dir)
+	}
+	if len(deltas) != 1 || deltas[0].Unit != "tokenA" || deltas[0].Quantity != "-4" {
+		t.Fatalf("deltas = %+v, want [{tokenA -4}]", deltas)
+	}
+}
+
+func TestComputeTxDeltaOmitsZeroAssetDelta(t *testing.T) {
+	// tokenA passes straight through (spent and returned in full): it did not
+	// actually move for the wallet, so it should not appear as a delta.
+	mine := map[string]bool{"addr_mine": true}
+	inputs := []chain.TxIO{{Address: "addr_mine", Amount: []chain.Amount{{Unit: "tokenA", Quantity: "10"}}}}
+	outputs := []chain.TxIO{{Address: "addr_mine", Amount: []chain.Amount{{Unit: "tokenA", Quantity: "10"}}}}
+	_, _, deltas, err := computeTxDelta(inputs, outputs, mine)
+	if err != nil {
+		t.Fatalf("computeTxDelta: %v", err)
+	}
+	if len(deltas) != 0 {
+		t.Fatalf("deltas = %v, want none (pass-through)", deltas)
+	}
+}
+
+func TestTxConfirmations(t *testing.T) {
+	cases := []struct {
+		name        string
+		tip, block  uint64
+		wantConf    uint64
+		wantPending bool
+	}{
+		{"pending", 100, 0, 0, true},
+		{"tip block itself", 100, 100, 0, false},
+		{"one behind tip", 100, 99, 1, false},
+		{"tip lagging (defensive)", 50, 60, 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			conf, pending := txConfirmations(c.tip, c.block)
+			if conf != c.wantConf || pending != c.wantPending {
+				t.Fatalf("txConfirmations(%d,%d) = (%d,%v), want (%d,%v)", c.tip, c.block, conf, pending, c.wantConf, c.wantPending)
+			}
+		})
+	}
+}
+
+func TestToTxIOs(t *testing.T) {
+	mine := map[string]bool{"addr_mine": true}
+	ios := []chain.TxIO{
+		{Address: "addr_mine", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "1000000"}}},
+		{Address: "addr_other", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "500000"}, {Unit: "tokenA", Quantity: "2"}}},
+	}
+	out, err := toTxIOs(ios, mine)
+	if err != nil {
+		t.Fatalf("toTxIOs: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("got %d, want 2", len(out))
+	}
+	if !out[0].IsMine || out[0].Lovelace != "1000000" {
+		t.Fatalf("out[0] = %+v", out[0])
+	}
+	if out[1].IsMine {
+		t.Fatal("out[1] should not be mine")
+	}
+	if out[1].Lovelace != "500000" || len(out[1].Assets) != 1 || out[1].Assets[0].Unit != "tokenA" {
+		t.Fatalf("out[1] = %+v", out[1])
+	}
+}

--- a/ui/internal/wallet/service.go
+++ b/ui/internal/wallet/service.go
@@ -18,6 +18,9 @@ type chainQuerier interface {
 	AccountAddresses(ctx context.Context, stakeAddr string) ([]string, error)
 	AddressUTxOs(ctx context.Context, addr string) ([]chain.UTxO, error)
 	AddressTransactions(ctx context.Context, addr string) ([]chain.AddressTx, error)
+	Transaction(ctx context.Context, hash string) (chain.TxInfo, error)
+	TransactionUTxOs(ctx context.Context, hash string) (chain.TxUTxOs, error)
+	LatestBlock(ctx context.Context) (chain.BlockTip, error)
 }
 
 // AddressView is the receive-address view: the derived window, the chain-seen
@@ -189,7 +192,11 @@ func (s *Service) Addresses(ctx context.Context) (AddressView, error) {
 }
 
 // Transactions returns the merged, newest-first history across the account's
-// chain-seen and derived addresses.
+// chain-seen and derived addresses, enriched with each transaction's
+// direction, net ADA/asset deltas, fee, and confirmation count relative to
+// the wallet's own addresses. Enrichment is node-only: it queries the node's
+// tx and tx/utxos endpoints and diffs the result against the wallet's own
+// addresses — no third-party indexer is involved.
 func (s *Service) Transactions(ctx context.Context) ([]Tx, error) {
 	acct, err := s.currentAccount()
 	if err != nil {
@@ -210,7 +217,162 @@ func (s *Service) Transactions(ctx context.Context) ([]Tx, error) {
 		}
 		per = append(per, ts)
 	}
-	return MergeTransactions(per), nil
+	merged := MergeTransactions(per)
+	if len(merged) == 0 {
+		return merged, nil
+	}
+
+	// A tip-lookup failure must not fail the whole history — the merged list
+	// (and each tx's own enrichment) is still valid; only the confirmation
+	// count relative to the tip is unknowable. Degrade to "pending" (0
+	// confirmations) for every entry rather than discarding the list.
+	tip, tipErr := s.chain.LatestBlock(ctx)
+	mine := ownerSet(addrs, acct)
+	for i := range merged {
+		if tipErr != nil {
+			merged[i].Confirmations, merged[i].Pending = 0, true
+		} else {
+			merged[i].Confirmations, merged[i].Pending = txConfirmations(tip.Height, merged[i].BlockHeight)
+		}
+		if err := s.enrichTx(ctx, &merged[i], mine); err != nil {
+			return nil, err
+		}
+	}
+	return merged, nil
+}
+
+// enrichTx fills in a Tx's direction/net-amount/fee fields by querying the
+// node for the transaction's summary and inputs+outputs. A transaction the
+// node no longer has a record of (e.g. pruned under the lean-node
+// history-expiry setting) is left with its basic fields only — set by the
+// caller before enrichTx runs — rather than failing the whole history.
+func (s *Service) enrichTx(ctx context.Context, tx *Tx, mine map[string]bool) error {
+	info, err := s.chain.Transaction(ctx, tx.TxHash)
+	if errors.Is(err, chain.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	// The fee is already known once the tx summary comes back; set it now so
+	// it survives even if the UTxO-detail call below fails or is pruned
+	// (lean-node history-expiry can drop UTxO detail on a tx whose summary
+	// is still retained).
+	tx.Fee = feeOrZero(info.Fees)
+	utxos, err := s.chain.TransactionUTxOs(ctx, tx.TxHash)
+	if errors.Is(err, chain.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	direction, netLovelace, deltas, err := computeTxDelta(utxos.Inputs, utxos.Outputs, mine)
+	if err != nil {
+		return err
+	}
+	tx.Direction = direction
+	tx.NetLovelace = netLovelace
+	tx.AssetDeltas = deltas
+	return nil
+}
+
+// TransactionDetail returns the drill-down view of a single transaction: its
+// enriched summary (direction/net-amount/fee/confirmations) plus the full
+// input/output breakdown, each entry marked as belonging to the active
+// wallet's own addresses or not. Node-only, like Transactions.
+func (s *Service) TransactionDetail(ctx context.Context, hash string) (TxDetail, error) {
+	acct, err := s.currentAccount()
+	if err != nil {
+		return TxDetail{}, err
+	}
+	addrs, err := s.scanAddresses(ctx, acct)
+	if err != nil {
+		return TxDetail{}, err
+	}
+	mine := ownerSet(addrs, acct)
+
+	info, err := s.chain.Transaction(ctx, hash)
+	if err != nil {
+		return TxDetail{}, err
+	}
+	utxos, err := s.chain.TransactionUTxOs(ctx, hash)
+	if err != nil {
+		return TxDetail{}, err
+	}
+	// A tip-lookup failure must not turn a found transaction into a 404 (serve()
+	// maps chain.ErrNotFound to 404, which would otherwise misreport a tx that
+	// genuinely exists purely because the tip call failed). Degrade to
+	// "pending" (0 confirmations) instead of propagating the tip error.
+	tip, tipErr := s.chain.LatestBlock(ctx)
+
+	direction, netLovelace, deltas, err := computeTxDelta(utxos.Inputs, utxos.Outputs, mine)
+	if err != nil {
+		return TxDetail{}, err
+	}
+	inputs, err := toTxIOs(utxos.Inputs, mine)
+	if err != nil {
+		return TxDetail{}, err
+	}
+	outputs, err := toTxIOs(utxos.Outputs, mine)
+	if err != nil {
+		return TxDetail{}, err
+	}
+	var confirmations uint64
+	var pending bool
+	if tipErr != nil {
+		confirmations, pending = 0, true
+	} else {
+		confirmations, pending = txConfirmations(tip.Height, info.BlockHeight)
+	}
+
+	return TxDetail{
+		Tx: Tx{
+			TxHash:        hash,
+			TxIndex:       info.Index,
+			BlockHeight:   info.BlockHeight,
+			BlockTime:     info.BlockTime,
+			Direction:     direction,
+			NetLovelace:   netLovelace,
+			AssetDeltas:   deltas,
+			Fee:           feeOrZero(info.Fees),
+			Confirmations: confirmations,
+			Pending:       pending,
+		},
+		Inputs:  inputs,
+		Outputs: outputs,
+	}, nil
+}
+
+// feeOrZero normalizes an empty fee string (the node omits it in edge cases)
+// to "0" so callers always see a valid decimal string.
+func feeOrZero(fee string) string {
+	if fee == "" {
+		return "0"
+	}
+	return fee
+}
+
+// toAddrSet builds a membership set from an address list, for O(1) "is this
+// address mine" checks during transaction-delta computation.
+func toAddrSet(addrs []string) map[string]bool {
+	set := make(map[string]bool, len(addrs))
+	for _, a := range addrs {
+		set[a] = true
+	}
+	return set
+}
+
+// ownerSet builds the "is this address mine" membership set used to classify
+// a transaction's direction and net amount. It is deliberately wider than
+// addrs (the set scanAddresses returns for querying history): it also
+// includes the account's locally-derived change addresses, which the node's
+// account index may not report yet (e.g. before the stake key is registered,
+// or before the node has seen a spend from them) but which the wallet still
+// controls. Excluding them would misclassify a wallet-owned change output as
+// external and skew direction/net-amount for spends that touch such an
+// address.
+func ownerSet(addrs []string, acct *Account) map[string]bool {
+	return toAddrSet(append(addrs, acct.ChangeAddresses...))
 }
 
 // Delegation returns the current delegation/rewards summary (provisional).

--- a/ui/internal/wallet/service.go
+++ b/ui/internal/wallet/service.go
@@ -11,6 +11,8 @@ import (
 // ErrNoWallet is returned by query methods when no wallet has been loaded.
 var ErrNoWallet = errors.New("no wallet set")
 
+const maxConcurrentTxEnrichments = 4
+
 // chainQuerier is the slice of the chain client the service needs (satisfied
 // by *chain.Client); it exists so tests can supply a fake.
 type chainQuerier interface {
@@ -234,11 +236,62 @@ func (s *Service) Transactions(ctx context.Context) ([]Tx, error) {
 		} else {
 			merged[i].Confirmations, merged[i].Pending = txConfirmations(tip.Height, merged[i].BlockHeight)
 		}
-		if err := s.enrichTx(ctx, &merged[i], mine); err != nil {
-			return nil, err
-		}
+	}
+	if err := s.enrichTxs(ctx, merged, mine); err != nil {
+		return nil, err
 	}
 	return merged, nil
+}
+
+func (s *Service) enrichTxs(ctx context.Context, txs []Tx, mine map[string]bool) error {
+	workers := maxConcurrentTxEnrichments
+	if len(txs) < workers {
+		workers = len(txs)
+	}
+	if workers == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	jobs := make(chan int)
+	errCh := make(chan error, 1)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range jobs {
+				if err := s.enrichTx(ctx, &txs[i], mine); err != nil {
+					select {
+					case errCh <- err:
+						cancel()
+					default:
+					}
+					return
+				}
+			}
+		}()
+	}
+
+send:
+	for i := range txs {
+		select {
+		case <-ctx.Done():
+			break send
+		case jobs <- i:
+		}
+	}
+	close(jobs)
+	wg.Wait()
+
+	select {
+	case err := <-errCh:
+		return err
+	default:
+		return ctx.Err()
+	}
 }
 
 // enrichTx fills in a Tx's direction/net-amount/fee fields by querying the
@@ -296,7 +349,8 @@ func (s *Service) TransactionDetail(ctx context.Context, hash string) (TxDetail,
 		return TxDetail{}, err
 	}
 	utxos, err := s.chain.TransactionUTxOs(ctx, hash)
-	if err != nil {
+	utxosPruned := errors.Is(err, chain.ErrNotFound)
+	if err != nil && !utxosPruned {
 		return TxDetail{}, err
 	}
 	// A tip-lookup failure must not turn a found transaction into a 404 (serve()
@@ -304,6 +358,29 @@ func (s *Service) TransactionDetail(ctx context.Context, hash string) (TxDetail,
 	// genuinely exists purely because the tip call failed). Degrade to
 	// "pending" (0 confirmations) instead of propagating the tip error.
 	tip, tipErr := s.chain.LatestBlock(ctx)
+	var confirmations uint64
+	var pending bool
+	if tipErr != nil {
+		confirmations, pending = 0, true
+	} else {
+		confirmations, pending = txConfirmations(tip.Height, info.BlockHeight)
+	}
+
+	if utxosPruned {
+		return TxDetail{
+			Tx: Tx{
+				TxHash:        hash,
+				TxIndex:       info.Index,
+				BlockHeight:   info.BlockHeight,
+				BlockTime:     info.BlockTime,
+				Fee:           feeOrZero(info.Fees),
+				Confirmations: confirmations,
+				Pending:       pending,
+			},
+			Inputs:  []TxIO{},
+			Outputs: []TxIO{},
+		}, nil
+	}
 
 	direction, netLovelace, deltas, err := computeTxDelta(utxos.Inputs, utxos.Outputs, mine)
 	if err != nil {
@@ -316,13 +393,6 @@ func (s *Service) TransactionDetail(ctx context.Context, hash string) (TxDetail,
 	outputs, err := toTxIOs(utxos.Outputs, mine)
 	if err != nil {
 		return TxDetail{}, err
-	}
-	var confirmations uint64
-	var pending bool
-	if tipErr != nil {
-		confirmations, pending = 0, true
-	} else {
-		confirmations, pending = txConfirmations(tip.Height, info.BlockHeight)
 	}
 
 	return TxDetail{
@@ -372,7 +442,10 @@ func toAddrSet(addrs []string) map[string]bool {
 // external and skew direction/net-amount for spends that touch such an
 // address.
 func ownerSet(addrs []string, acct *Account) map[string]bool {
-	return toAddrSet(append(addrs, acct.ChangeAddresses...))
+	owned := make([]string, 0, len(addrs)+len(acct.ChangeAddresses))
+	owned = append(owned, addrs...)
+	owned = append(owned, acct.ChangeAddresses...)
+	return toAddrSet(owned)
 }
 
 // Delegation returns the current delegation/rewards summary (provisional).

--- a/ui/internal/wallet/service_test.go
+++ b/ui/internal/wallet/service_test.go
@@ -3,7 +3,9 @@ package wallet
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/bursa/ui/internal/chain"
 )
@@ -20,6 +22,7 @@ type fakeChain struct {
 
 	txInfo      map[string]chain.TxInfo
 	txInfoErrs  map[string]error
+	txInfoHook  func(hash string)
 	txUTxOs     map[string]chain.TxUTxOs
 	txUTxOErrs  map[string]error
 	latestBlock chain.BlockTip
@@ -49,6 +52,9 @@ func (f *fakeChain) AddressTransactions(_ context.Context, addr string) ([]chain
 }
 
 func (f *fakeChain) Transaction(_ context.Context, hash string) (chain.TxInfo, error) {
+	if f.txInfoHook != nil {
+		f.txInfoHook(hash)
+	}
 	if err := f.txInfoErrs[hash]; err != nil {
 		return chain.TxInfo{}, err
 	}
@@ -268,6 +274,109 @@ func TestServiceTransactionsEnriched(t *testing.T) {
 	}
 }
 
+func TestServiceTransactionsEnrichmentConcurrentAndOrdered(t *testing.T) {
+	const txCount = maxConcurrentTxEnrichments + 2
+	addressTxs := make([]chain.AddressTx, 0, txCount)
+	txInfo := make(map[string]chain.TxInfo, txCount)
+	txUTxOs := make(map[string]chain.TxUTxOs, txCount)
+	for i := 0; i < txCount; i++ {
+		hash := fmt.Sprintf("tx%d", i)
+		blockHeight := uint64(100 - i)
+		addressTxs = append(addressTxs, chain.AddressTx{
+			TxHash:      hash,
+			TxIndex:     i,
+			BlockHeight: blockHeight,
+			BlockTime:   int64(1000 + i),
+		})
+		txInfo[hash] = chain.TxInfo{Hash: hash, BlockHeight: blockHeight, BlockTime: int64(1000 + i), Fees: "170000"}
+		txUTxOs[hash] = chain.TxUTxOs{
+			Hash: hash,
+			Outputs: []chain.TxIO{
+				{Address: "addr_test1a", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "1000000"}}},
+			},
+		}
+	}
+
+	started := make(chan string, txCount)
+	release := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+
+	fc := &fakeChain{
+		addresses: []string{"addr_test1a"},
+		txs: map[string][]chain.AddressTx{
+			"addr_test1a": addressTxs,
+		},
+		txInfo:      txInfo,
+		txUTxOs:     txUTxOs,
+		latestBlock: chain.BlockTip{Height: 120},
+		txInfoHook: func(hash string) {
+			started <- hash
+			<-release
+		},
+	}
+	s := NewService(fc)
+	if _, err := s.SetWallet(testMnemonic, "preview", 1); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+
+	resultCh := make(chan struct {
+		txs []Tx
+		err error
+	}, 1)
+	go func() {
+		txs, err := s.Transactions(context.Background())
+		resultCh <- struct {
+			txs []Tx
+			err error
+		}{txs: txs, err: err}
+	}()
+
+	for i := 0; i < maxConcurrentTxEnrichments; i++ {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("only %d enrichment calls started; want %d concurrent calls", i, maxConcurrentTxEnrichments)
+		}
+	}
+	select {
+	case hash := <-started:
+		t.Fatalf("enrichment started %q before a worker was released; want at most %d in flight", hash, maxConcurrentTxEnrichments)
+	default:
+	}
+	close(release)
+	released = true
+
+	var result struct {
+		txs []Tx
+		err error
+	}
+	select {
+	case result = <-resultCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Transactions did not finish after releasing enrichment workers")
+	}
+	if result.err != nil {
+		t.Fatalf("Transactions: %v", result.err)
+	}
+	if len(result.txs) != txCount {
+		t.Fatalf("got %d txs, want %d", len(result.txs), txCount)
+	}
+	for i, tx := range result.txs {
+		wantHash := fmt.Sprintf("tx%d", i)
+		if tx.TxHash != wantHash {
+			t.Fatalf("tx[%d].TxHash = %q, want %q (merged order must be preserved)", i, tx.TxHash, wantHash)
+		}
+		if tx.Direction != TxDirectionReceived || tx.NetLovelace != "1000000" || tx.Fee != "170000" {
+			t.Fatalf("tx[%d] enrichment = %+v, want received/1000000/170000", i, tx)
+		}
+	}
+}
+
 func TestServiceTransactionsEnrichmentNotFoundGraceful(t *testing.T) {
 	// A transaction the node no longer has a record of (e.g. pruned under
 	// lean-node history-expiry) must not fail the whole history — it keeps
@@ -388,6 +497,20 @@ func TestServiceTransactionsRecognizesChangeAddressOwnership(t *testing.T) {
 	}
 }
 
+func TestOwnerSetDoesNotMutateCallerSlice(t *testing.T) {
+	addrs := make([]string, 1, 2)
+	addrs[0] = "addr_test1a"
+	acct := &Account{ChangeAddresses: []string{"addr_test1change"}}
+
+	set := ownerSet(addrs, acct)
+	if !set["addr_test1a"] || !set["addr_test1change"] {
+		t.Fatalf("ownerSet = %+v, want receive and change addresses", set)
+	}
+	if got := addrs[:cap(addrs)][1]; got != "" {
+		t.Fatalf("ownerSet mutated caller slice backing array: got spare element %q, want empty", got)
+	}
+}
+
 func TestServiceTransactionDetail(t *testing.T) {
 	fc := &fakeChain{
 		addresses: []string{"addr_test1a"},
@@ -451,6 +574,40 @@ func TestServiceTransactionDetail(t *testing.T) {
 	}
 	if !sawMine || !sawExternal {
 		t.Fatalf("expected one mine + one external output, got %+v", detail.Outputs)
+	}
+}
+
+func TestServiceTransactionDetailFeePreservedWhenUTxOsPruned(t *testing.T) {
+	fc := &fakeChain{
+		addresses: []string{"addr_test1a"},
+		txInfo: map[string]chain.TxInfo{
+			"tx1": {Hash: "tx1", BlockHeight: 90, BlockTime: 1000, Fees: "170000", Index: 2},
+		},
+		txUTxOErrs:  map[string]error{"tx1": chain.ErrNotFound},
+		latestBlock: chain.BlockTip{Height: 95},
+	}
+	s := NewService(fc)
+	if _, err := s.SetWallet(testMnemonic, "preview", 1); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	detail, err := s.TransactionDetail(context.Background(), "tx1")
+	if err != nil {
+		t.Fatalf("TransactionDetail: %v", err)
+	}
+	if detail.TxHash != "tx1" || detail.TxIndex != 2 || detail.BlockHeight != 90 || detail.BlockTime != 1000 {
+		t.Fatalf("tx summary = %+v", detail.Tx)
+	}
+	if detail.Fee != "170000" {
+		t.Fatalf("fee = %q, want 170000", detail.Fee)
+	}
+	if detail.Confirmations != 5 || detail.Pending {
+		t.Fatalf("confirmations = %d pending=%v, want 5 false", detail.Confirmations, detail.Pending)
+	}
+	if detail.Direction != "" || detail.NetLovelace != "" || detail.AssetDeltas != nil {
+		t.Fatalf("pruned UTxO enrichment = direction %q net %q assets %+v, want zero-valued", detail.Direction, detail.NetLovelace, detail.AssetDeltas)
+	}
+	if len(detail.Inputs) != 0 || len(detail.Outputs) != 0 {
+		t.Fatalf("inputs/outputs = %+v/%+v, want empty slices", detail.Inputs, detail.Outputs)
 	}
 }
 

--- a/ui/internal/wallet/service_test.go
+++ b/ui/internal/wallet/service_test.go
@@ -17,6 +17,13 @@ type fakeChain struct {
 	utxoErrs     map[string]error
 	txs          map[string][]chain.AddressTx
 	txErrs       map[string]error
+
+	txInfo      map[string]chain.TxInfo
+	txInfoErrs  map[string]error
+	txUTxOs     map[string]chain.TxUTxOs
+	txUTxOErrs  map[string]error
+	latestBlock chain.BlockTip
+	latestErr   error
 }
 
 func (f *fakeChain) Account(_ context.Context, _ string) (chain.AccountInfo, error) {
@@ -39,6 +46,24 @@ func (f *fakeChain) AddressTransactions(_ context.Context, addr string) ([]chain
 		return nil, err
 	}
 	return f.txs[addr], nil
+}
+
+func (f *fakeChain) Transaction(_ context.Context, hash string) (chain.TxInfo, error) {
+	if err := f.txInfoErrs[hash]; err != nil {
+		return chain.TxInfo{}, err
+	}
+	return f.txInfo[hash], nil
+}
+
+func (f *fakeChain) TransactionUTxOs(_ context.Context, hash string) (chain.TxUTxOs, error) {
+	if err := f.txUTxOErrs[hash]; err != nil {
+		return chain.TxUTxOs{}, err
+	}
+	return f.txUTxOs[hash], nil
+}
+
+func (f *fakeChain) LatestBlock(_ context.Context) (chain.BlockTip, error) {
+	return f.latestBlock, f.latestErr
 }
 
 func TestServiceNoWallet(t *testing.T) {
@@ -193,5 +218,371 @@ func TestServiceIgnoresUnusedDerivedAddressNotFound(t *testing.T) {
 	}
 	if len(txs) != 1 || txs[0].TxHash != "tx-used" {
 		t.Fatalf("transactions = %+v, want tx-used only", txs)
+	}
+}
+
+func TestServiceTransactionsEnriched(t *testing.T) {
+	fc := &fakeChain{
+		addresses: []string{"addr_test1a"},
+		txs: map[string][]chain.AddressTx{
+			"addr_test1a": {{TxHash: "tx1", TxIndex: 0, BlockHeight: 90, BlockTime: 1000}},
+		},
+		txInfo: map[string]chain.TxInfo{
+			"tx1": {Hash: "tx1", BlockHeight: 90, BlockTime: 1000, Fees: "170000"},
+		},
+		txUTxOs: map[string]chain.TxUTxOs{
+			"tx1": {
+				Hash:   "tx1",
+				Inputs: []chain.TxIO{{Address: "addr_test1other", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "5000000"}}}},
+				Outputs: []chain.TxIO{
+					{Address: "addr_test1a", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "3000000"}}},
+					{Address: "addr_test1other", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "1830000"}}},
+				},
+			},
+		},
+		latestBlock: chain.BlockTip{Height: 100},
+	}
+	s := NewService(fc)
+	if _, err := s.SetWallet(testMnemonic, "preview", 1); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	txs, err := s.Transactions(context.Background())
+	if err != nil {
+		t.Fatalf("Transactions: %v", err)
+	}
+	if len(txs) != 1 {
+		t.Fatalf("got %d txs, want 1", len(txs))
+	}
+	tx := txs[0]
+	if tx.Direction != TxDirectionReceived {
+		t.Fatalf("direction = %v, want received", tx.Direction)
+	}
+	if tx.NetLovelace != "3000000" {
+		t.Fatalf("net = %v, want 3000000", tx.NetLovelace)
+	}
+	if tx.Fee != "170000" {
+		t.Fatalf("fee = %v, want 170000", tx.Fee)
+	}
+	if tx.Confirmations != 10 || tx.Pending {
+		t.Fatalf("confirmations = %d pending=%v, want 10 false", tx.Confirmations, tx.Pending)
+	}
+}
+
+func TestServiceTransactionsEnrichmentNotFoundGraceful(t *testing.T) {
+	// A transaction the node no longer has a record of (e.g. pruned under
+	// lean-node history-expiry) must not fail the whole history — it keeps
+	// its basic (hash/block) fields with enrichment left zero-valued.
+	fc := &fakeChain{
+		addresses: []string{"addr_test1a"},
+		txs: map[string][]chain.AddressTx{
+			"addr_test1a": {{TxHash: "tx-pruned", TxIndex: 0, BlockHeight: 50, BlockTime: 500}},
+		},
+		txInfoErrs:  map[string]error{"tx-pruned": chain.ErrNotFound},
+		latestBlock: chain.BlockTip{Height: 100},
+	}
+	s := NewService(fc)
+	if _, err := s.SetWallet(testMnemonic, "preview", 1); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	txs, err := s.Transactions(context.Background())
+	if err != nil {
+		t.Fatalf("Transactions: %v", err)
+	}
+	if len(txs) != 1 || txs[0].TxHash != "tx-pruned" {
+		t.Fatalf("txs = %+v, want [tx-pruned]", txs)
+	}
+	if txs[0].Direction != "" || txs[0].Fee != "" {
+		t.Fatalf("enrichment = %+v, want zero-valued (not found)", txs[0])
+	}
+	// Confirmations are computed from the already-known block height,
+	// independent of the failed enrichment call.
+	if txs[0].Confirmations != 50 || txs[0].Pending {
+		t.Fatalf("confirmations = %d pending=%v, want 50 false", txs[0].Confirmations, txs[0].Pending)
+	}
+}
+
+func TestServiceTransactionsFeePreservedWhenUTxOsPruned(t *testing.T) {
+	// The tx summary (and its fee) can still be available even when the
+	// node has pruned the UTxO-level detail for the same tx (lean-node
+	// history-expiry can drop UTxO detail before the summary itself ages
+	// out). The fee must not be silently discarded in that case.
+	fc := &fakeChain{
+		addresses: []string{"addr_test1a"},
+		txs: map[string][]chain.AddressTx{
+			"addr_test1a": {{TxHash: "tx1", TxIndex: 0, BlockHeight: 90, BlockTime: 1000}},
+		},
+		txInfo: map[string]chain.TxInfo{
+			"tx1": {Hash: "tx1", BlockHeight: 90, BlockTime: 1000, Fees: "170000"},
+		},
+		txUTxOErrs:  map[string]error{"tx1": chain.ErrNotFound},
+		latestBlock: chain.BlockTip{Height: 100},
+	}
+	s := NewService(fc)
+	if _, err := s.SetWallet(testMnemonic, "preview", 1); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	txs, err := s.Transactions(context.Background())
+	if err != nil {
+		t.Fatalf("Transactions: %v", err)
+	}
+	if len(txs) != 1 {
+		t.Fatalf("got %d txs, want 1", len(txs))
+	}
+	if txs[0].Fee != "170000" {
+		t.Fatalf("fee = %q, want 170000 (fee must survive a pruned UTxO-detail call)", txs[0].Fee)
+	}
+	if txs[0].Direction != "" {
+		t.Fatalf("direction = %v, want empty (direction still requires UTxO detail)", txs[0].Direction)
+	}
+}
+
+// TestServiceTransactionsRecognizesChangeAddressOwnership guards against
+// treating a not-yet-discovered change address as external. scanAddresses'
+// result (what mine used to be built from) only includes receive addresses
+// plus whatever the node's account index has already reported; a change
+// address the node hasn't seen a spend from yet is absent from it even
+// though the wallet controls it.
+func TestServiceTransactionsRecognizesChangeAddressOwnership(t *testing.T) {
+	fc := &fakeChain{
+		addresses: []string{"addr_test1a"},
+		txs: map[string][]chain.AddressTx{
+			"addr_test1a": {{TxHash: "tx1", TxIndex: 0, BlockHeight: 90, BlockTime: 1000}},
+		},
+		txInfo: map[string]chain.TxInfo{
+			"tx1": {Hash: "tx1", BlockHeight: 90, BlockTime: 1000, Fees: "200000"},
+		},
+		latestBlock: chain.BlockTip{Height: 100},
+	}
+	s := NewService(fc)
+	acct, err := s.SetWallet(testMnemonic, "preview", 1)
+	if err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	if len(acct.ChangeAddresses) == 0 {
+		t.Fatalf("account has no change addresses")
+	}
+	changeAddr := acct.ChangeAddresses[0]
+
+	// The wallet spends a discovered address entirely into its own
+	// not-yet-discovered change address: an internal consolidation, not a
+	// payment to or from an outside party.
+	fc.txUTxOs = map[string]chain.TxUTxOs{
+		"tx1": {
+			Hash:    "tx1",
+			Inputs:  []chain.TxIO{{Address: "addr_test1a", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "5000000"}}}},
+			Outputs: []chain.TxIO{{Address: changeAddr, Amount: []chain.Amount{{Unit: "lovelace", Quantity: "4800000"}}}},
+		},
+	}
+	txs, err := s.Transactions(context.Background())
+	if err != nil {
+		t.Fatalf("Transactions: %v", err)
+	}
+	if len(txs) != 1 {
+		t.Fatalf("got %d txs, want 1", len(txs))
+	}
+	if txs[0].Direction != TxDirectionSelf {
+		t.Fatalf("direction = %v, want self (change address must count as the wallet's own)", txs[0].Direction)
+	}
+	if txs[0].NetLovelace != "-200000" {
+		t.Fatalf("net = %v, want -200000 (fee only)", txs[0].NetLovelace)
+	}
+}
+
+func TestServiceTransactionDetail(t *testing.T) {
+	fc := &fakeChain{
+		addresses: []string{"addr_test1a"},
+		txInfo: map[string]chain.TxInfo{
+			"tx1": {Hash: "tx1", BlockHeight: 90, BlockTime: 1000, Fees: "170000", Index: 2},
+		},
+		txUTxOs: map[string]chain.TxUTxOs{
+			"tx1": {
+				Hash:   "tx1",
+				Inputs: []chain.TxIO{{Address: "addr_test1a", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "5000000"}}}},
+				Outputs: []chain.TxIO{
+					{Address: "addr_test1other", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "3000000"}}},
+					{Address: "addr_test1a", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "1830000"}}},
+				},
+			},
+		},
+		latestBlock: chain.BlockTip{Height: 95},
+	}
+	s := NewService(fc)
+	if _, err := s.SetWallet(testMnemonic, "preview", 1); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	detail, err := s.TransactionDetail(context.Background(), "tx1")
+	if err != nil {
+		t.Fatalf("TransactionDetail: %v", err)
+	}
+	if detail.TxHash != "tx1" || detail.TxIndex != 2 {
+		t.Fatalf("tx summary = %+v", detail.Tx)
+	}
+	if detail.Direction != TxDirectionSent {
+		t.Fatalf("direction = %v, want sent", detail.Direction)
+	}
+	if detail.NetLovelace != "-3170000" {
+		t.Fatalf("net = %v, want -3170000", detail.NetLovelace)
+	}
+	if detail.Fee != "170000" {
+		t.Fatalf("fee = %v, want 170000", detail.Fee)
+	}
+	if detail.Confirmations != 5 {
+		t.Fatalf("confirmations = %d, want 5", detail.Confirmations)
+	}
+	if len(detail.Inputs) != 1 || !detail.Inputs[0].IsMine || detail.Inputs[0].Lovelace != "5000000" {
+		t.Fatalf("inputs = %+v", detail.Inputs)
+	}
+	if len(detail.Outputs) != 2 {
+		t.Fatalf("outputs = %+v", detail.Outputs)
+	}
+	var sawExternal, sawMine bool
+	for _, o := range detail.Outputs {
+		if o.IsMine {
+			sawMine = true
+			if o.Lovelace != "1830000" {
+				t.Fatalf("mine output lovelace = %v, want 1830000", o.Lovelace)
+			}
+		} else {
+			sawExternal = true
+			if o.Lovelace != "3000000" {
+				t.Fatalf("external output lovelace = %v, want 3000000", o.Lovelace)
+			}
+		}
+	}
+	if !sawMine || !sawExternal {
+		t.Fatalf("expected one mine + one external output, got %+v", detail.Outputs)
+	}
+}
+
+func TestServiceTransactionDetailNoWallet(t *testing.T) {
+	s := NewService(&fakeChain{})
+	if _, err := s.TransactionDetail(context.Background(), "tx1"); !errors.Is(err, ErrNoWallet) {
+		t.Fatalf("TransactionDetail without wallet: err = %v, want ErrNoWallet", err)
+	}
+}
+
+func TestServiceTransactionDetailNotFound(t *testing.T) {
+	fc := &fakeChain{txInfoErrs: map[string]error{"unknown": chain.ErrNotFound}}
+	s := NewService(fc)
+	if _, err := s.SetWallet(testMnemonic, "preview", 1); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	if _, err := s.TransactionDetail(context.Background(), "unknown"); !errors.Is(err, chain.ErrNotFound) {
+		t.Fatalf("TransactionDetail unknown hash: err = %v, want chain.ErrNotFound", err)
+	}
+}
+
+func TestServiceTransactionDetailSelfTransfer(t *testing.T) {
+	// Every input and output belongs to the wallet's own addresses: a
+	// consolidation/self-transfer, not a payment to or from anyone else.
+	fc := &fakeChain{
+		addresses: []string{"addr_test1a", "addr_test1b"},
+		txInfo: map[string]chain.TxInfo{
+			"tx1": {Hash: "tx1", BlockHeight: 10, Fees: "170000"},
+		},
+		txUTxOs: map[string]chain.TxUTxOs{
+			"tx1": {
+				Hash:    "tx1",
+				Inputs:  []chain.TxIO{{Address: "addr_test1a", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "5000000"}}}},
+				Outputs: []chain.TxIO{{Address: "addr_test1b", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "4830000"}}}},
+			},
+		},
+		latestBlock: chain.BlockTip{Height: 10},
+	}
+	s := NewService(fc)
+	if _, err := s.SetWallet(testMnemonic, "preview", 1); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	detail, err := s.TransactionDetail(context.Background(), "tx1")
+	if err != nil {
+		t.Fatalf("TransactionDetail: %v", err)
+	}
+	if detail.Direction != TxDirectionSelf {
+		t.Fatalf("direction = %v, want self", detail.Direction)
+	}
+	if detail.NetLovelace != "-170000" {
+		t.Fatalf("net = %v, want -170000 (fee only)", detail.NetLovelace)
+	}
+}
+
+func TestServiceTransactionsTipLookupFailureDegradesGracefully(t *testing.T) {
+	// A LatestBlock failure must not fail the whole history endpoint — the
+	// already-merged, already-enriched list is still valid; only the
+	// confirmation count relative to the tip is unknowable.
+	fc := &fakeChain{
+		addresses: []string{"addr_test1a"},
+		txs: map[string][]chain.AddressTx{
+			"addr_test1a": {{TxHash: "tx1", TxIndex: 0, BlockHeight: 90, BlockTime: 1000}},
+		},
+		txInfo: map[string]chain.TxInfo{
+			"tx1": {Hash: "tx1", BlockHeight: 90, BlockTime: 1000, Fees: "170000"},
+		},
+		txUTxOs: map[string]chain.TxUTxOs{
+			"tx1": {
+				Hash: "tx1",
+				Outputs: []chain.TxIO{
+					{Address: "addr_test1a", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "3000000"}}},
+				},
+			},
+		},
+		latestErr: errors.New("tip lookup boom"),
+	}
+	s := NewService(fc)
+	if _, err := s.SetWallet(testMnemonic, "preview", 1); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	txs, err := s.Transactions(context.Background())
+	if err != nil {
+		t.Fatalf("Transactions: %v, want no error (tip failure must degrade)", err)
+	}
+	if len(txs) != 1 {
+		t.Fatalf("got %d txs, want 1", len(txs))
+	}
+	tx := txs[0]
+	if !tx.Pending || tx.Confirmations != 0 {
+		t.Fatalf("confirmations = %d pending=%v, want 0/pending (tip unknown)", tx.Confirmations, tx.Pending)
+	}
+	// Per-tx enrichment (direction/fee) is unaffected by the tip failure.
+	if tx.Direction != TxDirectionReceived || tx.Fee != "170000" {
+		t.Fatalf("enrichment = %+v, want direction=received fee=170000 despite tip failure", tx)
+	}
+}
+
+func TestServiceTransactionDetailTipLookupFailureDoesNotNotFound(t *testing.T) {
+	// A tip-lookup failure (even chain.ErrNotFound) must not turn a
+	// found transaction into a 404: serve() maps chain.ErrNotFound to 404,
+	// which would misreport a tx that genuinely exists.
+	fc := &fakeChain{
+		addresses: []string{"addr_test1a"},
+		txInfo: map[string]chain.TxInfo{
+			"tx1": {Hash: "tx1", BlockHeight: 90, Fees: "170000"},
+		},
+		txUTxOs: map[string]chain.TxUTxOs{
+			"tx1": {
+				Hash:   "tx1",
+				Inputs: []chain.TxIO{{Address: "addr_test1a", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "5000000"}}}},
+				Outputs: []chain.TxIO{
+					{Address: "addr_test1other", Amount: []chain.Amount{{Unit: "lovelace", Quantity: "4830000"}}},
+				},
+			},
+		},
+		latestErr: chain.ErrNotFound,
+	}
+	s := NewService(fc)
+	if _, err := s.SetWallet(testMnemonic, "preview", 1); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	detail, err := s.TransactionDetail(context.Background(), "tx1")
+	if err != nil {
+		t.Fatalf("TransactionDetail: %v, want no error (tip failure must not 404 a found tx)", err)
+	}
+	if detail.TxHash != "tx1" {
+		t.Fatalf("tx hash = %v, want tx1", detail.TxHash)
+	}
+	if !detail.Pending || detail.Confirmations != 0 {
+		t.Fatalf("confirmations = %d pending=%v, want 0/pending (tip unknown)", detail.Confirmations, detail.Pending)
+	}
+	if detail.Direction != TxDirectionSent {
+		t.Fatalf("direction = %v, want sent (unaffected by tip failure)", detail.Direction)
 	}
 }

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -3,6 +3,7 @@ import type {
   Balance,
   AddressView,
   Tx,
+  TxDetail,
   DelegationView,
   Preview,
   TxResult,
@@ -112,6 +113,8 @@ export const removeWallet = (id: string, vaultPassword: string) =>
 export const getBalance = () => apiGet<Balance>("/wallet/balance");
 export const getAddresses = () => apiGet<AddressView>("/wallet/addresses");
 export const getTransactions = () => apiGet<Tx[]>("/wallet/transactions");
+export const getTransactionDetail = (hash: string) =>
+  apiGet<TxDetail>(`/wallet/transactions/${encodeURIComponent(hash)}`);
 export const getDelegation = () => apiGet<DelegationView>("/wallet/delegation");
 export const buildSend = (req: SendRequest) => apiPost<Preview>("/wallet/send", req);
 export const confirmSend = (id: string, password: string) =>

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -47,11 +47,48 @@ export interface AddressView {
   next_unused: string;
 }
 
+export type TxDirection = "received" | "sent" | "self" | "";
+
+// AssetDelta is a signed per-native-asset quantity change (decimal STRING;
+// negative means the wallet's holdings of that asset decreased).
+export interface AssetDelta {
+  unit: string;
+  quantity: string;
+}
+
+// Tx is one entry of the transaction history, enriched with its direction,
+// net ADA/asset deltas, fee, and confirmation count relative to the active
+// wallet's own addresses. direction/net_lovelace/fee are empty and
+// asset_deltas is null when the node no longer has a record of the
+// transaction (e.g. pruned under lean-node history-expiry) — the backend's Go
+// nil slice serializes to JSON `null`, not `[]` —
+// block_height/block_time/confirmations still hold.
 export interface Tx {
   tx_hash: string;
   tx_index: number;
   block_height: number;
   block_time: number;
+  direction: TxDirection;
+  net_lovelace: string; // signed decimal STRING
+  asset_deltas: AssetDelta[] | null;
+  fee: string;
+  confirmations: number;
+  pending: boolean;
+}
+
+// TxIO is one input or output of a transaction detail view.
+export interface TxIO {
+  address: string;
+  lovelace: string;
+  assets: AssetBalance[];
+  is_mine: boolean;
+}
+
+// TxDetail is the drill-down view of a single transaction: its Tx summary
+// plus the full input/output breakdown.
+export interface TxDetail extends Tx {
+  inputs: TxIO[];
+  outputs: TxIO[];
 }
 
 export interface DelegationView {

--- a/ui/web/src/components/DownloadButton.tsx
+++ b/ui/web/src/components/DownloadButton.tsx
@@ -1,6 +1,11 @@
 interface DownloadButtonProps {
-  // The text content to download (e.g. CBOR hex).
-  value: string;
+  // The text content to download (e.g. CBOR hex). Mutually exclusive with
+  // getValue — use this form when the value is already computed and cheap.
+  value?: string;
+  // Lazily produces the text content on click. Use this form when computing
+  // the value eagerly on every render would be wasteful or unsafe (e.g. it
+  // reads fields that may be absent until the export is actually requested).
+  getValue?: () => string;
   // Suggested file name for the download.
   filename: string;
   label?: string;
@@ -9,9 +14,10 @@ interface DownloadButtonProps {
 // DownloadButton offers a string payload as a downloadable text file. It is used
 // to carry air-gap artifacts (unsigned tx / witness CBOR) to a separate machine
 // where copy/paste across an air gap is impractical.
-export function DownloadButton({ value, filename, label = "Download" }: DownloadButtonProps) {
+export function DownloadButton({ value, getValue, filename, label = "Download" }: DownloadButtonProps) {
   function handleClick() {
-    const blob = new Blob([value], { type: "text/plain" });
+    const content = getValue ? getValue() : (value ?? "");
+    const blob = new Blob([content], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
@@ -23,7 +29,7 @@ export function DownloadButton({ value, filename, label = "Download" }: Download
   }
 
   return (
-    <button type="button" className="btn ghost" onClick={handleClick} disabled={!value}>
+    <button type="button" className="btn ghost" onClick={handleClick} disabled={!getValue && !value}>
       {label}
     </button>
   );

--- a/ui/web/src/components/Drawer.tsx
+++ b/ui/web/src/components/Drawer.tsx
@@ -1,0 +1,81 @@
+import { ReactNode, useEffect, useRef } from "react";
+
+interface DrawerProps {
+  title: string;
+  onClose: () => void;
+  children?: ReactNode;
+}
+
+// Matches the elements a keyboard user can land on. Kept intentionally
+// simple (no visibility/offsetParent check, which jsdom can't compute
+// anyway) since drawer content is never conditionally hidden in place.
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * A slide-in side panel for a drill-down view (e.g. transaction detail),
+ * layered over the current screen. Closes on Escape, on clicking the
+ * backdrop, or via the close button.
+ *
+ * Manages focus like a modal: moves focus into the drawer on open, traps Tab
+ * navigation within it so the background UI can't be reached, and restores
+ * focus to whatever triggered the drawer once it closes.
+ */
+export function Drawer({ title, onClose, children }: DrawerProps) {
+  const drawerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const drawer = drawerRef.current;
+    const firstFocusable = drawer?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+    (firstFocusable ?? drawer)?.focus();
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab" || !drawerRef.current) return;
+      const focusable = Array.from(
+        drawerRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      previouslyFocused?.focus();
+    };
+  }, [onClose]);
+
+  return (
+    <div className="drawer-overlay" onClick={onClose}>
+      <div
+        className="drawer"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        ref={drawerRef}
+        tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="drawer-header">
+          <span className="drawer-title">{title}</span>
+          <button type="button" className="drawer-close" onClick={onClose} aria-label="Close">
+            Close
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/ui/web/src/csv.test.ts
+++ b/ui/web/src/csv.test.ts
@@ -1,0 +1,57 @@
+import { toCsv } from "./csv";
+
+test("toCsv joins headers and rows with commas and CRLF line endings", () => {
+  const csv = toCsv(
+    ["a", "b"],
+    [
+      ["1", "2"],
+      ["3", "4"],
+    ],
+  );
+  expect(csv).toBe("a,b\r\n1,2\r\n3,4");
+});
+
+test("toCsv quotes fields containing commas, quotes, or newlines", () => {
+  const csv = toCsv(["field"], [['has,comma'], ['has"quote'], ["has\nnewline"]]);
+  expect(csv).toBe('field\r\n"has,comma"\r\n"has""quote"\r\n"has\nnewline"');
+});
+
+test("toCsv accepts numeric fields", () => {
+  const csv = toCsv(["n"], [[42]]);
+  expect(csv).toBe("n\r\n42");
+});
+
+test("toCsv with no rows renders only the header", () => {
+  expect(toCsv(["a", "b"], [])).toBe("a,b");
+});
+
+test("toCsv neutralizes formula-injection leading characters with a single quote", () => {
+  const csv = toCsv(
+    ["field"],
+    [["=cmd|' /C calc'!A1"], ["+1+1"], ["-1+1"], ["@SUM(A1:A2)"]],
+  );
+  expect(csv).toBe(
+    [
+      "field",
+      "'=cmd|' /C calc'!A1",
+      "'+1+1",
+      "'-1+1",
+      "'@SUM(A1:A2)",
+    ].join("\r\n"),
+  );
+});
+
+test("toCsv quotes a field starting with a leading single quote after neutralizing AND containing a comma", () => {
+  const csv = toCsv(["field"], [["=1,2"]]);
+  expect(csv).toBe('field\r\n"\'=1,2"');
+});
+
+test("toCsv quotes fields containing a bare carriage return", () => {
+  const csv = toCsv(["field"], [["has\rcr"]]);
+  expect(csv).toBe('field\r\n"has\rcr"');
+});
+
+test("toCsv does not alter a plain negative-looking numeric field differently than any other leading-dash field", () => {
+  // Documents the accepted tradeoff: a negative amount exports as text.
+  expect(toCsv(["n"], [["-42"]])).toBe("n\r\n'-42");
+});

--- a/ui/web/src/csv.test.ts
+++ b/ui/web/src/csv.test.ts
@@ -28,7 +28,15 @@ test("toCsv with no rows renders only the header", () => {
 test("toCsv neutralizes formula-injection leading characters with a single quote", () => {
   const csv = toCsv(
     ["field"],
-    [["=cmd|' /C calc'!A1"], ["+1+1"], ["-1+1"], ["@SUM(A1:A2)"]],
+    [
+      ["=cmd|' /C calc'!A1"],
+      ["+1+1"],
+      ["-1+1"],
+      ["@SUM(A1:A2)"],
+      ["\t=SUM(A1:A2)"],
+      ["\n=SUM(A1:A2)"],
+      ["\r=SUM(A1:A2)"],
+    ],
   );
   expect(csv).toBe(
     [
@@ -37,6 +45,9 @@ test("toCsv neutralizes formula-injection leading characters with a single quote
       "'+1+1",
       "'-1+1",
       "'@SUM(A1:A2)",
+      "'\t=SUM(A1:A2)",
+      "\"'\n=SUM(A1:A2)\"",
+      "\"'\r=SUM(A1:A2)\"",
     ].join("\r\n"),
   );
 });
@@ -51,7 +62,10 @@ test("toCsv quotes fields containing a bare carriage return", () => {
   expect(csv).toBe('field\r\n"has\rcr"');
 });
 
-test("toCsv does not alter a plain negative-looking numeric field differently than any other leading-dash field", () => {
-  // Documents the accepted tradeoff: a negative amount exports as text.
-  expect(toCsv(["n"], [["-42"]])).toBe("n\r\n'-42");
+test("toCsv preserves plain signed numeric fields", () => {
+  const csv = toCsv(
+    ["n"],
+    [[-42], ["-42"], ["+42"], ["-.5"], ["+1.25e-3"], ["-1E+3"]],
+  );
+  expect(csv).toBe("n\r\n-42\r\n-42\r\n+42\r\n-.5\r\n+1.25e-3\r\n-1E+3");
 });

--- a/ui/web/src/csv.ts
+++ b/ui/web/src/csv.ts
@@ -3,15 +3,14 @@
  * quote, newline, or carriage return, doubling any embedded quotes.
  *
  * Also neutralizes spreadsheet formula-injection (OWASP CSV-injection
- * guidance): a field whose first character is one of `= + - @`, tab, or CR
- * gets a leading single quote (') prefixed, forcing spreadsheet apps to
- * render it as text instead of evaluating it as a formula. This means e.g. a
- * negative amount like "-42" exports as "'-42" (rendered as text) — an
- * accepted, safe tradeoff.
+ * guidance): a non-numeric field whose first character is one of `= + - @`,
+ * tab, LF, or CR gets a leading single quote (') prefixed, forcing spreadsheet
+ * apps to render it as text instead of evaluating it as a formula.
  */
 function csvField(value: string | number): string {
   let s = String(value);
-  if (/^[=+\-@\t\r]/.test(s)) {
+  const isPlainNumber = /^[+-]?(?:\d+|\d*\.\d+)(?:[eE][+-]?\d+)?$/.test(s);
+  if (/^[=+\-@\t\n\r]/.test(s) && !isPlainNumber) {
     s = `'${s}`;
   }
   if (/[",\n\r]/.test(s)) {

--- a/ui/web/src/csv.ts
+++ b/ui/web/src/csv.ts
@@ -1,0 +1,33 @@
+/**
+ * Escape one CSV field per RFC 4180: wrap in quotes if it contains a comma,
+ * quote, newline, or carriage return, doubling any embedded quotes.
+ *
+ * Also neutralizes spreadsheet formula-injection (OWASP CSV-injection
+ * guidance): a field whose first character is one of `= + - @`, tab, or CR
+ * gets a leading single quote (') prefixed, forcing spreadsheet apps to
+ * render it as text instead of evaluating it as a formula. This means e.g. a
+ * negative amount like "-42" exports as "'-42" (rendered as text) — an
+ * accepted, safe tradeoff.
+ */
+function csvField(value: string | number): string {
+  let s = String(value);
+  if (/^[=+\-@\t\r]/.test(s)) {
+    s = `'${s}`;
+  }
+  if (/[",\n\r]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+/**
+ * Build a CSV document (CRLF line endings, per RFC 4180) from a header row
+ * and data rows. Entirely client-side — no network involved.
+ */
+export function toCsv(headers: string[], rows: (string | number)[][]): string {
+  const lines = [headers.map(csvField).join(",")];
+  for (const row of rows) {
+    lines.push(row.map(csvField).join(","));
+  }
+  return lines.join("\r\n");
+}

--- a/ui/web/src/screens/Activity.test.tsx
+++ b/ui/web/src/screens/Activity.test.tsx
@@ -244,6 +244,8 @@ test("(n) clicking Details opens a drawer with the transaction breakdown", async
   const drawer = within(dialog);
   expect(await drawer.findAllByText("addr_other")).toHaveLength(2); // one input, one output
   expect(drawer.getByText("addr_mine")).toBeInTheDocument();
+  expect(drawer.getByText("Mine")).toBeInTheDocument();
+  expect(drawer.getAllByText("External")).toHaveLength(2);
 
   fireEvent.click(screen.getByRole("button", { name: /close/i }));
   expect(screen.queryByRole("dialog")).not.toBeInTheDocument();

--- a/ui/web/src/screens/Activity.test.tsx
+++ b/ui/web/src/screens/Activity.test.tsx
@@ -1,13 +1,20 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { Activity } from "./Activity";
 import * as hooks from "../api/hooks";
-import type { Tx } from "../api/types";
+import * as client from "../api/client";
+import type { Tx, TxDetail } from "../api/types";
 
 const TX1: Tx = {
   tx_hash: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
   tx_index: 0,
   block_height: 12345,
   block_time: 1700000000,
+  direction: "received",
+  net_lovelace: "3000000",
+  asset_deltas: [],
+  fee: "170000",
+  confirmations: 10,
+  pending: false,
 };
 
 const TX2: Tx = {
@@ -15,6 +22,31 @@ const TX2: Tx = {
   tx_index: 1,
   block_height: 12300,
   block_time: 1699000000,
+  direction: "sent",
+  net_lovelace: "-1500000",
+  asset_deltas: [{ unit: "tokenA", quantity: "-4" }],
+  fee: "180000",
+  confirmations: 0,
+  pending: true,
+};
+
+// A transaction pruned under lean-node history-expiry: the node no longer has
+// a record of it, so enrichTx (backend) leaves Direction/NetLovelace/Fee at
+// their Go zero values and never sets AssetDeltas at all — the Go nil slice
+// zero value serializes to JSON `null`, not `[]`, which is why the TS type
+// declares `AssetDelta[] | null`. block_height/block_time/confirmations still
+// hold, since those come from the address-history call, not enrichment.
+const TX_PRUNED: Tx = {
+  tx_hash: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+  tx_index: 0,
+  block_height: 500,
+  block_time: 1600000000,
+  direction: "",
+  net_lovelace: "",
+  asset_deltas: null,
+  fee: "",
+  confirmations: 200,
+  pending: false,
 };
 
 function mockTransactions(txs: Tx[]) {
@@ -24,6 +56,27 @@ function mockTransactions(txs: Tx[]) {
     loading: false,
     refresh: vi.fn(),
   } as never);
+}
+
+/**
+ * Stubs URL.createObjectURL/revokeObjectURL for the CSV-export tests via
+ * vi.spyOn, so the afterEach's vi.restoreAllMocks() actually cleans them up
+ * (a plain `Object.assign(URL, ...)` would mutate the global URL constructor
+ * permanently, since restoreAllMocks only reverts vi.spyOn/vi.mock wrappers).
+ * jsdom doesn't implement either method, so a no-op is installed first —
+ * vi.spyOn requires the property to already be a function to spy on it.
+ */
+function stubUrlObjectMethods() {
+  const target = URL as unknown as {
+    createObjectURL?: (obj: Blob) => string;
+    revokeObjectURL?: (url: string) => void;
+  };
+  target.createObjectURL ??= () => "";
+  target.revokeObjectURL ??= () => {};
+  return {
+    createObjectURL: vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock-url"),
+    revokeObjectURL: vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {}),
+  };
 }
 
 afterEach(() => {
@@ -106,4 +159,152 @@ test("(g) block_time is formatted to a readable date string", () => {
   // Use a broad regex so locale doesn't matter
   const datePattern = /2023/;
   expect(screen.getByText(datePattern)).toBeInTheDocument();
+});
+
+test("(h) shows a direction indicator and signed net amount per row", () => {
+  mockTransactions([TX1, TX2]);
+  render(<Activity />);
+  const table = within(screen.getByRole("table"));
+
+  expect(table.getByText("Received")).toBeInTheDocument();
+  expect(table.getByText("Sent")).toBeInTheDocument();
+  expect(table.getByText("+3 ADA")).toBeInTheDocument();
+  expect(table.getByText("-1.5 ADA")).toBeInTheDocument();
+});
+
+test("(i) shows the fee per row", () => {
+  mockTransactions([TX1]);
+  render(<Activity />);
+
+  expect(screen.getByText("0.17 ADA")).toBeInTheDocument();
+});
+
+test("(j) shows a Pending pill for unconfirmed transactions and a count otherwise", () => {
+  mockTransactions([TX1, TX2]);
+  render(<Activity />);
+
+  expect(screen.getByText("Pending")).toBeInTheDocument();
+  expect(screen.getByText("10")).toBeInTheDocument();
+});
+
+test("(k) search filters the list by tx hash substring", () => {
+  mockTransactions([TX1, TX2]);
+  render(<Activity />);
+
+  fireEvent.change(screen.getByLabelText(/search transactions/i), {
+    target: { value: TX2.tx_hash.slice(0, 10) },
+  });
+
+  const table = within(screen.getByRole("table"));
+  expect(table.queryByText("Sent")).toBeInTheDocument();
+  expect(table.queryByText("Received")).not.toBeInTheDocument();
+});
+
+test("(l) direction filter narrows the list", () => {
+  mockTransactions([TX1, TX2]);
+  render(<Activity />);
+
+  fireEvent.change(screen.getByLabelText(/filter by direction/i), {
+    target: { value: "sent" },
+  });
+
+  const table = within(screen.getByRole("table"));
+  expect(table.queryByText("Sent")).toBeInTheDocument();
+  expect(table.queryByText("Received")).not.toBeInTheDocument();
+});
+
+test("(m) filters combine to show 'no transactions match' when nothing matches", () => {
+  mockTransactions([TX1, TX2]);
+  render(<Activity />);
+
+  fireEvent.change(screen.getByLabelText(/search transactions/i), {
+    target: { value: "does-not-exist" },
+  });
+
+  expect(screen.getByText(/no transactions match your filters/i)).toBeInTheDocument();
+});
+
+test("(n) clicking Details opens a drawer with the transaction breakdown", async () => {
+  const detail: TxDetail = {
+    ...TX1,
+    inputs: [{ address: "addr_other", lovelace: "5000000", assets: [], is_mine: false }],
+    outputs: [
+      { address: "addr_mine", lovelace: "3000000", assets: [], is_mine: true },
+      { address: "addr_other", lovelace: "1830000", assets: [], is_mine: false },
+    ],
+  };
+  vi.spyOn(client, "getTransactionDetail").mockResolvedValue(detail);
+  mockTransactions([TX1]);
+  render(<Activity />);
+
+  fireEvent.click(screen.getByRole("button", { name: /view details/i }));
+
+  const dialog = await screen.findByRole("dialog");
+  await waitFor(() => expect(client.getTransactionDetail).toHaveBeenCalledWith(TX1.tx_hash));
+  const drawer = within(dialog);
+  expect(await drawer.findAllByText("addr_other")).toHaveLength(2); // one input, one output
+  expect(drawer.getByText("addr_mine")).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("button", { name: /close/i }));
+  expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+});
+
+test("(o) drawer shows an inline error if the detail fetch fails", async () => {
+  vi.spyOn(client, "getTransactionDetail").mockRejectedValue(new Error("boom"));
+  mockTransactions([TX1]);
+  render(<Activity />);
+
+  fireEvent.click(screen.getByRole("button", { name: /view details/i }));
+
+  expect(await screen.findByText("boom")).toBeInTheDocument();
+});
+
+test("(p) CSV export builds a downloadable Blob from the visible rows, with no network call", () => {
+  const { createObjectURL } = stubUrlObjectMethods();
+  const fetchSpy = vi.spyOn(globalThis, "fetch");
+  mockTransactions([TX1, TX2]);
+  render(<Activity />);
+
+  fireEvent.click(screen.getByRole("button", { name: /export csv/i }));
+
+  expect(createObjectURL).toHaveBeenCalledTimes(1);
+  const blob = createObjectURL.mock.calls[0][0] as Blob;
+  expect(blob).toBeInstanceOf(Blob);
+  expect(fetchSpy).not.toHaveBeenCalled();
+});
+
+test("(q) a pruned tx (null asset_deltas, no enrichment) renders without crashing and CSV export doesn't throw", () => {
+  const { createObjectURL } = stubUrlObjectMethods();
+  mockTransactions([TX1, TX_PRUNED]);
+
+  expect(() => render(<Activity />)).not.toThrow();
+
+  // Direction shows "Unknown" for the pruned tx; its known block height and
+  // confirmations (from the history call, not enrichment) still render.
+  expect(screen.getByText("Unknown")).toBeInTheDocument();
+  expect(screen.getByText("500")).toBeInTheDocument();
+  expect(screen.getByText("200")).toBeInTheDocument();
+
+  // The CSV export must not throw even though asset_deltas is null — the
+  // value is produced lazily by the click handler, not eagerly on render.
+  expect(() =>
+    fireEvent.click(screen.getByRole("button", { name: /export csv/i })),
+  ).not.toThrow();
+  expect(createObjectURL).toHaveBeenCalledTimes(1);
+});
+
+test("(r) drawer detail view renders a pruned tx (null asset_deltas) without crashing", async () => {
+  const detail: TxDetail = {
+    ...TX_PRUNED,
+    inputs: [],
+    outputs: [],
+  };
+  vi.spyOn(client, "getTransactionDetail").mockResolvedValue(detail);
+  mockTransactions([TX_PRUNED]);
+  render(<Activity />);
+
+  fireEvent.click(screen.getByRole("button", { name: /view details/i }));
+
+  const dialog = await screen.findByRole("dialog");
+  expect(within(dialog).getByText("Unknown")).toBeInTheDocument();
 });

--- a/ui/web/src/screens/Activity.tsx
+++ b/ui/web/src/screens/Activity.tsx
@@ -1,6 +1,21 @@
+import { useEffect, useMemo, useState } from "react";
 import { useTransactions } from "../api/hooks";
+import { getTransactionDetail, ApiError } from "../api/client";
+import type { Tx, TxDetail, TxDirection, TxIO } from "../api/types";
 import { Table } from "../components/Table";
 import { CopyButton } from "../components/CopyButton";
+import { Input } from "../components/Input";
+import { Select } from "../components/Select";
+import { DownloadButton } from "../components/DownloadButton";
+import { Drawer } from "../components/Drawer";
+import { formatAda } from "../format";
+import { toCsv } from "../csv";
+
+function errorMessage(err: unknown): string {
+  if (err instanceof ApiError) return err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
 
 /** Truncate a tx hash for display: first 8 … last 6 chars. */
 function truncateHash(hash: string): string {
@@ -16,8 +31,226 @@ function formatBlockTime(unixSeconds: number): string {
   return new Date(unixSeconds * 1000).toLocaleString();
 }
 
+const DIRECTION_LABEL: Record<Exclude<TxDirection, "">, string> = {
+  received: "Received",
+  sent: "Sent",
+  self: "Self",
+};
+
+const DIRECTION_ARROW: Record<Exclude<TxDirection, "">, string> = {
+  received: "↓",
+  sent: "↑",
+  self: "↔",
+};
+
+function DirectionBadge({ direction }: { direction: TxDirection }) {
+  if (!direction) {
+    return <span className="muted">Unknown</span>;
+  }
+  return (
+    <span className={`tx-direction tx-direction-${direction}`}>
+      <span className="tx-direction-arrow">{DIRECTION_ARROW[direction]}</span>
+      {DIRECTION_LABEL[direction]}
+    </span>
+  );
+}
+
+/** The signed net ADA amount for a tx, colored to match its direction. */
+function NetAmount({ tx }: { tx: Tx }) {
+  if (!tx.direction) {
+    return <span className="muted">—</span>;
+  }
+  const sign = tx.net_lovelace.startsWith("-") ? "" : "+";
+  const cls =
+    tx.direction === "sent"
+      ? "tx-amount-out"
+      : tx.direction === "received"
+        ? "tx-amount-in"
+        : "tx-amount-self";
+  return <span className={cls}>{`${sign}${formatAda(tx.net_lovelace)} ADA`}</span>;
+}
+
+/** Confirmations column: a "Pending" pill, or the confirmation count. */
+function Confirmations({ tx }: { tx: Tx }) {
+  if (tx.pending) {
+    return <span className="pill pill-warn">Pending</span>;
+  }
+  if (!tx.direction) {
+    return <span className="muted">{tx.confirmations}</span>;
+  }
+  return <span>{tx.confirmations}</span>;
+}
+
+/**
+ * Builds a CSV document of the given transactions, entirely client-side.
+ *
+ * Every optional/enrichment field (direction, net_lovelace, fee, asset_deltas)
+ * is guarded the same way the row rendering guards it: a pruned transaction
+ * (the node no longer has a record of it, e.g. lean-node history-expiry)
+ * carries `direction: ""` and a null `asset_deltas` from the API despite the
+ * TS type, so it must export cleanly with blank cells rather than throw.
+ */
+function transactionsToCsv(txs: Tx[]): string {
+  const headers = [
+    "tx_hash",
+    "direction",
+    "net_ada",
+    "fee_ada",
+    "block_height",
+    "block_time",
+    "confirmations",
+    "asset_deltas",
+  ];
+  const rows = txs.map((t) => [
+    t.tx_hash,
+    t.direction || "unknown",
+    t.direction ? formatAda(t.net_lovelace) : "",
+    t.direction ? formatAda(t.fee) : "",
+    t.block_height,
+    new Date(t.block_time * 1000).toISOString(),
+    t.pending ? "pending" : String(t.confirmations),
+    (t.asset_deltas ?? []).map((a) => `${a.unit}:${a.quantity}`).join(";"),
+  ]);
+  return toCsv(headers, rows);
+}
+
+function TxIORow({ io }: { io: TxIO }) {
+  return (
+    <div className={`io-row${io.is_mine ? " is-mine" : ""}`}>
+      <span className="io-address mono">{io.address}</span>
+      <span className="io-amount">
+        {formatAda(io.lovelace)} ADA
+        {io.assets.length > 0 && (
+          <> · {io.assets.map((a) => `${a.quantity} ${a.unit}`).join(", ")}</>
+        )}
+      </span>
+    </div>
+  );
+}
+
+function TransactionDetailDrawer({ hash, onClose }: { hash: string; onClose: () => void }) {
+  const [detail, setDetail] = useState<TxDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setDetail(null);
+    getTransactionDetail(hash)
+      .then((d) => {
+        if (!cancelled) setDetail(d);
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) setError(errorMessage(e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [hash]);
+
+  return (
+    <Drawer title="Transaction Detail" onClose={onClose}>
+      {loading && <p>Loading…</p>}
+      {error && (
+        <p role="alert" className="error-text">
+          {error}
+        </p>
+      )}
+      {detail && (
+        <>
+          <div className="drawer-section">
+            <h3>Summary</h3>
+            <div className="dl-row">
+              <dt>Hash</dt>
+              <dd className="tx-hash-row">
+                <span className="tx-hash">{detail.tx_hash}</span>
+                <CopyButton value={detail.tx_hash} />
+              </dd>
+            </div>
+            <div className="dl-row">
+              <dt>Direction</dt>
+              <dd>
+                <DirectionBadge direction={detail.direction} />
+              </dd>
+            </div>
+            <div className="dl-row">
+              <dt>Amount</dt>
+              <dd>
+                <NetAmount tx={detail} />
+              </dd>
+            </div>
+            <div className="dl-row">
+              <dt>Fee</dt>
+              <dd>
+                {detail.direction ? (
+                  `${formatAda(detail.fee)} ADA`
+                ) : (
+                  <span className="muted">—</span>
+                )}
+              </dd>
+            </div>
+            <div className="dl-row">
+              <dt>Block</dt>
+              <dd>{detail.block_height}</dd>
+            </div>
+            <div className="dl-row">
+              <dt>Time</dt>
+              <dd>{formatBlockTime(detail.block_time)}</dd>
+            </div>
+            <div className="dl-row">
+              <dt>Confirmations</dt>
+              <dd>{detail.pending ? "Pending" : detail.confirmations}</dd>
+            </div>
+            {(detail.asset_deltas ?? []).map((a) => (
+              <div className="dl-row" key={a.unit}>
+                <dt>{a.unit}</dt>
+                <dd>{a.quantity}</dd>
+              </div>
+            ))}
+          </div>
+
+          <div className="drawer-section">
+            <h3>Inputs ({detail.inputs.length})</h3>
+            {detail.inputs.map((io, i) => (
+              <TxIORow io={io} key={`${io.address}-${i}`} />
+            ))}
+          </div>
+
+          <div className="drawer-section">
+            <h3>Outputs ({detail.outputs.length})</h3>
+            {detail.outputs.map((io, i) => (
+              <TxIORow io={io} key={`${io.address}-${i}`} />
+            ))}
+          </div>
+        </>
+      )}
+    </Drawer>
+  );
+}
+
+type DirectionFilter = "all" | "received" | "sent" | "self";
+
 export function Activity() {
   const txs = useTransactions();
+  const [search, setSearch] = useState("");
+  const [directionFilter, setDirectionFilter] = useState<DirectionFilter>("all");
+  const [selectedHash, setSelectedHash] = useState<string | null>(null);
+
+  const list = useMemo(() => txs.data ?? [], [txs.data]);
+
+  const filtered = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    return list.filter((tx) => {
+      if (directionFilter !== "all" && tx.direction !== directionFilter) return false;
+      if (needle && !tx.tx_hash.toLowerCase().includes(needle)) return false;
+      return true;
+    });
+  }, [list, search, directionFilter]);
 
   if (txs.loading) {
     return <p>Loading…</p>;
@@ -31,8 +264,6 @@ export function Activity() {
     );
   }
 
-  const list = txs.data ?? [];
-
   if (list.length === 0) {
     return (
       <div className="activity">
@@ -42,26 +273,79 @@ export function Activity() {
   }
 
   const columns = [
-    { key: "tx_hash", label: "Tx Hash" },
+    { key: "direction", label: "Direction" },
+    { key: "amount", label: "Amount" },
+    { key: "fee", label: "Fee" },
     { key: "block_height", label: "Block" },
-    { key: "block_time", label: "Time" },
+    { key: "time", label: "Time" },
+    { key: "confirmations", label: "Confirmations" },
+    { key: "tx_hash", label: "Tx Hash" },
+    { key: "actions", label: "" },
   ];
 
   // API returns newest-first; preserve that order.
-  const rows = list.map((tx) => ({
+  const rows = filtered.map((tx) => ({
+    direction: <DirectionBadge direction={tx.direction} />,
+    amount: <NetAmount tx={tx} />,
+    fee: tx.direction ? `${formatAda(tx.fee)} ADA` : <span className="muted">—</span>,
+    block_height: tx.block_height,
+    time: formatBlockTime(tx.block_time),
+    confirmations: <Confirmations tx={tx} />,
     tx_hash: (
       <span className="hash-cell">
         <span className="mono">{truncateHash(tx.tx_hash)}</span>
         <CopyButton value={tx.tx_hash} />
       </span>
     ),
-    block_height: tx.block_height,
-    block_time: formatBlockTime(tx.block_time),
+    actions: (
+      <button
+        type="button"
+        className="btn ghost"
+        onClick={() => setSelectedHash(tx.tx_hash)}
+        aria-label={`View details for ${tx.tx_hash}`}
+      >
+        Details
+      </button>
+    ),
   }));
 
   return (
     <div className="activity">
-      <Table columns={columns} rows={rows} />
+      <div className="activity-filters">
+        <Input
+          type="text"
+          placeholder="Search by tx hash…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          aria-label="Search transactions by hash"
+        />
+        <Select
+          value={directionFilter}
+          onChange={(e) => setDirectionFilter(e.target.value as DirectionFilter)}
+          aria-label="Filter by direction"
+          options={[
+            { value: "all", label: "All Directions" },
+            { value: "received", label: "Received" },
+            { value: "sent", label: "Sent" },
+            { value: "self", label: "Self" },
+          ]}
+        />
+        <DownloadButton
+          getValue={() => transactionsToCsv(filtered)}
+          filename="bursa-transactions.csv"
+          label="Export CSV"
+        />
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className="muted">No transactions match your filters</p>
+      ) : (
+        <Table columns={columns} rows={rows} />
+      )}
+
+      {selectedHash && (
+        <TransactionDetailDrawer hash={selectedHash} onClose={() => setSelectedHash(null)} />
+      )}
     </div>
   );
 }

--- a/ui/web/src/screens/Activity.tsx
+++ b/ui/web/src/screens/Activity.tsx
@@ -115,9 +115,13 @@ function transactionsToCsv(txs: Tx[]): string {
 }
 
 function TxIORow({ io }: { io: TxIO }) {
+  const ownerLabel = io.is_mine ? "Mine" : "External";
   return (
     <div className={`io-row${io.is_mine ? " is-mine" : ""}`}>
-      <span className="io-address mono">{io.address}</span>
+      <span className="io-address-group">
+        <span className="io-address mono">{io.address}</span>
+        <span className="io-owner">{ownerLabel}</span>
+      </span>
       <span className="io-amount">
         {formatAda(io.lovelace)} ADA
         {io.assets.length > 0 && (

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -1229,6 +1229,154 @@ a:hover {
   min-width: 6rem;
 }
 
+/* --------------------------------------------------------------- activity -- */
+/* Filter bar: search + direction picker + CSV export, above the tx table. */
+.activity-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+.activity-filters .field {
+  width: auto;
+  flex: 1 1 220px;
+}
+.activity-filters select.field {
+  flex: 0 1 180px;
+}
+
+/* Direction indicator: a small arrow + label, color-coded like a ledger
+   (green in, red out) — the same convention used for the signed amount. */
+.tx-direction {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.8125rem;
+  white-space: nowrap;
+}
+.tx-direction-arrow {
+  font-weight: 700;
+}
+.tx-direction-received {
+  color: var(--ok);
+}
+.tx-direction-sent {
+  color: var(--error);
+}
+.tx-direction-self {
+  color: var(--text-muted);
+}
+
+/* Signed net amount — colored the same as its direction. */
+.tx-amount-in {
+  color: var(--ok);
+  font-family: var(--mono);
+  white-space: nowrap;
+}
+.tx-amount-out {
+  color: var(--error);
+  font-family: var(--mono);
+  white-space: nowrap;
+}
+.tx-amount-self {
+  color: var(--text-muted);
+  font-family: var(--mono);
+  white-space: nowrap;
+}
+
+/* ----------------------------------------------------- tx detail drawer -- */
+.drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, black 55%, transparent);
+  display: flex;
+  justify-content: flex-end;
+  z-index: 50;
+}
+.drawer {
+  width: min(480px, 100%);
+  height: 100%;
+  background: var(--surface);
+  border-left: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  padding: var(--space-4);
+  gap: var(--space-4);
+}
+.drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+.drawer-title {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.drawer-close {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-muted);
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 4px 10px;
+}
+.drawer-close:hover {
+  color: var(--text);
+  border-color: var(--accent);
+}
+.drawer-close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.drawer-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.drawer-section h3 {
+  font-family: var(--mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.io-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  background: var(--inset);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.io-row.is-mine {
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+}
+.io-address {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  word-break: break-all;
+  flex: 1;
+  min-width: 0;
+}
+.io-amount {
+  font-family: var(--mono);
+  font-size: 0.8125rem;
+  text-align: right;
+  white-space: nowrap;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .dot-warn,
   .sync-bar-indeterminate,

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -1363,12 +1363,29 @@ a:hover {
 .io-row.is-mine {
   border-color: color-mix(in srgb, var(--accent) 40%, transparent);
 }
+.io-address-group {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
 .io-address {
   font-family: var(--mono);
   font-size: 0.75rem;
   word-break: break-all;
   flex: 1;
   min-width: 0;
+}
+.io-owner {
+  font-family: var(--mono);
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.io-row.is-mine .io-owner {
+  color: var(--accent);
 }
 .io-amount {
   font-family: var(--mono);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds depth to wallet transaction history. The API enriches the list and adds a drill‑down endpoint; the UI shows direction, signed net amounts, fees, confirmations (with a Pending pill), a detail drawer, filters/search, and CSV export — handling pruned node data gracefully and returning 404 for unknown hashes.

- **New Features**
  - API
    - `GET /wallet/transactions` now includes direction, signed net ADA, per-asset deltas, fee, and confirmations.
    - `GET /wallet/transactions/{hash}` returns inputs/outputs plus the enriched summary; `chain.ErrNotFound` maps to 404.
  - Chain client
    - Added `Transaction`, `TransactionUTxOs`, `LatestBlock` (Blockfrost) for node-only enrichment.
  - Wallet service
    - Computes direction (`received`/`sent`/`self`), net amounts, asset deltas, fee, and confirmations against the wallet’s own addresses (includes change addresses).
    - Parallelizes enrichment with a small worker pool; preserves list order.
    - Handles missing node history (pruned tx): leaves enrichment empty but keeps block fields; preserves fee if UTxO detail is pruned; tip lookup failures degrade to “pending” without failing.
  - Web UI
    - Activity shows direction (with arrow), signed net amount, fee, block/time, and confirmations (Pending pill).
    - Search by tx hash and filter by direction.
    - Drawer-based transaction detail with inputs/outputs and “is mine” marking; new `Drawer` component with focus management.
    - CSV export (client-side) with safe quoting and formula-injection mitigation; handles pruned tx rows; `DownloadButton` supports lazy `getValue`.

<sup>Written for commit 3e32d58f968edcc8b9925e1a0ee69f126eb2e1d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transaction drill-down views with inputs, outputs, fees, confirmations, and per-asset deltas.
  * Enhanced the activity screen with direction filtering, search, detail drawer, and CSV export for visible transactions.
  * Introduced a reusable side drawer and improved download handling for generated exports.

* **Bug Fixes**
  * Transaction details now return a clear not-found result when no record exists.
  * Activity and export flows handle missing transaction enrichment data more gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->