### PR TITLE
feat(ui): native multi-sig (CIP-1854) accounts

### DIFF
--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -30,6 +30,7 @@ import (
 	"github.com/blinklabs-io/bursa/ui/internal/dex"
 	"github.com/blinklabs-io/bursa/ui/internal/handle"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
+	"github.com/blinklabs-io/bursa/ui/internal/multisig"
 	"github.com/blinklabs-io/bursa/ui/internal/poolops"
 	"github.com/blinklabs-io/bursa/ui/internal/spend"
 	"github.com/blinklabs-io/bursa/ui/internal/supervisor"
@@ -223,6 +224,22 @@ type DexQuoter interface {
 	Quote(ctx context.Context, assetIn, assetOut string, amountIn uint64) (dex.Quote, error)
 }
 
+// MultiSig is the native multi-signature surface the API exposes: managing saved
+// multi-sig accounts (list/create/get/delete), sharing the wallet's own CIP-1854
+// participant key, and the spend flow (balance/build/sign/submit) against a saved
+// account's script address.
+type MultiSig interface {
+	List() ([]multisig.Account, error)
+	Get(id string) (multisig.Account, error)
+	Create(req multisig.CreateRequest) (multisig.Account, error)
+	Delete(id string) error
+	MyKey(password string) (multisig.MyKey, error)
+	Balance(ctx context.Context, id string) (string, error)
+	Build(ctx context.Context, id string, req multisig.BuildRequest) (multisig.UnsignedTx, error)
+	Sign(unsignedTxCBOR, password string) (multisig.Witness, error)
+	Submit(ctx context.Context, id, unsignedTxCBOR string, witnessCBORs []string) (multisig.TxResult, error)
+}
+
 type decimalUint64 uint64
 
 func (n *decimalUint64) UnmarshalJSON(data []byte) error {
@@ -341,10 +358,11 @@ func toWalletView(w vault.WalletMeta, activeID string) walletView {
 // (the lean-node profile). cb is the local-only address-book store. lookup
 // verifies pasted pool/DRep IDs and resolves ADA Handles through the node (may
 // be nil, in which case those endpoints report unavailable). po is the Stake
-// Pool Operations surface. dx optionally enables node-local DEX routes. spa is
-// the embedded SPA, registered as the catch-all so the specific API routes take
-// precedence on the mux.
-func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings SettingsController, cb Contacts, lookup NodeLookup, po PoolOps, dx DexQuoter, network string, spa http.Handler, opts ...HandlerOption) http.Handler {
+// Pool Operations surface. dx optionally enables node-local DEX routes. ms is
+// the native multi-signature surface (may be nil, in which case the multi-sig
+// routes are not registered). spa is the embedded SPA, registered as the
+// catch-all so the specific API routes take precedence on the mux.
+func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings SettingsController, cb Contacts, lookup NodeLookup, po PoolOps, dx DexQuoter, ms MultiSig, network string, spa http.Handler, opts ...HandlerOption) http.Handler {
 	cfg := handlerOptions{}
 	for _, opt := range opts {
 		opt(&cfg)
@@ -934,6 +952,10 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 		registerPoolRoutes(mux, st, po)
 	}
 
+	if ms != nil {
+		registerMultiSigRoutes(mux, st, ms, network)
+	}
+
 	// SPA catch-all: the specific API routes above take precedence on the mux;
 	// everything else is served by the embedded frontend.
 	mux.Handle("/", spa)
@@ -1140,6 +1162,102 @@ func registerPoolRoutes(mux *http.ServeMux, st Statuser, po PoolOps) {
 	}))
 }
 
