### PR TITLE
feat(ui): create-wallet flow with recovery-phrase re-entry challenge

### DIFF
--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	bursa "github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/bursa/ui/internal/chain"
 	"github.com/blinklabs-io/bursa/ui/internal/handle"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
@@ -541,6 +542,20 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 		}
 		bindActive(meta)
 		writeJSON(w, http.StatusOK, toWalletView(meta, meta.ID))
+	})
+
+	// GET /wallet/mnemonic/generate returns a freshly generated 24-word BIP39
+	// mnemonic (256-bit entropy). The phrase is generated server-side so the
+	// client never handles raw entropy. This endpoint is ungated — it needs
+	// neither a running node nor an unlocked vault, and is loopback-only so there
+	// is no risk of the phrase leaking over the network.
+	mux.HandleFunc("GET /wallet/mnemonic/generate", func(w http.ResponseWriter, _ *http.Request) {
+		m, err := bursa.GenerateMnemonic()
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, errBody(err))
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"mnemonic": m})
 	})
 
 	mux.HandleFunc("POST /wallet/{id}/activate", func(w http.ResponseWriter, r *http.Request) {

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -653,6 +653,31 @@ func TestAddWalletDuplicateConflict(t *testing.T) {
 	}
 }
 
+// TestGenerateMnemonic asserts the generate endpoint returns a non-empty
+// mnemonic (24-word / 256-bit BIP39). It does not need a vault or a node —
+// the endpoint is ungated and uses only the bursa core lib.
+func TestGenerateMnemonic(t *testing.T) {
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/mnemonic/generate", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /wallet/mnemonic/generate = %d, want 200", rec.Code)
+	}
+	var body struct {
+		Mnemonic string `json:"mnemonic"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Mnemonic == "" {
+		t.Fatal("expected non-empty mnemonic")
+	}
+	words := strings.Fields(body.Mnemonic)
+	if len(words) != 24 {
+		t.Fatalf("expected 24-word mnemonic, got %d words", len(words))
+	}
+}
+
 func TestActivateWalletBinds(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -131,6 +131,10 @@ export const migrateLegacyKeystore = (req: MigrateLegacyKeystoreRequest) =>
   apiPost<WalletView>("/vault/migrate-legacy", req);
 
 // Wallet management.
+// generateMnemonic calls the server-side BIP39 generator (256-bit / 24 words).
+// Generating server-side keeps raw entropy inside the loopback process.
+export const generateMnemonic = () =>
+  apiGet<{ mnemonic: string }>("/wallet/mnemonic/generate").then((r) => r.mnemonic);
 export const addWallet = (req: AddWalletRequest) => apiPost<WalletView>("/wallet", req);
 export const activateWallet = (id: string) =>
   apiPost<WalletView>(`/wallet/${encodeURIComponent(id)}/activate`);

--- a/ui/web/src/app.test.tsx
+++ b/ui/web/src/app.test.tsx
@@ -264,7 +264,12 @@ test("Add wallet action opens the add-wallet form", async () => {
 
   await waitFor(() => expect(screen.getByText("Main")).toBeInTheDocument());
   fireEvent.click(screen.getByRole("button", { name: /add wallet/i }));
-  // The add-wallet form (with a recovery-phrase field) appears.
+  // The add-wallet flow now starts with a create/restore chooser.
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: /restore from recovery phrase/i })).toBeInTheDocument(),
+  );
+  // Navigate to the restore path to get the recovery phrase field.
+  fireEvent.click(screen.getByRole("button", { name: /restore from recovery phrase/i }));
   await waitFor(() => expect(screen.getByLabelText(/recovery phrase/i)).toBeInTheDocument());
 });
 

--- a/ui/web/src/phraseChallenge.test.ts
+++ b/ui/web/src/phraseChallenge.test.ts
@@ -1,0 +1,96 @@
+import {
+  pickChallengeIndices,
+  normalizeWord,
+  isChallengeAnswerCorrect,
+  validateChallenge,
+  CHALLENGE_WORD_COUNT,
+} from "./phraseChallenge";
+
+test("CHALLENGE_WORD_COUNT is 3", () => {
+  expect(CHALLENGE_WORD_COUNT).toBe(3);
+});
+
+test("pickChallengeIndices returns the requested count of distinct, in-range, sorted indices", () => {
+  // A deterministic rng that cycles through fixed fractions.
+  const values = [0.01, 0.5, 0.99, 0.2];
+  let i = 0;
+  const rng = () => values[i++ % values.length];
+  const indices = pickChallengeIndices(24, 3, rng);
+  expect(indices).toHaveLength(3);
+  expect(new Set(indices).size).toBe(3);
+  for (const idx of indices) {
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(idx).toBeLessThan(24);
+  }
+  expect(indices).toEqual([...indices].sort((a, b) => a - b));
+});
+
+test("pickChallengeIndices retries on duplicate rng draws until distinct", () => {
+  // First two draws collide (both map to index 0); rng must be called again.
+  const values = [0.0, 0.0, 0.5, 0.9];
+  let i = 0;
+  const rng = () => values[i++];
+  const indices = pickChallengeIndices(10, 2, rng);
+  expect(indices).toHaveLength(2);
+  expect(new Set(indices).size).toBe(2);
+});
+
+test("pickChallengeIndices throws when count exceeds wordCount", () => {
+  expect(() => pickChallengeIndices(2, 3)).toThrow();
+});
+
+test("normalizeWord trims whitespace and lowercases", () => {
+  expect(normalizeWord("  Zebra  ")).toBe("zebra");
+  expect(normalizeWord("ZEBRA")).toBe("zebra");
+  expect(normalizeWord("zebra")).toBe("zebra");
+});
+
+const WORDS = [
+  "abandon", "ability", "able", "about", "above", "absent",
+  "absorb", "abstract", "absurd", "abuse", "access", "accident",
+  "account", "accuse", "achieve", "acid", "acoustic", "acquire",
+  "across", "act", "action", "actor", "actress", "actual",
+];
+
+test("isChallengeAnswerCorrect matches case- and whitespace-insensitively", () => {
+  expect(isChallengeAnswerCorrect(WORDS, 0, "  Abandon  ")).toBe(true);
+  expect(isChallengeAnswerCorrect(WORDS, 0, "wrong")).toBe(false);
+  expect(isChallengeAnswerCorrect(WORDS, 0, undefined)).toBe(false);
+  expect(isChallengeAnswerCorrect(WORDS, 0, "   ")).toBe(false);
+});
+
+test("validateChallenge accepts exact matches at the challenged indices", () => {
+  const indices = [0, 5, 23];
+  const answers = { 0: "abandon", 5: "absent", 23: "actual" };
+  expect(validateChallenge(WORDS, indices, answers)).toBe(true);
+});
+
+test("validateChallenge is case- and whitespace-insensitive", () => {
+  const indices = [0, 5];
+  const answers = { 0: "  Abandon", 5: "ABSENT  " };
+  expect(validateChallenge(WORDS, indices, answers)).toBe(true);
+});
+
+test("validateChallenge rejects a wrong word at any challenged index", () => {
+  const indices = [0, 5, 23];
+  const answers = { 0: "abandon", 5: "wrong-word", 23: "actual" };
+  expect(validateChallenge(WORDS, indices, answers)).toBe(false);
+});
+
+test("validateChallenge rejects a missing answer", () => {
+  const indices = [0, 5];
+  const answers = { 0: "abandon" };
+  expect(validateChallenge(WORDS, indices, answers)).toBe(false);
+});
+
+test("validateChallenge rejects a blank answer", () => {
+  const indices = [0, 5];
+  const answers = { 0: "abandon", 5: "   " };
+  expect(validateChallenge(WORDS, indices, answers)).toBe(false);
+});
+
+test("validateChallenge ignores unrelated answers outside the challenged indices", () => {
+  const indices = [0];
+  const answers = { 0: "abandon", 1: "totally-wrong-but-not-asked" };
+  expect(validateChallenge(WORDS, indices, answers)).toBe(true);
+});

--- a/ui/web/src/phraseChallenge.ts
+++ b/ui/web/src/phraseChallenge.ts
@@ -1,0 +1,63 @@
+// Pure logic for the recovery-phrase re-entry challenge shown in the
+// create-confirm step: after the server generates the recovery phrase and the
+// user has viewed it, they must correctly re-type a few random words (by
+// position) before the "Create wallet" submit is enabled. This is a UX check
+// that the phrase was actually saved, not an entropy or security boundary, so
+// picking positions with Math.random is fine. Kept separate from the
+// AddWallet screen so "which positions are asked" and "was the answer
+// correct" are unit-testable without rendering anything.
+
+// CHALLENGE_WORD_COUNT is how many random positions the user must confirm.
+export const CHALLENGE_WORD_COUNT = 3;
+
+/**
+ * pickChallengeIndices picks `count` distinct random positions in
+ * [0, wordCount), returned sorted ascending so the challenge always presents
+ * "word #4, word #9, ..." in phrase order rather than a shuffled one. `rng`
+ * defaults to Math.random but is injectable for deterministic tests.
+ */
+export function pickChallengeIndices(
+  wordCount: number,
+  count: number,
+  rng: () => number = Math.random,
+): number[] {
+  if (count > wordCount) {
+    throw new Error("challenge word count exceeds the mnemonic length");
+  }
+  const indices = new Set<number>();
+  while (indices.size < count) {
+    // Clamp defensively: the `rng` contract is [0, 1), but a custom test rng
+    // could return exactly 1 (or higher) and push the index out of bounds.
+    indices.add(Math.min(Math.floor(rng() * wordCount), wordCount - 1));
+  }
+  return [...indices].sort((a, b) => a - b);
+}
+
+// normalizeWord makes comparison whitespace- and case-insensitive: the user
+// may type "Zebra" or add stray spaces, and it should still count as correct.
+export function normalizeWord(word: string): string {
+  return word.trim().toLowerCase();
+}
+
+/**
+ * isChallengeAnswerCorrect reports whether a single typed answer matches the
+ * mnemonic's actual word at the given index. A blank answer is never correct.
+ */
+export function isChallengeAnswerCorrect(words: string[], index: number, answer: string | undefined): boolean {
+  if (!answer) return false;
+  return normalizeWord(answer) === normalizeWord(words[index] ?? "");
+}
+
+/**
+ * validateChallenge reports whether the user's answers match the mnemonic's
+ * actual words at every challenged index. `answers` maps a challenged index
+ * to the user's typed word; a missing or blank answer never counts as
+ * correct.
+ */
+export function validateChallenge(
+  words: string[],
+  indices: number[],
+  answers: Partial<Record<number, string>>,
+): boolean {
+  return indices.every((i) => isChallengeAnswerCorrect(words, i, answers[i]));
+}

--- a/ui/web/src/screens/AddWallet.test.tsx
+++ b/ui/web/src/screens/AddWallet.test.tsx
@@ -14,13 +14,25 @@ const created: WalletView = {
 
 const MNEMONIC = "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12";
 
+// 24-word mnemonic for the create-new path.
+const GENERATED =
+  "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong";
+
 afterEach(() => vi.restoreAllMocks());
+
+// Helper: navigate from the "choose" screen to the "restore" form.
+function goToRestore() {
+  fireEvent.click(screen.getByRole("button", { name: /restore from recovery phrase/i }));
+}
 
 test("with a known vault password the vault field is hidden and add sends all fields", async () => {
   const spy = vi.spyOn(client, "addWallet").mockResolvedValue(created);
   const onAdded = vi.fn();
 
   render(<AddWallet network="preview" knownVaultPassword="vault-password-xyz" onAdded={onAdded} />);
+
+  // The initial screen is the create/restore chooser.
+  goToRestore();
 
   // No vault-password field when the vault password is already known.
   expect(screen.queryByLabelText(/^vault password$/i)).not.toBeInTheDocument();
@@ -47,6 +59,7 @@ test("without a known vault password the vault field is shown and required", asy
   const onAdded = vi.fn();
 
   render(<AddWallet network="preview" onAdded={onAdded} />);
+  goToRestore();
 
   expect(screen.getByLabelText(/^vault password$/i)).toBeInTheDocument();
 
@@ -67,6 +80,7 @@ test("a too-short spending password is rejected client-side before any request",
   const onAdded = vi.fn();
 
   render(<AddWallet network="preview" knownVaultPassword="vault-password-xyz" onAdded={onAdded} />);
+  goToRestore();
   fireEvent.change(screen.getByLabelText(/recovery phrase/i), { target: { value: MNEMONIC } });
   fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "short" } });
   fireEvent.click(screen.getByRole("button", { name: /add wallet/i }));
@@ -74,4 +88,111 @@ test("a too-short spending password is rejected client-side before any request",
   await waitFor(() => expect(screen.getByText(/at least 12 characters/i)).toBeInTheDocument());
   expect(spy).not.toHaveBeenCalled();
   expect(onAdded).not.toHaveBeenCalled();
+});
+
+// Fills in every rendered recovery-phrase challenge input with the correct
+// word from `words` (challenged positions are randomized, so this reads each
+// input's own label rather than assuming fixed indices).
+function fillChallengeAnswers(words: string[]) {
+  const inputs = screen.getAllByLabelText(/^word #\d+$/i);
+  for (const input of inputs) {
+    const match = /Word #(\d+)/i.exec(input.getAttribute("aria-label") ?? "");
+    if (!match) throw new Error("challenge input missing a parseable label");
+    const index = Number(match[1]) - 1;
+    fireEvent.change(input, { target: { value: words[index] } });
+  }
+}
+
+test("create new wallet: generate phrase → acknowledge → pass challenge → fill form → submit", async () => {
+  vi.spyOn(client, "generateMnemonic").mockResolvedValue(GENERATED);
+  const spy = vi.spyOn(client, "addWallet").mockResolvedValue(created);
+  const onAdded = vi.fn();
+
+  render(
+    <AddWallet
+      network="preview"
+      knownVaultPassword="vault-password-xyz"
+      onAdded={onAdded}
+      submitLabel="Finish setup"
+    />,
+  );
+
+  // Click "Create new wallet" to trigger mnemonic generation.
+  fireEvent.click(screen.getByRole("button", { name: /create new wallet/i }));
+
+  // The generated phrase should appear; check for the unique last word.
+  await waitFor(() => expect(screen.getByText("wrong")).toBeInTheDocument());
+
+  // Must acknowledge before proceeding.
+  fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+  await waitFor(() =>
+    expect(screen.getByRole("alert")).toHaveTextContent(/confirm.*saved/i),
+  );
+
+  // Check the acknowledgement checkbox then proceed.
+  fireEvent.click(screen.getByLabelText(/i have saved my recovery phrase/i));
+  fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+  // Now on the create-confirm form: the phrase re-entry challenge gates the
+  // submit button until every quizzed word is answered correctly.
+  await waitFor(() =>
+    expect(screen.getByLabelText(/spending password/i)).toBeInTheDocument(),
+  );
+  fireEvent.change(screen.getByLabelText(/spending password/i), {
+    target: { value: "spend-password-aaa" },
+  });
+
+  expect(screen.getByRole("button", { name: /finish setup/i })).toBeDisabled();
+
+  // A wrong answer surfaces per-field "Incorrect" feedback and keeps submit
+  // disabled.
+  const [firstChallengeInput] = screen.getAllByLabelText(/^word #\d+$/i);
+  fireEvent.change(firstChallengeInput, { target: { value: "definitely-not-it" } });
+  await waitFor(() => expect(screen.getByText("Incorrect")).toBeInTheDocument());
+  expect(screen.getByRole("status")).toHaveTextContent("Incorrect");
+  expect(screen.getByRole("button", { name: /finish setup/i })).toBeDisabled();
+
+  // Filling in every challenged word correctly unlocks submit.
+  fillChallengeAnswers(GENERATED.split(" "));
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: /finish setup/i })).toBeEnabled(),
+  );
+  expect(screen.getAllByText("Correct").length).toBeGreaterThan(0);
+
+  fireEvent.click(screen.getByRole("button", { name: /finish setup/i }));
+
+  await waitFor(() =>
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mnemonic: GENERATED,
+        spend_password: "spend-password-aaa",
+        vault_password: "vault-password-xyz",
+      }),
+    ),
+  );
+  await waitFor(() => expect(onAdded).toHaveBeenCalledWith(created));
+});
+
+test("create-confirm: submit stays blocked while the challenge is unanswered or wrong", async () => {
+  vi.spyOn(client, "generateMnemonic").mockResolvedValue(GENERATED);
+  const spy = vi.spyOn(client, "addWallet");
+
+  render(<AddWallet network="preview" knownVaultPassword="vault-password-xyz" onAdded={vi.fn()} />);
+
+  fireEvent.click(screen.getByRole("button", { name: /create new wallet/i }));
+  await waitFor(() => expect(screen.getByText("wrong")).toBeInTheDocument());
+  fireEvent.click(screen.getByLabelText(/i have saved my recovery phrase/i));
+  fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: /add wallet/i })).toBeDisabled(),
+  );
+
+  fireEvent.change(screen.getByLabelText(/spending password/i), {
+    target: { value: "spend-password-aaa" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /add wallet/i }));
+
+  // The button is disabled, so the click is a no-op — no request is sent.
+  expect(spy).not.toHaveBeenCalled();
 });

--- a/ui/web/src/screens/AddWallet.tsx
+++ b/ui/web/src/screens/AddWallet.tsx
@@ -4,9 +4,11 @@ import { Card } from "../components/Card";
 import { Input } from "../components/Input";
 import { Select } from "../components/Select";
 import { Button } from "../components/Button";
-import { addWallet, ApiError } from "../api/client";
+import { CopyButton } from "../components/CopyButton";
+import { addWallet, generateMnemonic, ApiError } from "../api/client";
 import type { WalletView } from "../api/types";
 import { MIN_PASSWORD_LEN, passwordLength } from "../password";
+import { CHALLENGE_WORD_COUNT, isChallengeAnswerCorrect, pickChallengeIndices, validateChallenge } from "../phraseChallenge";
 
 const NETWORK_OPTIONS = [
   { value: "preview", label: "Preview" },
@@ -26,6 +28,9 @@ interface AddWalletProps {
   submitLabel?: string;
 }
 
+// Mode within the Add Wallet flow.
+type Mode = "choose" | "create" | "create-confirm" | "restore";
+
 export function AddWallet({
   network,
   knownVaultPassword,
@@ -34,6 +39,19 @@ export function AddWallet({
   title = "Add Wallet",
   submitLabel = "Add Wallet",
 }: AddWalletProps) {
+  const [mode, setMode] = useState<Mode>("choose");
+
+  // Create-new state
+  const [generatedMnemonic, setGeneratedMnemonic] = useState("");
+  const [confirmed, setConfirmed] = useState(false);
+  const [generating, setGenerating] = useState(false);
+
+  // Recovery-phrase re-entry challenge (create-confirm gate): a few random
+  // word positions the user must retype correctly before submit unlocks.
+  const [challengeIndices, setChallengeIndices] = useState<number[]>([]);
+  const [challengeAnswers, setChallengeAnswers] = useState<Record<number, string>>({});
+
+  // Shared form state
   const [name, setName] = useState("");
   const [mnemonic, setMnemonic] = useState("");
   const [selectedNetwork, setSelectedNetwork] = useState(network);
@@ -44,17 +62,60 @@ export function AddWallet({
 
   const needsVaultPassword = knownVaultPassword === undefined;
 
+  // --- "Create new wallet" path -------------------------------------------
+
+  async function handleGenerate() {
+    setError(null);
+    setGenerating(true);
+    try {
+      const m = await generateMnemonic();
+      setGeneratedMnemonic(m);
+      setConfirmed(false);
+      setMode("create");
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Failed to generate mnemonic");
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  function handleProceedToConfirm() {
+    if (!confirmed) {
+      setError("Please confirm you have saved your recovery phrase before continuing.");
+      return;
+    }
+    setError(null);
+    // Freshly pick which word positions to quiz on each time this step is
+    // entered, and clear any answers left over from a previous attempt.
+    const wordCount = generatedMnemonic.split(" ").length;
+    setChallengeIndices(pickChallengeIndices(wordCount, Math.min(CHALLENGE_WORD_COUNT, wordCount)));
+    setChallengeAnswers({});
+    setMode("create-confirm");
+  }
+
+  function handleChallengeAnswerChange(index: number, value: string) {
+    setChallengeAnswers((prev) => ({ ...prev, [index]: value }));
+  }
+
+  const generatedWords = generatedMnemonic.split(" ");
+  const challengePassed = validateChallenge(generatedWords, challengeIndices, challengeAnswers);
+
+  // --- Common submit path (restore or after create-confirm) ---------------
+
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     setError(null);
 
-    // Normalise pasted phrases: trim and collapse any whitespace to single spaces.
-    const cleanMnemonic = mnemonic.trim().replace(/\s+/g, " ");
-    if (cleanMnemonic === "") {
+    const mnemonicToUse = mode === "create-confirm" ? generatedMnemonic : mnemonic.trim().replace(/\s+/g, " ");
+
+    if (mode !== "create-confirm" && mnemonicToUse === "") {
       setError("Recovery phrase is required");
       return;
     }
-    // Count code points, not UTF-16 units, to match the server's RuneCount.
+    if (mode === "create-confirm" && !challengePassed) {
+      setError("Please correctly re-enter the requested words from your recovery phrase.");
+      return;
+    }
     if (passwordLength(spendPassword) < MIN_PASSWORD_LEN) {
       setError(`Spending password must be at least ${MIN_PASSWORD_LEN} characters`);
       return;
@@ -69,7 +130,7 @@ export function AddWallet({
     try {
       const wallet = await addWallet({
         name: name.trim() || "Wallet",
-        mnemonic: cleanMnemonic,
+        mnemonic: mnemonicToUse,
         network: selectedNetwork,
         vault_password: vaultPw,
         spend_password: spendPassword,
@@ -82,8 +143,228 @@ export function AddWallet({
     }
   }
 
+  // --- Mode: choose -------------------------------------------------------
+
+  if (mode === "choose") {
+    return (
+      <Card title={title}>
+        <p className="helper-text" style={{ marginBottom: "var(--space-3)" }}>
+          Create a brand-new wallet with a freshly generated recovery phrase, or
+          restore an existing one from a phrase you already have.
+        </p>
+        <div className="preview-actions" style={{ flexDirection: "column" }}>
+          <Button onClick={handleGenerate} disabled={generating}>
+            {generating ? "Generating…" : "Create new wallet"}
+          </Button>
+          <Button variant="ghost" onClick={() => { setError(null); setMode("restore"); }} disabled={generating}>
+            Restore from recovery phrase
+          </Button>
+          {onCancel && (
+            <Button type="button" variant="ghost" onClick={onCancel}>
+              Cancel
+            </Button>
+          )}
+        </div>
+        {error && (
+          <p className="error-text" role="alert" style={{ marginTop: "var(--space-2)" }}>
+            {error}
+          </p>
+        )}
+      </Card>
+    );
+  }
+
+  // --- Mode: create (show phrase + backup warning) -----------------------
+
+  if (mode === "create") {
+    const words = generatedMnemonic.split(" ");
+    return (
+      <Card title="Save Your Recovery Phrase">
+        <p className="helper-text" style={{ marginBottom: "var(--space-2)" }}>
+          This is the <strong>only</strong> way to recover your wallet. Write it
+          down and store it somewhere safe. Never share it with anyone.
+        </p>
+
+        {/* Recovery phrase display */}
+        <div className="recovery-phrase-grid" aria-label="Recovery phrase">
+          {words.map((word, i) => (
+            <div key={i} className="recovery-phrase-word">
+              <span className="recovery-phrase-index">{i + 1}</span>
+              <span className="recovery-phrase-text">{word}</span>
+            </div>
+          ))}
+        </div>
+
+        <div style={{ margin: "var(--space-3) 0", display: "flex", gap: "var(--space-2)" }}>
+          <CopyButton value={generatedMnemonic} />
+        </div>
+
+        <div className="backup-warning">
+          <p>
+            ⚠ If you lose this phrase and forget your spending password, your funds
+            cannot be recovered.
+          </p>
+        </div>
+
+        {/* Required acknowledgement */}
+        <label className="checkbox-row" style={{ marginTop: "var(--space-3)" }}>
+          <input
+            type="checkbox"
+            checked={confirmed}
+            onChange={(e) => { setConfirmed(e.target.checked); setError(null); }}
+            aria-label="I have saved my recovery phrase"
+          />
+          I have saved my recovery phrase in a secure location
+        </label>
+
+        {error && (
+          <p className="error-text" role="alert" style={{ marginTop: "var(--space-2)" }}>
+            {error}
+          </p>
+        )}
+
+        <div className="preview-actions" style={{ marginTop: "var(--space-3)" }}>
+          <Button onClick={handleProceedToConfirm}>
+            Continue
+          </Button>
+          <Button variant="ghost" onClick={() => { setError(null); setMode("choose"); }}>
+            Back
+          </Button>
+        </div>
+      </Card>
+    );
+  }
+
+  // --- Mode: create-confirm (name + passwords, then submit) ----------------
+
+  if (mode === "create-confirm") {
+    return (
+      <Card title="Set Up Your New Wallet">
+        <p className="helper-text" style={{ marginBottom: "var(--space-3)" }}>
+          Your recovery phrase has been generated. Give your wallet a name and
+          set a spending password to protect it.
+        </p>
+
+        {/* Re-entry challenge: proves the phrase was actually saved before
+            the final submit is allowed. */}
+        <div className="field-group" aria-label="Recovery phrase confirmation">
+          <p className="helper-text">
+            Prove you saved your recovery phrase by re-entering the words below.
+          </p>
+          {challengeIndices.map((idx) => {
+            const answer = challengeAnswers[idx] ?? "";
+            const answered = answer.trim() !== "";
+            const correct = isChallengeAnswerCorrect(generatedWords, idx, answer);
+            return (
+              <div className="field-group" key={idx}>
+                <label htmlFor={`challenge-word-${idx}`}>Word #{idx + 1}</label>
+                <Input
+                  id={`challenge-word-${idx}`}
+                  value={answer}
+                  onChange={(e) => handleChallengeAnswerChange(idx, e.target.value)}
+                  aria-label={`Word #${idx + 1}`}
+                  autoComplete="off"
+                  autoCapitalize="none"
+                  spellCheck={false}
+                />
+                {answered && (
+                  correct ? (
+                    <p className="success-text" role="status" aria-live="polite">Correct</p>
+                  ) : (
+                    <p className="error-text" role="status" aria-live="polite">Incorrect</p>
+                  )
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className="field-group">
+            <label htmlFor="create-name">Wallet Name</label>
+            <Input
+              id="create-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Main"
+              aria-label="Wallet Name"
+            />
+          </div>
+
+          <div className="field-group">
+            <label htmlFor="create-network">Network</label>
+            <Select
+              id="create-network"
+              options={NETWORK_OPTIONS}
+              value={selectedNetwork}
+              onChange={(e) => setSelectedNetwork(e.target.value)}
+            />
+          </div>
+
+          <div className="field-group">
+            <label htmlFor="create-spend-password">Spending Password</label>
+            <Input
+              id="create-spend-password"
+              type="password"
+              value={spendPassword}
+              onChange={(e) => setSpendPassword(e.target.value)}
+              placeholder={`At least ${MIN_PASSWORD_LEN} characters`}
+              aria-label="Spending Password"
+            />
+            <p className="helper-text">
+              Encrypts this wallet&apos;s seed; required to sign and send.
+            </p>
+          </div>
+
+          {needsVaultPassword && (
+            <div className="field-group">
+              <label htmlFor="create-vault-password">Vault Password</label>
+              <Input
+                id="create-vault-password"
+                type="password"
+                value={vaultPassword}
+                onChange={(e) => setVaultPassword(e.target.value)}
+                placeholder="Your vault password"
+                aria-label="Vault Password"
+              />
+              <p className="helper-text">Confirms the change to your encrypted vault.</p>
+            </div>
+          )}
+
+          {!challengePassed && (
+            <p className="helper-text">
+              Correctly re-enter the requested words above to enable wallet creation.
+            </p>
+          )}
+
+          {error && (
+            <p className="error-text" role="alert">
+              {error}
+            </p>
+          )}
+
+          <div className="preview-actions">
+            <Button type="submit" disabled={loading || !challengePassed}>
+              {loading ? "Creating…" : submitLabel}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => { setError(null); setMode("create"); }}
+              disabled={loading}
+            >
+              Back
+            </Button>
+          </div>
+        </form>
+      </Card>
+    );
+  }
+
+  // --- Mode: restore (original form) --------------------------------------
+
   return (
-    <Card title={title}>
+    <Card title="Restore Wallet">
       <form onSubmit={handleSubmit}>
         <div className="field-group">
           <label htmlFor="add-name">Wallet Name</label>
@@ -158,6 +439,14 @@ export function AddWallet({
         <div className="preview-actions">
           <Button type="submit" disabled={loading}>
             {loading ? "Adding…" : submitLabel}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => { setError(null); setMode("choose"); }}
+            disabled={loading}
+          >
+            Back
           </Button>
           {onCancel && (
             <Button type="button" variant="ghost" onClick={onCancel} disabled={loading}>

--- a/ui/web/src/screens/AddWallet.tsx
+++ b/ui/web/src/screens/AddWallet.tsx
@@ -227,7 +227,15 @@ export function AddWallet({
           <Button onClick={handleProceedToConfirm}>
             Continue
           </Button>
-          <Button variant="ghost" onClick={() => { setError(null); setMode("choose"); }}>
+          <Button
+            variant="ghost"
+            onClick={() => {
+              setError(null);
+              setGeneratedMnemonic("");
+              setConfirmed(false);
+              setMode("choose");
+            }}
+          >
             Back
           </Button>
         </div>

--- a/ui/web/src/screens/CreateVault.test.tsx
+++ b/ui/web/src/screens/CreateVault.test.tsx
@@ -15,7 +15,12 @@ test("creating the vault then advances to the add-first-wallet step", async () =
   fireEvent.click(screen.getByRole("button", { name: /create vault/i }));
 
   await waitFor(() => expect(createSpy).toHaveBeenCalledWith({ password: "vault-password-xyz" }));
-  // After creation, the add-first-wallet form (recovery phrase) is shown.
+  // After creation, the add-first-wallet chooser (create/restore) is shown.
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: /restore from recovery phrase/i })).toBeInTheDocument(),
+  );
+  // Navigate to the restore path to get the recovery-phrase field.
+  fireEvent.click(screen.getByRole("button", { name: /restore from recovery phrase/i }));
   await waitFor(() => expect(screen.getByLabelText(/recovery phrase/i)).toBeInTheDocument());
 });
 
@@ -40,6 +45,11 @@ test("duplicate submits while create is in flight call create once", async () =>
 
   expect(createSpy).toHaveBeenCalledTimes(1);
   resolveCreate();
+  // After creation the add-wallet chooser (create/restore) appears.
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: /restore from recovery phrase/i })).toBeInTheDocument(),
+  );
+  fireEvent.click(screen.getByRole("button", { name: /restore from recovery phrase/i }));
   await waitFor(() => expect(screen.getByLabelText(/recovery phrase/i)).toBeInTheDocument());
 });
 

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -1225,16 +1225,15 @@ a:hover {
   border-top: 1px dashed var(--border);
 }
 
