### PR TITLE
feat(ui): light theme + toggle

### DIFF
--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -8,6 +8,7 @@ import { Button } from "./components/Button";
 import { SyncBanner } from "./components/SyncBanner";
 import { WalletSwitcher } from "./components/WalletSwitcher";
 import { MobileNav } from "./components/MobileNav";
+import { ThemeToggle } from "./components/ThemeToggle";
 import { useHashRoute, navigate } from "./router";
 import { CreateVault } from "./screens/CreateVault";
 import { UnlockVault } from "./screens/UnlockVault";
@@ -350,6 +351,9 @@ export function App() {
           <div className="brand">
             <span className="brand-mark">BVRSA</span>
             <span className="brand-motto">nodvs tvvs · claves tvæ</span>
+          </div>
+          <div className="sidebar-theme">
+            <ThemeToggle />
           </div>
           <WalletSwitcher
             wallets={wallets}

--- a/ui/web/src/components/ThemeToggle.test.tsx
+++ b/ui/web/src/components/ThemeToggle.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ThemeToggle } from "./ThemeToggle";
+
+const STORAGE_KEY = "bursa:theme";
+
+afterEach(() => {
+  localStorage.clear();
+  document.documentElement.removeAttribute("data-theme");
+});
+
+test("renders a Dark/Light group with the current theme marked pressed", () => {
+  render(<ThemeToggle />);
+  const dark = screen.getByRole("button", { name: "Dark" });
+  const light = screen.getByRole("button", { name: "Light" });
+  // No stored choice and the mocked matchMedia (test-setup.ts) reports no
+  // light preference, so dark is the resolved default.
+  expect(dark).toHaveAttribute("aria-pressed", "true");
+  expect(light).toHaveAttribute("aria-pressed", "false");
+});
+
+test("clicking Light sets data-theme=light on the document root and persists it", () => {
+  render(<ThemeToggle />);
+  fireEvent.click(screen.getByRole("button", { name: "Light" }));
+
+  expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  expect(localStorage.getItem(STORAGE_KEY)).toBe("light");
+  expect(screen.getByRole("button", { name: "Light" })).toHaveAttribute("aria-pressed", "true");
+  expect(screen.getByRole("button", { name: "Dark" })).toHaveAttribute("aria-pressed", "false");
+});
+
+test("clicking Dark after Light sets data-theme=dark and persists it", () => {
+  render(<ThemeToggle />);
+  fireEvent.click(screen.getByRole("button", { name: "Light" }));
+  fireEvent.click(screen.getByRole("button", { name: "Dark" }));
+
+  expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+  expect(localStorage.getItem(STORAGE_KEY)).toBe("dark");
+});
+
+test("a persisted choice is read back on the next mount (simulated reload)", () => {
+  localStorage.setItem(STORAGE_KEY, "light");
+
+  render(<ThemeToggle />);
+
+  expect(screen.getByRole("button", { name: "Light" })).toHaveAttribute("aria-pressed", "true");
+  expect(screen.getByRole("button", { name: "Dark" })).toHaveAttribute("aria-pressed", "false");
+});
+
+test("two mounted instances stay in sync: clicking one updates the other", () => {
+  // Mirrors the real app: the sidebar ThemeToggle and the Settings >
+  // Appearance ThemeToggle are mounted at the same time.
+  render(
+    <>
+      <ThemeToggle />
+      <ThemeToggle />
+    </>,
+  );
+  const [firstDark, secondDark] = screen.getAllByRole("button", { name: "Dark" });
+  const [firstLight, secondLight] = screen.getAllByRole("button", { name: "Light" });
+
+  fireEvent.click(firstLight);
+
+  // The clicked instance updates...
+  expect(firstLight).toHaveAttribute("aria-pressed", "true");
+  expect(firstDark).toHaveAttribute("aria-pressed", "false");
+  // ...and so does the OTHER, untouched instance.
+  expect(secondLight).toHaveAttribute("aria-pressed", "true");
+  expect(secondDark).toHaveAttribute("aria-pressed", "false");
+
+  fireEvent.click(secondDark);
+
+  expect(firstDark).toHaveAttribute("aria-pressed", "true");
+  expect(firstLight).toHaveAttribute("aria-pressed", "false");
+  expect(secondDark).toHaveAttribute("aria-pressed", "true");
+  expect(secondLight).toHaveAttribute("aria-pressed", "false");
+});

