### PR TITLE
feat(ui): local-only address book (contacts)

### DIFF
--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -26,6 +26,7 @@ import (
 
 	bursa "github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/bursa/ui/internal/chain"
+	"github.com/blinklabs-io/bursa/ui/internal/contacts"
 	"github.com/blinklabs-io/bursa/ui/internal/dex"
 	"github.com/blinklabs-io/bursa/ui/internal/handle"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
@@ -180,6 +181,17 @@ type SettingsController interface {
 // keep the frontend list in sync by hand.
 var autoLockOptions = map[int]bool{0: true, 1: true, 5: true, 15: true, 30: true}
 
+// Contacts is the local-only address-book surface: a per-instance store of
+// saved recipient addresses (a friendly name, a Cardano address, and an
+// optional note). It is pure on-device storage: CRUD only, no lookups against
+// any external service. Upsert creates a new contact when Entry.ID is empty,
+// or updates the contact with that ID when it matches an existing one.
+type Contacts interface {
+	List() []contacts.Entry
+	Upsert(entry contacts.Entry) (contacts.Entry, error)
+	Delete(id string) error
+}
+
 // PoolOps is the Stake Pool Operations surface the API exposes. Credential
 // generation and seed-derived certificate/opcert building need the active
 // wallet + spending password; the air-gap builders (pool ID, opcert payload /
@@ -326,12 +338,13 @@ func toWalletView(w vault.WalletMeta, activeID string) walletView {
 // the embedded node runs on; wallet requests must match it (or omit it). vlt is
 // the encrypted multi-wallet store; the API pushes the active wallet onto wl/sp
 // whenever the selection changes. settings exposes user-facing app settings
-// (the lean-node profile). lookup verifies pasted pool/DRep IDs and resolves
-// ADA Handles through the node (may be nil, in which case those endpoints
-// report unavailable). po is the Stake Pool Operations surface. dx optionally
-// enables node-local DEX routes. spa is the embedded SPA, registered as the
-// catch-all so the specific API routes take precedence on the mux.
-func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings SettingsController, lookup NodeLookup, po PoolOps, dx DexQuoter, network string, spa http.Handler, opts ...HandlerOption) http.Handler {
+// (the lean-node profile). cb is the local-only address-book store. lookup
+// verifies pasted pool/DRep IDs and resolves ADA Handles through the node (may
+// be nil, in which case those endpoints report unavailable). po is the Stake
+// Pool Operations surface. dx optionally enables node-local DEX routes. spa is
+// the embedded SPA, registered as the catch-all so the specific API routes take
+// precedence on the mux.
+func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings SettingsController, cb Contacts, lookup NodeLookup, po PoolOps, dx DexQuoter, network string, spa http.Handler, opts ...HandlerOption) http.Handler {
 	cfg := handlerOptions{}
 	for _, opt := range opts {
 		opt(&cfg)
@@ -779,6 +792,29 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 		writeJSON(w, http.StatusOK, map[string]int{"minutes": settings.AutoLockMinutes()})
 	})
 
+	// --- Address book (local-only, no network) -------------------------------
+	// Pure on-device CRUD storage: ungated (no node needed) and never reaches
+	// out to any external service.
+
+	mux.HandleFunc("GET /wallet/contacts", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, cb.List())
+	})
+	mux.HandleFunc("POST /wallet/contacts", func(w http.ResponseWriter, r *http.Request) {
+		var req contacts.Entry
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		entry, err := cb.Upsert(req)
+		serve(w, entry, err)
+	})
+	mux.HandleFunc("DELETE /wallet/contacts/{id}", func(w http.ResponseWriter, r *http.Request) {
+		if err := cb.Delete(r.PathValue("id")); err != nil {
+			serve(w, struct{}{}, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]bool{"removed": true})
+	})
+
 	// CIP-8 / CIP-30 message verification — the inverse of sign-data. Pure
 	// crypto: ungated, no node, no keystore (a read-only wallet can verify too).
 	mux.HandleFunc("POST /wallet/verify-data", func(w http.ResponseWriter, r *http.Request) {
@@ -1197,8 +1233,11 @@ func serve[T any](w http.ResponseWriter, v T, err error) {
 	case errors.Is(err, spend.ErrInvalidRequest),
 		errors.Is(err, spend.ErrInvalidTx),
 		errors.Is(err, spend.ErrInvalidWitness),
-		errors.Is(err, poolops.ErrInvalidRequest):
+		errors.Is(err, poolops.ErrInvalidRequest),
+		errors.Is(err, contacts.ErrInvalidRequest):
 		writeJSON(w, http.StatusBadRequest, errBody(err)) // 400
+	case errors.Is(err, contacts.ErrNotFound):
+		writeJSON(w, http.StatusNotFound, errBody(err)) // 404
 	case errors.Is(err, spend.ErrUnknownPending):
 		writeJSON(w, http.StatusNotFound, errBody(err)) // 404
 	case errors.Is(err, spend.ErrExpiredPending):

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/bursa/ui/internal/chain"
+	"github.com/blinklabs-io/bursa/ui/internal/contacts"
 	"github.com/blinklabs-io/bursa/ui/internal/dex"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/poolops"
@@ -253,6 +254,60 @@ func (f *fakeSettings) SetAutoLockMinutes(minutes int) error {
 	return nil
 }
 
+// fakeContacts is an in-memory Contacts controller for handler tests. It
+// mimics the real store's API semantics enough to exercise the API layer
+// without touching disk.
+type fakeContacts struct {
+	entries   []contacts.Entry
+	upsertErr error
+	deleteErr error
+	nextID    int
+}
+
+func (f *fakeContacts) List() []contacts.Entry {
+	out := make([]contacts.Entry, len(f.entries))
+	copy(out, f.entries)
+	return out
+}
+
+func (f *fakeContacts) Upsert(in contacts.Entry) (contacts.Entry, error) {
+	if f.upsertErr != nil {
+		return contacts.Entry{}, f.upsertErr
+	}
+	if in.Name == "" {
+		return contacts.Entry{}, fmt.Errorf("%w: name is required", contacts.ErrInvalidRequest)
+	}
+	if in.Address == "" {
+		return contacts.Entry{}, fmt.Errorf("%w: address is required", contacts.ErrInvalidRequest)
+	}
+	if in.ID == "" {
+		f.nextID++
+		in.ID = fmt.Sprintf("c%d", f.nextID)
+		f.entries = append(f.entries, in)
+		return in, nil
+	}
+	for i, e := range f.entries {
+		if e.ID == in.ID {
+			f.entries[i] = in
+			return in, nil
+		}
+	}
+	return contacts.Entry{}, fmt.Errorf("%w: %s", contacts.ErrNotFound, in.ID)
+}
+
+func (f *fakeContacts) Delete(id string) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	for i, e := range f.entries {
+		if e.ID == id {
+			f.entries = append(f.entries[:i], f.entries[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: %s", contacts.ErrNotFound, id)
+}
+
 func (f *fakeVault) TPMStatus() vault.TPMStatusInfo { return f.tpmStatus }
 
 func (f *fakeVault) EnableTPM(password string, pcrBound bool) error {
@@ -269,7 +324,7 @@ func (f *fakeVault) DisableTPM(password string) error {
 }
 
 func TestHealthAlwaysOK(t *testing.T) {
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
 	if rec.Code != http.StatusOK {
@@ -279,7 +334,7 @@ func TestHealthAlwaysOK(t *testing.T) {
 
 func TestStatusReturnsSnapshot(t *testing.T) {
 	want := supervisor.Status{State: supervisor.StateSyncing, Tip: 42, CaughtUp: true}
-	h := NewHandler(fakeStatuser{s: want}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{s: want}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
 	if rec.Code != http.StatusOK {
@@ -363,7 +418,7 @@ func (f *fakeWallet) Delegation(_ context.Context) (wallet.DelegationView, error
 
 func TestVaultStatusReports(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: true, wallets: []vault.WalletMeta{{ID: "a"}, {ID: "b"}}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/status", nil))
 	if rec.Code != http.StatusOK {
@@ -384,7 +439,7 @@ func TestVaultStatusReports(t *testing.T) {
 func TestVaultStatusReportsLegacyKeystore(t *testing.T) {
 	fv := &fakeVault{exists: false, locked: true}
 	legacy := &fakeLegacyKeystore{exists: true}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/status", nil))
 	if rec.Code != http.StatusOK {
@@ -401,7 +456,7 @@ func TestVaultStatusReportsLegacyKeystore(t *testing.T) {
 
 func TestVaultCreateRequiresPassword(t *testing.T) {
 	fv := &fakeVault{}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"short"}`)))
 	if rec.Code != http.StatusBadRequest {
@@ -414,7 +469,7 @@ func TestVaultCreateRequiresPassword(t *testing.T) {
 
 func TestVaultCreateOK(t *testing.T) {
 	fv := &fakeVault{}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusOK {
@@ -427,7 +482,7 @@ func TestVaultCreateOK(t *testing.T) {
 
 func TestVaultCreateConflict(t *testing.T) {
 	fv := &fakeVault{createErr: vault.ErrVaultExists}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusConflict {
@@ -444,7 +499,7 @@ func TestVaultUnlockBindsSoleWalletAndReads(t *testing.T) {
 		wallets: []vault.WalletMeta{{ID: "w1", Name: "main", Network: "preview", Account: sampleAccount("preview")}},
 	}
 	fw := &fakeWallet{balance: wallet.Balance{Lovelace: "1234"}}
-	h := NewHandler(st, fv, fw, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
@@ -471,7 +526,7 @@ func TestVaultUnlockBindsSoleWalletAndReads(t *testing.T) {
 
 func TestVaultUnlockWrongPassword(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: true, unlockErr: fmt.Errorf("%w: bad", vault.ErrWrongPassword)}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"wrong-but-long-pw"}`)))
 	if rec.Code != http.StatusUnauthorized {
@@ -483,7 +538,7 @@ func TestVaultLock(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false}
 	fw := &fakeWallet{set: true}
 	sp := &fakeSpender{set: true}
-	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/lock", nil))
 	if rec.Code != http.StatusOK {
@@ -502,7 +557,7 @@ func TestMigrateLegacyKeystoreImportsAndBinds(t *testing.T) {
 	fw := &fakeWallet{}
 	sp := &fakeSpender{}
 	legacy := &fakeLegacyKeystore{exists: true, mnemonic: []byte("abandon abandon about")}
-	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 
 	body := `{"name":"Imported","vault_password":"valid-vault-password","spend_password":"legacy-spend-password"}`
 	rec := httptest.NewRecorder()
@@ -541,7 +596,7 @@ func TestMigrateLegacyKeystoreImportsAndBinds(t *testing.T) {
 func TestMigrateLegacyKeystoreWrongPassword(t *testing.T) {
 	fv := &fakeVault{exists: false, locked: true}
 	legacy := &fakeLegacyKeystore{exists: true, err: keystore.ErrDecryptFailed}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 
 	body := `{"name":"Imported","vault_password":"valid-vault-password","spend_password":"wrong-password"}`
 	rec := httptest.NewRecorder()
@@ -557,7 +612,7 @@ func TestMigrateLegacyKeystoreWrongPassword(t *testing.T) {
 func TestMigrateLegacyKeystoreRequiresSpendPasswordMinLength(t *testing.T) {
 	fv := &fakeVault{exists: false, locked: true}
 	legacy := &fakeLegacyKeystore{exists: true, mnemonic: []byte("abandon abandon about")}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 
 	body := `{"name":"Imported","vault_password":"valid-vault-password","spend_password":"short"}`
 	rec := httptest.NewRecorder()
@@ -580,7 +635,7 @@ func TestAddWalletEnablesReadsAndSpend(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false}
 	fw := &fakeWallet{balance: wallet.Balance{Lovelace: "1234"}}
 	sp := &fakeSpender{}
-	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
@@ -609,7 +664,7 @@ func TestAddWalletRequiresSpendPassword(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
 	sp := &fakeSpender{}
-	h := NewHandler(st, fv, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","vault_password":"valid-vault-password","spend_password":"short"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -624,7 +679,7 @@ func TestAddWalletRequiresSpendPassword(t *testing.T) {
 func TestAddWalletRequiresVaultPassword(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -636,7 +691,7 @@ func TestAddWalletRequiresVaultPassword(t *testing.T) {
 func TestAddWalletNetworkMismatch(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"mainnet","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -648,7 +703,7 @@ func TestAddWalletNetworkMismatch(t *testing.T) {
 func TestAddWalletDefaultNetworkIsNodeNetwork(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preprod", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preprod", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -663,7 +718,7 @@ func TestAddWalletDefaultNetworkIsNodeNetwork(t *testing.T) {
 func TestAddWalletDuplicateConflict(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false, addErr: vault.ErrDuplicateWallet}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -676,7 +731,7 @@ func TestAddWalletDuplicateConflict(t *testing.T) {
 // mnemonic (24-word / 256-bit BIP39). It does not need a vault or a node —
 // the endpoint is ungated and uses only the bursa core lib.
 func TestGenerateMnemonic(t *testing.T) {
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/mnemonic/generate", nil))
 	if rec.Code != http.StatusOK {
@@ -708,7 +763,7 @@ func TestActivateWalletBinds(t *testing.T) {
 	}
 	fw := &fakeWallet{}
 	sp := &fakeSpender{}
-	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/w2/activate", nil))
 	if rec.Code != http.StatusOK {
@@ -731,7 +786,7 @@ func TestActivateWalletBinds(t *testing.T) {
 
 func TestActivateUnknownWallet(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/nope/activate", nil))
 	if rec.Code != http.StatusNotFound {
@@ -741,7 +796,7 @@ func TestActivateUnknownWallet(t *testing.T) {
 
 func TestDeleteWalletRequiresVaultPassword(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false, wallets: []vault.WalletMeta{{ID: "w1"}}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/wallet/w1", bytes.NewBufferString(`{}`)))
 	if rec.Code != http.StatusBadRequest {
@@ -756,7 +811,7 @@ func TestDeleteWalletOK(t *testing.T) {
 	}
 	fw := &fakeWallet{set: true}
 	sp := &fakeSpender{set: true}
-	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/wallet/w1", bytes.NewBufferString(`{"vault_password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusOK {
@@ -774,7 +829,7 @@ func TestDeleteWalletOK(t *testing.T) {
 
 func TestWalletGatedWhileStarting(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/balance", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -785,7 +840,7 @@ func TestWalletGatedWhileStarting(t *testing.T) {
 func TestWalletGatedWhileBootstrapping(t *testing.T) {
 	// Mithril bootstrap is not a servable state: reads must be gated (503).
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateBootstrapping}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/balance", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -798,7 +853,7 @@ func TestWalletNoActiveWalletConflict(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	for _, path := range []string{"/wallet/balance", "/wallet/addresses", "/wallet/transactions", "/wallet/transactions/tx1", "/wallet/delegation"} {
 		t.Run(path, func(t *testing.T) {
-			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
 			if rec.Code != http.StatusConflict {
@@ -823,7 +878,7 @@ func TestGetTransactionDetailOK(t *testing.T) {
 			Outputs: []wallet.TxIO{{Address: "addr_other", Lovelace: "3000000"}},
 		},
 	}
-	h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/transactions/tx1", nil))
 	if rec.Code != http.StatusOK {
@@ -846,7 +901,7 @@ func TestGetTransactionDetailNotFound(t *testing.T) {
 	// pool/DRep lookup convention ("not found by your node").
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fw := &fakeWallet{set: true, txDetailErr: chain.ErrNotFound}
-	h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/transactions/unknown", nil))
 	if rec.Code != http.StatusNotFound {
@@ -1128,7 +1183,7 @@ func (f *fakeDexQuoter) Quote(_ context.Context, assetIn, assetOut string, amoun
 func TestSignDataReturnsSignature(t *testing.T) {
 	// Ungated: message signing needs no synced node, only the keystore.
 	sp := &fakeSpender{signSig: "84a1deadbeef", signKey: "a4010103"}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"address":"addr_test1xyz","message":"hello","password":"pw"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-data", body))
@@ -1145,7 +1200,7 @@ func TestSignDataReturnsSignature(t *testing.T) {
 
 func TestSignDataWrongPasswordReturns401(t *testing.T) {
 	sp := &fakeSpender{signErr: fmt.Errorf("%w: bad", spend.ErrWrongPassword)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"address":"a","message":"m","password":"bad"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-data", body))
@@ -1157,7 +1212,7 @@ func TestSignDataWrongPasswordReturns401(t *testing.T) {
 func TestVerifyDataReturnsResult(t *testing.T) {
 	// Ungated: verification is pure crypto, needs no node and no keystore.
 	sp := &fakeSpender{verifyValid: true, verifyAddr: "addr_test1signed"}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"signature":"84a1","key":"a401","message":"hi","hashed":true,"expected_address":"addr_test1signed"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/verify-data", body))
@@ -1179,7 +1234,7 @@ func TestVerifyDataReturnsResult(t *testing.T) {
 
 func TestVerifyDataInvalidArgsReturns400(t *testing.T) {
 	sp := &fakeSpender{verifyErr: fmt.Errorf("%w: bad hex", spend.ErrInvalidRequest)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"signature":"zz","key":"a4","message":"hi"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/verify-data", body))
@@ -1190,7 +1245,7 @@ func TestVerifyDataInvalidArgsReturns400(t *testing.T) {
 
 func TestExportUnsignedRequiresReady(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend1/export-unsigned", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -1204,7 +1259,7 @@ func TestExportUnsignedReturnsTx(t *testing.T) {
 		UnsignedTxCBOR:  "84a400",
 		RequiredSigners: []string{"deadbeef"},
 	}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend1/export-unsigned", nil))
 	if rec.Code != http.StatusOK {
@@ -1222,7 +1277,7 @@ func TestSignTxUngated(t *testing.T) {
 	// Offline signing must not need a synced node -- only the keystore.
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
 	sp := &fakeSpender{witness: spend.Witness{WitnessCBOR: "81825820"}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","password":"pw","required_signers":["deadbeef"]}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-tx", body))
@@ -1242,7 +1297,7 @@ func TestSignTxUngated(t *testing.T) {
 
 func TestSignTxWrongPasswordReturns401(t *testing.T) {
 	sp := &fakeSpender{signTxErr: fmt.Errorf("%w: bad", spend.ErrWrongPassword)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","password":"bad","required_signers":["deadbeef"]}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-tx", body))
@@ -1253,7 +1308,7 @@ func TestSignTxWrongPasswordReturns401(t *testing.T) {
 
 func TestSignTxInvalidTxReturns400(t *testing.T) {
 	sp := &fakeSpender{signTxErr: fmt.Errorf("%w: bad cbor", spend.ErrInvalidTx)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"zz","password":"pw","required_signers":["deadbeef"]}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-tx", body))
@@ -1264,7 +1319,7 @@ func TestSignTxInvalidTxReturns400(t *testing.T) {
 
 func TestSubmitSignedRequiresReady(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witness_cbor":"81"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-signed", body))
@@ -1276,7 +1331,7 @@ func TestSubmitSignedRequiresReady(t *testing.T) {
 func TestSubmitSignedReturnsTxHash(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{submitResult: spend.TxResult{TxHash: "cafebabe"}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witness_cbor":"81825820"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-signed", body))
@@ -1294,7 +1349,7 @@ func TestSubmitSignedReturnsTxHash(t *testing.T) {
 func TestSubmitSignedInvalidWitnessReturns400(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{submitErr: fmt.Errorf("%w: bad cbor", spend.ErrInvalidWitness)}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witness_cbor":"zz"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-signed", body))
@@ -1306,7 +1361,7 @@ func TestSubmitSignedInvalidWitnessReturns400(t *testing.T) {
 func TestSpendSendReadyReturnsPreview(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{preview: spend.Preview{PendingID: "pend123", Fee: "170000"}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send", body))
@@ -1325,7 +1380,7 @@ func TestSpendSendReadyReturnsPreview(t *testing.T) {
 func TestSpendSendGatedWhileSyncing(t *testing.T) {
 	// Spending requires a fully synced node (StateReady), unlike reads.
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send", body))
@@ -1337,7 +1392,7 @@ func TestSpendSendGatedWhileSyncing(t *testing.T) {
 func TestSpendSendNoWalletConflict(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{buildErr: spend.ErrNoWallet}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send", body))
@@ -1349,7 +1404,7 @@ func TestSpendSendNoWalletConflict(t *testing.T) {
 func TestSpendConfirmReadyReturnsTxHash(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{result: spend.TxResult{TxHash: "deadbeef"}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-spend-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend123/confirm", body))
@@ -1370,7 +1425,7 @@ func TestSpendConfirmReadyReturnsTxHash(t *testing.T) {
 
 func TestSpendConfirmGatedWhileSyncing(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-spend-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend123/confirm", body))
@@ -1410,7 +1465,7 @@ func TestSpendErrorStatusCodes(t *testing.T) {
 				req = httptest.NewRequest(http.MethodPost, "/wallet/send",
 					bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`))
 			}
-			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
 			if rec.Code != tc.wantCode {
@@ -1452,7 +1507,7 @@ func TestGetHistoryExpiryReturnsState(t *testing.T) {
 	// node query).
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStopped}}
 	set := &fakeSettings{enabled: true, restartRequired: true}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/settings/history-expiry", nil))
 	if rec.Code != http.StatusOK {
@@ -1467,7 +1522,7 @@ func TestGetHistoryExpiryReturnsState(t *testing.T) {
 func TestGetHistoryExpiryDefaultOff(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{} // default off, no restart needed
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/settings/history-expiry", nil))
 	got := decodeHistoryExpiry(t, rec.Body)
@@ -1480,7 +1535,7 @@ func TestPutHistoryExpiryPersistsAndSignalsRestart(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	// Running node was built with off; flipping to on must signal a restart.
 	set := &fakeSettings{enabled: false, restartRequired: true}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"enabled":true}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
@@ -1502,7 +1557,7 @@ func TestPutHistoryExpiryPersistsAndSignalsRestart(t *testing.T) {
 func TestPutHistoryExpiryInvalidJSON(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{not json`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
@@ -1519,7 +1574,7 @@ func TestPutHistoryExpiryRequiresExplicitEnabled(t *testing.T) {
 		t.Run(bodyJSON, func(t *testing.T) {
 			st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 			set := &fakeSettings{}
-			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
 			body := bytes.NewBufferString(bodyJSON)
 			h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
@@ -1536,7 +1591,7 @@ func TestPutHistoryExpiryRequiresExplicitEnabled(t *testing.T) {
 func TestPutHistoryExpiryPersistError(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{setErr: errors.New("disk full")}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"enabled":true}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
@@ -1562,7 +1617,7 @@ func decodeAutoLock(t *testing.T, body *bytes.Buffer) int {
 func TestGetAutoLockReturnsPersistedValue(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStopped}}
 	set := &fakeSettings{autoLockMinutes: 30}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/settings/auto-lock", nil))
 	if rec.Code != http.StatusOK {
@@ -1576,7 +1631,7 @@ func TestGetAutoLockReturnsPersistedValue(t *testing.T) {
 func TestPutAutoLockPersists(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{autoLockMinutes: 15}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"minutes":5}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
@@ -1594,7 +1649,7 @@ func TestPutAutoLockPersists(t *testing.T) {
 func TestPutAutoLockAcceptsOff(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{autoLockMinutes: 15}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"minutes":0}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
@@ -1609,7 +1664,7 @@ func TestPutAutoLockAcceptsOff(t *testing.T) {
 func TestPutAutoLockInvalidJSON(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{not json`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
@@ -1624,7 +1679,7 @@ func TestPutAutoLockInvalidJSON(t *testing.T) {
 func TestPutAutoLockRequiresExplicitMinutes(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
@@ -1640,7 +1695,7 @@ func TestPutAutoLockRejectsOutOfSetValue(t *testing.T) {
 	for _, bad := range []int{-1, 2, 60} {
 		st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 		set := &fakeSettings{}
-		h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+		h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
 		body := bytes.NewBufferString(fmt.Sprintf(`{"minutes":%d}`, bad))
 		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
@@ -1656,7 +1711,7 @@ func TestPutAutoLockRejectsOutOfSetValue(t *testing.T) {
 func TestPutAutoLockPersistError(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{setAutoLockErr: errors.New("disk full")}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"minutes":5}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
@@ -1687,6 +1742,148 @@ func TestAutoLockOptionsMatchesSettingsPackage(t *testing.T) {
 	}
 }
 
+// --- Address book (local-only contacts) ---
+
+func decodeContactEntry(t *testing.T, body *bytes.Buffer) contacts.Entry {
+	t.Helper()
+	var got contacts.Entry
+	if err := json.Unmarshal(body.Bytes(), &got); err != nil {
+		t.Fatalf("decode contact entry: %v (body=%s)", err, body.String())
+	}
+	return got
+}
+
+func TestContactsListReturnsEntries(t *testing.T) {
+	cb := &fakeContacts{entries: []contacts.Entry{
+		{ID: "c1", Name: "Alice", Address: "addr_test1alice"},
+		{ID: "c2", Name: "Bob", Address: "addr_test1bob", Note: "friend"},
+	}}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/contacts", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /wallet/contacts = %d, want 200", rec.Code)
+	}
+	var got []contacts.Entry
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d entries, want 2", len(got))
+	}
+}
+
+// GET /wallet/contacts must answer even while the node is stopped: it is pure
+// local storage, not a node query.
+func TestContactsListUngated(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStopped}}
+	cb := &fakeContacts{}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/contacts", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /wallet/contacts while stopped = %d, want 200", rec.Code)
+	}
+}
+
+func TestContactsCreateGeneratesEntry(t *testing.T) {
+	cb := &fakeContacts{}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"name":"Alice","address":"addr_test1alice","note":"friend"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/contacts", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /wallet/contacts = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	got := decodeContactEntry(t, rec.Body)
+	if got.ID == "" {
+		t.Fatal("created contact should have a generated ID")
+	}
+	if got.Name != "Alice" || got.Address != "addr_test1alice" || got.Note != "friend" {
+		t.Fatalf("created contact = %+v, want name/address/note echoed back", got)
+	}
+	if len(cb.entries) != 1 {
+		t.Fatalf("fake store has %d entries, want 1", len(cb.entries))
+	}
+}
+
+func TestContactsUpdateExistingByID(t *testing.T) {
+	cb := &fakeContacts{entries: []contacts.Entry{{ID: "c1", Name: "Alice", Address: "addr_test1alice"}}}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"id":"c1","name":"Alice Updated","address":"addr_test1alice2"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/contacts", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST update = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	got := decodeContactEntry(t, rec.Body)
+	if got.ID != "c1" || got.Name != "Alice Updated" || got.Address != "addr_test1alice2" {
+		t.Fatalf("updated contact = %+v", got)
+	}
+	if len(cb.entries) != 1 {
+		t.Fatalf("update must not create a duplicate entry, got %d entries", len(cb.entries))
+	}
+}
+
+func TestContactsUpsertUnknownIDReturns404(t *testing.T) {
+	cb := &fakeContacts{}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"id":"missing","name":"Ghost","address":"addr_test1ghost"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/contacts", body))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("POST with unknown id = %d, want 404 (body=%s)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestContactsCreateValidationErrorReturns400(t *testing.T) {
+	cb := &fakeContacts{}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"name":"","address":"addr_test1alice"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/contacts", body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("POST with blank name = %d, want 400 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if len(cb.entries) != 0 {
+		t.Fatal("a rejected create must not persist anything")
+	}
+}
+
+func TestContactsCreateInvalidJSONReturns400(t *testing.T) {
+	cb := &fakeContacts{}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{not json`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/contacts", body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("POST with bad JSON = %d, want 400", rec.Code)
+	}
+}
+
+func TestContactsDeleteOK(t *testing.T) {
+	cb := &fakeContacts{entries: []contacts.Entry{{ID: "c1", Name: "Alice", Address: "addr_test1alice"}}}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/wallet/contacts/c1", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("DELETE /wallet/contacts/c1 = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if len(cb.entries) != 0 {
+		t.Fatal("contact should have been removed")
+	}
+}
+
+func TestContactsDeleteUnknownReturns404(t *testing.T) {
+	cb := &fakeContacts{}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/wallet/contacts/nope", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("DELETE unknown id = %d, want 404", rec.Code)
+	}
+}
+
 // --- Pool operations (SPO) ---
 
 // readyStatuser returns a fully-synced node for pool ops that need a node.
@@ -1696,7 +1893,7 @@ func readyStatuser() fakeStatuser {
 
 func TestPoolCredentialsReturnsCreds(t *testing.T) {
 	po := &fakePoolOps{creds: poolops.Credentials{PoolID: "pool1abc", Network: "preview"}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"spend-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/credentials", body))
@@ -1713,7 +1910,7 @@ func TestPoolCredentialsReturnsCreds(t *testing.T) {
 
 func TestPoolCredentialsRejectsTrailingJSON(t *testing.T) {
 	po := &fakePoolOps{creds: poolops.Credentials{PoolID: "pool1abc", Network: "preview"}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"spend-password"} {"password":"ignored"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/credentials", body))
@@ -1727,7 +1924,7 @@ func TestPoolCredentialsRejectsTrailingJSON(t *testing.T) {
 
 func TestPoolCredentialsNoWalletConflict(t *testing.T) {
 	po := &fakePoolOps{credErr: poolops.ErrNoWallet}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"x"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/credentials", body))
@@ -1738,7 +1935,7 @@ func TestPoolCredentialsNoWalletConflict(t *testing.T) {
 
 func TestPoolCredentialsWrongPassword401(t *testing.T) {
 	po := &fakePoolOps{credErr: fmt.Errorf("%w: bad", poolops.ErrWrongPassword)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"bad"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/credentials", body))
@@ -1749,7 +1946,7 @@ func TestPoolCredentialsWrongPassword401(t *testing.T) {
 
 func TestPoolKESPeriodGatedWhileStarting(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/pool/kes-period", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -1759,7 +1956,7 @@ func TestPoolKESPeriodGatedWhileStarting(t *testing.T) {
 
 func TestPoolKESPeriodReady(t *testing.T) {
 	po := &fakePoolOps{kes: poolops.KESPeriodInfo{CurrentPeriod: 7, SlotsPerKESPeriod: 129600}}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/pool/kes-period", nil))
 	if rec.Code != http.StatusOK {
@@ -1776,7 +1973,7 @@ func TestPoolKESPeriodReady(t *testing.T) {
 
 func TestPoolOpCertIssue(t *testing.T) {
 	po := &fakePoolOps{opcert: poolops.OpCert{IssueNumber: 3, KesPeriod: 7, KesVKeyHex: "abcd"}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","kes_index":0,"issue_number":3,"kes_period":7}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/opcert", body))
@@ -1793,7 +1990,7 @@ func TestPoolOpCertIssue(t *testing.T) {
 
 func TestPoolOpCertRotate(t *testing.T) {
 	po := &fakePoolOps{opcert: poolops.OpCert{IssueNumber: 4, KESIndex: 1}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","new_kes_index":1,"prev_issue_number":3,"kes_period":7}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/opcert/rotate", body))
@@ -1817,7 +2014,7 @@ func TestPoolOpCertPayloadAndAssembleAirGap(t *testing.T) {
 		payload: poolops.OpCertPayload{PayloadHex: "8203", KesVKeyHex: "ab"},
 		opcert:  poolops.OpCert{IssueNumber: 1},
 	}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"kes_vkey_hex":"ab","issue_number":1,"kes_period":2}`)
@@ -1842,7 +2039,7 @@ func TestPoolOpCertPayloadAndAssembleAirGap(t *testing.T) {
 
 func TestPoolAssembleOpCertBadSignature400(t *testing.T) {
 	po := &fakePoolOps{opcertErr: fmt.Errorf("%w: bad sig", poolops.ErrInvalidRequest)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"cold_vkey_hex":"aa","kes_vkey_hex":"bb","signature_hex":"00","issue_number":1,"kes_period":2}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/opcert/assemble", body))
@@ -1853,7 +2050,7 @@ func TestPoolAssembleOpCertBadSignature400(t *testing.T) {
 
 func TestPoolMetadataBuilder(t *testing.T) {
 	po := &fakePoolOps{metadata: poolops.MetadataResult{JSON: `{"name":"P"}`, HashHex: "deadbeef"}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"name":"P","ticker":"POOL","homepage":"https://x","description":"d"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/metadata", body))
@@ -1868,7 +2065,7 @@ func TestPoolMetadataBuilder(t *testing.T) {
 
 func TestPoolIDFromColdVKey(t *testing.T) {
 	po := &fakePoolOps{poolID: "pool1xyz", poolIDHex: "abcdef1234"}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"cold_vkey_hex":"` + strings.Repeat("ab", 32) + `"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/id", body))
@@ -1889,7 +2086,7 @@ func TestPoolIDFromColdVKey(t *testing.T) {
 
 func TestPoolRegistrationSeedAndAirGap(t *testing.T) {
 	po := &fakePoolOps{cert: poolops.CertResult{PoolID: "pool1reg", CBORHex: "8a03"}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","pledge":1,"cost":1,"margin_num":1,"margin_denom":50}`)
@@ -1914,7 +2111,7 @@ func TestPoolRegistrationSeedAndAirGap(t *testing.T) {
 
 func TestPoolRegistrationAcceptsStringAmounts(t *testing.T) {
 	po := &fakePoolOps{cert: poolops.CertResult{PoolID: "pool1reg", CBORHex: "8a03"}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","pledge":"9007199254740993","cost":"18446744073709551615","margin_num":1,"margin_denom":50}`)
@@ -1929,7 +2126,7 @@ func TestPoolRegistrationAcceptsStringAmounts(t *testing.T) {
 
 func TestPoolRetirementCert(t *testing.T) {
 	po := &fakePoolOps{cert: poolops.CertResult{PoolID: "pool1ret", CBORHex: "8304"}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","epoch":500}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/retirement/cert", body))
@@ -1953,7 +2150,7 @@ func TestPoolRetirementCert(t *testing.T) {
 
 func TestPoolRetirementSubmitGatedWhileSyncing(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","epoch":500}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/retirement/submit", body))
@@ -1964,7 +2161,7 @@ func TestPoolRetirementSubmitGatedWhileSyncing(t *testing.T) {
 
 func TestPoolRetirementSubmitReady(t *testing.T) {
 	po := &fakePoolOps{tx: poolops.TxResult{TxHash: "feedface"}}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","epoch":500}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/retirement/submit", body))
@@ -1978,7 +2175,7 @@ func TestPoolRetirementSubmitReady(t *testing.T) {
 
 func TestPoolRetirementSubmitRejected422(t *testing.T) {
 	po := &fakePoolOps{submitErr: fmt.Errorf("%w: ledger rule X", poolops.ErrSubmitRejected)}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","epoch":500}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/retirement/submit", body))
@@ -1997,7 +2194,7 @@ func TestVaultUnlockAttachesPoolWallet(t *testing.T) {
 		locked:  true,
 		wallets: []vault.WalletMeta{{ID: "w1", Name: "main", Network: "preview", Account: sampleAccount("preview")}},
 	}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusOK {
@@ -2017,7 +2214,7 @@ func TestTPMStatusReturnsProbeResult(t *testing.T) {
 		Enabled:   false,
 		PCRBound:  false,
 	}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/tpm/status", nil))
 	if rec.Code != http.StatusOK {
@@ -2039,7 +2236,7 @@ func TestTPMStatusReturnsUnavailableWithReason(t *testing.T) {
 		Enabled:   false,
 		PCRBound:  false,
 	}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/tpm/status", nil))
 	if rec.Code != http.StatusOK {
@@ -2060,7 +2257,7 @@ func TestTPMStatusReturnsEnabledAndPCRBound(t *testing.T) {
 		Enabled:   true,
 		PCRBound:  true,
 	}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/tpm/status", nil))
 	if rec.Code != http.StatusOK {
@@ -2077,7 +2274,7 @@ func TestTPMStatusReturnsEnabledAndPCRBound(t *testing.T) {
 
 func TestEnableTPMCallsVaultMethodWithPassword(t *testing.T) {
 	fv := &fakeVault{tpmStatus: vault.TPMStatusInfo{Available: true}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-vault-password","pcrBound":true}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/enable", body))
@@ -2097,7 +2294,7 @@ func TestEnableTPMCallsVaultMethodWithPassword(t *testing.T) {
 
 func TestEnableTPMWithoutPCRBound(t *testing.T) {
 	fv := &fakeVault{tpmStatus: vault.TPMStatusInfo{Available: true}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-vault-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/enable", body))
@@ -2114,7 +2311,7 @@ func TestEnableTPMWrongPasswordReturns401(t *testing.T) {
 		tpmStatus:    vault.TPMStatusInfo{Available: true},
 		enableTPMErr: fmt.Errorf("%w: bad", vault.ErrWrongPassword),
 	}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"wrong-but-long-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/enable", body))
@@ -2128,7 +2325,7 @@ func TestEnableTPMUnavailableReturns409(t *testing.T) {
 		tpmStatus:    vault.TPMStatusInfo{Available: false, Reason: "no device"},
 		enableTPMErr: fmt.Errorf("%w: no device", vault.ErrTPMUnavailable),
 	}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-vault-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/enable", body))
@@ -2142,7 +2339,7 @@ func TestEnableTPMRequiresPassword(t *testing.T) {
 	// MinPasswordLen floor (via requirePassword) without touching the vault.
 	for _, body := range []string{`{}`, `{"password":"short"}`} {
 		fv := &fakeVault{tpmStatus: vault.TPMStatusInfo{Available: true}}
-		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/enable", bytes.NewBufferString(body)))
 		if rec.Code != http.StatusBadRequest {
@@ -2156,7 +2353,7 @@ func TestEnableTPMRequiresPassword(t *testing.T) {
 
 func TestDisableTPMCallsVaultMethodWithPassword(t *testing.T) {
 	fv := &fakeVault{}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-vault-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/disable", body))
@@ -2173,7 +2370,7 @@ func TestDisableTPMCallsVaultMethodWithPassword(t *testing.T) {
 
 func TestDisableTPMWrongPasswordReturns401(t *testing.T) {
 	fv := &fakeVault{disableTPMErr: fmt.Errorf("%w: bad", vault.ErrWrongPassword)}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"wrong-but-long-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/disable", body))
@@ -2187,7 +2384,7 @@ func TestDisableTPMRequiresPassword(t *testing.T) {
 	// MinPasswordLen floor (via requirePassword) without touching the vault.
 	for _, body := range []string{`{}`, `{"password":"short"}`} {
 		fv := &fakeVault{}
-		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/disable", bytes.NewBufferString(body)))
 		if rec.Code != http.StatusBadRequest {
@@ -2205,7 +2402,7 @@ func TestTPMRoutesRejectTrailingJSON(t *testing.T) {
 	// rejected without touching the vault.
 	for _, route := range []string{"/vault/tpm/enable", "/vault/tpm/disable"} {
 		fv := &fakeVault{tpmStatus: vault.TPMStatusInfo{Available: true}}
-		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
 		body := bytes.NewBufferString(`{"password":"valid-vault-password"}{"junk":true}`)
 		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, route, body))
@@ -2245,7 +2442,7 @@ func (f *fakeNodeLookup) AssetAddresses(_ context.Context, asset string) ([]chai
 }
 
 func TestHandleLookupUnavailableWithoutLookup(t *testing.T) {
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "mainnet", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "mainnet", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/chris", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -2255,7 +2452,7 @@ func TestHandleLookupUnavailableWithoutLookup(t *testing.T) {
 
 func TestHandleLookupResolvesOnMainnet(t *testing.T) {
 	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr1abc", Quantity: "1"}}}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, lk, &fakePoolOps{}, nil, "mainnet", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, "mainnet", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusOK {
@@ -2276,7 +2473,7 @@ func TestHandleLookupResolvesOnMainnet(t *testing.T) {
 
 func TestHandleLookupResolvesOnPreview(t *testing.T) {
 	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr_test1abc", Quantity: "1"}}}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, lk, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusOK {
@@ -2297,7 +2494,7 @@ func TestHandleLookupResolvesOnPreview(t *testing.T) {
 
 func TestHandleLookupWithoutDollarSign(t *testing.T) {
 	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr1abc"}}}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, lk, &fakePoolOps{}, nil, "mainnet", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, "mainnet", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/chris", nil))
 	if rec.Code != http.StatusOK {
@@ -2307,7 +2504,7 @@ func TestHandleLookupWithoutDollarSign(t *testing.T) {
 
 func TestHandleLookupNotFoundOnInvalidNetwork(t *testing.T) {
 	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr1abc"}}}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, lk, &fakePoolOps{}, nil, "mainnte", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, "mainnte", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusNotFound {
@@ -2320,7 +2517,7 @@ func TestHandleLookupNotFoundOnInvalidNetwork(t *testing.T) {
 
 func TestHandleLookupNotFoundWhenNodeHasNotSeenAsset(t *testing.T) {
 	lk := &fakeNodeLookup{assetErr: chain.ErrNotFound}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, lk, &fakePoolOps{}, nil, "mainnet", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, "mainnet", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusNotFound {
@@ -2330,7 +2527,7 @@ func TestHandleLookupNotFoundWhenNodeHasNotSeenAsset(t *testing.T) {
 
 func TestHandleLookupBadGatewayOnHardError(t *testing.T) {
 	lk := &fakeNodeLookup{assetErr: errors.New("node exploded")}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, lk, &fakePoolOps{}, nil, "mainnet", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, "mainnet", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusBadGateway {
@@ -2341,7 +2538,7 @@ func TestHandleLookupBadGatewayOnHardError(t *testing.T) {
 func TestHandleLookupGatedWhileStarting(t *testing.T) {
 	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr1abc"}}}
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, lk, &fakePoolOps{}, nil, "mainnet", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, "mainnet", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -2353,7 +2550,7 @@ func TestDexRoutesAbsentWhenQuoterNil(t *testing.T) {
 	// dx is nil unless the node is on mainnet (see NewHandler wiring); the DEX
 	// routes must not be registered at all, so they fall through to the SPA/404
 	// handler rather than e.g. panicking on a nil DexQuoter.
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/dex/pools", nil))
@@ -2373,7 +2570,7 @@ func TestDexPoolsReturnsOK(t *testing.T) {
 	dx := &fakeDexQuoter{pools: []dex.Pool{
 		{Protocol: "minswap-v2", PoolID: "pool1", AssetX: "lovelace", AssetY: "deadbeef"},
 	}}
-	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, dx, "mainnet", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, "mainnet", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/dex/pools", nil))
@@ -2396,7 +2593,7 @@ func TestDexPoolsRequiresReadyNode(t *testing.T) {
 	// cannot yet serve queries must return 503, not reach the DexQuoter.
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
 	dx := &fakeDexQuoter{}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, dx, "mainnet", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, "mainnet", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/dex/pools", nil))
@@ -2410,7 +2607,7 @@ func TestDexQuoteReturnsOK(t *testing.T) {
 		Protocol: "minswap-v2", AssetIn: "lovelace", AssetOut: "deadbeef",
 		AmountIn: "1000000", AmountOut: "500000", Route: "minswap-v2 lovelace→deadbeef",
 	}}
-	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, dx, "mainnet", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, "mainnet", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"asset_in":"lovelace","asset_out":"deadbeef","amount_in":"1000000"}`)
@@ -2433,7 +2630,7 @@ func TestDexQuoteReturnsOK(t *testing.T) {
 
 func TestDexQuoteInvalidAmountReturns400(t *testing.T) {
 	dx := &fakeDexQuoter{}
-	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, dx, "mainnet", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, "mainnet", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"asset_in":"lovelace","asset_out":"deadbeef","amount_in":"not-a-number"}`)
@@ -2448,7 +2645,7 @@ func TestDexQuoteInvalidAmountReturns400(t *testing.T) {
 
 func TestDexQuoteRejectsTrailingJSON(t *testing.T) {
 	dx := &fakeDexQuoter{}
-	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, dx, "mainnet", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, "mainnet", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"asset_in":"lovelace","asset_out":"deadbeef","amount_in":"1000000"}{"junk":true}`)
@@ -2477,7 +2674,7 @@ func TestDexQuoteErrorMapping(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			dx := &fakeDexQuoter{quoteErr: tc.err}
-			h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, dx, "mainnet", http.NotFoundHandler())
+			h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, "mainnet", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
 			body := bytes.NewBufferString(`{"asset_in":"lovelace","asset_out":"deadbeef","amount_in":"1000000"}`)
 			h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/dex/quote", body))

--- a/ui/internal/boot/boot.go
+++ b/ui/internal/boot/boot.go
@@ -36,6 +36,7 @@ import (
 	"github.com/blinklabs-io/bursa/ui/internal/api"
 	"github.com/blinklabs-io/bursa/ui/internal/cardanonet"
 	"github.com/blinklabs-io/bursa/ui/internal/chain"
+	"github.com/blinklabs-io/bursa/ui/internal/contacts"
 	"github.com/blinklabs-io/bursa/ui/internal/dex"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/poolops"
@@ -187,6 +188,15 @@ func Boot(ctx context.Context, cfg Config) (*App, error) {
 		return nil, fmt.Errorf("seed lean-node default: %w", err)
 	}
 
+	// The address book is local-only, per-instance storage. It is non-essential:
+	// a corrupt contacts file should not brick startup, so boot with an empty
+	// in-memory book and leave the bad file untouched for manual recovery.
+	contactsStore, contactsWarn := contacts.LoadOrEmpty(filepath.Join(cfg.DataDir, "contacts.json"))
+	if contactsWarn != nil {
+		logger.Warn("address book could not be loaded; continuing with an empty one",
+			"error", contactsWarn)
+	}
+
 	nodeDataDir := filepath.Join(cfg.DataDir, "db")
 	sup := supervisor.New(supervisor.Config{
 		Network:        cfg.Network,
@@ -270,6 +280,7 @@ func Boot(ctx context.Context, cfg Config) (*App, error) {
 		Handler: api.NewHandler(
 			sup, vlt, walletSvc, spendSvc,
 			&settingsController{store: settingsStore, sup: sup},
+			contactsStore,
 			chainClient,
 			poolSvc,
 			dexSvc,

--- a/ui/internal/contacts/contacts.go
+++ b/ui/internal/contacts/contacts.go
@@ -1,0 +1,410 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package contacts persists the user's local address book (saved recipient
+// addresses with a friendly name and optional note) in the data dir as a small
+// JSON file. It is pure on-device storage: it never makes a network call and
+// never imports an address list from anywhere — the wallet's consent law
+// requires every external contact (favicon, name-service lookup, etc.) to stay
+// off the table for this feature. Writes are atomic (temp file + rename) so a
+// crash can never leave a half-written contacts file, and reads tolerate a
+// missing file (an empty address book), mirroring internal/settings.
+package contacts
+
+import (
+	cryptorand "crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// contactsVersion lets the on-disk format evolve without a hard break.
+const contactsVersion = 1
+
+// maxContactsLen caps Load's read of the contacts file. A real address book is
+// at most a few hundred entries; anything larger than this is not one of ours.
+const maxContactsLen = 1 * 1024 * 1024
+
+// Per-field caps enforced by Upsert, plus a matching entry-count cap, are
+// chosen so that a contacts file at the absolute maximum (maxEntries entries,
+// each field at its cap) stays comfortably under maxContactsLen above: this
+// keeps the read cap and the write path symmetric, so Upsert can never
+// silently produce a file that a later Load would refuse to read back.
+// writeLocked also enforces maxContactsLen directly as a defense-in-depth
+// backstop, in case these per-field caps are ever bypassed or miscalculated.
+const (
+	maxNameLen    = 256  // bytes, after trimming
+	maxAddressLen = 256  // bytes; real bech32/Byron addresses are far shorter, this is a defensive backstop
+	maxNoteLen    = 1024 // bytes, after trimming
+	maxEntries    = 500  // hard cap on the number of stored contacts
+)
+
+// ErrNotFound is returned by Upsert (update path) and Delete when the given ID
+// does not match any stored contact.
+var ErrNotFound = errors.New("contact not found")
+
+// ErrInvalidRequest is returned when a contact fails validation: a blank name,
+// a blank address, or an address that does not parse as a syntactically valid
+// Cardano address.
+var ErrInvalidRequest = errors.New("invalid contact")
+
+// Entry is one address-book contact. ID is server-generated and empty on a
+// create request; Note is optional.
+type Entry struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Address string `json:"address"`
+	Note    string `json:"note,omitempty"`
+}
+
+// data is the on-disk shape.
+type data struct {
+	Version int     `json:"version"`
+	Entries []Entry `json:"entries"`
+}
+
+// Store is a contacts file at Path. It is safe for concurrent use: every
+// method takes the mutex, and the in-memory snapshot is the authority once
+// loaded.
+type Store struct {
+	path string
+
+	mu sync.Mutex
+	d  data
+}
+
+// Load opens (or initializes) the contacts store at path. A missing file is
+// not an error — it yields an empty address book. A present but corrupt file
+// IS an error: silently discarding a user's saved contacts would be
+// surprising.
+func Load(path string) (*Store, error) {
+	s := &Store{path: path, d: data{Version: contactsVersion}}
+	blob, err := readFileCapped(path, maxContactsLen)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return s, nil
+		}
+		if errors.Is(err, errContactsTooLarge) {
+			return nil, fmt.Errorf("contacts file exceeds %d bytes", maxContactsLen)
+		}
+		return nil, fmt.Errorf("read contacts: %w", err)
+	}
+	var d data
+	if err := json.Unmarshal(blob, &d); err != nil {
+		return nil, fmt.Errorf("parse contacts %s: %w", path, err)
+	}
+	// Reject a file from a newer format version outright rather than loading
+	// it: writeLocked always stamps the current contactsVersion on save, so
+	// silently accepting it here would let this (older) build immediately
+	// rewrite the file as v1 on the next Upsert/Delete, permanently dropping
+	// any fields a newer version added.
+	if d.Version > contactsVersion {
+		return nil, fmt.Errorf("contacts file %s has version %d, newer than supported version %d", path, d.Version, contactsVersion)
+	}
+	d, err = normalizeLoadedData(d)
+	if err != nil {
+		return nil, fmt.Errorf("contacts file %s is invalid: %w", path, err)
+	}
+	s.d = d
+	return s, nil
+}
+
+// LoadOrEmpty behaves like Load, except a bad file (corrupt or oversized)
+// never prevents the caller from proceeding: it returns a fresh, empty store
+// together with the error Load would have returned, instead of that error
+// alone. Contacts are non-essential user data — unlike settings or the vault,
+// losing access to the address book must not stop the wallet from starting —
+// so callers on the startup path should use this instead of Load, log the
+// returned error as a warning, and continue with the empty store. The bad
+// file on disk is left untouched (never deleted or overwritten here), so it
+// remains available for manual recovery; it will only be overwritten if the
+// caller later performs a write (e.g. Upsert) against the returned Store.
+func LoadOrEmpty(path string) (*Store, error) {
+	s, err := Load(path)
+	if err != nil {
+		return &Store{path: path, d: data{Version: contactsVersion}}, err
+	}
+	return s, nil
+}
+
+func normalizeLoadedData(d data) (data, error) {
+	if len(d.Entries) > maxEntries {
+		return data{}, fmt.Errorf("has %d entries, max %d", len(d.Entries), maxEntries)
+	}
+	normalized := data{Version: d.Version, Entries: make([]Entry, len(d.Entries))}
+	seenIDs := make(map[string]struct{}, len(d.Entries))
+	for i, entry := range d.Entries {
+		id := strings.TrimSpace(entry.ID)
+		if id == "" {
+			return data{}, fmt.Errorf("entry %d has empty id", i)
+		}
+		if _, ok := seenIDs[id]; ok {
+			return data{}, fmt.Errorf("entry %d duplicates id %q", i, id)
+		}
+		seenIDs[id] = struct{}{}
+		name, addr, note, err := validateEntryFields(entry)
+		if err != nil {
+			return data{}, fmt.Errorf("entry %d: %w", i, err)
+		}
+		normalized.Entries[i] = Entry{ID: id, Name: name, Address: addr, Note: note}
+	}
+	return normalized, nil
+}
+
+// List returns a copy of all contacts, sorted by name (case-insensitive, ID as
+// a stable tiebreaker) so the UI shows a predictable order regardless of
+// insertion order. The returned slice and its elements are safe to mutate
+// without affecting the store.
+func (s *Store) List() []Entry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Entry, len(s.d.Entries))
+	copy(out, s.d.Entries)
+	sort.Slice(out, func(i, j int) bool {
+		ni, nj := strings.ToLower(out[i].Name), strings.ToLower(out[j].Name)
+		if ni != nj {
+			return ni < nj
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+// Upsert creates a new contact (when in.ID is empty) or updates an existing
+// one (when in.ID matches a stored contact). Name and Address are required
+// (trimmed of surrounding whitespace); Address must parse as a syntactically
+// valid Cardano address. Note is optional and trimmed. On success the final,
+// normalized Entry is returned.
+func (s *Store) Upsert(in Entry) (Entry, error) {
+	name, addr, note, err := validateEntryFields(in)
+	if err != nil {
+		return Entry{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	old := s.d
+
+	entry := Entry{Name: name, Address: addr, Note: note}
+	id := strings.TrimSpace(in.ID)
+	if id == "" {
+		if len(s.d.Entries) >= maxEntries {
+			return Entry{}, fmt.Errorf("%w: address book is full (max %d contacts)", ErrInvalidRequest, maxEntries)
+		}
+		gid, err := newID()
+		if err != nil {
+			return Entry{}, fmt.Errorf("create contact: %w", err)
+		}
+		entry.ID = gid
+		// Appending beyond the current length never touches the elements the
+		// old snapshot's slice header can see, so `old` stays valid for
+		// rollback even though it shares a backing array with s.d.Entries.
+		s.d.Entries = append(s.d.Entries, entry)
+	} else {
+		idx := indexOf(s.d.Entries, id)
+		if idx < 0 {
+			return Entry{}, fmt.Errorf("%w: %s", ErrNotFound, id)
+		}
+		entry.ID = id
+		// Copy-on-write: mutating s.d.Entries[idx] in place would also mutate
+		// old.Entries (same backing array), corrupting the rollback snapshot.
+		updated := make([]Entry, len(s.d.Entries))
+		copy(updated, s.d.Entries)
+		updated[idx] = entry
+		s.d.Entries = updated
+	}
+
+	if err := s.persistOrRollback(old); err != nil {
+		return Entry{}, err
+	}
+	return entry, nil
+}
+
+func validateEntryFields(in Entry) (name string, addr string, note string, err error) {
+	name = strings.TrimSpace(in.Name)
+	if name == "" {
+		return "", "", "", fmt.Errorf("%w: name is required", ErrInvalidRequest)
+	}
+	if len(name) > maxNameLen {
+		return "", "", "", fmt.Errorf("%w: name exceeds %d bytes", ErrInvalidRequest, maxNameLen)
+	}
+	addr = strings.TrimSpace(in.Address)
+	if addr == "" {
+		return "", "", "", fmt.Errorf("%w: address is required", ErrInvalidRequest)
+	}
+	if len(addr) > maxAddressLen {
+		return "", "", "", fmt.Errorf("%w: address exceeds %d bytes", ErrInvalidRequest, maxAddressLen)
+	}
+	if _, err := lcommon.NewAddress(addr); err != nil {
+		return "", "", "", fmt.Errorf("%w: invalid address %q: %w", ErrInvalidRequest, addr, err)
+	}
+	note = strings.TrimSpace(in.Note)
+	if len(note) > maxNoteLen {
+		return "", "", "", fmt.Errorf("%w: note exceeds %d bytes", ErrInvalidRequest, maxNoteLen)
+	}
+	return name, addr, note, nil
+}
+
+// Delete removes the contact with the given ID. Returns ErrNotFound if no
+// contact has that ID.
+func (s *Store) Delete(id string) error {
+	id = strings.TrimSpace(id)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := indexOf(s.d.Entries, id)
+	if idx < 0 {
+		return fmt.Errorf("%w: %s", ErrNotFound, id)
+	}
+	old := s.d
+
+	remaining := make([]Entry, 0, len(s.d.Entries)-1)
+	remaining = append(remaining, s.d.Entries[:idx]...)
+	remaining = append(remaining, s.d.Entries[idx+1:]...)
+	s.d.Entries = remaining
+
+	if err := s.persistOrRollback(old); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Store) persistOrRollback(old data) error {
+	if committed, err := s.writeLocked(); err != nil {
+		if !committed {
+			s.d = old
+		}
+		return err
+	}
+	return nil
+}
+
+// indexOf returns the index of the entry with the given id, or -1.
+func indexOf(entries []Entry, id string) int {
+	for i, e := range entries {
+		if e.ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+// newID returns a 16-byte random hex contact id. Random (not sequential) so an
+// id leaks nothing about creation order or contact count. crypto/rand.Read's
+// error is propagated rather than ignored: silently swallowing it would risk
+// handing back an all-zero (or otherwise under-random) id.
+func newID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := cryptorand.Read(b); err != nil {
+		return "", fmt.Errorf("generate contact id: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+var errContactsTooLarge = errors.New("contacts file too large")
+
+func readFileCapped(path string, maxLen int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() > maxLen {
+		return nil, errContactsTooLarge
+	}
+	blob, err := io.ReadAll(io.LimitReader(f, maxLen+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(blob)) > maxLen {
+		return nil, errContactsTooLarge
+	}
+	return blob, nil
+}
+
+// writeLocked atomically writes the current snapshot. The caller holds s.mu.
+// It writes to a temp file in the same directory then renames over the
+// target, so a reader never observes a partial write and a crash leaves
+// either the old file or the new one — never a truncated one. The committed
+// return value is true once the target path has been replaced, even if a
+// later durability step fails.
+func (s *Store) writeLocked() (committed bool, err error) {
+	s.d.Version = contactsVersion
+	blob, err := json.MarshalIndent(s.d, "", "  ")
+	if err != nil {
+		return false, err
+	}
+	// Defense in depth: Upsert's per-field and entry-count caps should make
+	// this unreachable, but if they're ever bypassed or miscalculated, refuse
+	// to write a file Load would then refuse to read back. committed stays
+	// false, so the caller rolls back its in-memory snapshot.
+	if len(blob) > maxContactsLen {
+		return false, fmt.Errorf("contacts write would exceed %d bytes", maxContactsLen)
+	}
+	dir := filepath.Dir(s.path)
+	tmp, err := os.CreateTemp(dir, ".contacts-*.tmp")
+	if err != nil {
+		return false, fmt.Errorf("create temp contacts: %w", err)
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if we bail before the rename; after a successful
+	// rename the temp name no longer exists, so the Remove is a harmless no-op.
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(blob); err != nil {
+		_ = tmp.Close()
+		return false, fmt.Errorf("write temp contacts: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return false, fmt.Errorf("sync temp contacts: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return false, fmt.Errorf("close temp contacts: %w", err)
+	}
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		return false, fmt.Errorf("chmod temp contacts: %w", err)
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		return false, fmt.Errorf("replace contacts: %w", err)
+	}
+	if err := syncDir(dir); err != nil {
+		return true, fmt.Errorf("sync contacts dir: %w", err)
+	}
+	return true, nil
+}
+
+var syncDir = syncDirFS
+
+func syncDirFS(dir string) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
+}

--- a/ui/internal/contacts/contacts_test.go
+++ b/ui/internal/contacts/contacts_test.go
@@ -1,0 +1,857 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package contacts
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+func tmpPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "contacts.json")
+}
+
+// validAddr / validAddr2 are real, checksummed bech32 testnet stake addresses
+// built from parts (rather than hand-typed literals) so the bech32 checksum is
+// always correct.
+func validAddr(t *testing.T, seed byte) string {
+	t.Helper()
+	hash := make([]byte, lcommon.AddressHashSize)
+	hash[0] = seed
+	addr, err := lcommon.NewAddressFromParts(lcommon.AddressTypeNoneKey, lcommon.AddressNetworkTestnet, nil, hash)
+	if err != nil {
+		t.Fatalf("build test address: %v", err)
+	}
+	return addr.String()
+}
+
+// TestLoadMissingFileYieldsEmpty: a missing contacts file is not an error — it
+// yields a store with no entries (mirrors settings.Load).
+func TestLoadMissingFileYieldsEmpty(t *testing.T) {
+	s, err := Load(tmpPath(t))
+	if err != nil {
+		t.Fatalf("Load with no file: %v", err)
+	}
+	if got := s.List(); len(got) != 0 {
+		t.Fatalf("List() = %v, want empty", got)
+	}
+}
+
+// TestLoadRejectsCorruptFile: a present-but-corrupt file is a hard error rather
+// than silently discarding the user's address book.
+func TestLoadRejectsCorruptFile(t *testing.T) {
+	path := tmpPath(t)
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatalf("seed corrupt file: %v", err)
+	}
+	if _, err := Load(path); err == nil {
+		t.Fatal("Load should error on a corrupt contacts file")
+	}
+}
+
+func TestLoadRejectsOversizedFile(t *testing.T) {
+	path := tmpPath(t)
+	if err := os.WriteFile(path, make([]byte, maxContactsLen+1), 0o600); err != nil {
+		t.Fatalf("seed oversized file: %v", err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load should reject an oversized contacts file")
+	}
+	if !strings.Contains(err.Error(), "contacts file exceeds") {
+		t.Fatalf("Load error = %q, want size-cap error", err)
+	}
+}
+
+// TestLoadRejectsNewerVersion: a contacts file stamped with a version newer
+// than this build supports must be refused outright, not silently loaded
+// (which would let this build immediately downgrade it back to v1 on the
+// next write, dropping whatever the newer version added).
+func TestLoadRejectsNewerVersion(t *testing.T) {
+	path := tmpPath(t)
+	future := data{
+		Version: contactsVersion + 1,
+		Entries: []Entry{{ID: "x", Name: "X", Address: validAddr(t, 99)}},
+	}
+	blob, err := json.Marshal(future)
+	if err != nil {
+		t.Fatalf("marshal future-version fixture: %v", err)
+	}
+	if err := os.WriteFile(path, blob, 0o600); err != nil {
+		t.Fatalf("seed future-version file: %v", err)
+	}
+	if _, err := Load(path); err == nil {
+		t.Fatal("Load should reject a contacts file with a newer version than supported")
+	}
+}
+
+func TestLoadRejectsInvalidPersistedData(t *testing.T) {
+	tooMany := make([]Entry, maxEntries+1)
+	for i := range tooMany {
+		tooMany[i] = Entry{
+			ID:      fmt.Sprintf("id-%d", i),
+			Name:    fmt.Sprintf("C%d", i),
+			Address: validAddr(t, byte(i)),
+		}
+	}
+
+	tests := []struct {
+		name    string
+		fixture data
+		want    string
+	}{
+		{
+			name: "invalid address",
+			fixture: data{
+				Version: contactsVersion,
+				Entries: []Entry{{
+					ID:      "bad-address",
+					Name:    "Bad",
+					Address: "not-a-real-address",
+				}},
+			},
+			want: "invalid address",
+		},
+		{
+			name: "oversized name",
+			fixture: data{
+				Version: contactsVersion,
+				Entries: []Entry{{
+					ID:      "long-name",
+					Name:    strings.Repeat("n", maxNameLen+1),
+					Address: validAddr(t, 70),
+				}},
+			},
+			want: "name exceeds",
+		},
+		{
+			name: "oversized note",
+			fixture: data{
+				Version: contactsVersion,
+				Entries: []Entry{{
+					ID:      "long-note",
+					Name:    "Long Note",
+					Address: validAddr(t, 71),
+					Note:    strings.Repeat("n", maxNoteLen+1),
+				}},
+			},
+			want: "note exceeds",
+		},
+		{
+			name: "too many entries",
+			fixture: data{
+				Version: contactsVersion,
+				Entries: tooMany,
+			},
+			want: "entries",
+		},
+		{
+			name: "empty id",
+			fixture: data{
+				Version: contactsVersion,
+				Entries: []Entry{{
+					Name:    "Missing ID",
+					Address: validAddr(t, 72),
+				}},
+			},
+			want: "empty id",
+		},
+		{
+			name: "duplicate id",
+			fixture: data{
+				Version: contactsVersion,
+				Entries: []Entry{
+					{ID: "dup", Name: "One", Address: validAddr(t, 73)},
+					{ID: "dup", Name: "Two", Address: validAddr(t, 74)},
+				},
+			},
+			want: "duplicates id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := tmpPath(t)
+			blob, err := json.Marshal(tt.fixture)
+			if err != nil {
+				t.Fatalf("marshal fixture: %v", err)
+			}
+			if err := os.WriteFile(path, blob, 0o600); err != nil {
+				t.Fatalf("seed invalid file: %v", err)
+			}
+			if _, err := Load(path); err == nil {
+				t.Fatal("Load should reject invalid persisted contact data")
+			} else if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Load error = %q, want it to contain %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadNormalizesPersistedData(t *testing.T) {
+	path := tmpPath(t)
+	addr := validAddr(t, 75)
+	fixture := data{
+		Version: contactsVersion,
+		Entries: []Entry{{
+			ID:      " c1 ",
+			Name:    "  Alice  ",
+			Address: "  " + addr + "  ",
+			Note:    "  friend  ",
+		}},
+	}
+	blob, err := json.Marshal(fixture)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(path, blob, 0o600); err != nil {
+		t.Fatalf("seed unnormalized file: %v", err)
+	}
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := s.List()
+	want := Entry{ID: "c1", Name: "Alice", Address: addr, Note: "friend"}
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("List() = %v, want [%+v]", got, want)
+	}
+}
+
+// TestLoadOrEmptyToleratesNewerVersion mirrors the corrupt/oversized cases:
+// a future-version file must not stop the wallet from starting.
+func TestLoadOrEmptyToleratesNewerVersion(t *testing.T) {
+	path := tmpPath(t)
+	future := data{
+		Version: contactsVersion + 1,
+		Entries: []Entry{{ID: "x", Name: "X", Address: validAddr(t, 98)}},
+	}
+	blob, err := json.Marshal(future)
+	if err != nil {
+		t.Fatalf("marshal future-version fixture: %v", err)
+	}
+	if err := os.WriteFile(path, blob, 0o600); err != nil {
+		t.Fatalf("seed future-version file: %v", err)
+	}
+	s, warn := LoadOrEmpty(path)
+	if warn == nil {
+		t.Fatal("LoadOrEmpty should return the underlying error as a warning for a newer-version file")
+	}
+	if got := s.List(); len(got) != 0 {
+		t.Fatalf("List() = %v, want empty store on a newer-version file", got)
+	}
+}
+
+func TestLoadOrEmptyToleratesInvalidPersistedData(t *testing.T) {
+	path := tmpPath(t)
+	fixture := data{
+		Version: contactsVersion,
+		Entries: []Entry{{
+			ID:      "bad-address",
+			Name:    "Bad",
+			Address: "not-a-real-address",
+		}},
+	}
+	blob, err := json.Marshal(fixture)
+	if err != nil {
+		t.Fatalf("marshal invalid fixture: %v", err)
+	}
+	if err := os.WriteFile(path, blob, 0o600); err != nil {
+		t.Fatalf("seed invalid file: %v", err)
+	}
+	s, warn := LoadOrEmpty(path)
+	if warn == nil {
+		t.Fatal("LoadOrEmpty should return the underlying error as a warning for invalid persisted data")
+	}
+	if got := s.List(); len(got) != 0 {
+		t.Fatalf("List() = %v, want empty store on invalid persisted data", got)
+	}
+}
+
+// TestUpsertCreateGeneratesIDPersistsAndReloads: creating a contact (no ID
+// supplied) generates one, writes the file, and a fresh Load observes it.
+func TestUpsertCreateGeneratesIDPersistsAndReloads(t *testing.T) {
+	path := tmpPath(t)
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	addr := validAddr(t, 1)
+	entry, err := s.Upsert(Entry{Name: "  Alice  ", Address: addr, Note: " friend "})
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if entry.ID == "" {
+		t.Fatal("Upsert should generate an ID when none is supplied")
+	}
+	if entry.Name != "Alice" {
+		t.Fatalf("Name = %q, want trimmed %q", entry.Name, "Alice")
+	}
+	if entry.Address != addr {
+		t.Fatalf("Address = %q, want %q", entry.Address, addr)
+	}
+	if entry.Note != "friend" {
+		t.Fatalf("Note = %q, want trimmed %q", entry.Note, "friend")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("contacts file not written: %v", err)
+	}
+
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	got := reloaded.List()
+	if len(got) != 1 {
+		t.Fatalf("List() after reload = %v, want 1 entry", got)
+	}
+	if got[0] != entry {
+		t.Fatalf("reloaded entry = %+v, want %+v", got[0], entry)
+	}
+}
+
+func TestUpsertRequiresName(t *testing.T) {
+	s, err := Load(tmpPath(t))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	_, err = s.Upsert(Entry{Name: "   ", Address: validAddr(t, 2)})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Upsert with blank name error = %v, want ErrInvalidRequest", err)
+	}
+	if len(s.List()) != 0 {
+		t.Fatal("a rejected Upsert must not persist anything")
+	}
+}
+
+func TestUpsertRequiresValidAddress(t *testing.T) {
+	s, err := Load(tmpPath(t))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	_, err = s.Upsert(Entry{Name: "Bob", Address: "not-a-real-address"})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Upsert with invalid address error = %v, want ErrInvalidRequest", err)
+	}
+	if len(s.List()) != 0 {
+		t.Fatal("a rejected Upsert must not persist anything")
+	}
+}
+
+func TestUpsertRequiresAddress(t *testing.T) {
+	s, err := Load(tmpPath(t))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	_, err = s.Upsert(Entry{Name: "Bob", Address: "   "})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Upsert with blank address error = %v, want ErrInvalidRequest", err)
+	}
+}
+
+// TestUpsertUpdateExistingByID: supplying an existing ID updates that entry in
+// place rather than creating a new one.
+func TestUpsertUpdateExistingByID(t *testing.T) {
+	path := tmpPath(t)
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	addr1 := validAddr(t, 3)
+	created, err := s.Upsert(Entry{Name: "Carol", Address: addr1})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	addr2 := validAddr(t, 4)
+	updated, err := s.Upsert(Entry{ID: created.ID, Name: "Carol Updated", Address: addr2, Note: "n2"})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.ID != created.ID {
+		t.Fatalf("update changed ID: got %q, want %q", updated.ID, created.ID)
+	}
+	if updated.Name != "Carol Updated" || updated.Address != addr2 || updated.Note != "n2" {
+		t.Fatalf("update did not apply: %+v", updated)
+	}
+
+	all := s.List()
+	if len(all) != 1 {
+		t.Fatalf("List() = %v, want exactly 1 entry after update (no duplicate)", all)
+	}
+
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got := reloaded.List(); len(got) != 1 || got[0] != updated {
+		t.Fatalf("reloaded = %v, want [%+v]", got, updated)
+	}
+}
+
+func TestUpsertUpdateUnknownIDReturnsNotFound(t *testing.T) {
+	s, err := Load(tmpPath(t))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	_, err = s.Upsert(Entry{ID: "does-not-exist", Name: "Dave", Address: validAddr(t, 5)})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Upsert with unknown ID error = %v, want ErrNotFound", err)
+	}
+}
+
+// TestUpsertUpdateDoesNotCorruptOtherEntries verifies that updating one entry
+// via copy-on-write doesn't leak into a previously-returned List() snapshot or
+// corrupt a rollback path.
+func TestUpsertUpdateDoesNotCorruptOtherEntries(t *testing.T) {
+	s, err := Load(tmpPath(t))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	a, err := s.Upsert(Entry{Name: "A", Address: validAddr(t, 6)})
+	if err != nil {
+		t.Fatalf("create a: %v", err)
+	}
+	b, err := s.Upsert(Entry{Name: "B", Address: validAddr(t, 7)})
+	if err != nil {
+		t.Fatalf("create b: %v", err)
+	}
+	snapshot := s.List()
+
+	if _, err := s.Upsert(Entry{ID: a.ID, Name: "A2", Address: validAddr(t, 8)}); err != nil {
+		t.Fatalf("update a: %v", err)
+	}
+
+	// The earlier snapshot slice must not have been mutated in place.
+	for _, e := range snapshot {
+		if e.ID == a.ID && e.Name != "A" {
+			t.Fatalf("earlier List() snapshot was mutated: %+v", e)
+		}
+	}
+	_ = b
+}
+
+func TestDeleteRemovesEntry(t *testing.T) {
+	path := tmpPath(t)
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	e1, err := s.Upsert(Entry{Name: "Eve", Address: validAddr(t, 9)})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	e2, err := s.Upsert(Entry{Name: "Frank", Address: validAddr(t, 10)})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if err := s.Delete(e1.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	got := s.List()
+	if len(got) != 1 || got[0].ID != e2.ID {
+		t.Fatalf("List() after delete = %v, want only %+v", got, e2)
+	}
+
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got := reloaded.List(); len(got) != 1 || got[0].ID != e2.ID {
+		t.Fatalf("reloaded after delete = %v, want only %+v", got, e2)
+	}
+}
+
+func TestDeleteUnknownIDReturnsNotFound(t *testing.T) {
+	s, err := Load(tmpPath(t))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := s.Delete("nope"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Delete unknown ID error = %v, want ErrNotFound", err)
+	}
+}
+
+// TestListSortedByNameCaseInsensitive: List() returns entries in a stable,
+// case-insensitive name order regardless of insertion order.
+func TestListSortedByNameCaseInsensitive(t *testing.T) {
+	s, err := Load(tmpPath(t))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, err := s.Upsert(Entry{Name: "charlie", Address: validAddr(t, 11)}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := s.Upsert(Entry{Name: "Alice", Address: validAddr(t, 12)}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := s.Upsert(Entry{Name: "bob", Address: validAddr(t, 13)}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got := s.List()
+	if len(got) != 3 {
+		t.Fatalf("List() = %v, want 3 entries", got)
+	}
+	names := []string{got[0].Name, got[1].Name, got[2].Name}
+	want := []string{"Alice", "bob", "charlie"}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("List() order = %v, want %v", names, want)
+		}
+	}
+}
+
+func TestListReturnsCopyNotInternalSlice(t *testing.T) {
+	s, err := Load(tmpPath(t))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, err := s.Upsert(Entry{Name: "Alice", Address: validAddr(t, 14)}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got := s.List()
+	got[0].Name = "mutated"
+	got2 := s.List()
+	if got2[0].Name == "mutated" {
+		t.Fatal("List() leaked internal storage — mutation via one snapshot affected another")
+	}
+}
+
+func TestUpsertRollsBackOnPersistError(t *testing.T) {
+	existing := Entry{ID: "keep-me", Name: "Grace", Address: validAddr(t, 15)}
+	s := &Store{
+		path: filepath.Join(t.TempDir(), "missing-parent", "contacts.json"),
+		d:    data{Version: contactsVersion, Entries: []Entry{existing}},
+	}
+	_, err := s.Upsert(Entry{Name: "Interloper", Address: validAddr(t, 17)})
+	if err == nil {
+		t.Fatal("Upsert should fail when the contacts directory is missing")
+	}
+	if got := s.List(); len(got) != 1 || got[0] != existing {
+		t.Fatalf("failed Upsert must leave the in-memory store unchanged, got %v", got)
+	}
+}
+
+// TestUpsertRejectsOversizedName: a Name over maxNameLen is rejected as a
+// validation error before anything is written, so an oversized field can
+// never make the contacts file unloadable.
+func TestUpsertRejectsOversizedName(t *testing.T) {
+	path := tmpPath(t)
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	longName := strings.Repeat("a", maxNameLen+1)
+	_, err = s.Upsert(Entry{Name: longName, Address: validAddr(t, 20)})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Upsert with oversized name error = %v, want ErrInvalidRequest", err)
+	}
+	if len(s.List()) != 0 {
+		t.Fatal("a rejected Upsert must not persist anything")
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("a rejected Upsert must not create a contacts file, stat err = %v", statErr)
+	}
+}
+
+// TestUpsertRejectsOversizedNote: mirrors TestUpsertRejectsOversizedName for
+// Note — this is the field the root-cause report called out (a large Note is
+// the easiest way to blow past the read cap via legitimate-looking traffic).
+func TestUpsertRejectsOversizedNote(t *testing.T) {
+	path := tmpPath(t)
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	longNote := strings.Repeat("n", maxNoteLen+1)
+	_, err = s.Upsert(Entry{Name: "Zed", Address: validAddr(t, 21), Note: longNote})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Upsert with oversized note error = %v, want ErrInvalidRequest", err)
+	}
+	if len(s.List()) != 0 {
+		t.Fatal("a rejected Upsert must not persist anything")
+	}
+	// The store must remain loadable: no half-valid/unloadable file was written.
+	if _, err := Load(path); err != nil {
+		t.Fatalf("contacts file became unloadable after a rejected Upsert: %v", err)
+	}
+}
+
+// TestUpsertRejectsOversizedAddress covers the defensive Address cap. The
+// length check runs before bech32/Byron parsing, so an over-length string
+// doesn't need to be a syntactically plausible address to be rejected.
+func TestUpsertRejectsOversizedAddress(t *testing.T) {
+	s, err := Load(tmpPath(t))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	longAddr := strings.Repeat("a", maxAddressLen+1)
+	_, err = s.Upsert(Entry{Name: "Zed", Address: longAddr})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Upsert with oversized address error = %v, want ErrInvalidRequest", err)
+	}
+}
+
+// TestUpsertRejectsWhenAddressBookFull: the entry-count cap only applies to
+// creates. The store is seeded directly (not via maxEntries real Upsert
+// calls) purely to keep the test fast — Upsert's own validation doesn't care
+// how the in-memory entries got there.
+func TestUpsertRejectsWhenAddressBookFull(t *testing.T) {
+	path := tmpPath(t)
+	entries := make([]Entry, maxEntries)
+	for i := range entries {
+		entries[i] = Entry{
+			ID:      fmt.Sprintf("id-%d", i),
+			Name:    fmt.Sprintf("C%d", i),
+			Address: validAddr(t, byte(i)),
+		}
+	}
+	s := &Store{path: path, d: data{Version: contactsVersion, Entries: entries}}
+
+	_, err := s.Upsert(Entry{Name: "Overflow", Address: validAddr(t, 250)})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Upsert beyond maxEntries error = %v, want ErrInvalidRequest", err)
+	}
+	if got := s.List(); len(got) != maxEntries {
+		t.Fatalf("List() = %d entries, want %d (overflow must not persist)", len(got), maxEntries)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("a rejected Upsert must not create a contacts file, stat err = %v", statErr)
+	}
+}
+
+// TestUpsertRejectsWhenAddressBookFullAllowsUpdate: the maxEntries cap must
+// only block creates. Updating one of the existing (at-capacity) entries
+// should still succeed.
+func TestUpsertRejectsWhenAddressBookFullAllowsUpdate(t *testing.T) {
+	path := tmpPath(t)
+	entries := make([]Entry, maxEntries)
+	for i := range entries {
+		entries[i] = Entry{
+			ID:      fmt.Sprintf("id-%d", i),
+			Name:    fmt.Sprintf("C%d", i),
+			Address: validAddr(t, byte(i)),
+		}
+	}
+	s := &Store{path: path, d: data{Version: contactsVersion, Entries: entries}}
+
+	updated, err := s.Upsert(Entry{ID: "id-0", Name: "Updated", Address: validAddr(t, 251)})
+	if err != nil {
+		t.Fatalf("update at full capacity should succeed: %v", err)
+	}
+	if updated.Name != "Updated" {
+		t.Fatalf("update did not apply: %+v", updated)
+	}
+	if got := s.List(); len(got) != maxEntries {
+		t.Fatalf("List() = %d entries, want unchanged %d", len(got), maxEntries)
+	}
+}
+
+// TestWriteLockedRejectsOversizedBlob exercises writeLocked's write-side
+// maxContactsLen guard directly (bypassing Upsert's per-field caps, which
+// would normally prevent this) so the defense-in-depth backstop is verified
+// on its own: it must refuse to write, report not-committed, and leave no
+// temp file or target file behind.
+func TestWriteLockedRejectsOversizedBlob(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "contacts.json")
+	huge := Entry{
+		ID:      "huge",
+		Name:    "Huge",
+		Address: validAddr(t, 30),
+		Note:    strings.Repeat("x", maxContactsLen),
+	}
+	s := &Store{path: path, d: data{Version: contactsVersion, Entries: []Entry{huge}}}
+
+	committed, err := s.writeLocked()
+	if err == nil {
+		t.Fatal("writeLocked should reject a blob larger than maxContactsLen")
+	}
+	if committed {
+		t.Fatal("writeLocked must not report committed when it refuses to write")
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("writeLocked must not create the target file when it refuses to write, stat err = %v", statErr)
+	}
+	matches, _ := filepath.Glob(filepath.Join(dir, ".contacts-*.tmp"))
+	if len(matches) != 0 {
+		t.Fatalf("writeLocked left a temp file behind: %v", matches)
+	}
+}
+
+// TestUpsertRollsBackWhenWriteWouldExceedMaxContactsLen exercises the guard
+// through Upsert (not just writeLocked directly): a store carrying an
+// oversized "legacy" entry (as if written before the per-field caps existed)
+// must reject and roll back an otherwise-ordinary new contact rather than
+// commit a file Load would then refuse to read back.
+func TestUpsertRollsBackWhenWriteWouldExceedMaxContactsLen(t *testing.T) {
+	path := tmpPath(t)
+	legacy := Entry{
+		ID:      "legacy",
+		Name:    "Legacy",
+		Address: validAddr(t, 40),
+		Note:    strings.Repeat("z", maxContactsLen-256),
+	}
+	s := &Store{path: path, d: data{Version: contactsVersion, Entries: []Entry{legacy}}}
+
+	_, err := s.Upsert(Entry{Name: "One More", Address: validAddr(t, 41), Note: "small note"})
+	if err == nil {
+		t.Fatal("Upsert should fail when the resulting file would exceed maxContactsLen")
+	}
+	if got := s.List(); len(got) != 1 || got[0] != legacy {
+		t.Fatalf("failed Upsert must leave the in-memory store unchanged, got %v", got)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("failed Upsert must not create a contacts file, stat err = %v", statErr)
+	}
+}
+
+// TestLoadOrEmptyToleratesCorruptFile: contacts are non-essential, so a
+// corrupt file must yield a usable empty store plus a non-nil warning, never
+// a crash — and the bad file must be left on disk untouched for recovery.
+func TestLoadOrEmptyToleratesCorruptFile(t *testing.T) {
+	path := tmpPath(t)
+	const badContent = "{not valid json"
+	if err := os.WriteFile(path, []byte(badContent), 0o600); err != nil {
+		t.Fatalf("seed corrupt file: %v", err)
+	}
+	s, warn := LoadOrEmpty(path)
+	if warn == nil {
+		t.Fatal("LoadOrEmpty should return the underlying error as a warning")
+	}
+	if s == nil {
+		t.Fatal("LoadOrEmpty must return a usable store even on error")
+	}
+	if got := s.List(); len(got) != 0 {
+		t.Fatalf("List() = %v, want empty store on a corrupt file", got)
+	}
+	raw, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("bad contacts file was removed: %v", readErr)
+	}
+	if string(raw) != badContent {
+		t.Fatalf("bad contacts file was modified: %q", raw)
+	}
+}
+
+// TestLoadOrEmptyToleratesOversizedFile mirrors the corrupt-file case for an
+// oversized file — the other way Load hard-errors.
+func TestLoadOrEmptyToleratesOversizedFile(t *testing.T) {
+	path := tmpPath(t)
+	if err := os.WriteFile(path, make([]byte, maxContactsLen+1), 0o600); err != nil {
+		t.Fatalf("seed oversized file: %v", err)
+	}
+	s, warn := LoadOrEmpty(path)
+	if warn == nil {
+		t.Fatal("LoadOrEmpty should return the underlying error as a warning")
+	}
+	if got := s.List(); len(got) != 0 {
+		t.Fatalf("List() = %v, want empty store on an oversized file", got)
+	}
+}
+
+// TestLoadOrEmptyStoreRemainsWritable: the empty store returned after a bad
+// file must still be a fully working Store — a subsequent Upsert succeeds and
+// (as an ordinary consequence of writing, not a proactive recovery step)
+// overwrites the bad file with a fresh, valid one.
+func TestLoadOrEmptyStoreRemainsWritable(t *testing.T) {
+	path := tmpPath(t)
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatalf("seed corrupt file: %v", err)
+	}
+	s, warn := LoadOrEmpty(path)
+	if warn == nil {
+		t.Fatal("expected a warning error from LoadOrEmpty")
+	}
+	entry, err := s.Upsert(Entry{Name: "Fresh", Address: validAddr(t, 60)})
+	if err != nil {
+		t.Fatalf("Upsert on a LoadOrEmpty-recovered store: %v", err)
+	}
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload after recovery: %v", err)
+	}
+	if got := reloaded.List(); len(got) != 1 || got[0] != entry {
+		t.Fatalf("reloaded = %v, want [%+v]", got, entry)
+	}
+}
+
+// TestLoadOrEmptyPassesThroughGoodFile: a valid file behaves exactly like
+// Load — no warning, contents preserved.
+func TestLoadOrEmptyPassesThroughGoodFile(t *testing.T) {
+	path := tmpPath(t)
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	entry, err := s.Upsert(Entry{Name: "Good", Address: validAddr(t, 61)})
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	reloaded, warn := LoadOrEmpty(path)
+	if warn != nil {
+		t.Fatalf("LoadOrEmpty on a valid file returned a warning: %v", warn)
+	}
+	if got := reloaded.List(); len(got) != 1 || got[0] != entry {
+		t.Fatalf("LoadOrEmpty = %v, want [%+v]", got, entry)
+	}
+}
+
+// TestLoadOrEmptyMissingFileYieldsEmptyNoWarning: a missing file is not an
+// error for Load, and must not be treated as one by LoadOrEmpty either.
+func TestLoadOrEmptyMissingFileYieldsEmptyNoWarning(t *testing.T) {
+	s, warn := LoadOrEmpty(tmpPath(t))
+	if warn != nil {
+		t.Fatalf("LoadOrEmpty on a missing file returned a warning: %v", warn)
+	}
+	if got := s.List(); len(got) != 0 {
+		t.Fatalf("List() = %v, want empty", got)
+	}
+}
+
+func TestDeleteRollsBackOnPersistError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "contacts.json")
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	e, err := s.Upsert(Entry{Name: "Henry", Address: validAddr(t, 16)})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Make the directory unwritable-by-rename by pointing the store at a path
+	// whose parent no longer exists.
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("remove dir: %v", err)
+	}
+
+	if err := s.Delete(e.ID); err == nil {
+		t.Fatal("Delete should fail when the contacts directory has vanished")
+	}
+	if got := s.List(); len(got) != 1 || got[0].ID != e.ID {
+		t.Fatalf("failed Delete must leave the in-memory store unchanged, got %v", got)
+	}
+}

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -41,6 +41,8 @@ import type {
   TPMStatus,
   EnableTPMRequest,
   DisableTPMRequest,
+  Contact,
+  UpsertContactRequest,
   DexPoolsResponse,
   DexQuoteRequest,
   DexQuote,
@@ -240,6 +242,14 @@ export const poolSubmitRetirement = (req: { password: string; epoch: number }) =
 export const getTPMStatus = () => apiGet<TPMStatus>("/vault/tpm/status");
 export const enableTPM = (req: EnableTPMRequest) => apiPost<TPMStatus>("/vault/tpm/enable", req);
 export const disableTPM = (req: DisableTPMRequest) => apiPost<TPMStatus>("/vault/tpm/disable", req);
+
+// Address book (local-only contacts). Upsert creates a new contact when
+// req.id is omitted, or updates the contact with that id when supplied.
+export const getContacts = () => apiGet<Contact[]>("/wallet/contacts");
+export const upsertContact = (req: UpsertContactRequest) =>
+  apiPost<Contact>("/wallet/contacts", req);
+export const deleteContact = (id: string) =>
+  apiDelete<{ removed: boolean }>(`/wallet/contacts/${encodeURIComponent(id)}`);
 
 // DEX swap quotes (node-local: pool prices and best-pool quotes).
 export const getDexPools = () => apiGet<DexPoolsResponse>("/wallet/dex/pools");

--- a/ui/web/src/api/hooks.ts
+++ b/ui/web/src/api/hooks.ts
@@ -9,6 +9,7 @@ import type {
   HistoryExpirySetting,
   AutoLockSetting,
   TPMStatus,
+  Contact,
   DexPoolsResponse,
 } from "./types";
 import {
@@ -21,6 +22,7 @@ import {
   getHistoryExpiry,
   getAutoLock,
   getTPMStatus,
+  getContacts,
   getDexPools,
 } from "./client";
 
@@ -118,5 +120,6 @@ export const useDelegation = (): AsyncState<DelegationView> => useAsync(getDeleg
 export const useHistoryExpiry = (): AsyncState<HistoryExpirySetting> => useAsync(getHistoryExpiry);
 export const useAutoLock = (): AsyncState<AutoLockSetting> => useAsync(getAutoLock);
 export const useTPMStatus = (): AsyncState<TPMStatus> => useAsync(getTPMStatus);
+export const useContacts = (): AsyncState<Contact[]> => useAsync(getContacts);
 export const useDexPools = (): AsyncState<DexPoolsResponse> =>
   useAsync(getDexPools, { pollMs: 15000 });

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -426,6 +426,24 @@ export interface DisableTPMRequest {
   password: string;
 }
 
+// Address book: local-only saved contacts (a friendly name, a Cardano
+// address, and an optional note). Pure on-device storage.
+export interface Contact {
+  id: string;
+  name: string;
+  address: string;
+  note?: string;
+}
+
+// UpsertContactRequest creates a new contact when id is omitted, or updates
+// the contact with that id when supplied.
+export interface UpsertContactRequest {
+  id?: string;
+  name: string;
+  address: string;
+  note?: string;
+}
+
 export interface DexPool {
   protocol: string;
   pool_id: string;

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -19,6 +19,7 @@ import { Receive } from "./screens/Receive";
 import { Activity } from "./screens/Activity";
 import { Send } from "./screens/Send";
 import { Swap } from "./screens/Swap";
+import { Contacts } from "./screens/Contacts";
 import { Staking } from "./screens/Staking";
 import { SignMessage } from "./screens/SignMessage";
 import { VerifyMessage } from "./screens/VerifyMessage";
@@ -35,6 +36,7 @@ const ROUTES = new Map<string, () => ReactElement>([
   ["activity", Activity],
   ["send", Send],
   ["swap", Swap],
+  ["contacts", Contacts],
 ]);
 
 const NAV: { key: string; label: string }[] = [
@@ -43,6 +45,7 @@ const NAV: { key: string; label: string }[] = [
   { key: "activity", label: "Activity" },
   { key: "send", label: "Send" },
   { key: "swap", label: "Swap" },
+  { key: "contacts", label: "Contacts" },
   { key: "staking", label: "Staking" },
   { key: "sign", label: "Sign" },
   { key: "verify", label: "Verify" },

--- a/ui/web/src/screens/Contacts.test.tsx
+++ b/ui/web/src/screens/Contacts.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Contacts } from "./Contacts";
+import * as client from "../api/client";
+import { mockContacts } from "../test/mockContacts";
+import type { Contact } from "../api/types";
+
+const ALICE: Contact = { id: "c1", name: "Alice", address: "addr_test1alice", note: "friend" };
+const BOB: Contact = { id: "c2", name: "Bob", address: "addr_test1bob" };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("(a) renders saved contacts with name, address, and note", () => {
+  mockContacts([ALICE, BOB]);
+  render(<Contacts />);
+  expect(screen.getByText("Alice")).toBeInTheDocument();
+  expect(screen.getByText("addr_test1alice")).toBeInTheDocument();
+  expect(screen.getByText("friend")).toBeInTheDocument();
+  expect(screen.getByText("Bob")).toBeInTheDocument();
+  expect(screen.getByText("addr_test1bob")).toBeInTheDocument();
+});
+
+test("(b) empty address book shows a helpful empty state", () => {
+  mockContacts([]);
+  render(<Contacts />);
+  expect(screen.getByText(/no saved contacts yet/i)).toBeInTheDocument();
+});
+
+test("(c) loading state renders gracefully before data arrives", () => {
+  mockContacts(null, { loading: true });
+  render(<Contacts />);
+  expect(screen.getByText(/loading/i)).toBeInTheDocument();
+});
+
+test("(d) 'Add contact' opens the create form, and saving calls upsertContact without an id", async () => {
+  mockContacts([]);
+  const upsertSpy = vi.spyOn(client, "upsertContact").mockResolvedValue({
+    id: "new1",
+    name: "Carol",
+    address: "addr_test1carol",
+  });
+
+  render(<Contacts />);
+  fireEvent.click(screen.getByRole("button", { name: /\+ add contact/i }));
+
+  fireEvent.change(screen.getByLabelText(/^name$/i), { target: { value: "Carol" } });
+  fireEvent.change(screen.getByLabelText(/^address$/i), { target: { value: "addr_test1carol" } });
+  fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+  await waitFor(() => {
+    expect(upsertSpy).toHaveBeenCalledWith({ name: "Carol", address: "addr_test1carol" });
+  });
+});
+
+test("(e) editing an existing contact pre-fills the form and calls upsertContact with its id", async () => {
+  mockContacts([ALICE]);
+  const upsertSpy = vi.spyOn(client, "upsertContact").mockResolvedValue({
+    ...ALICE,
+    name: "Alice Updated",
+  });
+
+  render(<Contacts />);
+  fireEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+
+  const nameInput = screen.getByLabelText(/^name$/i) as HTMLInputElement;
+  expect(nameInput.value).toBe("Alice");
+  const addressInput = screen.getByLabelText(/^address$/i) as HTMLInputElement;
+  expect(addressInput.value).toBe("addr_test1alice");
+
+  fireEvent.change(nameInput, { target: { value: "Alice Updated" } });
+  fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+  await waitFor(() => {
+    expect(upsertSpy).toHaveBeenCalledWith({
+      id: "c1",
+      name: "Alice Updated",
+      address: "addr_test1alice",
+      note: "friend",
+    });
+  });
+});
+
+test("(f) a failed save surfaces the error and keeps the form open", async () => {
+  mockContacts([]);
+  vi.spyOn(client, "upsertContact").mockRejectedValue(
+    new client.ApiError(400, "invalid contact: invalid address")
+  );
+
+  render(<Contacts />);
+  fireEvent.click(screen.getByRole("button", { name: /\+ add contact/i }));
+  fireEvent.change(screen.getByLabelText(/^name$/i), { target: { value: "Dave" } });
+  fireEvent.change(screen.getByLabelText(/^address$/i), { target: { value: "not-an-address" } });
+  fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+  expect(await screen.findByRole("alert")).toHaveTextContent(/invalid address/i);
+  // Still showing the form (Save button still present).
+  expect(screen.getByRole("button", { name: /^save$/i })).toBeInTheDocument();
+});
+
+test("(g) deleting a contact calls deleteContact with its id and refreshes the list", async () => {
+  const refresh = mockContacts([ALICE, BOB]);
+  const deleteSpy = vi.spyOn(client, "deleteContact").mockResolvedValue({ removed: true });
+
+  render(<Contacts />);
+  const deleteButtons = screen.getAllByRole("button", { name: /^delete$/i });
+  fireEvent.click(deleteButtons[0]);
+
+  await waitFor(() => {
+    expect(deleteSpy).toHaveBeenCalledWith("c1");
+  });
+  await waitFor(() => {
+    expect(refresh).toHaveBeenCalled();
+  });
+});
+
+test("(h) a failed delete surfaces an inline error", async () => {
+  mockContacts([ALICE]);
+  vi.spyOn(client, "deleteContact").mockRejectedValue(new client.ApiError(500, "disk full"));
+
+  render(<Contacts />);
+  fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+
+  expect(await screen.findByRole("alert")).toHaveTextContent(/disk full/i);
+});
+
+test("(j) the add form caps Name/Address/Note input length to match the backend's per-field limits", () => {
+  mockContacts([]);
+  render(<Contacts />);
+  fireEvent.click(screen.getByRole("button", { name: /\+ add contact/i }));
+
+  expect(screen.getByLabelText(/^name$/i)).toHaveAttribute("maxLength", "256");
+  expect(screen.getByLabelText(/^address$/i)).toHaveAttribute("maxLength", "256");
+  expect(screen.getByLabelText(/note/i)).toHaveAttribute("maxLength", "1024");
+});
+
+test("(l) the add form enforces backend UTF-8 byte limits while typing", async () => {
+  mockContacts([]);
+  const upsertSpy = vi.spyOn(client, "upsertContact").mockResolvedValue({
+    id: "new1",
+    name: "ok",
+    address: "addr_test1carol",
+  });
+
+  render(<Contacts />);
+  fireEvent.click(screen.getByRole("button", { name: /\+ add contact/i }));
+
+  const nameInput = screen.getByLabelText(/^name$/i);
+  const addressInput = screen.getByLabelText(/^address$/i);
+  const noteInput = screen.getByLabelText(/note/i);
+  const maxName = "\u00e9".repeat(128);
+  const maxAddress = "\u754c".repeat(85);
+  const maxNote = "\ud83d\ude00".repeat(256);
+
+  fireEvent.change(nameInput, { target: { value: "\u00e9".repeat(129) } });
+  fireEvent.change(addressInput, { target: { value: "\u754c".repeat(86) } });
+  fireEvent.change(noteInput, { target: { value: "\ud83d\ude00".repeat(257) } });
+
+  expect(nameInput).toHaveValue(maxName);
+  expect(addressInput).toHaveValue(maxAddress);
+  expect(noteInput).toHaveValue(maxNote);
+
+  fireEvent.change(addressInput, { target: { value: "addr_test1carol" } });
+  fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+  await waitFor(() => {
+    expect(upsertSpy).toHaveBeenCalledWith({
+      name: maxName,
+      address: "addr_test1carol",
+      note: maxNote,
+    });
+  });
+  expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+});
+
+test("(k) a failed initial fetch shows only the error, not the empty-state text", () => {
+  mockContacts(null, { error: new Error("network down") });
+  render(<Contacts />);
+  expect(screen.getByRole("alert")).toHaveTextContent(/network down/i);
+  expect(screen.queryByText(/no saved contacts yet/i)).not.toBeInTheDocument();
+});
+
+test("(i) 'Cancel' in the add form returns to the list without saving", () => {
+  mockContacts([ALICE]);
+  const upsertSpy = vi.spyOn(client, "upsertContact");
+
+  render(<Contacts />);
+  fireEvent.click(screen.getByRole("button", { name: /\+ add contact/i }));
+  fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+  expect(screen.getByText("Alice")).toBeInTheDocument();
+  expect(upsertSpy).not.toHaveBeenCalled();
+});

--- a/ui/web/src/screens/Contacts.tsx
+++ b/ui/web/src/screens/Contacts.tsx
@@ -1,0 +1,252 @@
+import { useState } from "react";
+import type { Contact } from "../api/types";
+import { useContacts } from "../api/hooks";
+import { upsertContact, deleteContact, ApiError } from "../api/client";
+import { Card } from "../components/Card";
+import { Input } from "../components/Input";
+import { Button } from "../components/Button";
+import { CopyButton } from "../components/CopyButton";
+
+function errorMessage(err: unknown): string {
+  if (err instanceof ApiError) return err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+interface ContactFormProps {
+  // null = new contact; otherwise the contact being edited.
+  initial: Contact | null;
+  onSaved: (contact: Contact) => void;
+  onCancel: () => void;
+}
+
+// Per-field byte caps mirror the backend's ui/internal/contacts constants
+// (maxNameLen / maxAddressLen / maxNoteLen). Browser maxLength counts UTF-16
+// code units, so onChange clamps UTF-8 bytes and handleSave validates the
+// trimmed payload as a final guard.
+const MAX_NAME_BYTES = 256;
+const MAX_ADDRESS_BYTES = 256;
+const MAX_NOTE_BYTES = 1024;
+
+const utf8Encoder = new TextEncoder();
+
+function byteLength(value: string): number {
+  return utf8Encoder.encode(value).length;
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  if (byteLength(value) <= maxBytes) return value;
+
+  let bytes = 0;
+  let out = "";
+  for (const char of value) {
+    const charBytes = byteLength(char);
+    if (bytes + charBytes > maxBytes) break;
+    out += char;
+    bytes += charBytes;
+  }
+  return out;
+}
+
+function byteLimitError(field: string, value: string, maxBytes: number): string | null {
+  if (byteLength(value) <= maxBytes) return null;
+  return `${field} exceeds ${maxBytes} bytes`;
+}
+
+// The add/edit form is the same component either way — a supplied `initial`
+// seeds the fields and its id is carried through as an update; omitting it
+// creates a new contact.
+function ContactForm({ initial, onSaved, onCancel }: ContactFormProps) {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [address, setAddress] = useState(initial?.address ?? "");
+  const [note, setNote] = useState(initial?.note ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  async function handleSave() {
+    setError(null);
+    const trimmedName = name.trim();
+    const trimmedAddress = address.trim();
+    const trimmedNote = note.trim();
+    const lengthError =
+      byteLimitError("name", trimmedName, MAX_NAME_BYTES) ??
+      byteLimitError("address", trimmedAddress, MAX_ADDRESS_BYTES) ??
+      byteLimitError("note", trimmedNote, MAX_NOTE_BYTES);
+    if (lengthError) {
+      setError(lengthError);
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const saved = await upsertContact({
+        ...(initial ? { id: initial.id } : {}),
+        name: trimmedName,
+        address: trimmedAddress,
+        ...(trimmedNote ? { note: trimmedNote } : {}),
+      });
+      onSaved(saved);
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Card title={initial ? "Edit Contact" : "Add Contact"}>
+      <div className="send-form">
+        <label htmlFor="contact-name">Name</label>
+        <Input
+          id="contact-name"
+          type="text"
+          placeholder="e.g. Alice"
+          value={name}
+          onChange={(e) => setName(truncateUtf8(e.target.value, MAX_NAME_BYTES))}
+          disabled={saving}
+          maxLength={MAX_NAME_BYTES}
+        />
+
+        <label htmlFor="contact-address">Address</label>
+        <Input
+          id="contact-address"
+          type="text"
+          placeholder="addr1..."
+          value={address}
+          onChange={(e) => setAddress(truncateUtf8(e.target.value, MAX_ADDRESS_BYTES))}
+          disabled={saving}
+          maxLength={MAX_ADDRESS_BYTES}
+        />
+
+        <label htmlFor="contact-note">Note (optional)</label>
+        <Input
+          id="contact-note"
+          type="text"
+          placeholder="optional note"
+          value={note}
+          onChange={(e) => setNote(truncateUtf8(e.target.value, MAX_NOTE_BYTES))}
+          disabled={saving}
+          maxLength={MAX_NOTE_BYTES}
+        />
+
+        {error && (
+          <p role="alert" className="error-text">
+            {error}
+          </p>
+        )}
+
+        <div className="row-actions">
+          <Button onClick={handleSave} disabled={saving || !name.trim() || !address.trim()}>
+            {saving ? "Saving…" : "Save"}
+          </Button>
+          <Button variant="ghost" onClick={onCancel} disabled={saving}>
+            Cancel
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// Contacts is the address-book screen: a local-only, per-instance list of
+// saved recipient addresses. It never reaches out to any external service —
+// purely on-device CRUD storage, matching the wallet's consent law.
+export function Contacts() {
+  const contacts = useContacts();
+  const [editing, setEditing] = useState<Contact | "new" | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  // Apply the saved contact to the in-memory list immediately (append for a
+  // new contact, replace-by-id for an edit) instead of waiting on the
+  // follow-up refresh() GET, so the list can't appear to have lost the just-
+  // saved contact if that GET fails. refresh() still runs as a background
+  // reconciliation against the server's canonical (sorted) order.
+  function handleSaved(saved: Contact) {
+    setEditing(null);
+    const current = contacts.data ?? [];
+    const idx = current.findIndex((c) => c.id === saved.id);
+    contacts.setData(idx >= 0 ? current.map((c, i) => (i === idx ? saved : c)) : [...current, saved]);
+    contacts.refresh();
+  }
+
+  async function handleDelete(id: string) {
+    setDeleteError(null);
+    setBusyId(id);
+    try {
+      await deleteContact(id);
+      // Remove locally right away — otherwise a successful delete whose
+      // follow-up refresh() fails would leave the deleted contact visible,
+      // looking like the delete itself failed.
+      contacts.setData((contacts.data ?? []).filter((c) => c.id !== id));
+      contacts.refresh();
+    } catch (e) {
+      setDeleteError(errorMessage(e));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  if (editing !== null) {
+    return (
+      <ContactForm
+        initial={editing === "new" ? null : editing}
+        onSaved={handleSaved}
+        onCancel={() => setEditing(null)}
+      />
+    );
+  }
+
+  const list = contacts.data ?? [];
+  const hasLoaded = contacts.data !== null;
+
+  return (
+    <div className="screen-contacts">
+      <Card title="Address Book">
+        {!hasLoaded && contacts.loading ? (
+          <p className="muted">Loading…</p>
+        ) : hasLoaded && list.length === 0 ? (
+          <p className="muted">No saved contacts yet.</p>
+        ) : hasLoaded ? (
+          <ul className="contact-list" aria-label="Contacts">
+            {list.map((c) => (
+              <li key={c.id} className="contact-row">
+                <div className="contact-info">
+                  <span className="contact-name">{c.name}</span>
+                  <code className="contact-address mono">{c.address}</code>
+                  {c.note && <span className="contact-note helper-text">{c.note}</span>}
+                </div>
+                <div className="contact-row-actions">
+                  <CopyButton value={c.address} ariaLabel={`Copy ${c.name}'s address`} />
+                  <Button variant="ghost" onClick={() => setEditing(c)} disabled={busyId !== null}>
+                    Edit
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    onClick={() => handleDelete(c.id)}
+                    disabled={busyId !== null}
+                  >
+                    {busyId === c.id ? "Removing…" : "Delete"}
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
+        {deleteError && (
+          <p role="alert" className="error-text">
+            {deleteError}
+          </p>
+        )}
+        {contacts.error && !contacts.loading && (
+          <p role="alert" className="error-text">
+            {contacts.error.message}
+          </p>
+        )}
+
+        <Button onClick={() => setEditing("new")}>+ Add contact</Button>
+      </Card>
+    </div>
+  );
+}

--- a/ui/web/src/screens/Send.test.tsx
+++ b/ui/web/src/screens/Send.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { Send } from "./Send";
 import * as client from "../api/client";
-import type { Preview, TxResult, HandleInfo } from "../api/types";
+import { mockContacts } from "../test/mockContacts";
+import type { Preview, TxResult, HandleInfo, Contact } from "../api/types";
 
 const MOCK_PREVIEW: Preview = {
   pending_id: "pending-abc-123",
@@ -17,6 +18,10 @@ const MOCK_PREVIEW: Preview = {
 const MOCK_TX_RESULT: TxResult = {
   tx_hash: "deadbeef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
 };
+
+beforeEach(() => {
+  mockContacts([]);
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -443,4 +448,52 @@ test("(n) a plain address recipient never calls resolveHandle", async () => {
     expect(screen.getByText(/2 inputs/i)).toBeInTheDocument();
   });
   expect(resolveHandle).not.toHaveBeenCalled();
+});
+
+// --- address-book picker on the recipient field ---
+
+const ALICE: Contact = { id: "c1", name: "Alice", address: "addr_test1alice" };
+const BOB: Contact = { id: "c2", name: "Bob", address: "addr_test1bob" };
+
+test("(o) no saved contacts: the Address book toggle is not rendered", () => {
+  mockContacts([]);
+  render(<Send />);
+  expect(screen.queryByRole("button", { name: /address book/i })).not.toBeInTheDocument();
+  // And the textbox indices other tests rely on stay exactly recipient/amount.
+  expect(screen.getAllByRole("textbox")).toHaveLength(2);
+});
+
+test("(p) saved contacts: clicking Address book lists them, and picking one fills the recipient", () => {
+  mockContacts([ALICE, BOB]);
+  render(<Send />);
+
+  const toggle = screen.getByRole("button", { name: /address book/i });
+  expect(toggle).toHaveAttribute("aria-controls", "send-contact-picker-list");
+  fireEvent.click(toggle);
+  expect(screen.getByRole("list", { name: /saved contacts/i })).toHaveAttribute(
+    "id",
+    "send-contact-picker-list"
+  );
+  expect(screen.getByText("Alice")).toBeInTheDocument();
+  expect(screen.getByText("addr_test1alice")).toBeInTheDocument();
+  expect(screen.getByText("Bob")).toBeInTheDocument();
+
+  fireEvent.click(screen.getByText("Alice"));
+
+  const inputs = screen.getAllByRole("textbox");
+  expect(inputs[0]).toHaveValue("addr_test1alice");
+  // The picker list closes after a selection.
+  expect(screen.queryByText("Bob")).not.toBeInTheDocument();
+});
+
+test("(q) the Address book picker closes on a second click of the toggle", () => {
+  mockContacts([ALICE]);
+  render(<Send />);
+
+  const toggle = screen.getByRole("button", { name: /address book/i });
+  fireEvent.click(toggle);
+  expect(screen.getByText("Alice")).toBeInTheDocument();
+
+  fireEvent.click(toggle);
+  expect(screen.queryByText("Alice")).not.toBeInTheDocument();
 });

--- a/ui/web/src/screens/Send.tsx
+++ b/ui/web/src/screens/Send.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import type { Preview, TxResult, SendAsset, UnsignedTx, HandleInfo } from "../api/types";
 import { buildSend, confirmSend, exportUnsigned, resolveHandle, ApiError } from "../api/client";
+import { useContacts } from "../api/hooks";
 import { Card } from "../components/Card";
 import { Input } from "../components/Input";
 import { Button } from "../components/Button";
@@ -51,6 +52,9 @@ interface ComposeProps {
 function Compose({ to, setTo, adaAmount, setAdaAmount, assetRows, setAssetRows, onPreview }: ComposeProps) {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const contacts = useContacts();
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const contactPickerListID = "send-contact-picker-list";
 
   // ADA Handle resolution: when `to` names a handle ($name), debounce a
   // lookup through the node and show the resolved address (or a clean
@@ -178,14 +182,47 @@ function Compose({ to, setTo, adaAmount, setAdaAmount, assetRows, setAssetRows, 
     <Card title="Send ADA">
       <div className="send-form">
         <label htmlFor="send-to">Recipient address or $handle</label>
-        <Input
-          id="send-to"
-          type="text"
-          placeholder="addr1... or $handle"
-          value={to}
-          onChange={(e) => setTo(e.target.value)}
-          disabled={loading}
-        />
+        <div className="send-to-row">
+          <Input
+            id="send-to"
+            type="text"
+            placeholder="addr1... or $handle"
+            value={to}
+            onChange={(e) => setTo(e.target.value)}
+            disabled={loading}
+          />
+          {contacts.data && contacts.data.length > 0 && (
+            <Button
+              variant="ghost"
+              onClick={() => setPickerOpen((open) => !open)}
+              disabled={loading}
+              aria-controls={contactPickerListID}
+              aria-expanded={pickerOpen}
+            >
+              Address book
+            </Button>
+          )}
+        </div>
+        {pickerOpen && contacts.data && contacts.data.length > 0 && (
+          <ul id={contactPickerListID} className="contact-picker-list" aria-label="Saved contacts">
+            {contacts.data.map((c) => (
+              <li key={c.id}>
+                <button
+                  type="button"
+                  className="contact-picker-item"
+                  disabled={loading}
+                  onClick={() => {
+                    setTo(c.address);
+                    setPickerOpen(false);
+                  }}
+                >
+                  <span className="contact-picker-name">{c.name}</span>
+                  <code className="contact-picker-address mono">{c.address}</code>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
         {handleInput && resolvingHandle && (
           <p className="helper-text">Resolving handle…</p>
         )}

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -1476,6 +1476,109 @@ a:hover {
   display: inline; /* shown on desktop; hidden inside the mobile query */
 }
 
+/* --------------------------------------------------- address book (contacts) - */
+.screen-contacts {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-width: 880px;
+}
+.contact-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: var(--space-3);
+}
+.contact-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+.contact-row:last-child {
+  border-bottom: none;
+}
+.contact-info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+.contact-name {
+  font-weight: 600;
+  color: var(--text);
+}
+.contact-address {
+  font-size: 0.8125rem;
+  word-break: break-all;
+  color: var(--text-muted);
+}
+.contact-note {
+  font-size: 0.8125rem;
+}
+.contact-row-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+/* Recipient row on Send: the address field plus the "Address book" toggle. */
+.send-to-row {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+.send-to-row .field {
+  flex: 1;
+  min-width: 0;
+}
+
+/* The address-book picker dropdown that opens under the Send recipient field. */
+.contact-picker-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  background: var(--inset);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--space-2);
+  margin-bottom: var(--space-1);
+  max-height: 220px;
+  overflow-y: auto;
+}
+.contact-picker-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  width: 100%;
+  padding: var(--space-2);
+  border: none;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+}
+.contact-picker-item:hover,
+.contact-picker-item:focus-visible {
+  background: var(--surface);
+}
+.contact-picker-name {
+  font-weight: 600;
+}
+.contact-picker-address {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  word-break: break-all;
+}
+
 /* ============================================================ mobile ===== */
 /* Below 768 px the left sidebar is replaced by a top bar + slide-out drawer.
    Everything above 768 px is unchanged — the desktop layout still rules.    */

--- a/ui/web/src/test/mockContacts.ts
+++ b/ui/web/src/test/mockContacts.ts
@@ -1,0 +1,17 @@
+import * as hooks from "../api/hooks";
+import type { Contact } from "../api/types";
+
+export function mockContacts(
+  data: Contact[] | null,
+  opts?: { loading?: boolean; error?: Error | null }
+) {
+  const refresh = vi.fn();
+  vi.spyOn(hooks, "useContacts").mockReturnValue({
+    data,
+    error: opts?.error ?? null,
+    loading: opts?.loading ?? false,
+    refresh,
+    setData: vi.fn(),
+  } as never);
+  return refresh;
+}


### PR DESCRIPTION

<img width="1440" height="900" alt="pr565-address-book" src="https://github.com/user-attachments/assets/b80c10f1-cee8-4c3a-811c-0a8424c857f7" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local-only address book to save, edit, and delete recipients, with a Contacts screen and a picker on Send. Data is stored on-device as `contacts.json`; startup continues with an empty book if the file is invalid or too large.

- New Features
  - Local store `ui/internal/contacts`: pure on-device JSON with validation (incl. address checks), byte/entry caps, atomic writes, and safe load that falls back to empty on bad/oversized files.
  - API: `GET /wallet/contacts`, `POST /wallet/contacts` (upsert by optional `id`), `DELETE /wallet/contacts/:id`.
  - Web: types `Contact`, `UpsertContactRequest`; client `getContacts`, `upsertContact`, `deleteContact`; hook `useContacts`.
  - UI: new `Contacts` screen, nav entry, and recipient picker in Send; client-side byte caps mirror backend; new styles.
  - Tests: store unit tests, API handler tests with fakes, Contacts screen tests, and updated Send tests.

<sup>Written for commit 99722fe98127a5f1b63a66f003acbd72dc59b962. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local contacts/address book screen to save, edit, and delete recipient entries.
  * Added a recipient picker in Send so you can choose from saved contacts to fill the address field.
  * Contacts are loaded automatically at startup and kept available even if stored data has issues, with the app continuing to open normally.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->