-.operate-form .checkbox-row,
-.operate-subform .checkbox-row {
-  display: flex;
+.checkbox-row {
+  display: flex !important;
   align-items: center;
   gap: var(--space-2);
-  text-transform: none;
-  letter-spacing: normal;
-  font-family: var(--font);
-  font-size: 0.8125rem;
-  color: var(--text);
+  text-transform: none !important;
+  letter-spacing: normal !important;
+  font-family: var(--font) !important;
+  font-size: 0.8125rem !important;
+  color: var(--text) !important;
 }
 
 .kes-period {
@@ -1423,6 +1422,49 @@ a:hover {
   font-size: 0.8125rem;
   text-align: right;
   white-space: nowrap;
+}
+
+/* ---------------------------------------------- recovery phrase display -- */
+/* 3-column word grid for the generated 24-word phrase. */
+.recovery-phrase-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-1) var(--space-2);
+  margin: var(--space-3) 0;
+}
+.recovery-phrase-word {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  background: var(--inset);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 6px 10px;
+}
+.recovery-phrase-index {
+  font-family: var(--mono);
+  font-size: 0.625rem;
+  color: var(--text-faint);
+  min-width: 1.4em;
+  text-align: right;
+  flex-shrink: 0;
+}
+.recovery-phrase-text {
+  font-family: var(--mono);
+  font-size: 0.875rem;
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* Backup warning box. */
+.backup-warning {
+  background: color-mix(in srgb, var(--error) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--error) 35%, transparent);
+  border-radius: var(--radius);
+  padding: 10px 14px;
+  font-size: 0.8125rem;
+  color: var(--error);
+  margin-top: var(--space-3);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a create‑wallet flow that generates a 24‑word BIP39 phrase on the server and requires a 3‑word re‑entry check before wallet creation. Updates Add Wallet with a create/restore chooser and a confirm step that blocks submit until the challenge is correct.

- **New Features**
  - Added GET `/wallet/mnemonic/generate` returning a 24‑word mnemonic via `bursa.GenerateMnemonic()`; ungated and loopback‑only.
  - Updated Add Wallet: create/restore chooser; Create shows a 24‑word grid with copy, a backup warning, and a required “I saved it” checkbox; Continue leads to a confirm form (name/network/passwords) with a 3‑word re‑entry challenge (random positions, case/whitespace‑insensitive, live Correct/Incorrect, submit disabled until all correct).
  - Added `phraseChallenge` utils (`CHALLENGE_WORD_COUNT`, `pickChallengeIndices`, `isChallengeAnswerCorrect`, `validateChallenge`) with tests; added client `generateMnemonic()`; updated tests and styles for the phrase grid, backup warning, and `.checkbox-row`.

- **Bug Fixes**
  - Clear the generated mnemonic when backing out of the create flow to prevent stale phrases from persisting.

<sup>Written for commit e4067d4edc3e08beb0c531f14f8cf687b542585e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided wallet setup flow with options to create a new wallet or restore an existing one.
  * Introduced recovery phrase display, copy support, and a short phrase re-entry check before wallet creation.
  * Added server and client support for generating a fresh recovery phrase.

* **Bug Fixes**
  * Improved form validation and feedback for recovery phrase entry.
  * Updated wallet setup and vault creation behavior to match the new multi-step flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->