--- a/ui/web/src/components/ThemeToggle.tsx
+++ b/ui/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,31 @@
+import { useTheme } from "../theme";
+
+// ThemeToggle is a compact two-way segmented control (the same instrument-tab
+// styling as the Operate screen's mode switch) for picking the dark cockpit
+// theme or its light counterpart. It's rendered both in the sidebar (a
+// header-level control, visible on every unlocked screen) and in
+// Settings > Appearance.
+export function ThemeToggle() {
+  const [theme, setTheme] = useTheme();
+
+  return (
+    <div className="theme-toggle" role="group" aria-label="Theme">
+      <button
+        type="button"
+        className={theme === "dark" ? "operate-tab active" : "operate-tab"}
+        aria-pressed={theme === "dark"}
+        onClick={() => setTheme("dark")}
+      >
+        Dark
+      </button>
+      <button
+        type="button"
+        className={theme === "light" ? "operate-tab active" : "operate-tab"}
+        aria-pressed={theme === "light"}
+        onClick={() => setTheme("light")}
+      >
+        Light
+      </button>
+    </div>
+  );
+}

--- a/ui/web/src/main.tsx
+++ b/ui/web/src/main.tsx
@@ -1,6 +1,11 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";
+import { initTheme } from "./theme";
 import "./styles/global.css";
+
+// Resolve and apply the theme (persisted choice, else OS preference) before
+// the first render so there's no flash of the wrong theme.
+initTheme();
 
 createRoot(document.getElementById("root")!).render(<StrictMode><App /></StrictMode>);

--- a/ui/web/src/screens/Settings.tsx
+++ b/ui/web/src/screens/Settings.tsx
@@ -5,6 +5,7 @@ import { CopyButton } from "../components/CopyButton";
 import { Button } from "../components/Button";
 import { Input } from "../components/Input";
 import { Select } from "../components/Select";