+// registerMultiSigRoutes wires the native multi-signature endpoints under
+// /wallet/multisig. Account management (list/create/get/delete) and sharing the
+// wallet's own participant key are local/offline; balance is a node read
+// (gated); build and submit need a synced node (readyGate); sign is pure crypto
+// over the keystore (ungated).
+func registerMultiSigRoutes(mux *http.ServeMux, st Statuser, ms MultiSig, network string) {
+	// List saved multi-sig accounts.
+	mux.HandleFunc("GET /wallet/multisig", func(w http.ResponseWriter, _ *http.Request) {
+		v, err := ms.List()
+		serve(w, v, err)
+	})
+
+	// Create a saved multi-sig account from a policy.
+	mux.HandleFunc("POST /wallet/multisig", func(w http.ResponseWriter, r *http.Request) {
+		var req multisig.CreateRequest
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		net, ok := resolveNetwork(w, req.Network, network)
+		if !ok {
+			return
+		}
+		req.Network = net
+		v, err := ms.Create(req)
+		serve(w, v, err)
+	})
+
+	// The active wallet's own CIP-1854 multi-sig participant key, to share. Needs
+	// the spending password to unlock the seed; ungated (pure crypto, no node).
+	mux.HandleFunc("POST /wallet/multisig/my-key", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Password string `json:"password"`
+		}
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		v, err := ms.MyKey(req.Password)
+		serve(w, v, err)
+	})
+
+	// Fetch one saved account.
+	mux.HandleFunc("GET /wallet/multisig/{id}", func(w http.ResponseWriter, r *http.Request) {
+		v, err := ms.Get(r.PathValue("id"))
+		serve(w, v, err)
+	})
+
+	// Delete a saved account.
+	mux.HandleFunc("DELETE /wallet/multisig/{id}", func(w http.ResponseWriter, r *http.Request) {
+		err := ms.Delete(r.PathValue("id"))
+		serve(w, map[string]string{"status": "deleted"}, err)
+	})
+
+	// Balance held at the account's script address.
+	mux.HandleFunc("GET /wallet/multisig/{id}/balance", gated(st, func(w http.ResponseWriter, r *http.Request) {
+		v, err := ms.Balance(r.Context(), r.PathValue("id"))
+		serve(w, map[string]string{"lovelace": v}, err)
+	}))
+
+	// Build an unsigned spend from the account's script address.
+	mux.HandleFunc("POST /wallet/multisig/{id}/build", readyGate(st, func(w http.ResponseWriter, r *http.Request) {
+		var req multisig.BuildRequest
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		v, err := ms.Build(r.Context(), r.PathValue("id"), req)
+		serve(w, v, err)
+	}))
+
+	// Co-sign an unsigned multi-sig tx with the wallet's CIP-1854 key. Ungated
+	// (pure crypto over the keystore, no node), like sign-tx.
+	mux.HandleFunc("POST /wallet/multisig/sign", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			UnsignedTxCBOR string `json:"unsigned_tx_cbor"`
+			Password       string `json:"password"`
+		}
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		v, err := ms.Sign(req.UnsignedTxCBOR, req.Password)
+		serve(w, v, err)
+	})
+
+	// Attach the script + collected witnesses and broadcast (threshold enforced).
+	mux.HandleFunc("POST /wallet/multisig/{id}/submit", readyGate(st, func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			UnsignedTxCBOR string   `json:"unsigned_tx_cbor"`
+			Witnesses      []string `json:"witnesses"`
+		}
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		v, err := ms.Submit(r.Context(), r.PathValue("id"), req.UnsignedTxCBOR, req.Witnesses)
+		serve(w, v, err)
+	}))
+}
+
 // decodeBody decodes a JSON request body into v, writing a 400 and returning
 // false on malformed input.
 func decodeBody(w http.ResponseWriter, r *http.Request, v any) bool {
@@ -1221,29 +1339,31 @@ func serve[T any](w http.ResponseWriter, v T, err error) {
 		writeJSON(w, http.StatusConflict, errBody(err)) // 409
 	case errors.Is(err, vault.ErrLocked), errors.Is(err, vault.ErrNoActiveWallet),
 		errors.Is(err, wallet.ErrNoWallet), errors.Is(err, spend.ErrNoWallet),
-		errors.Is(err, poolops.ErrNoWallet):
+		errors.Is(err, poolops.ErrNoWallet), errors.Is(err, multisig.ErrNoKeystore):
 		writeJSON(w, http.StatusConflict, errBody(err)) // 409: locked / no active wallet
 	case errors.Is(err, spend.ErrWalletChanged):
 		writeJSON(w, http.StatusConflict, errBody(err)) // 409: active wallet switched during build
 	case errors.Is(err, vault.ErrTPMUnavailable):
 		writeJSON(w, http.StatusConflict, errBody(err)) // 409: TPM not available on this machine
 	case errors.Is(err, vault.ErrWrongPassword), errors.Is(err, spend.ErrWrongPassword),
-		errors.Is(err, poolops.ErrWrongPassword):
+		errors.Is(err, poolops.ErrWrongPassword), errors.Is(err, multisig.ErrWrongPassword):
 		writeJSON(w, http.StatusUnauthorized, errBody(err)) // 401
 	case errors.Is(err, spend.ErrInvalidRequest),
 		errors.Is(err, spend.ErrInvalidTx),
 		errors.Is(err, spend.ErrInvalidWitness),
 		errors.Is(err, poolops.ErrInvalidRequest),
+		errors.Is(err, multisig.ErrInvalidRequest), errors.Is(err, multisig.ErrInvalidTx),
+		errors.Is(err, multisig.ErrInvalidWitness),
 		errors.Is(err, contacts.ErrInvalidRequest):
 		writeJSON(w, http.StatusBadRequest, errBody(err)) // 400
-	case errors.Is(err, contacts.ErrNotFound):
-		writeJSON(w, http.StatusNotFound, errBody(err)) // 404
-	case errors.Is(err, spend.ErrUnknownPending):
+	case errors.Is(err, contacts.ErrNotFound),
+		errors.Is(err, spend.ErrUnknownPending), errors.Is(err, multisig.ErrUnknownAccount):
 		writeJSON(w, http.StatusNotFound, errBody(err)) // 404
 	case errors.Is(err, spend.ErrExpiredPending):
 		writeJSON(w, http.StatusGone, errBody(err)) // 410
 	case errors.Is(err, spend.ErrInsufficientFunds), errors.Is(err, spend.ErrSubmitRejected),
-		errors.Is(err, spend.ErrNoChange), errors.Is(err, poolops.ErrSubmitRejected):
+		errors.Is(err, spend.ErrNoChange), errors.Is(err, poolops.ErrSubmitRejected),
+		errors.Is(err, multisig.ErrInsufficientFunds), errors.Is(err, multisig.ErrSubmitRejected):
 		// 422: the request was understood but cannot be fulfilled; the node's
 		// structured rejection reason (for submit), the funding shortfall, or the
 		// "already in the requested state" note rides along in the message.

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/blinklabs-io/bursa/ui/internal/contacts"
 	"github.com/blinklabs-io/bursa/ui/internal/dex"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
+	"github.com/blinklabs-io/bursa/ui/internal/multisig"
 	"github.com/blinklabs-io/bursa/ui/internal/poolops"
 	"github.com/blinklabs-io/bursa/ui/internal/settings"
 	"github.com/blinklabs-io/bursa/ui/internal/spend"
@@ -324,7 +325,7 @@ func (f *fakeVault) DisableTPM(password string) error {
 }
 
 func TestHealthAlwaysOK(t *testing.T) {
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
 	if rec.Code != http.StatusOK {
@@ -334,7 +335,7 @@ func TestHealthAlwaysOK(t *testing.T) {
 
 func TestStatusReturnsSnapshot(t *testing.T) {
 	want := supervisor.Status{State: supervisor.StateSyncing, Tip: 42, CaughtUp: true}
-	h := NewHandler(fakeStatuser{s: want}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{s: want}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
 	if rec.Code != http.StatusOK {
@@ -418,7 +419,7 @@ func (f *fakeWallet) Delegation(_ context.Context) (wallet.DelegationView, error
 
 func TestVaultStatusReports(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: true, wallets: []vault.WalletMeta{{ID: "a"}, {ID: "b"}}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/status", nil))
 	if rec.Code != http.StatusOK {
@@ -439,7 +440,7 @@ func TestVaultStatusReports(t *testing.T) {
 func TestVaultStatusReportsLegacyKeystore(t *testing.T) {
 	fv := &fakeVault{exists: false, locked: true}
 	legacy := &fakeLegacyKeystore{exists: true}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/status", nil))
 	if rec.Code != http.StatusOK {
@@ -456,7 +457,7 @@ func TestVaultStatusReportsLegacyKeystore(t *testing.T) {
 
 func TestVaultCreateRequiresPassword(t *testing.T) {
 	fv := &fakeVault{}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"short"}`)))
 	if rec.Code != http.StatusBadRequest {
@@ -469,7 +470,7 @@ func TestVaultCreateRequiresPassword(t *testing.T) {
 
 func TestVaultCreateOK(t *testing.T) {
 	fv := &fakeVault{}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusOK {
@@ -482,7 +483,7 @@ func TestVaultCreateOK(t *testing.T) {
 
 func TestVaultCreateConflict(t *testing.T) {
 	fv := &fakeVault{createErr: vault.ErrVaultExists}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusConflict {
@@ -499,7 +500,7 @@ func TestVaultUnlockBindsSoleWalletAndReads(t *testing.T) {
 		wallets: []vault.WalletMeta{{ID: "w1", Name: "main", Network: "preview", Account: sampleAccount("preview")}},
 	}
 	fw := &fakeWallet{balance: wallet.Balance{Lovelace: "1234"}}
-	h := NewHandler(st, fv, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
@@ -526,7 +527,7 @@ func TestVaultUnlockBindsSoleWalletAndReads(t *testing.T) {
 
 func TestVaultUnlockWrongPassword(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: true, unlockErr: fmt.Errorf("%w: bad", vault.ErrWrongPassword)}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"wrong-but-long-pw"}`)))
 	if rec.Code != http.StatusUnauthorized {
@@ -538,7 +539,7 @@ func TestVaultLock(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false}
 	fw := &fakeWallet{set: true}
 	sp := &fakeSpender{set: true}
-	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/lock", nil))
 	if rec.Code != http.StatusOK {
@@ -557,7 +558,7 @@ func TestMigrateLegacyKeystoreImportsAndBinds(t *testing.T) {
 	fw := &fakeWallet{}
 	sp := &fakeSpender{}
 	legacy := &fakeLegacyKeystore{exists: true, mnemonic: []byte("abandon abandon about")}
-	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 
 	body := `{"name":"Imported","vault_password":"valid-vault-password","spend_password":"legacy-spend-password"}`
 	rec := httptest.NewRecorder()
@@ -596,7 +597,7 @@ func TestMigrateLegacyKeystoreImportsAndBinds(t *testing.T) {
 func TestMigrateLegacyKeystoreWrongPassword(t *testing.T) {
 	fv := &fakeVault{exists: false, locked: true}
 	legacy := &fakeLegacyKeystore{exists: true, err: keystore.ErrDecryptFailed}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 
 	body := `{"name":"Imported","vault_password":"valid-vault-password","spend_password":"wrong-password"}`
 	rec := httptest.NewRecorder()
@@ -612,7 +613,7 @@ func TestMigrateLegacyKeystoreWrongPassword(t *testing.T) {
 func TestMigrateLegacyKeystoreRequiresSpendPasswordMinLength(t *testing.T) {
 	fv := &fakeVault{exists: false, locked: true}
 	legacy := &fakeLegacyKeystore{exists: true, mnemonic: []byte("abandon abandon about")}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 
 	body := `{"name":"Imported","vault_password":"valid-vault-password","spend_password":"short"}`
 	rec := httptest.NewRecorder()
@@ -635,7 +636,7 @@ func TestAddWalletEnablesReadsAndSpend(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false}
 	fw := &fakeWallet{balance: wallet.Balance{Lovelace: "1234"}}
 	sp := &fakeSpender{}
-	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
@@ -664,7 +665,7 @@ func TestAddWalletRequiresSpendPassword(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
 	sp := &fakeSpender{}
-	h := NewHandler(st, fv, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","vault_password":"valid-vault-password","spend_password":"short"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -679,7 +680,7 @@ func TestAddWalletRequiresSpendPassword(t *testing.T) {
 func TestAddWalletRequiresVaultPassword(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -691,7 +692,7 @@ func TestAddWalletRequiresVaultPassword(t *testing.T) {
 func TestAddWalletNetworkMismatch(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"mainnet","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -703,7 +704,7 @@ func TestAddWalletNetworkMismatch(t *testing.T) {
 func TestAddWalletDefaultNetworkIsNodeNetwork(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preprod", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preprod", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -718,7 +719,7 @@ func TestAddWalletDefaultNetworkIsNodeNetwork(t *testing.T) {
 func TestAddWalletDuplicateConflict(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fv := &fakeVault{exists: true, locked: false, addErr: vault.ErrDuplicateWallet}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
@@ -731,7 +732,7 @@ func TestAddWalletDuplicateConflict(t *testing.T) {
 // mnemonic (24-word / 256-bit BIP39). It does not need a vault or a node —
 // the endpoint is ungated and uses only the bursa core lib.
 func TestGenerateMnemonic(t *testing.T) {
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/mnemonic/generate", nil))
 	if rec.Code != http.StatusOK {
@@ -763,7 +764,7 @@ func TestActivateWalletBinds(t *testing.T) {
 	}
 	fw := &fakeWallet{}
 	sp := &fakeSpender{}
-	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/w2/activate", nil))
 	if rec.Code != http.StatusOK {
@@ -786,7 +787,7 @@ func TestActivateWalletBinds(t *testing.T) {
 
 func TestActivateUnknownWallet(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/nope/activate", nil))
 	if rec.Code != http.StatusNotFound {
@@ -796,7 +797,7 @@ func TestActivateUnknownWallet(t *testing.T) {
 
 func TestDeleteWalletRequiresVaultPassword(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false, wallets: []vault.WalletMeta{{ID: "w1"}}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/wallet/w1", bytes.NewBufferString(`{}`)))
 	if rec.Code != http.StatusBadRequest {
@@ -811,7 +812,7 @@ func TestDeleteWalletOK(t *testing.T) {
 	}
 	fw := &fakeWallet{set: true}
 	sp := &fakeSpender{set: true}
-	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/wallet/w1", bytes.NewBufferString(`{"vault_password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusOK {
@@ -829,7 +830,7 @@ func TestDeleteWalletOK(t *testing.T) {
 
 func TestWalletGatedWhileStarting(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/balance", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -840,7 +841,7 @@ func TestWalletGatedWhileStarting(t *testing.T) {
 func TestWalletGatedWhileBootstrapping(t *testing.T) {
 	// Mithril bootstrap is not a servable state: reads must be gated (503).
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateBootstrapping}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/balance", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -853,7 +854,7 @@ func TestWalletNoActiveWalletConflict(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	for _, path := range []string{"/wallet/balance", "/wallet/addresses", "/wallet/transactions", "/wallet/transactions/tx1", "/wallet/delegation"} {
 		t.Run(path, func(t *testing.T) {
-			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
 			if rec.Code != http.StatusConflict {
@@ -878,7 +879,7 @@ func TestGetTransactionDetailOK(t *testing.T) {
 			Outputs: []wallet.TxIO{{Address: "addr_other", Lovelace: "3000000"}},
 		},
 	}
-	h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/transactions/tx1", nil))
 	if rec.Code != http.StatusOK {
@@ -901,7 +902,7 @@ func TestGetTransactionDetailNotFound(t *testing.T) {
 	// pool/DRep lookup convention ("not found by your node").
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	fw := &fakeWallet{set: true, txDetailErr: chain.ErrNotFound}
-	h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/transactions/unknown", nil))
 	if rec.Code != http.StatusNotFound {
@@ -1180,10 +1181,267 @@ func (f *fakeDexQuoter) Quote(_ context.Context, assetIn, assetOut string, amoun
 	return f.quote, f.quoteErr
 }
 
+// fakeMultiSig satisfies the MultiSig interface for handler tests. It records
+// arguments so route wiring, gating, and status mapping can be exercised without
+// real key derivation or node access.
+type fakeMultiSig struct {
+	accounts []multisig.Account
+	account  multisig.Account
+	myKey    multisig.MyKey
+	balance  string
+	unsigned multisig.UnsignedTx
+	witness  multisig.Witness
+	tx       multisig.TxResult
+
+	listErr    error
+	getErr     error
+	createErr  error
+	deleteErr  error
+	myKeyErr   error
+	balanceErr error
+	buildErr   error
+	signErr    error
+	submitErr  error
+
+	gotGetID         string
+	gotCreate        multisig.CreateRequest
+	gotDeleteID      string
+	gotMyKeyPass     string
+	gotBalanceID     string
+	gotBuildID       string
+	gotBuild         multisig.BuildRequest
+	gotSignTxCBOR    string
+	gotSignPassword  string
+	gotSubmitID      string
+	gotSubmitTxCBOR  string
+	gotSubmitWitness []string
+}
+
+func (f *fakeMultiSig) List() ([]multisig.Account, error) {
+	return f.accounts, f.listErr
+}
+
+func (f *fakeMultiSig) Get(id string) (multisig.Account, error) {
+	f.gotGetID = id
+	return f.account, f.getErr
+}
+
+func (f *fakeMultiSig) Create(req multisig.CreateRequest) (multisig.Account, error) {
+	f.gotCreate = req
+	return f.account, f.createErr
+}
+
+func (f *fakeMultiSig) Delete(id string) error {
+	f.gotDeleteID = id
+	return f.deleteErr
+}
+
+func (f *fakeMultiSig) MyKey(password string) (multisig.MyKey, error) {
+	f.gotMyKeyPass = password
+	return f.myKey, f.myKeyErr
+}
+
+func (f *fakeMultiSig) Balance(_ context.Context, id string) (string, error) {
+	f.gotBalanceID = id
+	if f.balance == "" {
+		f.balance = "0"
+	}
+	return f.balance, f.balanceErr
+}
+
+func (f *fakeMultiSig) Build(_ context.Context, id string, req multisig.BuildRequest) (multisig.UnsignedTx, error) {
+	f.gotBuildID = id
+	f.gotBuild = req
+	return f.unsigned, f.buildErr
+}
+
+func (f *fakeMultiSig) Sign(unsignedTxCBOR, password string) (multisig.Witness, error) {
+	f.gotSignTxCBOR = unsignedTxCBOR
+	f.gotSignPassword = password
+	return f.witness, f.signErr
+}
+
+func (f *fakeMultiSig) Submit(_ context.Context, id, unsignedTxCBOR string, witnessCBORs []string) (multisig.TxResult, error) {
+	f.gotSubmitID = id
+	f.gotSubmitTxCBOR = unsignedTxCBOR
+	f.gotSubmitWitness = append([]string(nil), witnessCBORs...)
+	return f.tx, f.submitErr
+}
+
+func sampleMultiSigAccount() multisig.Account {
+	kh := strings.Repeat("a", 56)
+	return multisig.Account{
+		ID:      "acct1",
+		Label:   "Treasury",
+		Network: "preview",
+		Policy: multisig.Policy{
+			Threshold:    1,
+			Participants: []multisig.Participant{{KeyHashHex: kh, Label: "me"}},
+		},
+		ScriptCBOR:    "8201818200581c" + kh,
+		ScriptAddress: "addr_test1wqscriptaddressxyz",
+	}
+}
+
+func TestMultiSigRoutesUngatedWhileNodeNotReady(t *testing.T) {
+	acct := sampleMultiSigAccount()
+	ms := &fakeMultiSig{
+		accounts: []multisig.Account{acct},
+		account:  acct,
+		myKey:    multisig.MyKey{KeyHashHex: strings.Repeat("b", 56), VKeyHex: strings.Repeat("c", 64)},
+		witness:  multisig.Witness{WitnessCBOR: "81825820"},
+	}
+	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, ms, "preview", http.NotFoundHandler())
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/multisig", nil))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "Treasury") {
+		t.Fatalf("GET /wallet/multisig = %d body %s, want account", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	createBody := `{"label":"Treasury","policy":{"threshold":1,"participants":[{"key_hash_hex":"` + strings.Repeat("a", 56) + `"}]}}`
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/multisig", bytes.NewBufferString(createBody)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /wallet/multisig = %d body %s, want 200", rec.Code, rec.Body.String())
+	}
+	if ms.gotCreate.Label != "Treasury" || ms.gotCreate.Network != "preview" || ms.gotCreate.Policy.Threshold != 1 {
+		t.Fatalf("create args = %+v, want label/network/policy", ms.gotCreate)
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/multisig/my-key", bytes.NewBufferString(`{"password":"pw"}`)))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), strings.Repeat("b", 56)) {
+		t.Fatalf("POST /wallet/multisig/my-key = %d body %s, want key", rec.Code, rec.Body.String())
+	}
+	if ms.gotMyKeyPass != "pw" {
+		t.Fatalf("my-key password = %q, want pw", ms.gotMyKeyPass)
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/multisig/sign", bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","password":"pw"}`)))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "81825820") {
+		t.Fatalf("POST /wallet/multisig/sign = %d body %s, want witness", rec.Code, rec.Body.String())
+	}
+	if ms.gotSignTxCBOR != "84a400" || ms.gotSignPassword != "pw" {
+		t.Fatalf("sign args = tx %q password %q, want 84a400/pw", ms.gotSignTxCBOR, ms.gotSignPassword)
+	}
+}
+
+func TestMultiSigRoutesGated(t *testing.T) {
+	ms := &fakeMultiSig{
+		balance:  "1234567",
+		unsigned: multisig.UnsignedTx{UnsignedTxCBOR: "84a400", RequiredSigners: []string{strings.Repeat("a", 56)}, Threshold: 1},
+		tx:       multisig.TxResult{TxHash: "feedface"},
+	}
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, ms, "preview", http.NotFoundHandler())
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/multisig/acct1/balance", nil))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "1234567") {
+		t.Fatalf("GET balance = %d body %s, want balance", rec.Code, rec.Body.String())
+	}
+	if ms.gotBalanceID != "acct1" {
+		t.Fatalf("balance id = %q, want acct1", ms.gotBalanceID)
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/multisig/acct1/build", bytes.NewBufferString(`{"to":"addr_test1recipient","lovelace":"1000000"}`)))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "84a400") {
+		t.Fatalf("POST build = %d body %s, want unsigned tx", rec.Code, rec.Body.String())
+	}
+	if ms.gotBuildID != "acct1" || ms.gotBuild.To != "addr_test1recipient" || ms.gotBuild.Lovelace != "1000000" {
+		t.Fatalf("build args = id %q req %+v, want acct1/recipient/1000000", ms.gotBuildID, ms.gotBuild)
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/multisig/acct1/submit", bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witnesses":["81"]}`)))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "feedface") {
+		t.Fatalf("POST submit = %d body %s, want tx hash", rec.Code, rec.Body.String())
+	}
+	if ms.gotSubmitID != "acct1" || ms.gotSubmitTxCBOR != "84a400" || len(ms.gotSubmitWitness) != 1 || ms.gotSubmitWitness[0] != "81" {
+		t.Fatalf("submit args = id %q tx %q witnesses %v, want acct1/84a400/[81]", ms.gotSubmitID, ms.gotSubmitTxCBOR, ms.gotSubmitWitness)
+	}
+
+	blocked := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{"balance", http.MethodGet, "/wallet/multisig/acct1/balance", ""},
+		{"build", http.MethodPost, "/wallet/multisig/acct1/build", `{"to":"addr_test1recipient","lovelace":"1000000"}`},
+		{"submit", http.MethodPost, "/wallet/multisig/acct1/submit", `{"unsigned_tx_cbor":"84a400","witnesses":["81"]}`},
+	} {
+		t.Run("blocked "+tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			blocked.ServeHTTP(rec, httptest.NewRequest(tc.method, tc.path, bytes.NewBufferString(tc.body)))
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Fatalf("%s while node starting = %d, want 503", tc.name, rec.Code)
+			}
+		})
+	}
+}
+
+func TestMultiSigErrorStatusCodes(t *testing.T) {
+	cases := []struct {
+		name     string
+		ms       *fakeMultiSig
+		method   string
+		path     string
+		body     string
+		wantCode int
+	}{
+		{
+			name:     "insufficient funds",
+			ms:       &fakeMultiSig{buildErr: fmt.Errorf("%w: short", multisig.ErrInsufficientFunds)},
+			method:   http.MethodPost,
+			path:     "/wallet/multisig/acct1/build",
+			body:     `{"to":"addr_test1recipient","lovelace":"1000000"}`,
+			wantCode: http.StatusUnprocessableEntity,
+		},
+		{
+			name:     "invalid witness",
+			ms:       &fakeMultiSig{submitErr: fmt.Errorf("%w: bad witness", multisig.ErrInvalidWitness)},
+			method:   http.MethodPost,
+			path:     "/wallet/multisig/acct1/submit",
+			body:     `{"unsigned_tx_cbor":"84a400","witnesses":["zz"]}`,
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name:     "submit rejected",
+			ms:       &fakeMultiSig{submitErr: fmt.Errorf("%w: ledger rule", multisig.ErrSubmitRejected)},
+			method:   http.MethodPost,
+			path:     "/wallet/multisig/acct1/submit",
+			body:     `{"unsigned_tx_cbor":"84a400","witnesses":["81"]}`,
+			wantCode: http.StatusUnprocessableEntity,
+		},
+		{
+			name:     "no keystore",
+			ms:       &fakeMultiSig{myKeyErr: fmt.Errorf("%w: read-only", multisig.ErrNoKeystore)},
+			method:   http.MethodPost,
+			path:     "/wallet/multisig/my-key",
+			body:     `{"password":"pw"}`,
+			wantCode: http.StatusConflict,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, tc.ms, "preview", http.NotFoundHandler())
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(tc.method, tc.path, bytes.NewBufferString(tc.body)))
+			if rec.Code != tc.wantCode {
+				t.Fatalf("%s status = %d, want %d; body %s", tc.name, rec.Code, tc.wantCode, rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestSignDataReturnsSignature(t *testing.T) {
 	// Ungated: message signing needs no synced node, only the keystore.
 	sp := &fakeSpender{signSig: "84a1deadbeef", signKey: "a4010103"}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"address":"addr_test1xyz","message":"hello","password":"pw"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-data", body))
@@ -1200,7 +1458,7 @@ func TestSignDataReturnsSignature(t *testing.T) {
 
 func TestSignDataWrongPasswordReturns401(t *testing.T) {
 	sp := &fakeSpender{signErr: fmt.Errorf("%w: bad", spend.ErrWrongPassword)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"address":"a","message":"m","password":"bad"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-data", body))
@@ -1212,7 +1470,7 @@ func TestSignDataWrongPasswordReturns401(t *testing.T) {
 func TestVerifyDataReturnsResult(t *testing.T) {
 	// Ungated: verification is pure crypto, needs no node and no keystore.
 	sp := &fakeSpender{verifyValid: true, verifyAddr: "addr_test1signed"}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"signature":"84a1","key":"a401","message":"hi","hashed":true,"expected_address":"addr_test1signed"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/verify-data", body))
@@ -1234,7 +1492,7 @@ func TestVerifyDataReturnsResult(t *testing.T) {
 
 func TestVerifyDataInvalidArgsReturns400(t *testing.T) {
 	sp := &fakeSpender{verifyErr: fmt.Errorf("%w: bad hex", spend.ErrInvalidRequest)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"signature":"zz","key":"a4","message":"hi"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/verify-data", body))
@@ -1245,7 +1503,7 @@ func TestVerifyDataInvalidArgsReturns400(t *testing.T) {
 
 func TestExportUnsignedRequiresReady(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend1/export-unsigned", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -1259,7 +1517,7 @@ func TestExportUnsignedReturnsTx(t *testing.T) {
 		UnsignedTxCBOR:  "84a400",
 		RequiredSigners: []string{"deadbeef"},
 	}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend1/export-unsigned", nil))
 	if rec.Code != http.StatusOK {
@@ -1277,7 +1535,7 @@ func TestSignTxUngated(t *testing.T) {
 	// Offline signing must not need a synced node -- only the keystore.
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
 	sp := &fakeSpender{witness: spend.Witness{WitnessCBOR: "81825820"}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","password":"pw","required_signers":["deadbeef"]}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-tx", body))
@@ -1297,7 +1555,7 @@ func TestSignTxUngated(t *testing.T) {
 
 func TestSignTxWrongPasswordReturns401(t *testing.T) {
 	sp := &fakeSpender{signTxErr: fmt.Errorf("%w: bad", spend.ErrWrongPassword)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","password":"bad","required_signers":["deadbeef"]}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-tx", body))
@@ -1308,7 +1566,7 @@ func TestSignTxWrongPasswordReturns401(t *testing.T) {
 
 func TestSignTxInvalidTxReturns400(t *testing.T) {
 	sp := &fakeSpender{signTxErr: fmt.Errorf("%w: bad cbor", spend.ErrInvalidTx)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"zz","password":"pw","required_signers":["deadbeef"]}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-tx", body))
@@ -1319,7 +1577,7 @@ func TestSignTxInvalidTxReturns400(t *testing.T) {
 
 func TestSubmitSignedRequiresReady(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witness_cbor":"81"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-signed", body))
@@ -1331,7 +1589,7 @@ func TestSubmitSignedRequiresReady(t *testing.T) {
 func TestSubmitSignedReturnsTxHash(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{submitResult: spend.TxResult{TxHash: "cafebabe"}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witness_cbor":"81825820"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-signed", body))
@@ -1349,7 +1607,7 @@ func TestSubmitSignedReturnsTxHash(t *testing.T) {
 func TestSubmitSignedInvalidWitnessReturns400(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{submitErr: fmt.Errorf("%w: bad cbor", spend.ErrInvalidWitness)}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witness_cbor":"zz"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-signed", body))
@@ -1361,7 +1619,7 @@ func TestSubmitSignedInvalidWitnessReturns400(t *testing.T) {
 func TestSpendSendReadyReturnsPreview(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{preview: spend.Preview{PendingID: "pend123", Fee: "170000"}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send", body))
@@ -1380,7 +1638,7 @@ func TestSpendSendReadyReturnsPreview(t *testing.T) {
 func TestSpendSendGatedWhileSyncing(t *testing.T) {
 	// Spending requires a fully synced node (StateReady), unlike reads.
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send", body))
@@ -1392,7 +1650,7 @@ func TestSpendSendGatedWhileSyncing(t *testing.T) {
 func TestSpendSendNoWalletConflict(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{buildErr: spend.ErrNoWallet}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send", body))
@@ -1404,7 +1662,7 @@ func TestSpendSendNoWalletConflict(t *testing.T) {
 func TestSpendConfirmReadyReturnsTxHash(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	sp := &fakeSpender{result: spend.TxResult{TxHash: "deadbeef"}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-spend-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend123/confirm", body))
@@ -1425,7 +1683,7 @@ func TestSpendConfirmReadyReturnsTxHash(t *testing.T) {
 
 func TestSpendConfirmGatedWhileSyncing(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-spend-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend123/confirm", body))
@@ -1465,7 +1723,7 @@ func TestSpendErrorStatusCodes(t *testing.T) {
 				req = httptest.NewRequest(http.MethodPost, "/wallet/send",
 					bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`))
 			}
-			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
 			if rec.Code != tc.wantCode {
@@ -1507,7 +1765,7 @@ func TestGetHistoryExpiryReturnsState(t *testing.T) {
 	// node query).
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStopped}}
 	set := &fakeSettings{enabled: true, restartRequired: true}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/settings/history-expiry", nil))
 	if rec.Code != http.StatusOK {
@@ -1522,7 +1780,7 @@ func TestGetHistoryExpiryReturnsState(t *testing.T) {
 func TestGetHistoryExpiryDefaultOff(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{} // default off, no restart needed
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/settings/history-expiry", nil))
 	got := decodeHistoryExpiry(t, rec.Body)
@@ -1535,7 +1793,7 @@ func TestPutHistoryExpiryPersistsAndSignalsRestart(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	// Running node was built with off; flipping to on must signal a restart.
 	set := &fakeSettings{enabled: false, restartRequired: true}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"enabled":true}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
@@ -1557,7 +1815,7 @@ func TestPutHistoryExpiryPersistsAndSignalsRestart(t *testing.T) {
 func TestPutHistoryExpiryInvalidJSON(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{not json`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
@@ -1574,7 +1832,7 @@ func TestPutHistoryExpiryRequiresExplicitEnabled(t *testing.T) {
 		t.Run(bodyJSON, func(t *testing.T) {
 			st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 			set := &fakeSettings{}
-			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
 			body := bytes.NewBufferString(bodyJSON)
 			h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
@@ -1591,7 +1849,7 @@ func TestPutHistoryExpiryRequiresExplicitEnabled(t *testing.T) {
 func TestPutHistoryExpiryPersistError(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{setErr: errors.New("disk full")}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"enabled":true}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
@@ -1617,7 +1875,7 @@ func decodeAutoLock(t *testing.T, body *bytes.Buffer) int {
 func TestGetAutoLockReturnsPersistedValue(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStopped}}
 	set := &fakeSettings{autoLockMinutes: 30}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/settings/auto-lock", nil))
 	if rec.Code != http.StatusOK {
@@ -1631,7 +1889,7 @@ func TestGetAutoLockReturnsPersistedValue(t *testing.T) {
 func TestPutAutoLockPersists(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{autoLockMinutes: 15}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"minutes":5}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
@@ -1649,7 +1907,7 @@ func TestPutAutoLockPersists(t *testing.T) {
 func TestPutAutoLockAcceptsOff(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{autoLockMinutes: 15}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"minutes":0}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
@@ -1664,7 +1922,7 @@ func TestPutAutoLockAcceptsOff(t *testing.T) {
 func TestPutAutoLockInvalidJSON(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{not json`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
@@ -1679,7 +1937,7 @@ func TestPutAutoLockInvalidJSON(t *testing.T) {
 func TestPutAutoLockRequiresExplicitMinutes(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
@@ -1695,7 +1953,7 @@ func TestPutAutoLockRejectsOutOfSetValue(t *testing.T) {
 	for _, bad := range []int{-1, 2, 60} {
 		st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 		set := &fakeSettings{}
-		h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+		h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
 		body := bytes.NewBufferString(fmt.Sprintf(`{"minutes":%d}`, bad))
 		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
@@ -1711,7 +1969,7 @@ func TestPutAutoLockRejectsOutOfSetValue(t *testing.T) {
 func TestPutAutoLockPersistError(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 	set := &fakeSettings{setAutoLockErr: errors.New("disk full")}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"minutes":5}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
@@ -1758,7 +2016,7 @@ func TestContactsListReturnsEntries(t *testing.T) {
 		{ID: "c1", Name: "Alice", Address: "addr_test1alice"},
 		{ID: "c2", Name: "Bob", Address: "addr_test1bob", Note: "friend"},
 	}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/contacts", nil))
 	if rec.Code != http.StatusOK {
@@ -1778,7 +2036,7 @@ func TestContactsListReturnsEntries(t *testing.T) {
 func TestContactsListUngated(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStopped}}
 	cb := &fakeContacts{}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/contacts", nil))
 	if rec.Code != http.StatusOK {
@@ -1788,7 +2046,7 @@ func TestContactsListUngated(t *testing.T) {
 
 func TestContactsCreateGeneratesEntry(t *testing.T) {
 	cb := &fakeContacts{}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"name":"Alice","address":"addr_test1alice","note":"friend"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/contacts", body))
@@ -1809,7 +2067,7 @@ func TestContactsCreateGeneratesEntry(t *testing.T) {
 
 func TestContactsUpdateExistingByID(t *testing.T) {
 	cb := &fakeContacts{entries: []contacts.Entry{{ID: "c1", Name: "Alice", Address: "addr_test1alice"}}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"id":"c1","name":"Alice Updated","address":"addr_test1alice2"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/contacts", body))
@@ -1827,7 +2085,7 @@ func TestContactsUpdateExistingByID(t *testing.T) {
 
 func TestContactsUpsertUnknownIDReturns404(t *testing.T) {
 	cb := &fakeContacts{}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"id":"missing","name":"Ghost","address":"addr_test1ghost"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/contacts", body))
@@ -1838,7 +2096,7 @@ func TestContactsUpsertUnknownIDReturns404(t *testing.T) {
 
 func TestContactsCreateValidationErrorReturns400(t *testing.T) {
 	cb := &fakeContacts{}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"name":"","address":"addr_test1alice"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/contacts", body))
@@ -1852,7 +2110,7 @@ func TestContactsCreateValidationErrorReturns400(t *testing.T) {
 
 func TestContactsCreateInvalidJSONReturns400(t *testing.T) {
 	cb := &fakeContacts{}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{not json`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/contacts", body))
@@ -1863,7 +2121,7 @@ func TestContactsCreateInvalidJSONReturns400(t *testing.T) {
 
 func TestContactsDeleteOK(t *testing.T) {
 	cb := &fakeContacts{entries: []contacts.Entry{{ID: "c1", Name: "Alice", Address: "addr_test1alice"}}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/wallet/contacts/c1", nil))
 	if rec.Code != http.StatusOK {
@@ -1876,7 +2134,7 @@ func TestContactsDeleteOK(t *testing.T) {
 
 func TestContactsDeleteUnknownReturns404(t *testing.T) {
 	cb := &fakeContacts{}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/wallet/contacts/nope", nil))
 	if rec.Code != http.StatusNotFound {
@@ -1893,7 +2151,7 @@ func readyStatuser() fakeStatuser {
 
 func TestPoolCredentialsReturnsCreds(t *testing.T) {
 	po := &fakePoolOps{creds: poolops.Credentials{PoolID: "pool1abc", Network: "preview"}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"spend-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/credentials", body))
@@ -1910,7 +2168,7 @@ func TestPoolCredentialsReturnsCreds(t *testing.T) {
 
 func TestPoolCredentialsRejectsTrailingJSON(t *testing.T) {
 	po := &fakePoolOps{creds: poolops.Credentials{PoolID: "pool1abc", Network: "preview"}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"spend-password"} {"password":"ignored"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/credentials", body))
@@ -1924,7 +2182,7 @@ func TestPoolCredentialsRejectsTrailingJSON(t *testing.T) {
 
 func TestPoolCredentialsNoWalletConflict(t *testing.T) {
 	po := &fakePoolOps{credErr: poolops.ErrNoWallet}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"x"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/credentials", body))
@@ -1935,7 +2193,7 @@ func TestPoolCredentialsNoWalletConflict(t *testing.T) {
 
 func TestPoolCredentialsWrongPassword401(t *testing.T) {
 	po := &fakePoolOps{credErr: fmt.Errorf("%w: bad", poolops.ErrWrongPassword)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"bad"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/credentials", body))
@@ -1946,7 +2204,7 @@ func TestPoolCredentialsWrongPassword401(t *testing.T) {
 
 func TestPoolKESPeriodGatedWhileStarting(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/pool/kes-period", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -1956,7 +2214,7 @@ func TestPoolKESPeriodGatedWhileStarting(t *testing.T) {
 
 func TestPoolKESPeriodReady(t *testing.T) {
 	po := &fakePoolOps{kes: poolops.KESPeriodInfo{CurrentPeriod: 7, SlotsPerKESPeriod: 129600}}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/pool/kes-period", nil))
 	if rec.Code != http.StatusOK {
@@ -1973,7 +2231,7 @@ func TestPoolKESPeriodReady(t *testing.T) {
 
 func TestPoolOpCertIssue(t *testing.T) {
 	po := &fakePoolOps{opcert: poolops.OpCert{IssueNumber: 3, KesPeriod: 7, KesVKeyHex: "abcd"}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","kes_index":0,"issue_number":3,"kes_period":7}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/opcert", body))
@@ -1990,7 +2248,7 @@ func TestPoolOpCertIssue(t *testing.T) {
 
 func TestPoolOpCertRotate(t *testing.T) {
 	po := &fakePoolOps{opcert: poolops.OpCert{IssueNumber: 4, KESIndex: 1}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","new_kes_index":1,"prev_issue_number":3,"kes_period":7}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/opcert/rotate", body))
@@ -2014,7 +2272,7 @@ func TestPoolOpCertPayloadAndAssembleAirGap(t *testing.T) {
 		payload: poolops.OpCertPayload{PayloadHex: "8203", KesVKeyHex: "ab"},
 		opcert:  poolops.OpCert{IssueNumber: 1},
 	}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"kes_vkey_hex":"ab","issue_number":1,"kes_period":2}`)
@@ -2039,7 +2297,7 @@ func TestPoolOpCertPayloadAndAssembleAirGap(t *testing.T) {
 
 func TestPoolAssembleOpCertBadSignature400(t *testing.T) {
 	po := &fakePoolOps{opcertErr: fmt.Errorf("%w: bad sig", poolops.ErrInvalidRequest)}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"cold_vkey_hex":"aa","kes_vkey_hex":"bb","signature_hex":"00","issue_number":1,"kes_period":2}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/opcert/assemble", body))
@@ -2050,7 +2308,7 @@ func TestPoolAssembleOpCertBadSignature400(t *testing.T) {
 
 func TestPoolMetadataBuilder(t *testing.T) {
 	po := &fakePoolOps{metadata: poolops.MetadataResult{JSON: `{"name":"P"}`, HashHex: "deadbeef"}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"name":"P","ticker":"POOL","homepage":"https://x","description":"d"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/metadata", body))
@@ -2065,7 +2323,7 @@ func TestPoolMetadataBuilder(t *testing.T) {
 
 func TestPoolIDFromColdVKey(t *testing.T) {
 	po := &fakePoolOps{poolID: "pool1xyz", poolIDHex: "abcdef1234"}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"cold_vkey_hex":"` + strings.Repeat("ab", 32) + `"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/id", body))
@@ -2086,7 +2344,7 @@ func TestPoolIDFromColdVKey(t *testing.T) {
 
 func TestPoolRegistrationSeedAndAirGap(t *testing.T) {
 	po := &fakePoolOps{cert: poolops.CertResult{PoolID: "pool1reg", CBORHex: "8a03"}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","pledge":1,"cost":1,"margin_num":1,"margin_denom":50}`)
@@ -2111,7 +2369,7 @@ func TestPoolRegistrationSeedAndAirGap(t *testing.T) {
 
 func TestPoolRegistrationAcceptsStringAmounts(t *testing.T) {
 	po := &fakePoolOps{cert: poolops.CertResult{PoolID: "pool1reg", CBORHex: "8a03"}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","pledge":"9007199254740993","cost":"18446744073709551615","margin_num":1,"margin_denom":50}`)
@@ -2126,7 +2384,7 @@ func TestPoolRegistrationAcceptsStringAmounts(t *testing.T) {
 
 func TestPoolRetirementCert(t *testing.T) {
 	po := &fakePoolOps{cert: poolops.CertResult{PoolID: "pool1ret", CBORHex: "8304"}}
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","epoch":500}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/retirement/cert", body))
@@ -2150,7 +2408,7 @@ func TestPoolRetirementCert(t *testing.T) {
 
 func TestPoolRetirementSubmitGatedWhileSyncing(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","epoch":500}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/retirement/submit", body))
@@ -2161,7 +2419,7 @@ func TestPoolRetirementSubmitGatedWhileSyncing(t *testing.T) {
 
 func TestPoolRetirementSubmitReady(t *testing.T) {
 	po := &fakePoolOps{tx: poolops.TxResult{TxHash: "feedface"}}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","epoch":500}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/retirement/submit", body))
@@ -2175,7 +2433,7 @@ func TestPoolRetirementSubmitReady(t *testing.T) {
 
 func TestPoolRetirementSubmitRejected422(t *testing.T) {
 	po := &fakePoolOps{submitErr: fmt.Errorf("%w: ledger rule X", poolops.ErrSubmitRejected)}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","epoch":500}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/retirement/submit", body))
@@ -2194,7 +2452,7 @@ func TestVaultUnlockAttachesPoolWallet(t *testing.T) {
 		locked:  true,
 		wallets: []vault.WalletMeta{{ID: "w1", Name: "main", Network: "preview", Account: sampleAccount("preview")}},
 	}
-	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusOK {
@@ -2214,7 +2472,7 @@ func TestTPMStatusReturnsProbeResult(t *testing.T) {
 		Enabled:   false,
 		PCRBound:  false,
 	}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/tpm/status", nil))
 	if rec.Code != http.StatusOK {
@@ -2236,7 +2494,7 @@ func TestTPMStatusReturnsUnavailableWithReason(t *testing.T) {
 		Enabled:   false,
 		PCRBound:  false,
 	}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/tpm/status", nil))
 	if rec.Code != http.StatusOK {
@@ -2257,7 +2515,7 @@ func TestTPMStatusReturnsEnabledAndPCRBound(t *testing.T) {
 		Enabled:   true,
 		PCRBound:  true,
 	}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/tpm/status", nil))
 	if rec.Code != http.StatusOK {
@@ -2274,7 +2532,7 @@ func TestTPMStatusReturnsEnabledAndPCRBound(t *testing.T) {
 
 func TestEnableTPMCallsVaultMethodWithPassword(t *testing.T) {
 	fv := &fakeVault{tpmStatus: vault.TPMStatusInfo{Available: true}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-vault-password","pcrBound":true}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/enable", body))
@@ -2294,7 +2552,7 @@ func TestEnableTPMCallsVaultMethodWithPassword(t *testing.T) {
 
 func TestEnableTPMWithoutPCRBound(t *testing.T) {
 	fv := &fakeVault{tpmStatus: vault.TPMStatusInfo{Available: true}}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-vault-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/enable", body))
@@ -2311,7 +2569,7 @@ func TestEnableTPMWrongPasswordReturns401(t *testing.T) {
 		tpmStatus:    vault.TPMStatusInfo{Available: true},
 		enableTPMErr: fmt.Errorf("%w: bad", vault.ErrWrongPassword),
 	}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"wrong-but-long-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/enable", body))
@@ -2325,7 +2583,7 @@ func TestEnableTPMUnavailableReturns409(t *testing.T) {
 		tpmStatus:    vault.TPMStatusInfo{Available: false, Reason: "no device"},
 		enableTPMErr: fmt.Errorf("%w: no device", vault.ErrTPMUnavailable),
 	}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-vault-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/enable", body))
@@ -2339,7 +2597,7 @@ func TestEnableTPMRequiresPassword(t *testing.T) {
 	// MinPasswordLen floor (via requirePassword) without touching the vault.
 	for _, body := range []string{`{}`, `{"password":"short"}`} {
 		fv := &fakeVault{tpmStatus: vault.TPMStatusInfo{Available: true}}
-		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/enable", bytes.NewBufferString(body)))
 		if rec.Code != http.StatusBadRequest {
@@ -2353,7 +2611,7 @@ func TestEnableTPMRequiresPassword(t *testing.T) {
 
 func TestDisableTPMCallsVaultMethodWithPassword(t *testing.T) {
 	fv := &fakeVault{}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-vault-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/disable", body))
@@ -2370,7 +2628,7 @@ func TestDisableTPMCallsVaultMethodWithPassword(t *testing.T) {
 
 func TestDisableTPMWrongPasswordReturns401(t *testing.T) {
 	fv := &fakeVault{disableTPMErr: fmt.Errorf("%w: bad", vault.ErrWrongPassword)}
-	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"wrong-but-long-password"}`)
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/disable", body))
@@ -2384,7 +2642,7 @@ func TestDisableTPMRequiresPassword(t *testing.T) {
 	// MinPasswordLen floor (via requirePassword) without touching the vault.
 	for _, body := range []string{`{}`, `{"password":"short"}`} {
 		fv := &fakeVault{}
-		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/disable", bytes.NewBufferString(body)))
 		if rec.Code != http.StatusBadRequest {
@@ -2402,7 +2660,7 @@ func TestTPMRoutesRejectTrailingJSON(t *testing.T) {
 	// rejected without touching the vault.
 	for _, route := range []string{"/vault/tpm/enable", "/vault/tpm/disable"} {
 		fv := &fakeVault{tpmStatus: vault.TPMStatusInfo{Available: true}}
-		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
 		body := bytes.NewBufferString(`{"password":"valid-vault-password"}{"junk":true}`)
 		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, route, body))
@@ -2442,7 +2700,7 @@ func (f *fakeNodeLookup) AssetAddresses(_ context.Context, asset string) ([]chai
 }
 
 func TestHandleLookupUnavailableWithoutLookup(t *testing.T) {
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "mainnet", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/chris", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -2452,7 +2710,7 @@ func TestHandleLookupUnavailableWithoutLookup(t *testing.T) {
 
 func TestHandleLookupResolvesOnMainnet(t *testing.T) {
 	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr1abc", Quantity: "1"}}}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, "mainnet", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusOK {
@@ -2473,7 +2731,7 @@ func TestHandleLookupResolvesOnMainnet(t *testing.T) {
 
 func TestHandleLookupResolvesOnPreview(t *testing.T) {
 	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr_test1abc", Quantity: "1"}}}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusOK {
@@ -2494,7 +2752,7 @@ func TestHandleLookupResolvesOnPreview(t *testing.T) {
 
 func TestHandleLookupWithoutDollarSign(t *testing.T) {
 	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr1abc"}}}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, "mainnet", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/chris", nil))
 	if rec.Code != http.StatusOK {
@@ -2504,7 +2762,7 @@ func TestHandleLookupWithoutDollarSign(t *testing.T) {
 
 func TestHandleLookupNotFoundOnInvalidNetwork(t *testing.T) {
 	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr1abc"}}}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, "mainnte", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, &fakeMultiSig{}, "mainnte", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusNotFound {
@@ -2517,7 +2775,7 @@ func TestHandleLookupNotFoundOnInvalidNetwork(t *testing.T) {
 
 func TestHandleLookupNotFoundWhenNodeHasNotSeenAsset(t *testing.T) {
 	lk := &fakeNodeLookup{assetErr: chain.ErrNotFound}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, "mainnet", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusNotFound {
@@ -2527,7 +2785,7 @@ func TestHandleLookupNotFoundWhenNodeHasNotSeenAsset(t *testing.T) {
 
 func TestHandleLookupBadGatewayOnHardError(t *testing.T) {
 	lk := &fakeNodeLookup{assetErr: errors.New("node exploded")}
-	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, "mainnet", http.NotFoundHandler())
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusBadGateway {
@@ -2538,7 +2796,7 @@ func TestHandleLookupBadGatewayOnHardError(t *testing.T) {
 func TestHandleLookupGatedWhileStarting(t *testing.T) {
 	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr1abc"}}}
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, "mainnet", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusServiceUnavailable {
@@ -2550,7 +2808,7 @@ func TestDexRoutesAbsentWhenQuoterNil(t *testing.T) {
 	// dx is nil unless the node is on mainnet (see NewHandler wiring); the DEX
 	// routes must not be registered at all, so they fall through to the SPA/404
 	// handler rather than e.g. panicking on a nil DexQuoter.
-	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, "preview", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/dex/pools", nil))
@@ -2570,7 +2828,7 @@ func TestDexPoolsReturnsOK(t *testing.T) {
 	dx := &fakeDexQuoter{pools: []dex.Pool{
 		{Protocol: "minswap-v2", PoolID: "pool1", AssetX: "lovelace", AssetY: "deadbeef"},
 	}}
-	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, "mainnet", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/dex/pools", nil))
@@ -2593,7 +2851,7 @@ func TestDexPoolsRequiresReadyNode(t *testing.T) {
 	// cannot yet serve queries must return 503, not reach the DexQuoter.
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
 	dx := &fakeDexQuoter{}
-	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, "mainnet", http.NotFoundHandler())
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/dex/pools", nil))
@@ -2607,7 +2865,7 @@ func TestDexQuoteReturnsOK(t *testing.T) {
 		Protocol: "minswap-v2", AssetIn: "lovelace", AssetOut: "deadbeef",
 		AmountIn: "1000000", AmountOut: "500000", Route: "minswap-v2 lovelace→deadbeef",
 	}}
-	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, "mainnet", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"asset_in":"lovelace","asset_out":"deadbeef","amount_in":"1000000"}`)
@@ -2630,7 +2888,7 @@ func TestDexQuoteReturnsOK(t *testing.T) {
 
 func TestDexQuoteInvalidAmountReturns400(t *testing.T) {
 	dx := &fakeDexQuoter{}
-	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, "mainnet", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"asset_in":"lovelace","asset_out":"deadbeef","amount_in":"not-a-number"}`)
@@ -2645,7 +2903,7 @@ func TestDexQuoteInvalidAmountReturns400(t *testing.T) {
 
 func TestDexQuoteRejectsTrailingJSON(t *testing.T) {
 	dx := &fakeDexQuoter{}
-	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, "mainnet", http.NotFoundHandler())
+	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"asset_in":"lovelace","asset_out":"deadbeef","amount_in":"1000000"}{"junk":true}`)
@@ -2674,7 +2932,7 @@ func TestDexQuoteErrorMapping(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			dx := &fakeDexQuoter{quoteErr: tc.err}
-			h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, "mainnet", http.NotFoundHandler())
+			h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
 			body := bytes.NewBufferString(`{"asset_in":"lovelace","asset_out":"deadbeef","amount_in":"1000000"}`)
 			h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/dex/quote", body))

--- a/ui/internal/boot/boot.go
+++ b/ui/internal/boot/boot.go
@@ -39,6 +39,7 @@ import (
 	"github.com/blinklabs-io/bursa/ui/internal/contacts"
 	"github.com/blinklabs-io/bursa/ui/internal/dex"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
+	"github.com/blinklabs-io/bursa/ui/internal/multisig"
 	"github.com/blinklabs-io/bursa/ui/internal/poolops"
 	"github.com/blinklabs-io/bursa/ui/internal/settings"
 	"github.com/blinklabs-io/bursa/ui/internal/spend"
@@ -248,6 +249,10 @@ func Boot(ctx context.Context, cfg Config) (*App, error) {
 	// ErrNotMainnet on non-mainnet networks.
 	dexSvc := dex.NewService(chainClient, cfg.Network)
 
+	// Native multi-sig accounts are persisted under the data dir; signing uses
+	// the active wallet's CIP-1854 key, decrypted from the vault on demand.
+	multisigSvc := multisig.NewService(chainCtx, vaultKeystore{v: vlt}, filepath.Join(cfg.DataDir, "multisig.json"))
+
 	// Bind the control-surface listener BEFORE starting the node so an
 	// OS-assigned port (127.0.0.1:0) is known to the caller the moment Boot
 	// returns — the mobile WebView needs the concrete port to load the SPA.
@@ -284,6 +289,7 @@ func Boot(ctx context.Context, cfg Config) (*App, error) {
 			chainClient,
 			poolSvc,
 			dexSvc,
+			multisigSvc,
 			cfg.Network, webui.Handler(),
 			api.WithLegacyKeystore(legacyKeyStore),
 		),

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -1,0 +1,774 @@
+package multisig
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	apollo "github.com/blinklabs-io/apollo/v2"
+	"github.com/blinklabs-io/apollo/v2/backend"
+	"github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/bursa/bip32"
+	"github.com/blinklabs-io/bursa/ui/internal/cardanonet"
+	"github.com/blinklabs-io/bursa/ui/internal/keystore"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// Sentinel errors. The API layer maps these to HTTP status codes via errors.Is.
+var (
+	// ErrInvalidRequest: a malformed policy, participant, recipient, or amount (→ 400).
+	ErrInvalidRequest = errors.New("invalid multisig request")
+	// ErrUnknownAccount: no saved multi-sig account for the given id (→ 404).
+	ErrUnknownAccount = errors.New("unknown multisig account")
+	// ErrNoKeystore: the active wallet is read-only (no keystore) so it cannot
+	// derive its own participant key or co-sign (→ 409).
+	ErrNoKeystore = errors.New("no keystore configured")
+	// ErrWrongPassword: keystore authentication failed (→ 401).
+	ErrWrongPassword = errors.New("incorrect spending password")
+	// ErrInsufficientFunds: coin selection could not fund the spend (→ 422).
+	ErrInsufficientFunds = errors.New("insufficient funds")
+	// ErrInvalidTx: a supplied transaction CBOR is malformed (→ 400).
+	ErrInvalidTx = errors.New("invalid transaction")
+	// ErrInvalidWitness: a supplied witness CBOR is malformed, or the collected
+	// witnesses do not satisfy the script's threshold (→ 400).
+	ErrInvalidWitness = errors.New("invalid witness")
+	// ErrSubmitRejected: the node rejected the signed transaction (→ 422).
+	ErrSubmitRejected = errors.New("transaction rejected by node")
+)
+
+// Participant is one signer in a multi-sig policy. KeyHashHex (Blake2b-224 of the
+// CIP-1854 multi-sig vkey, 28 bytes / 56 hex chars) is the only field the script
+// needs; VKeyHex (the 32-byte vkey) is optional and carried for display/sharing.
+type Participant struct {
+	Label      string `json:"label,omitempty"`
+	KeyHashHex string `json:"key_hash_hex"`
+	VKeyHex    string `json:"vkey_hex,omitempty"`
+}
+
+// Policy is the spending rule: a threshold of M participants must sign, optionally
+// inside a validity interval bounded by InvalidBefore / InvalidAfter slots.
+type Policy struct {
+	// Threshold is N in "N-of-M": the number of participant signatures required.
+	Threshold int `json:"threshold"`
+	// Participants are the M candidate signers.
+	Participants []Participant `json:"participants"`
+	// InvalidBefore, when non-nil, makes the script invalid before this slot
+	// (NewScriptAfter / IntervalBefore: the tx must set validity start ≥ slot).
+	InvalidBefore *uint64 `json:"invalid_before,omitempty"`
+	// InvalidAfter, when non-nil, makes the script invalid from this slot onward
+	// (NewScriptBefore / TTL: the tx must set TTL ≤ slot).
+	InvalidAfter *uint64 `json:"invalid_after,omitempty"`
+}
+
+// Account is a saved, reusable multi-sig account: a label + policy, plus the
+// derived native script (CBOR) and its address. It holds only public material.
+type Account struct {
+	ID            string `json:"id"`
+	Label         string `json:"label"`
+	Network       string `json:"network"`
+	Policy        Policy `json:"policy"`
+	ScriptCBOR    string `json:"script_cbor"`    // hex-encoded native-script CBOR
+	ScriptAddress string `json:"script_address"` // bech32 script address (receive)
+}
+
+// MyKey is the active wallet's own CIP-1854 multi-sig participant identity, to
+// share so others can include it in a policy and so the user can add themselves.
+type MyKey struct {
+	VKeyHex    string `json:"vkey_hex"`     // 32-byte multi-sig vkey
+	KeyHashHex string `json:"key_hash_hex"` // Blake2b-224 of the vkey (28 bytes)
+}
+
+// UnsignedTx is the export artifact for a multi-sig spend: the completed-but-
+// unsigned tx CBOR plus everything a co-signer / collector needs to coordinate
+// signatures off-band (the script's candidate key-hashes and the threshold).
+type UnsignedTx struct {
+	UnsignedTxCBOR  string   `json:"unsigned_tx_cbor"`
+	RequiredSigners []string `json:"required_signers"` // candidate key-hashes (hex) in the script
+	Threshold       int      `json:"threshold"`        // how many of them must sign
+}
+
+// Witness is one co-signer's vkey witness over an unsigned tx (hex CBOR array of
+// common.VkeyWitness, normally length 1 — this co-signer's multi-sig key).
+type Witness struct {
+	WitnessCBOR string `json:"witness_cbor"`
+}
+
+// Keystore is the minimal interface the service needs of *keystore.Keystore.
+type Keystore interface {
+	Exists() bool
+	Unlock(password string) (mnemonic []byte, err error)
+}
+
+// feePaddingLovelace reserves the few-hundred-lovelace shortfall between Apollo's
+// pre-witness fee estimate and the node's minimum once witnesses are attached;
+// it mirrors the send path. A multi-sig tx carries several vkey witnesses plus
+// the native script, so the headroom matters more here — see
+// multisigFeePadding, which scales this baseline for the extra witnesses.
+const feePaddingLovelace = 2000
+
+// vkeyWitnessCBORBytes is the CBOR-encoded size of one common.VkeyWitness: a
+// 2-element array header (1 byte) plus a 32-byte vkey and a 64-byte signature,
+// each prefixed by a 2-byte bstr length header (both exceed the 1-byte
+// short-form length threshold of 23 bytes).
+const vkeyWitnessCBORBytes = 1 + (2 + 32) + (2 + 64)
+
+// Service manages saved multi-sig accounts and builds/signs/submits their spends.
+// It is node-local: spend ops query the embedded node's chain context, signing is
+// pure crypto over the keystore. There is no in-memory pending state — a multi-sig
+// spend is exported as CBOR and coordinated off-band, so build returns the
+// unsigned tx directly (like the air-gap export) rather than holding it.
+type Service struct {
+	chain backend.ChainContext
+	keys  Keystore // may be nil; then my-key and signing are unavailable
+	store *store
+	mkID  func() string
+}
+
+// NewService constructs a Service backed by the JSON store at storePath.
+func NewService(cc backend.ChainContext, ks Keystore, storePath string) *Service {
+	return &Service{
+		chain: cc,
+		keys:  ks,
+		store: newStore(storePath),
+		mkID:  randID,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Script composition
+// ---------------------------------------------------------------------------
+
+// composeScript builds the native script for a policy: an N-of-M threshold over
+// the participant key-hashes, wrapped in an "all" with the time-lock clause(s)
+// when a validity bound is set. The composition is:
+//
+//	threshold := NewMultiSigScript(N, keyHash...)            // NofK over pubkey sigs
+//	if invalidBefore: after  := NewScriptAfter(invalidBefore) // type 4
+//	if invalidAfter:  before := NewScriptBefore(invalidAfter) // type 5
+//	script := NewScriptAll(after?, before?, threshold)        // all clauses required
+//
+// With no time-lock the script is just the threshold script.
+func composeScript(p Policy) (*bursa.NativeScript, error) {
+	if p.Threshold < 1 {
+		return nil, fmt.Errorf("%w: threshold must be at least 1", ErrInvalidRequest)
+	}
+	if p.Threshold > len(p.Participants) {
+		return nil, fmt.Errorf(
+			"%w: threshold %d exceeds participant count %d",
+			ErrInvalidRequest, p.Threshold, len(p.Participants),
+		)
+	}
+	keyHashes := make([][]byte, 0, len(p.Participants))
+	seen := make(map[string]bool, len(p.Participants))
+	for _, part := range p.Participants {
+		kh, err := hex.DecodeString(strings.TrimSpace(part.KeyHashHex))
+		if err != nil {
+			return nil, fmt.Errorf("%w: key hash %q is not valid hex: %w", ErrInvalidRequest, part.KeyHashHex, err)
+		}
+		if len(kh) != 28 {
+			return nil, fmt.Errorf(
+				"%w: key hash %q must be 28 bytes (Blake2b-224), got %d",
+				ErrInvalidRequest, part.KeyHashHex, len(kh),
+			)
+		}
+		if seen[string(kh)] {
+			return nil, fmt.Errorf("%w: duplicate participant key hash %s", ErrInvalidRequest, part.KeyHashHex)
+		}
+		seen[string(kh)] = true
+		keyHashes = append(keyHashes, kh)
+	}
+	if len(keyHashes) == 0 {
+		return nil, fmt.Errorf("%w: at least one participant required", ErrInvalidRequest)
+	}
+	if p.InvalidBefore != nil && p.InvalidAfter != nil && *p.InvalidBefore >= *p.InvalidAfter {
+		return nil, fmt.Errorf(
+			"%w: invalid_before (%d) must be less than invalid_after (%d)",
+			ErrInvalidRequest, *p.InvalidBefore, *p.InvalidAfter,
+		)
+	}
+
+	threshold, err := bursa.NewMultiSigScript(p.Threshold, keyHashes...)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidRequest, err)
+	}
+
+	if p.InvalidBefore == nil && p.InvalidAfter == nil {
+		return threshold, nil
+	}
+
+	clauses := make([]bursa.Script, 0, 3)
+	if p.InvalidBefore != nil {
+		after, err := bursa.NewScriptAfter(*p.InvalidBefore)
+		if err != nil {
+			return nil, fmt.Errorf("invalid-before clause: %w", err)
+		}
+		clauses = append(clauses, after)
+	}
+	if p.InvalidAfter != nil {
+		before, err := bursa.NewScriptBefore(*p.InvalidAfter)
+		if err != nil {
+			return nil, fmt.Errorf("invalid-after clause: %w", err)
+		}
+		clauses = append(clauses, before)
+	}
+	clauses = append(clauses, threshold)
+	all, err := bursa.NewScriptAll(clauses...)
+	if err != nil {
+		return nil, fmt.Errorf("compose timelocked script: %w", err)
+	}
+	return all, nil
+}
+
+// scriptAddress derives the canonical Cardano script address for a native script.
+//
+// IMPORTANT: this does NOT use bursa.GetScriptAddress, which hashes only the bare
+// script CBOR (RawScriptBytes) and so produces a credential the ledger never
+// agrees with — funds sent there would be unspendable. The ledger (and apollo's
+// AttachScript dedup) hash Blake2b-224(0x00 || scriptCBOR), which is exactly what
+// NativeScript.Hash() computes. We build the address from that hash so the
+// payment credential matches the script the ledger validates on spend.
+func scriptAddress(script *bursa.NativeScript, network string) (string, error) {
+	netID, err := cardanonet.AddressNetworkID(network)
+	if err != nil {
+		return "", err
+	}
+	hash := script.Hash() // Blake2b-224(0x00 || cbor); the canonical native-script hash
+	addr, err := lcommon.NewAddressFromParts(lcommon.AddressTypeScriptNone, netID, hash.Bytes(), nil)
+	if err != nil {
+		return "", fmt.Errorf("script address: %w", err)
+	}
+	return addr.String(), nil
+}
+
+// ---------------------------------------------------------------------------
+// Account CRUD
+// ---------------------------------------------------------------------------
+
+// List returns the saved multi-sig accounts.
+func (s *Service) List() ([]Account, error) {
+	accts, err := s.store.list()
+	if err != nil {
+		return nil, err
+	}
+	if accts == nil {
+		accts = []Account{}
+	}
+	return accts, nil
+}
+
+// Get returns one saved account by id.
+func (s *Service) Get(id string) (Account, error) {
+	return s.store.get(id)
+}
+
+// Delete removes a saved account by id.
+func (s *Service) Delete(id string) error {
+	return s.store.remove(id)
+}
+
+// CreateRequest is the input to Create: a label, the network, and the policy.
+type CreateRequest struct {
+	Label   string `json:"label"`
+	Network string `json:"network"`
+	Policy  Policy `json:"policy"`
+}
+
+// Create composes the script for the policy, derives its address, persists the
+// account, and returns it. The network must be a supported Cardano network.
+func (s *Service) Create(req CreateRequest) (Account, error) {
+	label := strings.TrimSpace(req.Label)
+	if label == "" {
+		return Account{}, fmt.Errorf("%w: label is required", ErrInvalidRequest)
+	}
+	if !cardanonet.ValidNetwork(req.Network) {
+		return Account{}, fmt.Errorf("%w: unknown network %q", ErrInvalidRequest, req.Network)
+	}
+	script, err := composeScript(req.Policy)
+	if err != nil {
+		return Account{}, err
+	}
+	addr, err := scriptAddress(script, req.Network)
+	if err != nil {
+		return Account{}, err
+	}
+	acct := Account{
+		ID:            s.mkID(),
+		Label:         label,
+		Network:       req.Network,
+		Policy:        req.Policy,
+		ScriptCBOR:    hex.EncodeToString(script.Cbor()),
+		ScriptAddress: addr,
+	}
+	if err := s.store.add(acct); err != nil {
+		return Account{}, err
+	}
+	return acct, nil
+}
+
+// ---------------------------------------------------------------------------
+// The wallet's own participant key (CIP-1854)
+// ---------------------------------------------------------------------------
+
+// MyKey derives the active wallet's CIP-1854 multi-sig participant identity from
+// the keystore seed: multi-sig account key 0 → multi-sig payment key 0 → its
+// 32-byte vkey and the Blake2b-224 key-hash used in scripts. It needs the
+// spending password (to unlock the seed) but no node. The user shares the
+// key-hash (and/or vkey) so co-signers can include them in a policy.
+func (s *Service) MyKey(password string) (MyKey, error) {
+	if s.keys == nil || !s.keys.Exists() {
+		return MyKey{}, ErrNoKeystore
+	}
+	mnemonicBytes, err := s.keys.Unlock(password)
+	if err != nil {
+		if errors.Is(err, keystore.ErrDecryptFailed) {
+			return MyKey{}, fmt.Errorf("%w: %w", ErrWrongPassword, err)
+		}
+		return MyKey{}, fmt.Errorf("unlock keystore: %w", err)
+	}
+	var rootKey, acctKey, payKey bip32.XPrv
+	defer func() {
+		for _, k := range []bip32.XPrv{rootKey, acctKey, payKey} {
+			zero(k)
+		}
+		zeroBytes(mnemonicBytes)
+	}()
+
+	rootKey, err = bursa.GetRootKeyFromMnemonic(string(mnemonicBytes), "")
+	if err != nil {
+		return MyKey{}, fmt.Errorf("root key: %w", err)
+	}
+	acctKey, err = bursa.GetMultiSigAccountKey(rootKey, 0)
+	if err != nil {
+		return MyKey{}, fmt.Errorf("multisig account key: %w", err)
+	}
+	payKey, err = bursa.GetMultiSigPaymentKey(acctKey, 0)
+	if err != nil {
+		return MyKey{}, fmt.Errorf("multisig payment key: %w", err)
+	}
+	vkey := payKey.Public().PublicKey() // 32-byte ed25519 vkey
+	keyHash := lcommon.Blake2b224Hash(vkey)
+	return MyKey{
+		VKeyHex:    hex.EncodeToString(vkey),
+		KeyHashHex: hex.EncodeToString(keyHash.Bytes()),
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Spend: build → (collect witnesses) → submit
+// ---------------------------------------------------------------------------
+
+// Balance returns the lovelace held at the account's script address as a decimal
+// string (uint64-safe, matching the read-side balance API).
+func (s *Service) Balance(ctx context.Context, id string) (string, error) {
+	acct, err := s.store.get(id)
+	if err != nil {
+		return "", err
+	}
+	addr, err := lcommon.NewAddress(acct.ScriptAddress)
+	if err != nil {
+		return "", fmt.Errorf("script address: %w", err)
+	}
+	utxos, err := s.chain.Utxos(ctx, addr)
+	if err != nil {
+		return "", fmt.Errorf("utxos for %s: %w", acct.ScriptAddress, err)
+	}
+	var total uint64
+	for _, u := range utxos {
+		if u.Output == nil {
+			continue
+		}
+		amt := u.Output.Amount()
+		if amt != nil {
+			total += amt.Uint64()
+		}
+	}
+	return strconv.FormatUint(total, 10), nil
+}
+
+// BuildRequest is the input to Build: where to send and how much.
+type BuildRequest struct {
+	To       string `json:"to"`
+	Lovelace string `json:"lovelace"` // decimal lovelace string (uint64-safe)
+}
+
+// multisigFeePadding returns the fee padding for a Build spend. Apollo's fee
+// estimator sizes its dummy tx for exactly one vkey witness (see its
+// estimateFee docs), but Submit may ultimately attach anywhere from the
+// policy's threshold up to all participantCount candidate key-hashes —
+// co-signers are free to add a witness beyond what the threshold strictly
+// needs, and Submit keeps every valid one it is given (see Submit). Pad for
+// the worst case (every participant signs) using the network's actual
+// per-byte fee coefficient, on top of the flat feePaddingLovelace shortfall
+// margin that mirrors the single-sig send path. Overpaying a little is
+// harmless — change returns to the script address — but underpaying causes a
+// hard FeeTooSmallUTxO node rejection once the extra witnesses are attached.
+func (s *Service) multisigFeePadding(ctx context.Context, participantCount int) (int64, error) {
+	extraWitnesses := participantCount - 1
+	if extraWitnesses < 1 {
+		return feePaddingLovelace, nil
+	}
+	pp, err := s.chain.ProtocolParams(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return feePaddingLovelace + int64(extraWitnesses)*vkeyWitnessCBORBytes*pp.MinFeeCoefficient, nil
+}
+
+// Build composes a transaction spending UTxOs at the account's script address.
+// It loads the script-address UTxOs, pays the recipient (change returns to the
+// script address), attaches the native script to the witness set, and — when the
+// policy is time-locked — sets the tx validity interval so the script's bounds
+// are satisfied. The completed-but-unsigned tx CBOR is returned along with the
+// script's candidate key-hashes and threshold, so co-signers can be coordinated.
+//
+// Unlike the send path there is no in-memory pending entry: the unsigned tx is
+// the durable artifact, carried/collected off-band and handed back to Submit.
+func (s *Service) Build(ctx context.Context, id string, req BuildRequest) (UnsignedTx, error) {
+	acct, err := s.store.get(id)
+	if err != nil {
+		return UnsignedTx{}, err
+	}
+	script, err := decodeScript(acct.ScriptCBOR)
+	if err != nil {
+		return UnsignedTx{}, err
+	}
+
+	scriptAddr, err := lcommon.NewAddress(acct.ScriptAddress)
+	if err != nil {
+		return UnsignedTx{}, fmt.Errorf("script address: %w", err)
+	}
+	recvAddr, err := lcommon.NewAddress(strings.TrimSpace(req.To))
+	if err != nil {
+		return UnsignedTx{}, fmt.Errorf("%w: recipient %q: %w", ErrInvalidRequest, req.To, err)
+	}
+	lovelace, err := parseAmount(req.Lovelace)
+	if err != nil {
+		return UnsignedTx{}, fmt.Errorf("%w: lovelace: %w", ErrInvalidRequest, err)
+	}
+
+	keyHashes, err := scriptKeyHashes(acct.Policy)
+	if err != nil {
+		return UnsignedTx{}, err
+	}
+	padding, err := s.multisigFeePadding(ctx, len(keyHashes))
+	if err != nil {
+		return UnsignedTx{}, fmt.Errorf("protocol params: %w", err)
+	}
+
+	// Change returns to the script address so the account stays funded.
+	a := apollo.New(s.chain).
+		SetWallet(apollo.NewExternalWallet(scriptAddr)).
+		SetChangeAddress(scriptAddr).
+		SetFeePadding(padding)
+
+	utxos, err := s.chain.Utxos(ctx, scriptAddr)
+	if err != nil {
+		return UnsignedTx{}, fmt.Errorf("utxos for %s: %w", acct.ScriptAddress, err)
+	}
+	if len(utxos) == 0 {
+		return UnsignedTx{}, fmt.Errorf("%w: no UTxOs at script address", ErrInsufficientFunds)
+	}
+	a = a.AddLoadedUTxOs(utxos...)
+
+	a = a.PayToAddress(recvAddr, int64(lovelace)) //nolint:gosec // validated by parseAmount
+
+	// Attach the native script so the witness set carries it (the ledger needs
+	// the script that hashes to the input's payment credential). We deliberately
+	// do NOT register the participant key-hashes as tx-level required signers:
+	// the ledger enforces reqSignerHashes unconditionally, on top of (not instead
+	// of) the native script's own threshold check, so listing every candidate
+	// there would force all M participants to sign even when the policy only
+	// needs N-of-M. The script's threshold, evaluated against whichever vkey
+	// witnesses Submit ultimately attaches, is what enforces the policy — see
+	// multisigFeePadding for how the fee still accounts for those witnesses.
+	a = a.AttachScript(*script)
+
+	// Time-locks: a "before" bound (InvalidAfter) sets the tx TTL; an "after"
+	// bound (InvalidBefore) sets the validity start. The interval must lie inside
+	// the script's bounds or the ledger rejects the spend.
+	if acct.Policy.InvalidBefore != nil {
+		start := *acct.Policy.InvalidBefore
+		if start > math.MaxInt64 {
+			return UnsignedTx{}, fmt.Errorf("%w: invalid_before slot out of range", ErrInvalidRequest)
+		}
+		a = a.SetValidityStart(int64(start)) //nolint:gosec // bounded above
+	}
+	if acct.Policy.InvalidAfter != nil {
+		ttl := *acct.Policy.InvalidAfter
+		if ttl > math.MaxInt64 {
+			return UnsignedTx{}, fmt.Errorf("%w: invalid_after slot out of range", ErrInvalidRequest)
+		}
+		a = a.SetTtl(int64(ttl)) //nolint:gosec // bounded above
+	}
+
+	a, err = a.CompleteContext(ctx)
+	if err != nil {
+		if isInsufficientFundsError(err) {
+			return UnsignedTx{}, fmt.Errorf("%w: %w", ErrInsufficientFunds, err)
+		}
+		return UnsignedTx{}, fmt.Errorf("complete transaction: %w", err)
+	}
+
+	cborBytes, err := a.GetTxCbor()
+	if err != nil {
+		return UnsignedTx{}, fmt.Errorf("encode unsigned tx: %w", err)
+	}
+
+	signers := make([]string, len(keyHashes))
+	for i, kh := range keyHashes {
+		signers[i] = hex.EncodeToString(kh)
+	}
+	return UnsignedTx{
+		UnsignedTxCBOR:  hex.EncodeToString(cborBytes),
+		RequiredSigners: signers,
+		Threshold:       acct.Policy.Threshold,
+	}, nil
+}
+
+// Sign is a co-signer's step: it decrypts the seed, derives the wallet's CIP-1854
+// multi-sig key (NOT the CIP-1852 payment key used for ordinary sends), and emits
+// that key's vkey witness over the unsigned tx body. The witness is collected with
+// the others and handed to Submit. It needs only the unsigned tx CBOR and the
+// password — no node.
+func (s *Service) Sign(unsignedTxCBOR, password string) (Witness, error) {
+	if s.keys == nil || !s.keys.Exists() {
+		return Witness{}, ErrNoKeystore
+	}
+	loader, err := apollo.New(s.chain).LoadTxCbor(unsignedTxCBOR)
+	if err != nil {
+		return Witness{}, fmt.Errorf("%w: %w", ErrInvalidTx, err)
+	}
+	tx := loader.GetTx()
+	if tx == nil {
+		return Witness{}, fmt.Errorf("%w: no transaction body", ErrInvalidTx)
+	}
+	// Witnesses sign the exact body bytes carried by the unsigned transaction.
+	// Re-encoding can drift while preserving semantics.
+	bodyCbor := tx.Body.Cbor()
+	if bodyCbor == nil {
+		bodyCbor, err = cbor.Encode(&tx.Body)
+		if err != nil {
+			return Witness{}, fmt.Errorf("encode tx body: %w", err)
+		}
+	}
+	bodyHash := lcommon.Blake2b256Hash(bodyCbor)
+
+	mnemonicBytes, err := s.keys.Unlock(password)
+	if err != nil {
+		if errors.Is(err, keystore.ErrDecryptFailed) {
+			return Witness{}, fmt.Errorf("%w: %w", ErrWrongPassword, err)
+		}
+		return Witness{}, fmt.Errorf("unlock keystore: %w", err)
+	}
+	var rootKey, acctKey, payKey bip32.XPrv
+	defer func() {
+		for _, k := range []bip32.XPrv{rootKey, acctKey, payKey} {
+			zero(k)
+		}
+		zeroBytes(mnemonicBytes)
+	}()
+
+	rootKey, err = bursa.GetRootKeyFromMnemonic(string(mnemonicBytes), "")
+	if err != nil {
+		return Witness{}, fmt.Errorf("root key: %w", err)
+	}
+	acctKey, err = bursa.GetMultiSigAccountKey(rootKey, 0)
+	if err != nil {
+		return Witness{}, fmt.Errorf("multisig account key: %w", err)
+	}
+	payKey, err = bursa.GetMultiSigPaymentKey(acctKey, 0)
+	if err != nil {
+		return Witness{}, fmt.Errorf("multisig payment key: %w", err)
+	}
+
+	w, err := apollo.NewVkeyWitnessFromSkey(bodyHash, []byte(payKey))
+	if err != nil {
+		return Witness{}, fmt.Errorf("sign with multisig key: %w", err)
+	}
+	encoded, err := cbor.Encode([]lcommon.VkeyWitness{w})
+	if err != nil {
+		return Witness{}, fmt.Errorf("encode witness: %w", err)
+	}
+	return Witness{WitnessCBOR: hex.EncodeToString(encoded)}, nil
+}
+
+// Submit is the final step: it loads the unsigned tx, attaches the account's
+// native script, decodes and attaches the collected co-signer vkey witnesses,
+// verifies that at least `threshold` of the script's participant key-hashes are
+// covered, and submits. Witnesses are deduped by key-hash and only those that
+// belong to the script's participants are attached; the tx body is never mutated
+// so the witnesses' body hash still matches.
+//
+// witnessCBORs is the list of per-co-signer witness blobs (each a hex CBOR array
+// of common.VkeyWitness) collected during the multi-party flow.
+func (s *Service) Submit(ctx context.Context, id, unsignedTxCBOR string, witnessCBORs []string) (TxResult, error) {
+	acct, err := s.store.get(id)
+	if err != nil {
+		return TxResult{}, err
+	}
+	script, err := decodeScript(acct.ScriptCBOR)
+	if err != nil {
+		return TxResult{}, err
+	}
+	participants, err := scriptKeyHashes(acct.Policy)
+	if err != nil {
+		return TxResult{}, err
+	}
+	participantSet := make(map[string]bool, len(participants))
+	for _, kh := range participants {
+		participantSet[hex.EncodeToString(kh)] = true
+	}
+
+	a, err := apollo.New(s.chain).LoadTxCbor(unsignedTxCBOR)
+	if err != nil {
+		return TxResult{}, fmt.Errorf("%w: %w", ErrInvalidTx, err)
+	}
+	tx := a.GetTx()
+	if tx == nil {
+		return TxResult{}, fmt.Errorf("%w: no transaction body", ErrInvalidTx)
+	}
+
+	// Re-attach the native script. LoadTxCbor restores whatever witness set the
+	// unsigned tx carried (Build already attached it), but attaching again is
+	// idempotent (AttachScript dedups by hash) and makes Submit robust to an
+	// unsigned tx assembled elsewhere.
+	a = a.AttachScript(*script)
+
+	// Decode and attach every collected witness that belongs to a script
+	// participant, deduped by key-hash.
+	attached := make(map[string]bool)
+	for i, wc := range witnessCBORs {
+		witBytes, err := hex.DecodeString(strings.TrimSpace(wc))
+		if err != nil {
+			return TxResult{}, fmt.Errorf("%w: witness %d hex: %w", ErrInvalidWitness, i, err)
+		}
+		var witnesses []lcommon.VkeyWitness
+		if _, err := cbor.Decode(witBytes, &witnesses); err != nil {
+			return TxResult{}, fmt.Errorf("%w: witness %d: %w", ErrInvalidWitness, i, err)
+		}
+		for _, wit := range witnesses {
+			kh := hex.EncodeToString(lcommon.Blake2b224Hash(wit.Vkey).Bytes())
+			if !participantSet[kh] || attached[kh] {
+				continue
+			}
+			attached[kh] = true
+			if a, err = a.AddVerificationKeyWitness(wit); err != nil {
+				return TxResult{}, fmt.Errorf("attach witness: %w", err)
+			}
+		}
+	}
+
+	if len(attached) < acct.Policy.Threshold {
+		return TxResult{}, fmt.Errorf(
+			"%w: have %d of %d required signatures",
+			ErrInvalidWitness, len(attached), acct.Policy.Threshold,
+		)
+	}
+
+	// LoadTxCbor cached the decoded tx's raw CBOR; clear the tx-level and
+	// witness-set caches so SubmitContext re-serializes the witnesses + script we
+	// attached. The BODY cache stays intact: the witnesses signed the original
+	// body bytes (mirrors the send path's SubmitSigned).
+	tx.SetCbor(nil)
+	tx.WitnessSet.SetCbor(nil)
+
+	txHash, err := a.SubmitContext(context.WithoutCancel(ctx))
+	if err != nil {
+		return TxResult{}, fmt.Errorf("%w: %w", ErrSubmitRejected, err)
+	}
+	return TxResult{TxHash: hex.EncodeToString(txHash.Bytes())}, nil
+}
+
+// TxResult is returned from Submit after broadcast.
+type TxResult struct {
+	TxHash string `json:"tx_hash"`
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// decodeScript reconstructs a native script from its hex CBOR.
+func decodeScript(scriptCBORHex string) (*bursa.NativeScript, error) {
+	b, err := hex.DecodeString(scriptCBORHex)
+	if err != nil {
+		return nil, fmt.Errorf("%w: script hex: %w", ErrInvalidRequest, err)
+	}
+	var ns bursa.NativeScript
+	if _, err := cbor.Decode(b, &ns); err != nil {
+		return nil, fmt.Errorf("%w: decode script: %w", ErrInvalidRequest, err)
+	}
+	return &ns, nil
+}
+
+// scriptKeyHashes returns the participant key-hashes (as raw 28-byte slices) of a
+// policy, in policy order.
+func scriptKeyHashes(p Policy) ([][]byte, error) {
+	out := make([][]byte, 0, len(p.Participants))
+	for _, part := range p.Participants {
+		kh, err := hex.DecodeString(strings.TrimSpace(part.KeyHashHex))
+		if err != nil {
+			return nil, fmt.Errorf("%w: key hash %q: %w", ErrInvalidRequest, part.KeyHashHex, err)
+		}
+		out = append(out, kh)
+	}
+	return out, nil
+}
+
+// parseAmount parses a decimal uint64 lovelace string, rejecting values past the
+// int64 range Apollo accepts.
+func parseAmount(s string) (uint64, error) {
+	v, err := strconv.ParseUint(strings.TrimSpace(s), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%q is not a valid amount", s)
+	}
+	if v > math.MaxInt64 {
+		return 0, fmt.Errorf("amount %s exceeds int64 range", s)
+	}
+	return v, nil
+}
+
+func isInsufficientFundsError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "insufficient UTxOs to cover required value"):
+		return true
+	case strings.Contains(msg, "insufficient funds: coin underflow"):
+		return true
+	case strings.Contains(msg, "insufficient funds: asset underflow"):
+		return true
+	case strings.Contains(msg, "insufficient funds: need ") &&
+		strings.Contains(msg, " more lovelace for change output min UTxO"):
+		return true
+	default:
+		return false
+	}
+}
+
+func zero(k bip32.XPrv) {
+	for i := range k {
+		k[i] = 0
+	}
+}
+
+func zeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// randID generates a 16-byte random hex string for account ids.
+func randID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/ui/internal/multisig/multisig_test.go
+++ b/ui/internal/multisig/multisig_test.go
@@ -1,0 +1,533 @@
+package multisig
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"math"
+	"math/big"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	apollo "github.com/blinklabs-io/apollo/v2"
+	"github.com/blinklabs-io/apollo/v2/backend"
+	"github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/bursa/bip32"
+	"github.com/blinklabs-io/bursa/ui/internal/keystore"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/blinklabs-io/plutigo/data"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+// Two distinct 24-word "abandon" test vectors so we can derive two independent
+// multi-sig participant identities.
+const mnemonicA = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art"
+
+const mnemonicB = "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title"
+
+// multiSigKeyHash derives a mnemonic's CIP-1854 multi-sig payment vkey + key-hash.
+func multiSigKeyHash(t *testing.T, mnemonic string) (vkeyHex, keyHashHex string, skey bip32.XPrv) {
+	t.Helper()
+	root, err := bursa.GetRootKeyFromMnemonic(mnemonic, "")
+	if err != nil {
+		t.Fatalf("root key: %v", err)
+	}
+	acct, err := bursa.GetMultiSigAccountKey(root, 0)
+	if err != nil {
+		t.Fatalf("multisig account key: %v", err)
+	}
+	pay, err := bursa.GetMultiSigPaymentKey(acct, 0)
+	if err != nil {
+		t.Fatalf("multisig payment key: %v", err)
+	}
+	vkey := pay.Public().PublicKey()
+	kh := lcommon.Blake2b224Hash(vkey)
+	return hex.EncodeToString(vkey), hex.EncodeToString(kh.Bytes()), pay
+}
+
+// --- fakeChain (mirrors the spend package's test harness) ------------------
+
+type fakeChain struct {
+	utxos      map[string][]lcommon.Utxo
+	pp         backend.ProtocolParameters
+	submitHash lcommon.Blake2b256
+	submitCbor []byte
+	submitMu   sync.Mutex
+}
+
+func newFakeChain() *fakeChain {
+	var h lcommon.Blake2b256
+	b, _ := hex.DecodeString("deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	copy(h[:], b)
+	return &fakeChain{
+		utxos: map[string][]lcommon.Utxo{},
+		pp: backend.ProtocolParameters{
+			MinFeeConstant:    155381,
+			MinFeeCoefficient: 44,
+			MaxTxSize:         16384,
+			CoinsPerUtxoByte:  "4310",
+			KeyDeposits:       "2000000",
+			PoolDeposits:      "500000000",
+		},
+		submitHash: h,
+	}
+}
+
+func (fc *fakeChain) addUTxO(addr, txHashHex string, outIdx uint32, lovelace uint64) {
+	var txID lcommon.Blake2b256
+	b, _ := hex.DecodeString(txHashHex)
+	copy(txID[:], b)
+	input := shelley.ShelleyTransactionInput{TxId: txID, OutputIndex: outIdx}
+	a, _ := lcommon.NewAddress(addr)
+	fc.utxos[addr] = append(fc.utxos[addr], lcommon.Utxo{
+		Id:     input,
+		Output: &fakeOutput{address: a, lovelace: lovelace},
+	})
+}
+
+type fakeOutput struct {
+	address  lcommon.Address
+	lovelace uint64
+}
+
+func (o *fakeOutput) Address() lcommon.Address { return o.address }
+func (o *fakeOutput) Amount() *big.Int         { return new(big.Int).SetUint64(o.lovelace) }
+func (o *fakeOutput) Assets() *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput] {
+	return nil
+}
+func (o *fakeOutput) Datum() *lcommon.Datum               { return nil }
+func (o *fakeOutput) DatumHash() *lcommon.Blake2b256      { return nil }
+func (o *fakeOutput) Cbor() []byte                        { return nil }
+func (o *fakeOutput) Utxorpc() (*utxorpc.TxOutput, error) { return nil, nil }
+func (o *fakeOutput) ScriptRef() lcommon.Script           { return nil }
+func (o *fakeOutput) ToPlutusData() data.PlutusData       { return nil }
+func (o *fakeOutput) String() string                      { return o.address.String() }
+
+func (fc *fakeChain) ProtocolParams(_ context.Context) (backend.ProtocolParameters, error) {
+	return fc.pp, nil
+}
+func (fc *fakeChain) GenesisParams(_ context.Context) (backend.GenesisParameters, error) {
+	return backend.GenesisParameters{ActiveSlotsCoefficient: 0.05, EpochLength: 432000, SlotLength: 1, NetworkMagic: 1}, nil
+}
+func (fc *fakeChain) NetworkId() uint8                               { return 0 }
+func (fc *fakeChain) CurrentEpoch(_ context.Context) (uint64, error) { return 500, nil }
+func (fc *fakeChain) MaxTxFee(_ context.Context) (uint64, error) {
+	return backend.ComputeMaxTxFee(fc.pp)
+}
+func (fc *fakeChain) Tip(_ context.Context) (uint64, error) { return 10_000_000, nil }
+func (fc *fakeChain) Utxos(_ context.Context, address lcommon.Address) ([]lcommon.Utxo, error) {
+	return fc.utxos[address.String()], nil
+}
+func (fc *fakeChain) SubmitTx(_ context.Context, tx []byte) (lcommon.Blake2b256, error) {
+	fc.submitMu.Lock()
+	fc.submitCbor = append(fc.submitCbor[:0], tx...)
+	fc.submitMu.Unlock()
+	return fc.submitHash, nil
+}
+func (fc *fakeChain) EvaluateTx(_ context.Context, _ []byte, _ []lcommon.Utxo) (map[lcommon.RedeemerKey]lcommon.ExUnits, error) {
+	return nil, nil
+}
+func (fc *fakeChain) UtxoByRef(_ context.Context, txHash lcommon.Blake2b256, index uint32) (*lcommon.Utxo, error) {
+	for _, utxos := range fc.utxos {
+		for _, u := range utxos {
+			if u.Id.Id() == txHash && u.Id.Index() == index {
+				cp := u
+				return &cp, nil
+			}
+		}
+	}
+	return nil, nil
+}
+func (fc *fakeChain) ScriptCbor(_ context.Context, _ lcommon.Blake2b224) ([]byte, error) {
+	return nil, nil
+}
+
+// --- fake keystore ---------------------------------------------------------
+
+// fakeKeystore implements the multisig.Keystore interface in memory, returning
+// the configured mnemonic for the right password — avoiding scrypt's cost in
+// tests. A wrong password yields keystore.ErrDecryptFailed, matching the real
+// keystore so the ErrWrongPassword mapping is exercised.
+type fakeKeystore struct {
+	mnemonic string
+	password string
+}
+
+func (k *fakeKeystore) Exists() bool { return k.mnemonic != "" }
+func (k *fakeKeystore) Unlock(password string) ([]byte, error) {
+	if password != k.password {
+		return nil, keystore.ErrDecryptFailed
+	}
+	return []byte(k.mnemonic), nil
+}
+
+func newTestKeystore(_ *testing.T, mnemonic string) *fakeKeystore {
+	return &fakeKeystore{mnemonic: mnemonic, password: "test-password-123"}
+}
+
+// --- tests -----------------------------------------------------------------
+
+func TestComposeScriptThresholdAndAddress(t *testing.T) {
+	_, khA, _ := multiSigKeyHash(t, mnemonicA)
+	_, khB, _ := multiSigKeyHash(t, mnemonicB)
+
+	pol := Policy{
+		Threshold:    2,
+		Participants: []Participant{{KeyHashHex: khA}, {KeyHashHex: khB}},
+	}
+	script, err := composeScript(pol)
+	if err != nil {
+		t.Fatalf("composeScript: %v", err)
+	}
+	if id, err := bursa.GetScriptType(script); err != nil || id != 3 {
+		t.Fatalf("expected NofK (type 3), got type %d err %v", id, err)
+	}
+	addr, err := scriptAddress(script, "preview")
+	if err != nil {
+		t.Fatalf("scriptAddress: %v", err)
+	}
+	// The address payment credential must equal the canonical native-script hash
+	// (NativeScript.Hash) — the ledger derives the same on spend.
+	parsed, err := lcommon.NewAddress(addr)
+	if err != nil {
+		t.Fatalf("parse addr: %v", err)
+	}
+	if got := hex.EncodeToString(parsed.PaymentKeyHash().Bytes()); got != hex.EncodeToString(script.Hash().Bytes()) {
+		t.Fatalf("address credential %s != script hash %s", got, script.Hash().String())
+	}
+}
+
+func TestComposeScriptTimelock(t *testing.T) {
+	_, khA, _ := multiSigKeyHash(t, mnemonicA)
+	before := uint64(1000)
+	after := uint64(9_000_000)
+	pol := Policy{
+		Threshold:     1,
+		Participants:  []Participant{{KeyHashHex: khA}},
+		InvalidBefore: &before,
+		InvalidAfter:  &after,
+	}
+	script, err := composeScript(pol)
+	if err != nil {
+		t.Fatalf("composeScript timelock: %v", err)
+	}
+	// A time-locked policy wraps the threshold in an "all" (type 1).
+	if id, err := bursa.GetScriptType(script); err != nil || id != 1 {
+		t.Fatalf("expected All (type 1) for timelocked, got type %d err %v", id, err)
+	}
+}
+
+func TestComposeScriptRejectsBadThreshold(t *testing.T) {
+	_, khA, _ := multiSigKeyHash(t, mnemonicA)
+	_, err := composeScript(Policy{Threshold: 2, Participants: []Participant{{KeyHashHex: khA}}})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("expected ErrInvalidRequest, got %v", err)
+	}
+}
+
+func TestCreateListGetDelete(t *testing.T) {
+	fc := newFakeChain()
+	svc := NewService(fc, nil, filepath.Join(t.TempDir(), "multisig.json"))
+	_, khA, _ := multiSigKeyHash(t, mnemonicA)
+	_, khB, _ := multiSigKeyHash(t, mnemonicB)
+
+	acct, err := svc.Create(CreateRequest{
+		Label:   "treasury",
+		Network: "preview",
+		Policy:  Policy{Threshold: 2, Participants: []Participant{{KeyHashHex: khA}, {KeyHashHex: khB}}},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if acct.ScriptAddress == "" || acct.ScriptCBOR == "" || acct.ID == "" {
+		t.Fatalf("incomplete account: %+v", acct)
+	}
+
+	// Persisted: a fresh service reading the same file sees it.
+	svc2 := NewService(fc, nil, svc.store.path)
+	list, err := svc2.List()
+	if err != nil || len(list) != 1 || list[0].ID != acct.ID {
+		t.Fatalf("List after reload: %v, %+v", err, list)
+	}
+
+	got, err := svc2.Get(acct.ID)
+	if err != nil || got.ScriptAddress != acct.ScriptAddress {
+		t.Fatalf("Get: %v %+v", err, got)
+	}
+
+	if err := svc2.Delete(acct.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := svc2.Get(acct.ID); !errors.Is(err, ErrUnknownAccount) {
+		t.Fatalf("expected ErrUnknownAccount after delete, got %v", err)
+	}
+}
+
+func TestStoreAddRollsBackOnPersistFailure(t *testing.T) {
+	s := newStore(filepath.Join(t.TempDir(), "missing", "multisig.json"))
+	s.loaded = true
+	s.accounts = []Account{{ID: "existing", Label: "existing"}}
+
+	if err := s.add(Account{ID: "new", Label: "new"}); err == nil {
+		t.Fatal("add succeeded with unwritable store path, want error")
+	}
+	if len(s.accounts) != 1 || s.accounts[0].ID != "existing" {
+		t.Fatalf("accounts after failed add = %+v, want original existing account", s.accounts)
+	}
+}
+
+func TestStoreRemoveRollsBackOnPersistFailure(t *testing.T) {
+	s := newStore(filepath.Join(t.TempDir(), "missing", "multisig.json"))
+	s.loaded = true
+	s.accounts = []Account{
+		{ID: "a", Label: "a"},
+		{ID: "b", Label: "b"},
+		{ID: "c", Label: "c"},
+	}
+
+	if err := s.remove("b"); err == nil {
+		t.Fatal("remove succeeded with unwritable store path, want error")
+	}
+	if len(s.accounts) != 3 || s.accounts[0].ID != "a" || s.accounts[1].ID != "b" || s.accounts[2].ID != "c" {
+		t.Fatalf("accounts after failed remove = %+v, want original a,b,c", s.accounts)
+	}
+}
+
+func TestMyKeyMatchesParticipantDerivation(t *testing.T) {
+	fc := newFakeChain()
+	ks := newTestKeystore(t, mnemonicA)
+	svc := NewService(fc, ks, filepath.Join(t.TempDir(), "multisig.json"))
+
+	mk, err := svc.MyKey("test-password-123")
+	if err != nil {
+		t.Fatalf("MyKey: %v", err)
+	}
+	_, wantKH, _ := multiSigKeyHash(t, mnemonicA)
+	if mk.KeyHashHex != wantKH {
+		t.Fatalf("MyKey hash %s != derived %s", mk.KeyHashHex, wantKH)
+	}
+}
+
+func TestMyKeyWrongPassword(t *testing.T) {
+	fc := newFakeChain()
+	ks := newTestKeystore(t, mnemonicA)
+	svc := NewService(fc, ks, filepath.Join(t.TempDir(), "multisig.json"))
+	if _, err := svc.MyKey("wrong-password-xx"); !errors.Is(err, ErrWrongPassword) {
+		t.Fatalf("expected ErrWrongPassword, got %v", err)
+	}
+}
+
+// TestSpendFlow is the end-to-end multi-party test: create a 2-of-2 account, fund
+// the script address, build an unsigned spend, have BOTH participants co-sign with
+// their CIP-1854 keys, and submit. It asserts the threshold is enforced and that
+// submission only succeeds once both witnesses are collected.
+func TestSpendFlow(t *testing.T) {
+	fc := newFakeChain()
+	ksA := newTestKeystore(t, mnemonicA)
+	ksB := newTestKeystore(t, mnemonicB)
+	_, khA, _ := multiSigKeyHash(t, mnemonicA)
+	_, khB, _ := multiSigKeyHash(t, mnemonicB)
+
+	// Participant A's service creates the account (its store).
+	svcA := NewService(fc, ksA, filepath.Join(t.TempDir(), "a.json"))
+	acct, err := svcA.Create(CreateRequest{
+		Label:   "joint",
+		Network: "preview",
+		Policy:  Policy{Threshold: 2, Participants: []Participant{{KeyHashHex: khA}, {KeyHashHex: khB}}},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Fund the script address with 10 ADA.
+	fc.addUTxO(acct.ScriptAddress, "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890", 0, 10_000_000)
+
+	// Balance reflects the funded UTxO.
+	bal, err := svcA.Balance(context.Background(), acct.ID)
+	if err != nil || bal != "10000000" {
+		t.Fatalf("Balance = %q err %v, want 10000000", bal, err)
+	}
+
+	// Build a spend to a third-party address (reuse khA's own ordinary receive is
+	// fine; we just need a valid bech32 — derive a plain payment address).
+	recv := externalAddr(t)
+	built, err := svcA.Build(context.Background(), acct.ID, BuildRequest{To: recv, Lovelace: "3000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if built.Threshold != 2 || len(built.RequiredSigners) != 2 {
+		t.Fatalf("unexpected build metadata: %+v", built)
+	}
+
+	// Both participants co-sign (each on their own keyed instance).
+	witA, err := svcA.Sign(built.UnsignedTxCBOR, "test-password-123")
+	if err != nil {
+		t.Fatalf("Sign A: %v", err)
+	}
+	svcB := NewService(fc, ksB, filepath.Join(t.TempDir(), "b.json"))
+	witB, err := svcB.Sign(built.UnsignedTxCBOR, "test-password-123")
+	if err != nil {
+		t.Fatalf("Sign B: %v", err)
+	}
+
+	// Submitting with only one witness must fail the threshold check.
+	if _, err := svcA.Submit(context.Background(), acct.ID, built.UnsignedTxCBOR, []string{witA.WitnessCBOR}); !errors.Is(err, ErrInvalidWitness) {
+		t.Fatalf("expected ErrInvalidWitness with 1/2 sigs, got %v", err)
+	}
+
+	// With both witnesses, submission succeeds.
+	res, err := svcA.Submit(context.Background(), acct.ID, built.UnsignedTxCBOR, []string{witA.WitnessCBOR, witB.WitnessCBOR})
+	if err != nil {
+		t.Fatalf("Submit 2/2: %v", err)
+	}
+	if res.TxHash == "" {
+		t.Fatal("expected non-empty tx hash")
+	}
+
+	// The submitted tx must carry the native script and exactly the two vkey
+	// witnesses (so the ledger can validate the 2-of-2 against the script).
+	assertSubmittedWitnesses(t, fc, acct, khA, khB)
+}
+
+// externalAddr derives a plain CIP-1852 payment address (mnemonicB) as a spend
+// recipient distinct from the script address.
+func externalAddr(t *testing.T) string {
+	t.Helper()
+	root, _ := bursa.GetRootKeyFromMnemonic(mnemonicB, "")
+	acct, _ := bursa.GetAccountKey(root, 0)
+	pay, _ := bursa.GetPaymentKey(acct, 0)
+	stake, _ := bursa.GetStakeKey(acct, 0)
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyKey, lcommon.AddressNetworkTestnet,
+		pay.Public().PublicKey().Hash(), stake.Public().PublicKey().Hash(),
+	)
+	if err != nil {
+		t.Fatalf("external addr: %v", err)
+	}
+	return addr.String()
+}
+
+// assertSubmittedWitnesses decodes the broadcast tx CBOR and checks the witness
+// set carries the native script and both participant vkey witnesses.
+func assertSubmittedWitnesses(t *testing.T, fc *fakeChain, acct Account, khA, khB string) {
+	t.Helper()
+	fc.submitMu.Lock()
+	raw := append([]byte(nil), fc.submitCbor...)
+	fc.submitMu.Unlock()
+	if len(raw) == 0 {
+		t.Fatal("no tx was submitted")
+	}
+	loaded, err := apollo.New(fc).LoadTxCbor(hex.EncodeToString(raw))
+	if err != nil {
+		t.Fatalf("reload submitted tx: %v", err)
+	}
+	tx := loaded.GetTx()
+	if tx == nil {
+		t.Fatal("submitted tx has no body")
+	}
+	ws := tx.WitnessSet
+	if len(ws.WsNativeScripts.Items()) == 0 {
+		t.Error("submitted tx is missing the native script")
+	}
+	have := map[string]bool{}
+	for _, vw := range ws.VkeyWitnesses.Items() {
+		have[hex.EncodeToString(lcommon.Blake2b224Hash(vw.Vkey).Bytes())] = true
+	}
+	if !have[khA] || !have[khB] {
+		t.Errorf("submitted tx missing a participant witness: have %v want %s,%s", have, khA, khB)
+	}
+}
+
+func TestBuildTimelockValidityInterval(t *testing.T) {
+	fc := newFakeChain()
+	svc := NewService(fc, nil, filepath.Join(t.TempDir(), "multisig.json"))
+	_, khA, _ := multiSigKeyHash(t, mnemonicA)
+	before := uint64(1234)
+	after := uint64(5678)
+
+	acct, err := svc.Create(CreateRequest{
+		Label:   "timelocked",
+		Network: "preview",
+		Policy: Policy{
+			Threshold:     1,
+			Participants:  []Participant{{KeyHashHex: khA}},
+			InvalidBefore: &before,
+			InvalidAfter:  &after,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	fc.addUTxO(acct.ScriptAddress, "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890", 0, 10_000_000)
+
+	built, err := svc.Build(context.Background(), acct.ID, BuildRequest{To: externalAddr(t), Lovelace: "3000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	loaded, err := apollo.New(fc).LoadTxCbor(built.UnsignedTxCBOR)
+	if err != nil {
+		t.Fatalf("reload unsigned tx: %v", err)
+	}
+	tx := loaded.GetTx()
+	if tx == nil {
+		t.Fatal("unsigned tx has no body")
+	}
+	if got := tx.Body.ValidityIntervalStart(); got != before {
+		t.Fatalf("validity start = %d, want %d", got, before)
+	}
+	if got := tx.Body.TTL(); got != after {
+		t.Fatalf("ttl = %d, want %d", got, after)
+	}
+
+	tooLarge := uint64(math.MaxInt64) + 1
+	for _, tc := range []struct {
+		name          string
+		invalidBefore *uint64
+		invalidAfter  *uint64
+		want          string
+	}{
+		{name: "invalid before", invalidBefore: &tooLarge, want: "invalid_before slot out of range"},
+		{name: "invalid after", invalidAfter: &tooLarge, want: "invalid_after slot out of range"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			acct, err := svc.Create(CreateRequest{
+				Label:   tc.name,
+				Network: "preview",
+				Policy: Policy{
+					Threshold:     1,
+					Participants:  []Participant{{KeyHashHex: khA}},
+					InvalidBefore: tc.invalidBefore,
+					InvalidAfter:  tc.invalidAfter,
+				},
+			})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			fc.addUTxO(acct.ScriptAddress, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 0, 10_000_000)
+			_, err = svc.Build(context.Background(), acct.ID, BuildRequest{To: externalAddr(t), Lovelace: "3000000"})
+			if !errors.Is(err, ErrInvalidRequest) || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Build error = %v, want ErrInvalidRequest containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildNoUTxOs(t *testing.T) {
+	fc := newFakeChain()
+	svc := NewService(fc, nil, filepath.Join(t.TempDir(), "multisig.json"))
+	_, khA, _ := multiSigKeyHash(t, mnemonicA)
+	acct, err := svc.Create(CreateRequest{
+		Label:   "empty",
+		Network: "preview",
+		Policy:  Policy{Threshold: 1, Participants: []Participant{{KeyHashHex: khA}}},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := svc.Build(context.Background(), acct.ID, BuildRequest{To: externalAddr(t), Lovelace: "1000000"}); !errors.Is(err, ErrInsufficientFunds) {
+		t.Fatalf("expected ErrInsufficientFunds with no UTxOs, got %v", err)
+	}
+}

--- a/ui/internal/multisig/store.go
+++ b/ui/internal/multisig/store.go
@@ -1,0 +1,192 @@
+// Package multisig manages native-script multi-signature accounts: composing the
+// N-of-M (optionally time-locked) native script, deriving its address, persisting
+// the named account, and building/signing/submitting transactions that spend from
+// the script address with co-signer witnesses.
+//
+// NOTE on persistence: the wallet vault is NOT on this branch, so multi-sig
+// accounts are persisted independently in a small JSON file under the data dir
+// (see store.go). Migrating this store into the vault is a deferred, post-merge
+// concern.
+package multisig
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// store is an atomic-write JSON file holding the saved multi-sig accounts. It
+// mirrors the keystore's at-rest model (a single file under the data dir, mode
+// 0600) but writes via a temp-file + rename so a crash never leaves a truncated
+// file. The accounts hold only public material (key-hashes, vkeys, the script,
+// the script address) — no secrets — so unlike the keystore it is not encrypted.
+type store struct {
+	path string
+
+	mu       sync.Mutex
+	accounts []Account
+	loaded   bool
+}
+
+func newStore(path string) *store {
+	return &store{path: path}
+}
+
+// loadLocked reads the file into s.accounts. A missing file is an empty store.
+// Callers hold s.mu.
+func (s *store) loadLocked() error {
+	if s.loaded {
+		return nil
+	}
+	b, err := os.ReadFile(s.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			s.accounts = nil
+			s.loaded = true
+			return nil
+		}
+		return fmt.Errorf("read multisig store: %w", err)
+	}
+	var accts []Account
+	if len(b) > 0 {
+		if err := json.Unmarshal(b, &accts); err != nil {
+			return fmt.Errorf("decode multisig store: %w", err)
+		}
+	}
+	s.accounts = accts
+	s.loaded = true
+	return nil
+}
+
+// persistLocked atomically writes s.accounts to disk. Callers hold s.mu.
+func (s *store) persistLocked() error {
+	blob, err := json.MarshalIndent(s.accounts, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode multisig store: %w", err)
+	}
+	dir := filepath.Dir(s.path)
+	tmp, err := os.CreateTemp(dir, ".multisig-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	// Best-effort cleanup if anything below fails before the rename.
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if _, err := tmp.Write(blob); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, s.path); err != nil {
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+	return nil
+}
+
+// list returns a deep copy of the saved accounts, so a caller holding the
+// result past the lock release cannot observe later add/remove calls through
+// shared backing arrays or time-lock pointers.
+func (s *store) list() ([]Account, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.loadLocked(); err != nil {
+		return nil, err
+	}
+	out := make([]Account, len(s.accounts))
+	for i, a := range s.accounts {
+		out[i] = cloneAccount(a)
+	}
+	return out, nil
+}
+
+// get returns a deep copy of the account with the given id, or
+// ErrUnknownAccount. See list for why a deep copy matters here.
+func (s *store) get(id string) (Account, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.loadLocked(); err != nil {
+		return Account{}, err
+	}
+	for _, a := range s.accounts {
+		if a.ID == id {
+			return cloneAccount(a), nil
+		}
+	}
+	return Account{}, fmt.Errorf("%w: %q", ErrUnknownAccount, id)
+}
+
+// cloneAccount deep-copies an Account so callers can't observe later mutation
+// of the store's internal state through shared reference-typed fields: a
+// plain `Account` value copy only copies the Policy.Participants slice header
+// (not its backing array) and the InvalidBefore/InvalidAfter *uint64
+// pointers, so without this the copy would still alias the store's data.
+func cloneAccount(a Account) Account {
+	a.Policy.Participants = append([]Participant(nil), a.Policy.Participants...)
+	if a.Policy.InvalidBefore != nil {
+		v := *a.Policy.InvalidBefore
+		a.Policy.InvalidBefore = &v
+	}
+	if a.Policy.InvalidAfter != nil {
+		v := *a.Policy.InvalidAfter
+		a.Policy.InvalidAfter = &v
+	}
+	return a
+}
+
+// add appends a new account and persists. It rejects a duplicate id.
+func (s *store) add(a Account) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.loadLocked(); err != nil {
+		return err
+	}
+	for _, existing := range s.accounts {
+		if existing.ID == a.ID {
+			return fmt.Errorf("multisig account %q already exists", a.ID)
+		}
+	}
+	prior := append([]Account(nil), s.accounts...)
+	s.accounts = append(s.accounts, a)
+	if err := s.persistLocked(); err != nil {
+		s.accounts = prior
+		return err
+	}
+	return nil
+}
+
+// remove deletes the account with the given id and persists. It is a no-op (no
+// error) if the id is not present, so a double-delete is idempotent.
+func (s *store) remove(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.loadLocked(); err != nil {
+		return err
+	}
+	prior := append([]Account(nil), s.accounts...)
+	filtered := s.accounts[:0]
+	for _, a := range s.accounts {
+		if a.ID != id {
+			filtered = append(filtered, a)
+		}
+	}
+	s.accounts = filtered
+	if err := s.persistLocked(); err != nil {
+		s.accounts = prior
+		return err
+	}
+	return nil
+}

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -46,6 +46,14 @@ import type {
   DexPoolsResponse,
   DexQuoteRequest,
   DexQuote,
+  MultiSigAccount,
+  CreateMultiSigRequest,
+  MultiSigMyKey,
+  MultiSigBalance,
+  MultiSigBuildRequest,
+  MultiSigUnsignedTx,
+  MultiSigSignRequest,
+  MultiSigSubmitRequest,
 } from "./types";
 
 export class ApiError extends Error {
@@ -255,3 +263,22 @@ export const deleteContact = (id: string) =>
 export const getDexPools = () => apiGet<DexPoolsResponse>("/wallet/dex/pools");
 export const computeDexQuote = (req: DexQuoteRequest) =>
   apiPost<DexQuote>("/wallet/dex/quote", req);
+
+// Native multi-signature accounts.
+export const listMultiSig = () => apiGet<MultiSigAccount[]>("/wallet/multisig");
+export const createMultiSig = (req: CreateMultiSigRequest) =>
+  apiPost<MultiSigAccount>("/wallet/multisig", req);
+export const getMultiSig = (id: string) =>
+  apiGet<MultiSigAccount>(`/wallet/multisig/${encodeURIComponent(id)}`);
+export const deleteMultiSig = (id: string) =>
+  request<{ status: string }>("DELETE", `/wallet/multisig/${encodeURIComponent(id)}`);
+export const multiSigMyKey = (password: string) =>
+  apiPost<MultiSigMyKey>("/wallet/multisig/my-key", { password });
+export const multiSigBalance = (id: string) =>
+  apiGet<MultiSigBalance>(`/wallet/multisig/${encodeURIComponent(id)}/balance`);
+export const multiSigBuild = (id: string, req: MultiSigBuildRequest) =>
+  apiPost<MultiSigUnsignedTx>(`/wallet/multisig/${encodeURIComponent(id)}/build`, req);
+export const multiSigSign = (req: MultiSigSignRequest) =>
+  apiPost<WitnessResult>("/wallet/multisig/sign", req);
+export const multiSigSubmit = (id: string, req: MultiSigSubmitRequest) =>
+  apiPost<TxResult>(`/wallet/multisig/${encodeURIComponent(id)}/submit`, req);

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -476,3 +476,71 @@ export interface DexQuote {
   effective_fee: number;
   route: string;
 }
+
+// --- Native multi-signature -------------------------------------------------
+
+// A signer in a multi-sig policy. key_hash_hex (Blake2b-224 of the CIP-1854
+// multi-sig vkey) is what the script needs; vkey_hex is carried for sharing.
+export interface MultiSigParticipant {
+  label?: string;
+  key_hash_hex: string;
+  vkey_hex?: string;
+}
+
+// The spending rule: a threshold of M participants, optionally inside a slot
+// validity interval (time-lock). Slots are numbers; if they ever exceed 2^53
+// they would be sent as strings, but Cardano slots stay well within range.
+export interface MultiSigPolicy {
+  threshold: number;
+  participants: MultiSigParticipant[];
+  invalid_before?: number;
+  invalid_after?: number;
+}
+
+// A saved multi-sig account: label + policy, plus the derived script + address.
+export interface MultiSigAccount {
+  id: string;
+  label: string;
+  network: string;
+  policy: MultiSigPolicy;
+  script_cbor: string;
+  script_address: string;
+}
+
+export interface CreateMultiSigRequest {
+  label: string;
+  network?: string;
+  policy: MultiSigPolicy;
+}
+
+// The wallet's own CIP-1854 participant identity, to share with co-signers.
+export interface MultiSigMyKey {
+  vkey_hex: string;
+  key_hash_hex: string;
+}
+
+// The unsigned multi-sig spend plus the data needed to collect signatures.
+export interface MultiSigUnsignedTx {
+  unsigned_tx_cbor: string;
+  required_signers: string[]; // candidate participant key-hashes (hex)
+  threshold: number; // how many must sign
+}
+
+export interface MultiSigBuildRequest {
+  to: string;
+  lovelace: string;
+}
+
+export interface MultiSigBalance {
+  lovelace: string;
+}
+
+export interface MultiSigSignRequest {
+  unsigned_tx_cbor: string;
+  password: string;
+}
+
+export interface MultiSigSubmitRequest {
+  unsigned_tx_cbor: string;
+  witnesses: string[];
+}

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -25,6 +25,7 @@ import { SignMessage } from "./screens/SignMessage";
 import { VerifyMessage } from "./screens/VerifyMessage";
 import { Offline } from "./screens/Offline";
 import { Operate } from "./screens/Operate";
+import { MultiSig } from "./screens/MultiSig";
 import { Settings } from "./screens/Settings";
 
 // A Map (not a plain object) so a crafted hash like "#/constructor" or
@@ -51,6 +52,7 @@ const NAV: { key: string; label: string }[] = [
   { key: "verify", label: "Verify" },
   { key: "offline", label: "Offline" },
   { key: "operate", label: "Operate" },
+  { key: "multisig", label: "Multi-sig" },
   { key: "settings", label: "Settings" },
 ];
 
@@ -242,6 +244,7 @@ export function App() {
     else if (route === "verify") activeRoute = "verify";
     else if (route === "offline" && canSign) activeRoute = "offline";
     else if (route === "operate" && canSign) activeRoute = "operate";
+    else if (route === "multisig") activeRoute = "multisig";
     else if (ROUTES.has(route) && route !== "send" && route !== "swap") activeRoute = route;
     else activeRoute = "portfolio";
   }
@@ -297,6 +300,11 @@ export function App() {
     // pool ops are offline; only retirement submission needs a synced node,
     // gated at the API.
     content = canSign ? <Operate account={toAccount(activeWallet)} /> : <Portfolio />;
+  } else if (route === "multisig") {
+    // Managing multi-sig accounts (list/create/view) is local state and works on
+    // any active wallet; the spend sub-flow gates itself on canSend (synced node
+    // + spending-enabled wallet).
+    content = <MultiSig canSpend={canSend} />;
   } else {
     const Screen = ROUTES.get(route) ?? Portfolio;
     content = <Screen />;

--- a/ui/web/src/screens/MultiSig.test.tsx
+++ b/ui/web/src/screens/MultiSig.test.tsx
@@ -1,0 +1,206 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MultiSig } from "./MultiSig";
+import * as client from "../api/client";
+import type { MultiSigAccount } from "../api/types";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const KH_A = "a".repeat(56);
+const KH_B = "b".repeat(56);
+
+const sampleAccount: MultiSigAccount = {
+  id: "acct1",
+  label: "Treasury",
+  network: "preview",
+  policy: {
+    threshold: 2,
+    participants: [
+      { key_hash_hex: KH_A, label: "me" },
+      { key_hash_hex: KH_B },
+    ],
+  },
+  script_cbor: "8201818200581c" + KH_A,
+  script_address: "addr_test1wqscriptaddressxyz",
+};
+
+test("lists saved multi-sig accounts with their policy summary", async () => {
+  vi.spyOn(client, "listMultiSig").mockResolvedValue([sampleAccount]);
+
+  render(<MultiSig canSpend={true} />);
+
+  expect(await screen.findByText("Treasury")).toBeInTheDocument();
+  expect(screen.getByText(/2-of-2/)).toBeInTheDocument();
+});
+
+test("shows a user-facing error when listing multi-sig accounts fails", async () => {
+  vi.spyOn(client, "listMultiSig").mockRejectedValue(new Error("list failed"));
+
+  render(<MultiSig canSpend={true} />);
+
+  expect(await screen.findByRole("alert")).toHaveTextContent("list failed");
+});
+
+test("create flow: reveals my-key and creates an account", async () => {
+  vi.spyOn(client, "listMultiSig").mockResolvedValue([]);
+  const myKey = vi
+    .spyOn(client, "multiSigMyKey")
+    .mockResolvedValue({ vkey_hex: "c".repeat(64), key_hash_hex: KH_A });
+  const create = vi.spyOn(client, "createMultiSig").mockResolvedValue(sampleAccount);
+  vi.spyOn(client, "multiSigBalance").mockResolvedValue({ lovelace: "0" });
+
+  render(<MultiSig canSpend={true} />);
+
+  fireEvent.click(await screen.findByRole("button", { name: /new multi-sig account/i }));
+
+  fireEvent.change(screen.getByLabelText(/^label$/i), { target: { value: "Treasury" } });
+
+  // Reveal my key.
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /reveal my key/i }));
+  await waitFor(() => expect(myKey).toHaveBeenCalledWith("pw"));
+  fireEvent.click(await screen.findByRole("button", { name: /add myself/i }));
+
+  // Add a co-signer key-hash.
+  fireEvent.change(screen.getByLabelText(/participant key hash/i), { target: { value: KH_B } });
+  fireEvent.click(screen.getByRole("button", { name: /^add$/i }));
+
+  fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+
+  await waitFor(() => expect(create).toHaveBeenCalled());
+  const arg = create.mock.calls[0][0];
+  expect(arg.label).toBe("Treasury");
+  expect(arg.policy.threshold).toBe(2);
+  expect(arg.policy.participants).toHaveLength(2);
+});
+
+test("create rejects a malformed co-signer key hash", async () => {
+  vi.spyOn(client, "listMultiSig").mockResolvedValue([]);
+
+  render(<MultiSig canSpend={true} />);
+  fireEvent.click(await screen.findByRole("button", { name: /new multi-sig account/i }));
+
+  fireEvent.change(screen.getByLabelText(/participant key hash/i), { target: { value: "xyz" } });
+  fireEvent.click(screen.getByRole("button", { name: /^add$/i }));
+
+  expect(await screen.findByText(/56 hex characters/i)).toBeInTheDocument();
+});
+
+test("delete flow removes the selected account from the list", async () => {
+  vi.spyOn(client, "listMultiSig")
+    .mockResolvedValueOnce([sampleAccount])
+    .mockResolvedValueOnce([]);
+  vi.spyOn(client, "multiSigBalance").mockResolvedValue({ lovelace: "0" });
+  const del = vi.spyOn(client, "deleteMultiSig").mockResolvedValue({ status: "deleted" });
+
+  render(<MultiSig canSpend={true} />);
+
+  fireEvent.click(await screen.findByText("Treasury"));
+  fireEvent.click(await screen.findByRole("button", { name: /^delete$/i }));
+
+  await waitFor(() => expect(del).toHaveBeenCalledWith("acct1"));
+  expect(await screen.findByText(/no multi-sig accounts yet/i)).toBeInTheDocument();
+});
+
+test("spend flow: build then collect a threshold of witnesses and submit", async () => {
+  vi.spyOn(client, "listMultiSig").mockResolvedValue([sampleAccount]);
+  const balance = vi
+    .spyOn(client, "multiSigBalance")
+    .mockResolvedValueOnce({ lovelace: "10000000" })
+    .mockResolvedValueOnce({ lovelace: "7000000" });
+  vi.spyOn(client, "multiSigBuild").mockResolvedValue({
+    unsigned_tx_cbor: "84a400",
+    required_signers: [KH_A, KH_B],
+    threshold: 2,
+  });
+  const sign = vi.spyOn(client, "multiSigSign").mockResolvedValue({ witness_cbor: "81a0sigA" });
+  const submit = vi.spyOn(client, "multiSigSubmit").mockResolvedValue({ tx_hash: "feedface" });
+
+  render(<MultiSig canSpend={true} />);
+
+  fireEvent.click(await screen.findByText("Treasury"));
+
+  // Build a spend.
+  fireEvent.change(await screen.findByLabelText(/recipient address/i), {
+    target: { value: "addr_test1recipient" },
+  });
+  fireEvent.change(screen.getByLabelText(/amount \(ada\)/i), { target: { value: "3" } });
+  fireEvent.click(screen.getByRole("button", { name: /build transaction/i }));
+
+  // Collect screen: progress starts at 0 of 2.
+  expect(await screen.findByText(/0 of 2 collected/i)).toBeInTheDocument();
+
+  // Sign here (1 of 2).
+  fireEvent.change(screen.getByLabelText(/sign with this wallet/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /sign here/i }));
+  await waitFor(() => expect(sign).toHaveBeenCalled());
+  expect(await screen.findByText(/1 of 2 collected/i)).toBeInTheDocument();
+
+  // Paste a second co-signer witness (2 of 2 → threshold met).
+  fireEvent.change(screen.getByLabelText(/co-signer witness/i), { target: { value: "81a0sigB" } });
+  fireEvent.click(screen.getByRole("button", { name: /add witness/i }));
+  expect(await screen.findByText(/2 of 2 collected/i)).toBeInTheDocument();
+
+  // Submit.
+  fireEvent.click(screen.getByRole("button", { name: /^submit$/i }));
+  await waitFor(() =>
+    expect(submit).toHaveBeenCalledWith("acct1", {
+      unsigned_tx_cbor: "84a400",
+      witnesses: ["81a0sigA", "81a0sigB"],
+    }),
+  );
+  expect(await screen.findByText("feedface")).toBeInTheDocument();
+  await waitFor(() => expect(balance).toHaveBeenCalledTimes(2));
+  expect(await screen.findByText("7 ADA")).toBeInTheDocument();
+});
+
+test("shows a user-facing error when building a multi-sig spend fails", async () => {
+  vi.spyOn(client, "listMultiSig").mockResolvedValue([sampleAccount]);
+  vi.spyOn(client, "multiSigBalance").mockResolvedValue({ lovelace: "10000000" });
+  vi.spyOn(client, "multiSigBuild").mockRejectedValue(new Error("build failed"));
+
+  render(<MultiSig canSpend={true} />);
+
+  fireEvent.click(await screen.findByText("Treasury"));
+  fireEvent.change(await screen.findByLabelText(/recipient address/i), {
+    target: { value: "addr_test1recipient" },
+  });
+  fireEvent.change(screen.getByLabelText(/amount \(ada\)/i), { target: { value: "3" } });
+  fireEvent.click(screen.getByRole("button", { name: /build transaction/i }));
+
+  expect(await screen.findByRole("alert")).toHaveTextContent("build failed");
+});
+
+test("submit is disabled until the threshold is met", async () => {
+  vi.spyOn(client, "listMultiSig").mockResolvedValue([sampleAccount]);
+  vi.spyOn(client, "multiSigBalance").mockResolvedValue({ lovelace: "10000000" });
+  vi.spyOn(client, "multiSigBuild").mockResolvedValue({
+    unsigned_tx_cbor: "84a400",
+    required_signers: [KH_A, KH_B],
+    threshold: 2,
+  });
+
+  render(<MultiSig canSpend={true} />);
+  fireEvent.click(await screen.findByText("Treasury"));
+  fireEvent.change(await screen.findByLabelText(/recipient address/i), {
+    target: { value: "addr_test1recipient" },
+  });
+  fireEvent.change(screen.getByLabelText(/amount \(ada\)/i), { target: { value: "3" } });
+  fireEvent.click(screen.getByRole("button", { name: /build transaction/i }));
+
+  // The submit button reads "Need 2 more" and is disabled.
+  expect(await screen.findByRole("button", { name: /need 2 more/i })).toBeDisabled();
+});
+
+test("spend is unavailable when canSpend is false", async () => {
+  vi.spyOn(client, "listMultiSig").mockResolvedValue([sampleAccount]);
+  vi.spyOn(client, "multiSigBalance").mockResolvedValue({ lovelace: "0" });
+
+  render(<MultiSig canSpend={false} />);
+  fireEvent.click(await screen.findByText("Treasury"));
+
+  expect(
+    await screen.findByText(/spending needs a fully synced node/i),
+  ).toBeInTheDocument();
+});

--- a/ui/web/src/screens/MultiSig.tsx
+++ b/ui/web/src/screens/MultiSig.tsx
@@ -1,0 +1,811 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
+import type {
+  MultiSigAccount,
+  MultiSigParticipant,
+  MultiSigUnsignedTx,
+  TxResult,
+  WitnessResult,
+} from "../api/types";
+import {
+  listMultiSig,
+  createMultiSig,
+  deleteMultiSig,
+  multiSigMyKey,
+  multiSigBalance,
+  multiSigBuild,
+  multiSigSign,
+  multiSigSubmit,
+  ApiError,
+} from "../api/client";
+import { Card } from "../components/Card";
+import { Input } from "../components/Input";
+import { Button } from "../components/Button";
+import { CopyButton } from "../components/CopyButton";
+import { DownloadButton } from "../components/DownloadButton";
+import { formatAda, parseAda } from "../format";
+
+function errorMessage(err: unknown): string {
+  if (err instanceof ApiError) return err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+// A 28-byte Blake2b-224 key hash is 56 hex chars. Participant input currently
+// accepts only key hashes; vkeys must be hashed before being added here.
+const KEY_HASH_RE = /^[0-9a-fA-F]{56}$/;
+
+function useMountedRef() {
+  const mounted = useRef(false);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+  return mounted;
+}
+
+function ErrorText({ message }: { message: string }) {
+  return <p role="alert" className="error-text">{message}</p>;
+}
+
+// ---------------------------------------------------------------------------
+// List view
+// ---------------------------------------------------------------------------
+
+interface ListViewProps {
+  accounts: MultiSigAccount[];
+  onCreate: () => void;
+  onOpen: (acct: MultiSigAccount) => void;
+}
+
+function ListView({ accounts, onCreate, onOpen }: ListViewProps) {
+  return (
+    <Card title="Multi-sig Accounts">
+      <p className="helper-text">
+        Saved native-script accounts: an N-of-M signing policy (optionally
+        time-locked) with a shared script address. Fund the script address, then
+        spend by collecting a threshold of co-signer witnesses.
+      </p>
+      {accounts.length === 0 ? (
+        <p className="muted">No multi-sig accounts yet.</p>
+      ) : (
+        <ul className="ms-account-list">
+          {accounts.map((a) => (
+            <li key={a.id} className="ms-account-item">
+              <button className="ms-account-open" onClick={() => onOpen(a)}>
+                <span className="ms-account-label">{a.label}</span>
+                <span className="ms-account-policy">
+                  {a.policy.threshold}-of-{a.policy.participants.length}
+                  {(a.policy.invalid_before != null || a.policy.invalid_after != null) && " · time-locked"}
+                </span>
+                <span className="mono ms-account-addr">{a.script_address}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <Button onClick={onCreate}>+ New multi-sig account</Button>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Create view
+// ---------------------------------------------------------------------------
+
+interface CreateViewProps {
+  onCancel: () => void;
+  onCreated: (acct: MultiSigAccount) => void;
+}
+
+function CreateView({ onCancel, onCreated }: CreateViewProps) {
+  const mounted = useMountedRef();
+  const [label, setLabel] = useState("");
+  const [threshold, setThreshold] = useState("2");
+  const [participants, setParticipants] = useState<MultiSigParticipant[]>([]);
+  const [invalidBefore, setInvalidBefore] = useState("");
+  const [invalidAfter, setInvalidAfter] = useState("");
+
+  // The wallet's own participant identity (fetched with the spending password) so
+  // it can be shown to share and added to the policy.
+  const [myKeyPassword, setMyKeyPassword] = useState("");
+  const [myKeyHash, setMyKeyHash] = useState<string | null>(null);
+  const [myKeyVkey, setMyKeyVkey] = useState<string | null>(null);
+  const [myKeyError, setMyKeyError] = useState<string | null>(null);
+  const [loadingMyKey, setLoadingMyKey] = useState(false);
+
+  // Adding a co-signer participant.
+  const [newKeyHash, setNewKeyHash] = useState("");
+  const [newLabel, setNewLabel] = useState("");
+
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleRevealMyKey() {
+    setMyKeyError(null);
+    setLoadingMyKey(true);
+    try {
+      const mk = await multiSigMyKey(myKeyPassword);
+      if (!mounted.current) return;
+      setMyKeyHash(mk.key_hash_hex);
+      setMyKeyVkey(mk.vkey_hex);
+      setMyKeyPassword("");
+    } catch (e) {
+      if (mounted.current) setMyKeyError(errorMessage(e));
+    } finally {
+      if (mounted.current) setLoadingMyKey(false);
+    }
+  }
+
+  // Returns whether the participant was added, so callers can decide whether
+  // to clear their input (keeping it on failure lets the user fix and retry
+  // instead of retyping).
+  function addParticipant(keyHash: string, partLabel?: string): boolean {
+    const kh = keyHash.trim().toLowerCase();
+    if (!KEY_HASH_RE.test(kh)) {
+      setError("Key hash must be 56 hex characters (28-byte Blake2b-224).");
+      return false;
+    }
+    if (participants.some((p) => p.key_hash_hex.toLowerCase() === kh)) {
+      setError("That participant is already in the policy.");
+      return false;
+    }
+    setError(null);
+    setParticipants((prev) => [...prev, { key_hash_hex: kh, ...(partLabel ? { label: partLabel } : {}) }]);
+    return true;
+  }
+
+  function addMyself() {
+    if (myKeyHash) addParticipant(myKeyHash, "me");
+  }
+
+  function removeParticipant(idx: number) {
+    setParticipants((prev) => prev.filter((_, i) => i !== idx));
+  }
+
+  async function handleCreate() {
+    setError(null);
+    const n = Number(threshold);
+    if (!Number.isInteger(n) || n < 1) {
+      setError("Threshold must be a positive whole number.");
+      return;
+    }
+    if (n > participants.length) {
+      setError(`Threshold ${n} exceeds the ${participants.length} participants.`);
+      return;
+    }
+    if (!label.trim()) {
+      setError("A label is required.");
+      return;
+    }
+    const policy = {
+      threshold: n,
+      participants,
+      ...(invalidBefore.trim() ? { invalid_before: Number(invalidBefore.trim()) } : {}),
+      ...(invalidAfter.trim() ? { invalid_after: Number(invalidAfter.trim()) } : {}),
+    };
+    if (
+      (policy.invalid_before != null &&
+        (!Number.isInteger(policy.invalid_before) || policy.invalid_before < 0)) ||
+      (policy.invalid_after != null &&
+        (!Number.isInteger(policy.invalid_after) || policy.invalid_after < 0))
+    ) {
+      setError("Time-lock slots must be whole, non-negative numbers.");
+      return;
+    }
+    setLoading(true);
+    try {
+      const acct = await createMultiSig({ label: label.trim(), policy });
+      if (!mounted.current) return;
+      onCreated(acct);
+    } catch (e) {
+      if (mounted.current) setError(errorMessage(e));
+    } finally {
+      if (mounted.current) setLoading(false);
+    }
+  }
+
+  return (
+    <Card title="New Multi-sig Account">
+      <div className="send-form">
+        <label htmlFor="ms-label">Label</label>
+        <Input
+          id="ms-label"
+          type="text"
+          placeholder="e.g. Treasury"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          disabled={loading}
+        />
+
+        <label htmlFor="ms-threshold">Required signatures (N)</label>
+        <Input
+          id="ms-threshold"
+          type="text"
+          inputMode="numeric"
+          placeholder="2"
+          value={threshold}
+          onChange={(e) => setThreshold(e.target.value)}
+          disabled={loading}
+        />
+
+        {/* Your own participant key, to share and to add to the policy. */}
+        <div className="ms-mykey">
+          <p className="field-label">Your participant key (CIP-1854)</p>
+          {myKeyHash ? (
+            <>
+              <p className="helper-text">Share this key-hash so others can include you.</p>
+              <div className="tx-hash-row">
+                <code className="tx-hash">{myKeyHash}</code>
+                <CopyButton value={myKeyHash} />
+              </div>
+              {myKeyVkey && (
+                <div className="tx-hash-row">
+                  <code className="tx-hash">vkey: {myKeyVkey}</code>
+                  <CopyButton value={myKeyVkey} />
+                </div>
+              )}
+              <Button
+                variant="ghost"
+                onClick={addMyself}
+                disabled={
+                  loading ||
+                  participants.some((p) => p.key_hash_hex.toLowerCase() === myKeyHash?.toLowerCase())
+                }
+              >
+                + Add myself
+              </Button>
+            </>
+          ) : (
+            <>
+              <p className="helper-text">
+                Enter your spending password to reveal your key-hash to share.
+              </p>
+              <Input
+                type="password"
+                placeholder="Spending password"
+                value={myKeyPassword}
+                onChange={(e) => setMyKeyPassword(e.target.value)}
+                disabled={loadingMyKey}
+                aria-label="Spending password"
+              />
+              {myKeyError && <ErrorText message={myKeyError} />}
+              <Button variant="ghost" onClick={handleRevealMyKey} disabled={loadingMyKey || !myKeyPassword}>
+                {loadingMyKey ? "Deriving…" : "Reveal my key"}
+              </Button>
+            </>
+          )}
+        </div>
+
+        {/* Co-signer participants. */}
+        <p className="field-label">Participants ({participants.length})</p>
+        {participants.length > 0 && (
+          <ul className="signer-list">
+            {participants.map((p, idx) => (
+              <li key={p.key_hash_hex} className="ms-participant">
+                <code className="tx-hash">{p.label ? `${p.label}: ` : ""}{p.key_hash_hex}</code>
+                <Button
+                  variant="ghost"
+                  onClick={() => removeParticipant(idx)}
+                  disabled={loading}
+                  aria-label={`Remove ${p.label || p.key_hash_hex}`}
+                >
+                  Remove
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="asset-row">
+          <Input
+            type="text"
+            placeholder="label (optional)"
+            value={newLabel}
+            onChange={(e) => setNewLabel(e.target.value)}
+            disabled={loading}
+            aria-label="Participant label"
+          />
+          <Input
+            type="text"
+            placeholder="co-signer key-hash (56 hex)"
+            value={newKeyHash}
+            onChange={(e) => setNewKeyHash(e.target.value)}
+            disabled={loading}
+            aria-label="Participant key hash"
+          />
+          <Button
+            variant="ghost"
+            onClick={() => {
+              if (addParticipant(newKeyHash, newLabel.trim() || undefined)) {
+                setNewKeyHash("");
+                setNewLabel("");
+              }
+            }}
+            disabled={loading || !newKeyHash.trim()}
+          >
+            Add
+          </Button>
+        </div>
+
+        {/* Optional time-lock. */}
+        <p className="field-label">Time-lock (optional, slots)</p>
+        <div className="asset-row">
+          <Input
+            type="text"
+            inputMode="numeric"
+            placeholder="valid from slot (invalid_before)"
+            value={invalidBefore}
+            onChange={(e) => setInvalidBefore(e.target.value)}
+            disabled={loading}
+            aria-label="Invalid before slot"
+          />
+          <Input
+            type="text"
+            inputMode="numeric"
+            placeholder="valid until slot (invalid_after)"
+            value={invalidAfter}
+            onChange={(e) => setInvalidAfter(e.target.value)}
+            disabled={loading}
+            aria-label="Invalid after slot"
+          />
+        </div>
+
+        {error && <ErrorText message={error} />}
+
+        <div className="preview-actions">
+          <Button variant="ghost" onClick={onCancel} disabled={loading}>
+            Cancel
+          </Button>
+          <Button onClick={handleCreate} disabled={loading || participants.length === 0}>
+            {loading ? "Creating…" : "Create account"}
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Detail view (receive address, balance, policy, spend flow)
+// ---------------------------------------------------------------------------
+
+interface DetailViewProps {
+  account: MultiSigAccount;
+  canSpend: boolean;
+  onBack: () => void;
+  onDeleted: () => void;
+}
+
+function DetailView({ account, canSpend, onBack, onDeleted }: DetailViewProps) {
+  const mounted = useMountedRef();
+  const [balance, setBalance] = useState<string | null>(null);
+  const [balanceError, setBalanceError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const loadBalance = useCallback(
+    async (isCancelled: () => boolean = () => !mounted.current) => {
+      try {
+        const b = await multiSigBalance(account.id);
+        if (isCancelled()) return;
+        setBalance(b.lovelace);
+        setBalanceError(null);
+      } catch (e) {
+        if (!isCancelled()) setBalanceError(errorMessage(e));
+      }
+    },
+    [account.id, mounted],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadBalance(() => cancelled || !mounted.current);
+    return () => {
+      cancelled = true;
+    };
+  }, [loadBalance, mounted]);
+
+  async function handleDelete() {
+    setDeleteError(null);
+    setDeleting(true);
+    try {
+      await deleteMultiSig(account.id);
+      if (!mounted.current) return;
+      onDeleted();
+    } catch (e) {
+      // Stay put and show why: navigating away on failure would leave the user
+      // thinking the account was removed when it's still there.
+      if (mounted.current) setDeleteError(errorMessage(e));
+    } finally {
+      if (mounted.current) setDeleting(false);
+    }
+  }
+
+  return (
+    <div className="ms-detail">
+      <Card title={account.label}>
+        <p className="field-label">Script address (receive)</p>
+        <p className="mono address-full">{account.script_address}</p>
+        <CopyButton value={account.script_address} />
+
+        <dl className="preview-summary">
+          <div className="dl-row">
+            <dt>Policy</dt>
+            <dd>
+              {account.policy.threshold}-of-{account.policy.participants.length}
+              {account.policy.invalid_before != null && ` · from slot ${account.policy.invalid_before}`}
+              {account.policy.invalid_after != null && ` · until slot ${account.policy.invalid_after}`}
+            </dd>
+          </div>
+          <div className="dl-row">
+            <dt>Balance</dt>
+            <dd>{balanceError ? "—" : balance != null ? `${formatAda(balance)} ADA` : "…"}</dd>
+          </div>
+        </dl>
+
+        <p className="field-label">Participants</p>
+        <ul className="signer-list">
+          {account.policy.participants.map((p) => (
+            <li key={p.key_hash_hex}>
+              <code className="tx-hash">{p.label ? `${p.label}: ` : ""}{p.key_hash_hex}</code>
+            </li>
+          ))}
+        </ul>
+
+        {deleteError && <ErrorText message={deleteError} />}
+
+        <div className="preview-actions">
+          <Button variant="ghost" onClick={onBack}>
+            Back
+          </Button>
+          <Button variant="ghost" onClick={handleDelete} disabled={deleting}>
+            {deleting ? "Deleting…" : "Delete"}
+          </Button>
+        </div>
+      </Card>
+
+      <SpendFlow account={account} canSpend={canSpend} onSpent={() => void loadBalance()} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Spend flow: build → collect witnesses (progress) → submit
+// ---------------------------------------------------------------------------
+
+interface SpendFlowProps {
+  account: MultiSigAccount;
+  canSpend: boolean;
+  onSpent: () => void;
+}
+
+function SpendFlow({ account, canSpend, onSpent }: SpendFlowProps) {
+  const [to, setTo] = useState("");
+  const [ada, setAda] = useState("");
+  const [built, setBuilt] = useState<MultiSigUnsignedTx | null>(null);
+  const [witnesses, setWitnesses] = useState<string[]>([]);
+  const [result, setResult] = useState<TxResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  function reset() {
+    setBuilt(null);
+    setWitnesses([]);
+    setResult(null);
+    setError(null);
+    setTo("");
+    setAda("");
+  }
+
+  async function handleBuild() {
+    setError(null);
+    let lovelace: string;
+    try {
+      lovelace = parseAda(ada);
+    } catch (e) {
+      setError(errorMessage(e));
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await multiSigBuild(account.id, { to: to.trim(), lovelace });
+      setBuilt(res);
+      setWitnesses([]);
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!canSpend) {
+    return (
+      <Card title="Spend">
+        <p className="muted">
+          Spending needs a fully synced node and a spending-enabled wallet.
+        </p>
+      </Card>
+    );
+  }
+
+  if (result) {
+    return (
+      <Card title="Transaction Submitted">
+        <div className="done-details">
+          <p>Your multi-sig transaction has been submitted.</p>
+          <p className="field-label">Transaction hash</p>
+          <div className="tx-hash-row">
+            <code className="tx-hash">{result.tx_hash}</code>
+            <CopyButton value={result.tx_hash} />
+          </div>
+          <Button onClick={reset}>Spend again</Button>
+        </div>
+      </Card>
+    );
+  }
+
+  if (built) {
+    return (
+      <CollectAndSubmit
+        accountId={account.id}
+        built={built}
+        witnesses={witnesses}
+        setWitnesses={setWitnesses}
+        onResult={setResult}
+        onSpent={onSpent}
+        onBack={reset}
+      />
+    );
+  }
+
+  return (
+    <Card title="Spend">
+      <div className="send-form">
+        <label htmlFor="ms-to">Recipient address</label>
+        <Input
+          id="ms-to"
+          type="text"
+          placeholder="addr1..."
+          value={to}
+          onChange={(e) => setTo(e.target.value)}
+          disabled={loading}
+        />
+        <label htmlFor="ms-ada">Amount (ADA)</label>
+        <Input
+          id="ms-ada"
+          type="text"
+          placeholder="0.000000"
+          value={ada}
+          onChange={(e) => setAda(e.target.value)}
+          disabled={loading}
+        />
+        {error && <ErrorText message={error} />}
+        <Button onClick={handleBuild} disabled={loading || !to.trim() || !ada.trim()}>
+          {loading ? "Building…" : "Build transaction"}
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+interface CollectProps {
+  accountId: string;
+  built: MultiSigUnsignedTx;
+  witnesses: string[];
+  setWitnesses: Dispatch<SetStateAction<string[]>>;
+  onResult: (r: TxResult) => void;
+  onSpent: () => void;
+  onBack: () => void;
+}
+
+// CollectAndSubmit shows the unsigned tx for export, lets a co-signer on THIS
+// instance sign with their password, accepts pasted witnesses from other
+// co-signers, tracks "X of N collected", and submits once the threshold is met.
+function CollectAndSubmit({ accountId, built, witnesses, setWitnesses, onResult, onSpent, onBack }: CollectProps) {
+  const [password, setPassword] = useState("");
+  const [pasteWitness, setPasteWitness] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [signing, setSigning] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const collected = witnesses.length;
+  const met = collected >= built.threshold;
+
+  function addWitness(w: WitnessResult | string) {
+    const cbor = (typeof w === "string" ? w : w.witness_cbor).trim();
+    if (!cbor) return;
+    setWitnesses((prev) => (prev.includes(cbor) ? prev : [...prev, cbor]));
+  }
+
+  async function handleSignHere() {
+    setError(null);
+    setSigning(true);
+    try {
+      const res = await multiSigSign({ unsigned_tx_cbor: built.unsigned_tx_cbor, password });
+      addWitness(res);
+      setPassword("");
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setSigning(false);
+    }
+  }
+
+  function handlePaste() {
+    if (pasteWitness.trim()) {
+      addWitness(pasteWitness);
+      setPasteWitness("");
+    }
+  }
+
+  async function handleSubmit() {
+    setError(null);
+    setSubmitting(true);
+    try {
+      const res = await multiSigSubmit(accountId, {
+        unsigned_tx_cbor: built.unsigned_tx_cbor,
+        witnesses,
+      });
+      onResult(res);
+      onSpent();
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Card title="Collect Signatures">
+      <div className="send-form">
+        <p className="helper-text">
+          Share this unsigned transaction with co-signers. Each signs with their
+          multi-sig key; collect their witnesses below. Submit once
+          {" "}{built.threshold} of {built.required_signers.length} have signed.
+        </p>
+
+        <p className="field-label">Unsigned transaction (CBOR)</p>
+        <div className="tx-hash-row">
+          <code className="tx-hash">{built.unsigned_tx_cbor}</code>
+          <CopyButton value={built.unsigned_tx_cbor} />
+          <DownloadButton
+            value={built.unsigned_tx_cbor}
+            filename="multisig-unsigned-tx.cbor"
+            label="Download"
+          />
+        </div>
+
+        <p className="ms-progress">
+          {collected} of {built.threshold} collected
+          {collected > 0 && ` (${collected} witness${collected === 1 ? "" : "es"})`}
+        </p>
+
+        {/* Sign on this instance. */}
+        <label htmlFor="ms-sign-pw">Sign with this wallet</label>
+        <Input
+          id="ms-sign-pw"
+          type="password"
+          placeholder="Spending password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          disabled={signing}
+        />
+        <Button variant="ghost" onClick={handleSignHere} disabled={signing || !password}>
+          {signing ? "Signing…" : "Sign here"}
+        </Button>
+
+        {/* Paste a witness from another co-signer. */}
+        <label htmlFor="ms-paste">Add a co-signer's witness (CBOR)</label>
+        <textarea
+          id="ms-paste"
+          className="field"
+          rows={2}
+          value={pasteWitness}
+          onChange={(e) => setPasteWitness(e.target.value)}
+          placeholder="hex…"
+          aria-label="Co-signer witness"
+        />
+        <Button variant="ghost" onClick={handlePaste} disabled={!pasteWitness.trim()}>
+          Add witness
+        </Button>
+
+        {error && <ErrorText message={error} />}
+
+        <div className="preview-actions">
+          <Button variant="ghost" onClick={onBack} disabled={submitting}>
+            Back
+          </Button>
+          <Button onClick={handleSubmit} disabled={submitting || !met}>
+            {submitting ? "Submitting…" : met ? "Submit" : `Need ${built.threshold - collected} more`}
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Top-level screen
+// ---------------------------------------------------------------------------
+
+type View = "list" | "create" | "detail";
+
+interface MultiSigProps {
+  canSpend: boolean;
+}
+
+export function MultiSig({ canSpend }: MultiSigProps) {
+  const mounted = useMountedRef();
+  const [view, setView] = useState<View>("list");
+  const [accounts, setAccounts] = useState<MultiSigAccount[]>([]);
+  const [selected, setSelected] = useState<MultiSigAccount | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    if (!mounted.current) return;
+    setLoading(true);
+    try {
+      const a = await listMultiSig();
+      if (!mounted.current) return;
+      setAccounts(a);
+      setError(null);
+    } catch (e) {
+      if (mounted.current) setError(errorMessage(e));
+    } finally {
+      if (mounted.current) setLoading(false);
+    }
+  }, [mounted]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  if (view === "create") {
+    return (
+      <CreateView
+        onCancel={() => setView("list")}
+        onCreated={(acct) => {
+          setSelected(acct);
+          void refresh();
+          setView("detail");
+        }}
+      />
+    );
+  }
+
+  if (view === "detail" && selected) {
+    return (
+      <DetailView
+        account={selected}
+        canSpend={canSpend}
+        onBack={() => {
+          setSelected(null);
+          void refresh();
+          setView("list");
+        }}
+        onDeleted={() => {
+          setSelected(null);
+          void refresh();
+          setView("list");
+        }}
+      />
+    );
+  }
+
+  if (loading) return <p>Loading…</p>;
+  if (error) return <ErrorText message={error} />;
+
+  return (
+    <ListView
+      accounts={accounts}
+      onCreate={() => setView("create")}
+      onOpen={(a) => {
+        setSelected(a);
+        setView("detail");
+      }}
+    />
+  );
+}

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -1888,3 +1888,76 @@ a:hover {
     transition: none !important;
   }
 }
+
+
+/* Multi-sig. */
+.ms-account-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+.ms-account-open {
+  width: 100%;
+  text-align: left;
+  appearance: none;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  color: var(--text);
+}
+.ms-account-open:hover {
+  border-color: var(--accent);
+}
+.ms-account-open:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-color: var(--accent);
+}
+.ms-account-label {
+  font-weight: 600;
+}
+.ms-account-policy {
+  font-family: var(--mono);
+  font-size: 0.6875rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.ms-account-addr {
+  font-size: 0.75rem;
+  word-break: break-all;
+  color: var(--text-muted);
+}
+.ms-mykey {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--space-3);
+  margin-bottom: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.ms-participant {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  justify-content: space-between;
+}
+.ms-detail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+.ms-progress {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  color: var(--accent);
+  margin: var(--space-2) 0;
+}


### PR DESCRIPTION
Adds native multi-sig (CIP-1854) accounts: define an N-of-M signing policy (optionally time-locked), derive the shared script address, and collect co-signer witnesses to spend. Node-only; no external calls.

<img width="1440" height="900" alt="pr568-multisig" src="https://github.com/user-attachments/assets/1276d7ea-57e6-424a-9741-9f6a3109c337" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native multi-sig (CIP-1854) accounts with N-of-M policies and optional timelocks, plus a full spend flow (balance/build/sign/submit) using the active wallet key. Adds REST endpoints and a Multi‑sig screen to create, manage, and spend from shared accounts; accounts are network‑scoped and stored locally, no external calls.

- **New Features**
  - Manage accounts (create/list/get/delete), saved in an atomic local JSON store with derived script CBOR and script address.
  - Define policies with a threshold and participants (key-hash and optional vkey/label), plus optional invalid_before/after timelocks.
  - Export “My Key” (vkey + key-hash) gated by wallet password; read‑only wallets can’t sign.
  - Spend flow: get balance, build unsigned tx from the script address, sign to produce deduped witnesses, and submit when the threshold is met. New Multi‑sig UI, REST API, and tests.

<sup>Written for commit dd6e7d5c11ba2966734246171dc2412f9e2f09c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native multi-signature wallet support.
  * Create, manage, and delete multi-signature accounts with configurable signing policies and optional time locks.
  * View account balances, generate unsigned transactions, collect signatures, and submit completed transactions.
  * Added a dedicated Multi-sig screen with account details, key management, validation, and transaction progress tracking.
* **Tests**
  * Added coverage for account management, policy validation, signing thresholds, transaction submission, and UI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->