+import { ThemeToggle } from "../components/ThemeToggle";
 import { useStatus, useHistoryExpiry, useTPMStatus } from "../api/hooks";
 import type { AsyncState } from "../api/hooks";
 import {
@@ -443,6 +444,13 @@ export function Settings({ account, spendingEnabled, autoLock }: SettingsProps) 
 
   return (
     <div className="screen-settings">
+      <Card title="Appearance">
+        <div className="setting-toggle-row">
+          <span className="setting-toggle-label">Theme</span>
+          <ThemeToggle />
+        </div>
+      </Card>
+
       <Card title="Network">
         <p>{account.network}</p>
       </Card>

--- a/ui/web/src/smoke.test.tsx
+++ b/ui/web/src/smoke.test.tsx
@@ -13,7 +13,15 @@ const walletA: WalletView = {
   active: true,
 };
 
-test("renders the app shell once a wallet is active", async () => {
+afterEach(() => {
+  document.documentElement.removeAttribute("data-theme");
+  vi.restoreAllMocks();
+});
+
+// renderUnlockedApp stubs the data hooks + unlockVault, renders the app, and
+// drives the vault-unlock form. Shared by both tests below so the theme
+// variations stay focused on the thing they're actually asserting.
+async function renderUnlockedApp() {
   vi.spyOn(hooks, "useStatus").mockReturnValue({
     data: { state: "ready", tip: 0, caughtUp: true },
     error: null,
@@ -38,4 +46,23 @@ test("renders the app shell once a wallet is active", async () => {
   // On mobile and desktop the nav is rendered in both the sidebar and the
   // mobile drawer, so multiple elements with the same label may be present.
   await waitFor(() => expect(screen.getAllByText("Portfolio").length).toBeGreaterThan(0));
+}
+
+test.each(["dark", "light"] as const)("renders the app shell in the %s theme", async (theme) => {
+  document.documentElement.setAttribute("data-theme", theme);
+
+  await renderUnlockedApp();
+
+  // The document root keeps carrying the theme the app started with — the app
+  // itself never touches data-theme (only src/theme.ts + the toggle do).
+  expect(document.documentElement.getAttribute("data-theme")).toBe(theme);
+});
+
+test("renders the app shell once a wallet is active", async () => {
+  await renderUnlockedApp();
+
+  // Nav items appear once the vault is unlocked and a wallet is active. On
+  // mobile and desktop the nav is rendered in both the sidebar and the
+  // mobile drawer, so multiple elements with the same label may be present.
+  expect(screen.getAllByText("Portfolio").length).toBeGreaterThan(0);
 });

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -867,6 +867,27 @@ a:hover {
   margin-bottom: 0;
 }
 
+/* ------------------------------------------------------------ theme toggle - */
+/* Compact Dark/Light segmented control, reusing .operate-tab's instrument
+   styling at a smaller size so it fits the sidebar header as well as a
+   Settings card. */
+.theme-toggle {
+  display: inline-flex;
+  gap: var(--space-1);
+}
+.theme-toggle .operate-tab {
+  padding: 5px var(--space-2);
+  font-size: 0.625rem;
+}
+
+/* The sidebar's copy of the toggle sits under the brand, set off the same way
+   the wallet switcher is (bottom hairline + bottom margin) for rhythm. */
+.sidebar-theme {
+  padding: 0 var(--space-2) var(--space-3);
+  margin-bottom: var(--space-2);
+  border-bottom: 1px solid var(--border);
+}
+
 /* ------------------------------------------------------ settings toggles -- */
 /* A labeled switch row: caption on the left, a sliding toggle on the right. */
 .setting-toggle-row {

--- a/ui/web/src/styles/tokens.css
+++ b/ui/web/src/styles/tokens.css
@@ -1,8 +1,45 @@
-:root {
-  /* Bursa — Lat. "purse / treasury". A node-operator instrument panel:
-     a dark cockpit for your own full node, with a classical gold (coin) accent. */
+/* Bursa — Lat. "purse / treasury". A node-operator instrument panel:
+   a cockpit for your own full node, with a classical gold (coin) accent.
 
-  /* Surfaces — dark, cool blue-slate cockpit */
+   Two themes share one shape: dark cockpit (default) and a light counterpart.
+   Every color lives in a CSS custom property here; global.css never hardcodes
+   a color. The active theme is selected by a `data-theme` attribute on the
+   document root (<html>), written by src/theme.ts:
+     - `:root[data-theme="dark"]`  — explicit dark (same values as the :root default)
+     - `:root[data-theme="light"]` — explicit light
+   `:root` alone (no attribute yet, e.g. before JS runs) falls back to dark.
+   Selectors are order-independent by specificity, not by source order:
+   `:root[data-theme="light"]` and `:root[data-theme="dark"]` are both
+   0,2,0 (`:root` + an attribute selector), which beats a plain `:root`
+   (0,1,0). So light always wins when the attribute says "light", and a
+   reorder of these blocks (or an inserted rule between them) can't
+   silently flip the default. */
+
+:root {
+  /* Shape + type — identical across themes. */
+  --radius: 6px;
+  --radius-lg: 10px;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 16px;
+  --space-4: 24px;
+  --space-5: 36px;
+
+  --font:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --mono: ui-monospace, "SF Mono", SFMono-Regular, "JetBrains Mono", Menlo, Consolas, monospace;
+
+  /* Gold-tint wash used behind active nav/wallet rows and focus rings. Derived
+     from --accent so it automatically follows whichever theme is active. */
+  --accent-dim: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+/* ------------------------------------------------------- dark (default) -- */
+/* Surfaces — dark, cool blue-slate cockpit. */
+:root,
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
   --bg: #0c0f15; /* ground */
   --surface: #151a22; /* panels */
   --inset: #1d2531; /* inputs, hovers, table stripes */
@@ -16,23 +53,37 @@
   /* Gold — the purse/coin; primary interactive + identity + key readouts */
   --accent: #d8a657;
   --accent-strong: #ecc079; /* hover / bright */
-  --accent-dim: color-mix(in srgb, var(--accent) 16%, transparent);
   --accent-text: #14110a; /* dark ink on gold fills */
 
   /* Node-health readouts — a distinct family so none clashes with gold */
   --ok: #58c47a; /* ready */
   --warn: #5fa2e6; /* syncing / working (blue reads as "in progress") */
   --error: #ff6166; /* error */
+}
 
-  --radius: 6px;
-  --radius-lg: 10px;
-  --space-1: 4px;
-  --space-2: 8px;
-  --space-3: 16px;
-  --space-4: 24px;
-  --space-5: 36px;
+/* ------------------------------------------------------------- light -- */
+/* A legible light counterpart: light blue-slate surfaces, dark ink, and a
+   deepened "antique bronze" gold. The airy dark-mode gold (#d8a657) drops
+   below WCAG AA (~2.2:1) when used as text on a light ground, so the light
+   theme darkens it (~5.9-6.9:1 against bg/surface/inset) and flips
+   --accent-text to white for fills (gold buttons, active tabs). */
+:root[data-theme="light"] {
+  color-scheme: light;
 
-  --font:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  --mono: ui-monospace, "SF Mono", SFMono-Regular, "JetBrains Mono", Menlo, Consolas, monospace;
+  --bg: #f7f9fc;
+  --surface: #ffffff;
+  --inset: #eef1f6;
+  --border: #ccd6e0;
+
+  --text: #1a2230;
+  --text-muted: #55606f;
+  --text-faint: #5f6b7a;
+
+  --accent: #7d5010;
+  --accent-strong: #64400c;
+  --accent-text: #ffffff;
+
+  --ok: #187a42;
+  --warn: #2f6fb5;
+  --error: #c22f37;
 }

--- a/ui/web/src/test-setup.ts
+++ b/ui/web/src/test-setup.ts
@@ -1,1 +1,19 @@
 import "@testing-library/jest-dom/vitest";
+
+// jsdom doesn't implement matchMedia; src/theme.ts uses it to read the OS
+// light/dark preference. Default to "no match" (dark) so any test that
+// renders theme-aware UI works without further setup; individual tests can
+// still override window.matchMedia to exercise a specific OS preference.
+if (typeof window !== "undefined" && !window.matchMedia) {
+  window.matchMedia = ((query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList) as typeof window.matchMedia;
+}

--- a/ui/web/src/theme.test.ts
+++ b/ui/web/src/theme.test.ts
@@ -1,0 +1,167 @@
+import { renderHook, act } from "@testing-library/react";
+import {
+  getStoredTheme,
+  getSystemTheme,
+  resolveTheme,
+  applyTheme,
+  setTheme,
+  initTheme,
+  watchSystemTheme,
+  useTheme,
+} from "./theme";
+
+const STORAGE_KEY = "bursa:theme";
+
+function mockMatchMedia(matchesLight: boolean) {
+  const listeners = new Set<(e: MediaQueryListEvent) => void>();
+  const mql = {
+    matches: matchesLight,
+    media: "(prefers-color-scheme: light)",
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: (_event: string, cb: (e: MediaQueryListEvent) => void) => listeners.add(cb),
+    removeEventListener: (_event: string, cb: (e: MediaQueryListEvent) => void) =>
+      listeners.delete(cb),
+    dispatchEvent: () => false,
+  } as unknown as MediaQueryList;
+  window.matchMedia = vi.fn().mockReturnValue(mql);
+  return {
+    fire: (matches: boolean) => listeners.forEach((cb) => cb({ matches } as MediaQueryListEvent)),
+  };
+}
+
+afterEach(() => {
+  localStorage.clear();
+  document.documentElement.removeAttribute("data-theme");
+  vi.restoreAllMocks();
+});
+
+test("getStoredTheme returns null when nothing has been saved", () => {
+  expect(getStoredTheme()).toBeNull();
+});
+
+test("getStoredTheme returns a previously persisted valid theme", () => {
+  localStorage.setItem(STORAGE_KEY, "light");
+  expect(getStoredTheme()).toBe("light");
+});
+
+test("getStoredTheme ignores a garbage stored value", () => {
+  localStorage.setItem(STORAGE_KEY, "solarized");
+  expect(getStoredTheme()).toBeNull();
+});
+
+test("getSystemTheme reflects the OS light preference", () => {
+  mockMatchMedia(true);
+  expect(getSystemTheme()).toBe("light");
+});
+
+test("getSystemTheme falls back to dark when the OS has no light preference", () => {
+  mockMatchMedia(false);
+  expect(getSystemTheme()).toBe("dark");
+});
+
+test("resolveTheme prefers the stored choice over the OS preference", () => {
+  mockMatchMedia(true); // OS says light
+  localStorage.setItem(STORAGE_KEY, "dark"); // user chose dark
+  expect(resolveTheme()).toBe("dark");
+});
+
+test("resolveTheme falls back to the OS preference when nothing is stored", () => {
+  mockMatchMedia(true);
+  expect(resolveTheme()).toBe("light");
+});
+
+test("applyTheme sets data-theme on the document root", () => {
+  applyTheme("light");
+  expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  applyTheme("dark");
+  expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+});
+
+test("setTheme applies AND persists the choice, so it reads back after a reload", () => {
+  setTheme("light");
+  expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  expect(localStorage.getItem(STORAGE_KEY)).toBe("light");
+  // Simulate a fresh load: a new resolveTheme() call reads the persisted value.
+  expect(resolveTheme()).toBe("light");
+});
+
+test("initTheme applies and returns the resolved theme", () => {
+  mockMatchMedia(true);
+  const theme = initTheme();
+  expect(theme).toBe("light");
+  expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+});
+
+test("watchSystemTheme invokes the callback on OS preference changes and can unsubscribe", () => {
+  const { fire } = mockMatchMedia(false);
+  const cb = vi.fn();
+  const unsubscribe = watchSystemTheme(cb);
+
+  fire(true);
+  expect(cb).toHaveBeenCalledWith("light");
+
+  unsubscribe();
+  cb.mockClear();
+  fire(false);
+  expect(cb).not.toHaveBeenCalled();
+});
+
+test("watchSystemTheme falls back to addListener/removeListener when addEventListener is unavailable (Safari < 14)", () => {
+  const listeners = new Set<(e: MediaQueryListEvent) => void>();
+  const mql = {
+    matches: false,
+    media: "(prefers-color-scheme: light)",
+    onchange: null,
+    addListener: (cb: (e: MediaQueryListEvent) => void) => listeners.add(cb),
+    removeListener: (cb: (e: MediaQueryListEvent) => void) => listeners.delete(cb),
+    dispatchEvent: () => false,
+  } as unknown as MediaQueryList;
+  window.matchMedia = vi.fn().mockReturnValue(mql);
+
+  const cb = vi.fn();
+  const unsubscribe = watchSystemTheme(cb);
+
+  listeners.forEach((l) => l({ matches: true } as MediaQueryListEvent));
+  expect(cb).toHaveBeenCalledWith("light");
+
+  unsubscribe();
+  cb.mockClear();
+  listeners.forEach((l) => l({ matches: false } as MediaQueryListEvent));
+  expect(cb).not.toHaveBeenCalled();
+});
+
+test("useTheme reads the initial theme and its setter applies + persists", () => {
+  mockMatchMedia(false);
+  const { result } = renderHook(() => useTheme());
+  expect(result.current[0]).toBe("dark");
+
+  act(() => result.current[1]("light"));
+
+  expect(result.current[0]).toBe("light");
+  expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  expect(localStorage.getItem(STORAGE_KEY)).toBe("light");
+});
+
+test("useTheme tracks live OS changes only until the user makes an explicit choice", () => {
+  const { fire } = mockMatchMedia(false);
+  const { result } = renderHook(() => useTheme());
+  expect(result.current[0]).toBe("dark");
+
+  // No explicit choice yet: OS flipping to light should update the hook AND
+  // the DOM attribute the CSS keys off of.
+  act(() => fire(true));
+  expect(result.current[0]).toBe("light");
+  expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+
+  // User makes an explicit choice...
+  act(() => result.current[1]("dark"));
+  expect(result.current[0]).toBe("dark");
+
+  // ...so a later OS change must NOT override it, in state or in the DOM.
+  act(() => fire(true));
+  expect(result.current[0]).toBe("dark");
+  expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+  expect(localStorage.getItem(STORAGE_KEY)).toBe("dark");
+});

--- a/ui/web/src/theme.ts
+++ b/ui/web/src/theme.ts
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type Theme = "light" | "dark";
+
+// STORAGE_KEY is the localStorage key that persists the user's explicit
+// choice. Nothing stored means "follow the OS preference" (see resolveTheme).
+const STORAGE_KEY = "bursa:theme";
+
+function isTheme(value: unknown): value is Theme {
+  return value === "light" || value === "dark";
+}
+
+// getStoredTheme reads the user's persisted choice, if any. Returns null on
+// first run (nothing saved yet) or if storage throws (private browsing,
+// disabled storage, quota) so callers fall back to the OS preference.
+export function getStoredTheme(): Theme | null {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return isTheme(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+// persistTheme saves an explicit choice. Failures are swallowed on purpose:
+// the theme still applies for this session via the DOM attribute, it just
+// won't survive a reload.
+function persistTheme(theme: Theme): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  } catch {
+    // ignore
+  }
+}
+
+// getSystemTheme reads the OS-level light/dark preference. Defaults to "dark"
+// (Bursa's native cockpit theme) when the environment can't report one at all
+// (no matchMedia support).
+export function getSystemTheme(): Theme {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return "dark";
+  }
+  return window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+}
+
+// resolveTheme is the effective theme: the user's explicit choice if they've
+// made one, else the OS preference.
+export function resolveTheme(): Theme {
+  return getStoredTheme() ?? getSystemTheme();
+}
+
+// applyTheme sets the data-theme attribute that tokens.css keys off of.
+export function applyTheme(theme: Theme): void {
+  document.documentElement.setAttribute("data-theme", theme);
+}
+
+// listeners holds every mounted `useTheme` instance's resync callback. Theme
+// state is otherwise global (a single DOM attribute + localStorage key), but
+// each `useTheme` call keeps its own React state mirroring it — without this
+// fan-out, flipping the theme from one instance (e.g. the sidebar
+// ThemeToggle) would apply immediately in the DOM while a second mounted
+// instance (e.g. the Settings > Appearance ThemeToggle) kept rendering the
+// stale value until some unrelated re-render caught it up.
+const listeners = new Set<(theme: Theme) => void>();
+
+// setTheme applies and persists an explicit user choice, then notifies every
+// subscribed `useTheme` instance so they all stay in sync.
+export function setTheme(theme: Theme): void {
+  applyTheme(theme);
+  persistTheme(theme);
+  listeners.forEach((listener) => listener(theme));
+}
+
+// initTheme resolves and applies the initial theme. Call once at startup
+// (before the app renders) to avoid a flash of the wrong theme.
+export function initTheme(): Theme {
+  const theme = resolveTheme();
+  applyTheme(theme);
+  return theme;
+}
+
+// watchSystemTheme invokes `cb` whenever the OS-level preference changes and
+// returns an unsubscribe function. Callers should only listen while the user
+// has not made an explicit choice of their own (getStoredTheme() === null).
+export function watchSystemTheme(cb: (theme: Theme) => void): () => void {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return () => {};
+  }
+  const mql = window.matchMedia("(prefers-color-scheme: light)");
+  const handler = (e: MediaQueryListEvent) => cb(e.matches ? "light" : "dark");
+  if (typeof mql.addEventListener === "function") {
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }
+  // Safari < 14 only exposes the deprecated addListener/removeListener pair;
+  // without this fallback, subscribing throws during effect setup there.
+  mql.addListener(handler);
+  return () => mql.removeListener(handler);
+}
+
+// useTheme gives components the current theme plus a setter that both applies
+// and persists the choice. While the user hasn't made an explicit choice
+// (tracked by `hasExplicit`, seeded from storage and flipped true the moment
+// `set` is called), it also tracks live OS-preference changes, applying them
+// to the DOM as they happen; once the user picks a theme this session, the
+// subscription is torn down so a later OS change can't silently override it.
+export function useTheme(): [Theme, (theme: Theme) => void] {
+  const [theme, setThemeState] = useState<Theme>(() => resolveTheme());
+  const [hasExplicit, setHasExplicit] = useState<boolean>(() => getStoredTheme() !== null);
+
+  useEffect(() => {
+    if (hasExplicit) return undefined;
+    return watchSystemTheme((next) => {
+      applyTheme(next);
+      setThemeState(next);
+    });
+  }, [hasExplicit]);
+
+  // Resync with explicit choices made by any OTHER mounted `useTheme`
+  // instance (see `listeners` above). Also fires for this instance's own
+  // `set` call below, which is a harmless no-op re-render.
+  useEffect(() => {
+    const listener = (next: Theme) => {
+      setThemeState(next);
+      setHasExplicit(true);
+    };
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  const set = useCallback((next: Theme) => {
+    setTheme(next);
+    setThemeState(next);
+    setHasExplicit(true);
+  }, []);
+
+  return [theme, set];
+}


### PR DESCRIPTION

<img width="1440" height="900" alt="pr566-theme-dark" src="https://github.com/user-attachments/assets/ee371fd4-a528-4630-a603-67b72d13f6a8" />
<img width="1440" height="900" alt="pr566-theme-light" src="https://github.com/user-attachments/assets/aad5f02a-beed-41d9-b17b-197f90d9132a" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a light theme with a Dark/Light toggle in the sidebar and Settings. The app follows the OS preference until the user picks, remembers the choice, and applies it before first render to avoid flashes.

- **New Features**
  - Adds light/dark tokens keyed by a `data-theme` attribute on `<html>`; dark is default, light uses higher-contrast colors, and each sets `color-scheme` appropriately.
  - Introduces a `ThemeToggle` used in the sidebar and Settings > Appearance; multiple instances stay in sync.
  - Resolves the theme from localStorage or OS preference; `initTheme()` applies pre-render and `useTheme()` manages updates, persistence, and OS changes (with a Safari `addListener` fallback) until the user picks.
  - Adds tests for theme resolution and applying `data-theme`, OS change watching/unsubscribe, Safari fallback, toggle sync, a `matchMedia` test shim, and smoke tests verifying the app renders correctly in both themes.

<sup>Written for commit 81a18bd1148f507f718cc5bee8a257ffec0cd13f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added light/dark theme switching throughout the web app.
  * Included a theme toggle in the sidebar and on the Settings page.
  * Theme preference now applies before the app finishes loading and stays in sync across the interface.

* **Bug Fixes**
  * Improved theme persistence so the selected appearance is remembered.
  * Added better fallback behavior when browser theme detection isn’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->