### PR TITLE
feat(ui): external block-explorer links (open in OS browser)

### DIFF
--- a/ui/cmd/bursa-wallet/ui_webview.go
+++ b/ui/cmd/bursa-wallet/ui_webview.go
@@ -23,6 +23,8 @@ package main
 import (
 	"context"
 	"log/slog"
+	"net/url"
+	"os/exec"
 	"runtime"
 	"time"
 
@@ -45,6 +47,19 @@ func awaitUI(ctx context.Context, url string, logger *slog.Logger, srvErr <-chan
 	w := webview.New(false)
 	w.SetTitle("Bursa")
 	w.SetSize(1120, 760, webview.HintNone)
+
+	// The embedded webview has no tab-strip: a plain `target="_blank"` anchor
+	// click would navigate this window itself, turning the wallet into a
+	// general-purpose browser. The frontend (ExplorerLink.tsx) always
+	// preventDefault()s its own anchor navigation and, when this bridge is
+	// present, calls it instead so external links open in the OS's real
+	// browser. Bind before Navigate so the function exists for the first
+	// page load, not just subsequent ones.
+	if err := w.Bind("bursaOpenExternal", func(rawurl string) {
+		openExternal(logger, rawurl)
+	}); err != nil {
+		logger.Warn("failed to bind bursaOpenExternal", "error", err)
+	}
 
 	uiErr := make(chan error, 1)
 	done := make(chan struct{})
@@ -79,4 +94,44 @@ func awaitUI(ctx context.Context, url string, logger *slog.Logger, srvErr <-chan
 	default:
 		return nil
 	}
+}
+
+// openExternal opens rawurl in the OS's default browser, never in the
+// embedded webview. It is the Go side of the `bursaOpenExternal` JS bridge
+// bound above: the frontend calls this instead of letting an anchor's own
+// `target="_blank"` navigate the wallet window.
+//
+// rawurl is validated before use — it must parse as an absolute http(s) URL —
+// so a compromised or buggy frontend can't smuggle a `file://` path or an
+// arbitrary shell-meaningful string into an external command. Anything else
+// is logged and dropped rather than opened.
+func openExternal(logger *slog.Logger, rawurl string) {
+	u, err := url.Parse(rawurl)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Hostname() == "" {
+		logger.Warn("refusing to open external URL", "url", rawurl)
+		return
+	}
+
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "linux":
+		cmd = exec.Command("xdg-open", u.String())
+	case "darwin":
+		cmd = exec.Command("open", u.String())
+	case "windows":
+		// rundll32's url.dll opener takes the URL as its sole argument; it
+		// does not go through a shell, so no extra quoting is needed.
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", u.String())
+	default:
+		logger.Warn("no external-browser opener for this OS", "os", runtime.GOOS, "url", u.String())
+		return
+	}
+
+	// Fire-and-forget: the wallet doesn't wait on or manage the browser
+	// process's lifetime, it only launches it.
+	if err := cmd.Start(); err != nil {
+		logger.Warn("failed to open external URL", "url", u.String(), "error", err)
+		return
+	}
+	go func() { _ = cmd.Wait() }()
 }

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -31,6 +31,17 @@ import { Settings } from "./screens/Settings";
 // A Map (not a plain object) so a crafted hash like "#/constructor" or
 // "#/toString" can't resolve to an inherited Object.prototype member and get
 // rendered as a screen — unknown routes always fall back to Portfolio.
+//
+// Dual purpose, and NOT the same for every entry: `ROUTES.has(route)` (below,
+// in the activeRoute/sidebar-highlight logic) treats every key here — plus
+// "staking"/"sign"/etc., which aren't in this map at all — as a real,
+// highlightable route. But `ROUTES.get(route)` is only reached by the final
+// `else` in the content-selection branches further down, and "receive" and
+// "activity" never reach it: they're intercepted by their own explicit
+// `else if` branches earlier so they can be passed the active wallet's real
+// `network` (this map's factories take no props). So `receive`/`activity`
+// stay listed here for route-highlighting and prototype-pollution-safe
+// lookup purposes only — their actual content never comes from this map.
 const ROUTES = new Map<string, () => ReactElement>([
   ["portfolio", Portfolio],
   ["receive", Receive],
@@ -283,7 +294,7 @@ export function App() {
     // Staking/governance is gated like send: a synced node AND a
     // spending-enabled wallet. A read-only or unsynced wallet falls back to
     // Portfolio.
-    content = canStake ? <Staking /> : <Portfolio />;
+    content = canStake ? <Staking network={activeWallet.network} /> : <Portfolio />;
   } else if (route === "sign") {
     content = canSign ? <SignMessage account={toAccount(activeWallet)} /> : <Portfolio />;
   } else if (route === "verify") {
@@ -305,6 +316,15 @@ export function App() {
     // any active wallet; the spend sub-flow gates itself on canSend (synced node
     // + spending-enabled wallet).
     content = <MultiSig canSpend={canSend} />;
+  } else if (route === "receive") {
+    // Explorer links on each address need the active wallet's real network
+    // (preview/preprod/mainnet), which the generic ROUTES map (no props)
+    // can't carry.
+    content = <Receive network={activeWallet.network} />;
+  } else if (route === "activity") {
+    // Same reasoning as "receive": the tx-hash explorer link needs the
+    // active wallet's network.
+    content = <Activity network={activeWallet.network} />;
   } else {
     const Screen = ROUTES.get(route) ?? Portfolio;
     content = <Screen />;

--- a/ui/web/src/components/ExplorerLink.tsx
+++ b/ui/web/src/components/ExplorerLink.tsx
@@ -1,0 +1,59 @@
+import type { MouseEvent } from "react";
+import { explorerUrl } from "../explorer";
+import type { ExplorerKind } from "../explorer";
+
+interface ExplorerLinkProps {
+  network: string;
+  kind: ExplorerKind;
+  id: string;
+  /** Accessible name; defaults to a generic, clearly-external label. */
+  label?: string;
+}
+
+/**
+ * A clearly-labeled affordance ("↗") linking out to a PUBLIC block explorer.
+ *
+ * This is user-initiated navigation only: the wallet never fetches this URL
+ * itself — nothing happens until the user clicks, at which point their own
+ * browser opens the explorer in a new tab/window. `rel="noopener noreferrer"`
+ * prevents a new tab from getting a `window.opener` handle back into the
+ * wallet, and the title/aria-label make the "leaves the wallet" boundary
+ * explicit rather than looking like an in-app link.
+ *
+ * The desktop build embeds a webview (see `ui/cmd/bursa-wallet/ui_webview.go`)
+ * rather than a real browser tab-strip: a plain `target="_blank"` there would
+ * NAVIGATE the wallet window itself to the explorer, turning it into a
+ * general-purpose browser. To prevent that, the click handler always
+ * `preventDefault()`s the anchor's own navigation and instead opens the URL
+ * externally — through the webview-injected `window.bursaOpenExternal`
+ * bridge when present, or `window.open` (a real new tab) otherwise. The
+ * `href`/`target`/`rel` attributes are kept for accessibility, hover
+ * previews, and "open in new tab" middle-click/ctrl-click in a real browser.
+ */
+export function ExplorerLink({ network, kind, id, label }: ExplorerLinkProps) {
+  const accessibleLabel = label ?? "View on public block explorer (opens in a new tab)";
+  const url = explorerUrl(network, kind, id);
+
+  function handleClick(e: MouseEvent<HTMLAnchorElement>) {
+    e.preventDefault();
+    if (typeof window.bursaOpenExternal === "function") {
+      window.bursaOpenExternal(url);
+    } else {
+      window.open(url, "_blank", "noopener,noreferrer");
+    }
+  }
+
+  return (
+    <a
+      className="explorer-link"
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={accessibleLabel}
+      aria-label={accessibleLabel}
+      onClick={handleClick}
+    >
+      ↗
+    </a>
+  );
+}

--- a/ui/web/src/components/components.test.tsx
+++ b/ui/web/src/components/components.test.tsx
@@ -1,10 +1,11 @@
-import { act, render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { act, render, screen, fireEvent, waitFor, within, createEvent } from "@testing-library/react";
 import type { WalletView } from "../api/types";
 import { Button } from "./Button";
 import { StatusPill } from "./StatusPill";
 import { CopyButton } from "./CopyButton";
 import { SyncBanner } from "./SyncBanner";
 import { MobileNav } from "./MobileNav";
+import { ExplorerLink } from "./ExplorerLink";
 
 type MobileNavProps = Parameters<typeof MobileNav>[0];
 
@@ -49,6 +50,9 @@ afterEach(() => {
     value: originalMatchMedia,
   });
   document.body.style.overflow = "";
+  // The real build never has this bridge in a browser/test environment; undo
+  // whatever an ExplorerLink test above stubbed in, to avoid leakage.
+  delete (window as { bursaOpenExternal?: unknown }).bursaOpenExternal;
 });
 
 test("Button fires onClick", () => {
@@ -210,4 +214,71 @@ test("MobileNav keeps lock failures visible in the open drawer", () => {
   rerender(<MobileNav {...props} lockError="network error" />);
 
   expect(screen.getByRole("alert")).toHaveTextContent("network error");
+});
+
+// --- ExplorerLink ---
+// The wallet must never call out to a block explorer itself — this link only
+// ever fires from a user click, and must open in a new, unlinked tab.
+
+test("ExplorerLink renders an <a> with the correct href, target, and rel", () => {
+  render(<ExplorerLink network="preview" kind="tx" id="deadbeef" />);
+  const link = screen.getByRole("link");
+  expect(link).toHaveAttribute("href", "https://preview.cardanoscan.io/transaction/deadbeef");
+  expect(link).toHaveAttribute("target", "_blank");
+  expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  expect(link).toHaveAttribute("rel", expect.stringContaining("noreferrer"));
+});
+
+test("ExplorerLink maps network + kind to the right host and path", () => {
+  render(<ExplorerLink network="mainnet" kind="pool" id="pool1abc" />);
+  expect(screen.getByRole("link")).toHaveAttribute(
+    "href",
+    "https://cardanoscan.io/pool/pool1abc",
+  );
+});
+
+test("ExplorerLink has an accessible label that signals it leaves the wallet", () => {
+  render(<ExplorerLink network="preprod" kind="drep" id="drep1abc" />);
+  const link = screen.getByRole("link");
+  expect(link.getAttribute("aria-label")?.toLowerCase()).toContain("explorer");
+  expect(link).toHaveAttribute("title");
+});
+
+// The desktop build embeds a webview with no tab-strip: a plain
+// `target="_blank"` click would navigate the wallet window itself. The click
+// handler must always prevent the anchor's own navigation and instead open
+// externally — via the webview-injected `window.bursaOpenExternal` bridge
+// when present, or `window.open` otherwise (see ui_webview.go / ui_headless.go).
+
+test("ExplorerLink opens via window.open and prevents default navigation when no webview bridge is present", () => {
+  const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+  render(<ExplorerLink network="preview" kind="tx" id="deadbeef" />);
+  const link = screen.getByRole("link");
+  const event = createEvent.click(link);
+  const preventDefault = vi.spyOn(event, "preventDefault");
+  fireEvent(link, event);
+
+  expect(preventDefault).toHaveBeenCalled();
+  expect(openSpy).toHaveBeenCalledWith(
+    "https://preview.cardanoscan.io/transaction/deadbeef",
+    "_blank",
+    "noopener,noreferrer",
+  );
+});
+
+test("ExplorerLink calls the webview bursaOpenExternal bridge instead of window.open when present", () => {
+  const bridge = vi.fn();
+  (window as { bursaOpenExternal?: (url: string) => void }).bursaOpenExternal = bridge;
+  const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+  render(<ExplorerLink network="mainnet" kind="pool" id="pool1abc" />);
+  const link = screen.getByRole("link");
+  const event = createEvent.click(link);
+  const preventDefault = vi.spyOn(event, "preventDefault");
+  fireEvent(link, event);
+
+  expect(preventDefault).toHaveBeenCalled();
+  expect(bridge).toHaveBeenCalledWith("https://cardanoscan.io/pool/pool1abc");
+  expect(openSpy).not.toHaveBeenCalled();
 });

--- a/ui/web/src/explorer.test.ts
+++ b/ui/web/src/explorer.test.ts
@@ -1,0 +1,42 @@
+import { explorerUrl } from "./explorer";
+import type { ExplorerKind } from "./explorer";
+
+const NETWORKS = ["mainnet", "preprod", "preview"] as const;
+const KINDS: ExplorerKind[] = ["tx", "address", "pool", "drep"];
+
+const EXPECTED_HOST: Record<(typeof NETWORKS)[number], string> = {
+  mainnet: "cardanoscan.io",
+  preprod: "preprod.cardanoscan.io",
+  preview: "preview.cardanoscan.io",
+};
+
+const EXPECTED_PATH: Record<ExplorerKind, string> = {
+  tx: "transaction",
+  address: "address",
+  pool: "pool",
+  drep: "drep",
+};
+
+for (const network of NETWORKS) {
+  for (const kind of KINDS) {
+    test(`explorerUrl(${network}, ${kind}, id) uses the correct host + path`, () => {
+      const url = explorerUrl(network, kind, "some-id-123");
+      expect(url).toBe(`https://${EXPECTED_HOST[network]}/${EXPECTED_PATH[kind]}/some-id-123`);
+    });
+  }
+}
+
+test("explorerUrl URL-encodes the id", () => {
+  const url = explorerUrl("preview", "tx", "abc def/ghi");
+  expect(url).toBe("https://preview.cardanoscan.io/transaction/abc%20def%2Fghi");
+});
+
+test("explorerUrl falls back to the mainnet host for an unknown network string", () => {
+  const url = explorerUrl("some-unknown-network", "address", "addr1xyz");
+  expect(url).toBe("https://cardanoscan.io/address/addr1xyz");
+});
+
+test("explorerUrl always produces an https URL (never calls out to it itself)", () => {
+  const url = explorerUrl("mainnet", "pool", "pool1abc");
+  expect(url.startsWith("https://")).toBe(true);
+});

--- a/ui/web/src/explorer.ts
+++ b/ui/web/src/explorer.ts
@@ -1,0 +1,41 @@
+// Public block-explorer link building.
+//
+// This module only builds URL strings — it never performs a network request.
+// The wallet's no-background-network-call boundary is preserved because the
+// resulting URL is only ever used as the `href` of a plain
+// `<a target="_blank" rel="noopener noreferrer">` that the user must click
+// (see components/ExplorerLink.tsx); the wallet process itself never fetches
+// it, and clicking opens the explorer in the user's own browser, outside the
+// wallet.
+//
+// Explorer of choice: cardanoscan.io. It publishes a dedicated subdomain per
+// Cardano network (mainnet / preprod / preview) with an identical path
+// structure across all three, so the mapping below is a simple lookup.
+
+export type ExplorerKind = "tx" | "address" | "pool" | "drep";
+
+const HOSTS: Record<string, string> = {
+  mainnet: "cardanoscan.io",
+  preprod: "preprod.cardanoscan.io",
+  preview: "preview.cardanoscan.io",
+};
+
+const PATHS: Record<ExplorerKind, string> = {
+  tx: "transaction",
+  address: "address",
+  pool: "pool",
+  drep: "drep",
+};
+
+/**
+ * Build the public cardanoscan.io URL for a given network/kind/id.
+ *
+ * An unrecognized network string falls back to the mainnet host rather than
+ * throwing — callers pass through whatever network string the server reports
+ * for a wallet, and a broken/unknown value should still produce a usable (if
+ * possibly wrong-network) link rather than crash the screen.
+ */
+export function explorerUrl(network: string, kind: ExplorerKind, id: string): string {
+  const host = HOSTS[network] ?? HOSTS.mainnet;
+  return `https://${host}/${PATHS[kind]}/${encodeURIComponent(id)}`;
+}

--- a/ui/web/src/globals.d.ts
+++ b/ui/web/src/globals.d.ts
@@ -1,0 +1,14 @@
+// Ambient bridge injected by the desktop (webview) build only.
+//
+// `ui/cmd/bursa-wallet/ui_webview.go` binds `bursaOpenExternal` into the
+// window's JS context via `webview.Bind` so that clicking an external link
+// (see components/ExplorerLink.tsx) opens the OS's default browser instead
+// of navigating the embedded webview itself. The headless (browser) build
+// never injects this, so callers must always feature-detect before use.
+export {};
+
+declare global {
+  interface Window {
+    bursaOpenExternal?: (url: string) => void;
+  }
+}

--- a/ui/web/src/screens/Activity.test.tsx
+++ b/ui/web/src/screens/Activity.test.tsx
@@ -310,3 +310,13 @@ test("(r) drawer detail view renders a pruned tx (null asset_deltas) without cra
   const dialog = await screen.findByRole("dialog");
   expect(within(dialog).getByText("Unknown")).toBeInTheDocument();
 });
+
+test("(s) each row has an external explorer link to the FULL tx hash, scoped to the wallet's network", () => {
+  mockTransactions([TX1]);
+  render(<Activity network="mainnet" />);
+
+  const link = screen.getByRole("link");
+  expect(link).toHaveAttribute("href", `https://cardanoscan.io/transaction/${TX1.tx_hash}`);
+  expect(link).toHaveAttribute("target", "_blank");
+  expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+});

--- a/ui/web/src/screens/Activity.tsx
+++ b/ui/web/src/screens/Activity.tsx
@@ -8,8 +8,15 @@ import { Input } from "../components/Input";
 import { Select } from "../components/Select";
 import { DownloadButton } from "../components/DownloadButton";
 import { Drawer } from "../components/Drawer";
+import { ExplorerLink } from "../components/ExplorerLink";
 import { formatAda } from "../format";
 import { toCsv } from "../csv";
+
+interface ActivityProps {
+  // Optional so existing no-prop callers/tests keep working; the app always
+  // passes the active wallet's real network when routing to this screen.
+  network?: string;
+}
 
 function errorMessage(err: unknown): string {
   if (err instanceof ApiError) return err.message;
@@ -239,7 +246,7 @@ function TransactionDetailDrawer({ hash, onClose }: { hash: string; onClose: () 
 
 type DirectionFilter = "all" | "received" | "sent" | "self";
 
-export function Activity() {
+export function Activity({ network = "preview" }: ActivityProps = {}) {
   const txs = useTransactions();
   const [search, setSearch] = useState("");
   const [directionFilter, setDirectionFilter] = useState<DirectionFilter>("all");
@@ -299,6 +306,12 @@ export function Activity() {
       <span className="hash-cell">
         <span className="mono">{truncateHash(tx.tx_hash)}</span>
         <CopyButton value={tx.tx_hash} />
+        <ExplorerLink
+          network={network}
+          kind="tx"
+          id={tx.tx_hash}
+          label={`View transaction ${truncateHash(tx.tx_hash)} on block explorer`}
+        />
       </span>
     ),
     actions: (

--- a/ui/web/src/screens/Receive.test.tsx
+++ b/ui/web/src/screens/Receive.test.tsx
@@ -107,3 +107,25 @@ test("(g) empty receive list renders gracefully (fresh wallet)", () => {
   // Card with next_unused still visible
   expect(screen.getByText(ADDR_A)).toBeInTheDocument();
 });
+
+test("(h) each address gets an external explorer link, scoped to the wallet's network", () => {
+  mockAddresses();
+  render(<Receive network="preprod" />);
+
+  const links = screen.getAllByRole("link");
+  expect(links.length).toBeGreaterThanOrEqual(1);
+
+  // The next-unused card's link points at the FULL address, not the truncated form.
+  const nextUnusedLink = links.find(
+    (l) => l.getAttribute("href") === `https://preprod.cardanoscan.io/address/${ADDR_B}`,
+  );
+  expect(nextUnusedLink).toBeDefined();
+  expect(nextUnusedLink).toHaveAttribute("target", "_blank");
+  expect(nextUnusedLink).toHaveAttribute("rel", expect.stringContaining("noopener"));
+
+  // The table row for ADDR_A also links out, using the same network.
+  const rowLink = links.find(
+    (l) => l.getAttribute("href") === `https://preprod.cardanoscan.io/address/${ADDR_A}`,
+  );
+  expect(rowLink).toBeDefined();
+});

--- a/ui/web/src/screens/Receive.tsx
+++ b/ui/web/src/screens/Receive.tsx
@@ -4,6 +4,13 @@ import { useAddresses } from "../api/hooks";
 import { Card } from "../components/Card";
 import { Table } from "../components/Table";
 import { CopyButton } from "../components/CopyButton";
+import { ExplorerLink } from "../components/ExplorerLink";
+
+interface ReceiveProps {
+  // Optional so existing no-prop callers/tests keep working; the app always
+  // passes the active wallet's real network when routing to this screen.
+  network?: string;
+}
 
 /** Truncate a long bech32 address for display: first 12 … last 8 chars. */
 function truncateAddr(addr: string): string {
@@ -29,7 +36,7 @@ function AddressQR({ address, size, title }: { address: string; size: number; ti
   );
 }
 
-export function Receive() {
+export function Receive({ network = "preview" }: ReceiveProps = {}) {
   const addresses = useAddresses();
   const [expandedQr, setExpandedQr] = useState<string | null>(null);
 
@@ -78,7 +85,17 @@ export function Receive() {
           )}
         </div>
       ),
-      copy: <CopyButton value={addr} />,
+      copy: (
+        <>
+          <CopyButton value={addr} />
+          <ExplorerLink
+            network={network}
+            kind="address"
+            id={addr}
+            label={`View address ${truncateAddr(addr)} on block explorer`}
+          />
+        </>
+      ),
     };
   });
 
@@ -92,6 +109,7 @@ export function Receive() {
           <div className="receive-next-details">
             <p className="mono address-full">{nextUnused}</p>
             <CopyButton value={nextUnused} />
+            {nextUnused && <ExplorerLink network={network} kind="address" id={nextUnused} />}
           </div>
         </div>
       </Card>

--- a/ui/web/src/screens/Staking.test.tsx
+++ b/ui/web/src/screens/Staking.test.tsx
@@ -342,6 +342,64 @@ test("(k) withdraw button is disabled when there are no withdrawable rewards", (
 
 // --- build error stays on compose ---
 
+// --- external explorer links (pool + DRep) ---
+
+test("(m) pasting a verified pool ID renders an explorer link scoped to the wallet's network", async () => {
+  mockDelegation({ active: false });
+  vi.spyOn(client, "getPool").mockResolvedValue(MOCK_POOL);
+
+  render(<Staking network="preprod" />);
+
+  const poolInput = screen.getByPlaceholderText(/pool1\.\.\./i);
+  fireEvent.change(poolInput, { target: { value: "pool1abc" } });
+  fireEvent.blur(poolInput);
+
+  await waitFor(() => expect(screen.getByText("✓ Verified by your node")).toBeInTheDocument());
+
+  const link = screen.getByRole("link");
+  expect(link).toHaveAttribute("href", "https://preprod.cardanoscan.io/pool/pool1abc");
+  expect(link).toHaveAttribute("target", "_blank");
+  expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+});
+
+test("(n) verifying a DRep ID renders an explorer link scoped to the wallet's network", async () => {
+  mockDelegation({ active: false });
+  vi.spyOn(client, "getDRep").mockResolvedValue(MOCK_DREP);
+
+  render(<Staking network="mainnet" />);
+
+  fireEvent.click(screen.getByLabelText(/a specific drep/i));
+  const drepInput = screen.getByLabelText(/drep id/i);
+  fireEvent.change(drepInput, { target: { value: "drep1abc" } });
+  fireEvent.blur(drepInput);
+
+  await waitFor(() => expect(screen.getByText("✓ Verified by your node")).toBeInTheDocument());
+
+  const link = screen.getByRole("link");
+  expect(link).toHaveAttribute("href", "https://cardanoscan.io/drep/drep1abc");
+});
+
+test("(o) an active delegation's pool ID in the status panel links out to the explorer", () => {
+  mockDelegation({ active: true, pool_id: "pool1active", withdrawable_amount: "0" });
+
+  render(<Staking network="preview" />);
+
+  const link = screen.getByRole("link");
+  expect(link).toHaveAttribute("href", "https://preview.cardanoscan.io/pool/pool1active");
+});
+
+test("(p) an active delegation with a null pool_id (e.g. DRep-only vote delegation) shows the muted dash and renders NO pool explorer link", () => {
+  mockDelegation({ active: true, pool_id: null, withdrawable_amount: "0" });
+
+  render(<Staking network="preview" />);
+
+  // Registered (stake key active) but no delegated pool: muted placeholder,
+  // not a literal "null" or a broken /pool/null link.
+  expect(screen.getByText(/registered/i)).toBeInTheDocument();
+  expect(screen.getByText("—")).toBeInTheDocument();
+  expect(screen.queryByRole("link")).not.toBeInTheDocument();
+});
+
 test("(l) a buildDelegation error (e.g. no change) is shown inline on the form", async () => {
   mockDelegation({ active: false });
   vi.spyOn(client, "buildDelegation").mockRejectedValue(

--- a/ui/web/src/screens/Staking.tsx
+++ b/ui/web/src/screens/Staking.tsx
@@ -22,6 +22,7 @@ import { Input } from "../components/Input";
 import { Button } from "../components/Button";
 import { StatusPill } from "../components/StatusPill";
 import { CopyButton } from "../components/CopyButton";
+import { ExplorerLink } from "../components/ExplorerLink";
 import { formatAda } from "../format";
 
 type Phase = "status" | "compose" | "preview" | "done";
@@ -66,9 +67,11 @@ const VOTE_OPTIONS: { type: VoteType; title: string; sub: string }[] = [
 function StatusPanel({
   poolId,
   active,
+  network,
 }: {
   poolId: string | null;
   active: boolean;
+  network: string;
 }) {
   return (
     <Card title="Current status">
@@ -85,7 +88,16 @@ function StatusPanel({
         </div>
         <div className="dl-row">
           <dt>Delegated pool</dt>
-          <dd>{poolId ?? <span className="muted">—</span>}</dd>
+          <dd>
+            {poolId ? (
+              <>
+                {poolId}
+                <ExplorerLink network={network} kind="pool" id={poolId} />
+              </>
+            ) : (
+              <span className="muted">—</span>
+            )}
+          </dd>
         </div>
       </dl>
     </Card>
@@ -106,6 +118,7 @@ interface ComposeProps {
   anchorHash: string;
   setAnchorHash: (v: string) => void;
   onPreview: (preview: DelegationPreview) => void;
+  network: string;
 }
 
 function Compose(props: ComposeProps) {
@@ -121,6 +134,7 @@ function Compose(props: ComposeProps) {
     anchorHash,
     setAnchorHash,
     onPreview,
+    network,
   } = props;
 
   const [pool, setPool] = useState<PoolInfo | null>(null);
@@ -270,6 +284,7 @@ function Compose(props: ComposeProps) {
             {" · "}pledge {formatAda(pool.declared_pledge)} ₳
             {" · "}fixed {formatAda(pool.fixed_cost)} ₳
             {" · "}live stake {formatAda(pool.live_stake)} ₳
+            <ExplorerLink network={network} kind="pool" id={pool.pool_id} />
           </p>
         )}
         {poolError && (
@@ -321,6 +336,7 @@ function Compose(props: ComposeProps) {
                       <p className="verified-readout">
                         <span className="verified-tick">✓ Verified by your node</span>
                         {drep.registered ? " · registered" : " · not registered"}
+                        <ExplorerLink network={network} kind="drep" id={drep.drep_id} />
                       </p>
                     )}
                     {drepError && (
@@ -512,14 +528,15 @@ function DonePhase({ result, onReset }: { result: TxResult; onReset: () => void 
 // --- Active state: status + withdraw + change ---
 
 interface ActiveProps {
-  poolId: string;
+  poolId: string | null;
   withdrawable: string;
   note: string;
   onChange: () => void;
   onWithdraw: (preview: DelegationPreview) => void;
+  network: string;
 }
 
-function ActiveState({ poolId, withdrawable, note, onChange, onWithdraw }: ActiveProps) {
+function ActiveState({ poolId, withdrawable, note, onChange, onWithdraw, network }: ActiveProps) {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const canWithdraw = /^\d+$/.test(withdrawable) && BigInt(withdrawable) > 0n;
@@ -538,7 +555,7 @@ function ActiveState({ poolId, withdrawable, note, onChange, onWithdraw }: Activ
 
   return (
     <>
-      <StatusPanel poolId={poolId} active={true} />
+      <StatusPanel poolId={poolId} active={true} network={network} />
       <Card title="Rewards">
         <div className="dl-row">
           <dt className="field-label">Withdrawable</dt>
@@ -567,7 +584,13 @@ function ActiveState({ poolId, withdrawable, note, onChange, onWithdraw }: Activ
 
 // --- Top-level Staking screen ---
 
-export function Staking() {
+interface StakingProps {
+  // Optional so existing no-prop callers/tests keep working; the app always
+  // passes the active wallet's real network when routing to this screen.
+  network?: string;
+}
+
+export function Staking({ network = "preview" }: StakingProps = {}) {
   const delegation = useDelegation();
 
   const [phase, setPhase] = useState<Phase>("status");
@@ -647,11 +670,12 @@ export function Staking() {
     return (
       <div className="staking">
         <ActiveState
-          poolId={del.pool_id ?? "—"}
+          poolId={del.pool_id}
           withdrawable={del.withdrawable_amount}
           note={del.provisional ? del.note : ""}
           onChange={goCompose}
           onWithdraw={(p) => handlePreview(p, "status")}
+          network={network}
         />
       </div>
     );
@@ -660,7 +684,7 @@ export function Staking() {
   // Compose (set-up / change) form, with the status panel above it.
   return (
     <div className="staking">
-      <StatusPanel poolId={del?.pool_id ?? null} active={isActive} />
+      <StatusPanel poolId={del?.pool_id ?? null} active={isActive} network={network} />
       <Compose
         poolId={poolId}
         setPoolId={setPoolId}
@@ -673,6 +697,7 @@ export function Staking() {
         anchorHash={anchorHash}
         setAnchorHash={setAnchorHash}
         onPreview={handlePreview}
+        network={network}
       />
     </div>
   );

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -525,6 +525,23 @@ a:hover {
   margin-bottom: var(--space-3);
 }
 
+/* External block-explorer affordance ("↗"): a plain <a target="_blank"> the
+   user clicks to leave the wallet for a PUBLIC explorer. The wallet itself
+   never fetches this URL — see src/explorer.ts. */
+.explorer-link {
+  display: inline-flex;
+  align-items: center;
+  margin-left: var(--space-1);
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 0.8125rem;
+  line-height: 1;
+}
+.explorer-link:hover,
+.explorer-link:focus-visible {
+  color: var(--accent);
+}
+
 /* ---------------------------------------------------------------- tables -- */
 .table-wrap {
   overflow-x: auto;


### PR DESCRIPTION
External block-explorer links (cardanoscan) on Receive/Staking/Activity. Consent-safe: the wallet makes no request — links open in the user's OS browser (webview build binds an OS-open bridge; browser build uses window.open), never navigating the embedded webview.



<img width="1440" height="1742" alt="pr571-explorer-links" src="https://github.com/user-attachments/assets/fca6519a-7e12-4aca-952a-1b088c81455d" />





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add external Cardanoscan links across Receive, Staking, and Activity that open in the user’s default browser, not inside the embedded webview. No background requests are made; links only open on user click.

- New Features
  - Added `ExplorerLink` that builds explorer URLs, shows a clear "↗" affordance, and opens via `window.bursaOpenExternal` (webview) or `window.open` with `rel="noopener noreferrer"`; always prevents in-webview navigation.
  - Introduced `explorerUrl` for `mainnet`/`preprod`/`preview` and `tx`/`address`/`pool`/`drep`; https-only, URL-encodes IDs, falls back to mainnet on unknown networks.
  - Routed `network` into `Receive`, `Activity`, and `Staking`; added links for full addresses, tx hashes, pool IDs, and DRep IDs; hide when data is missing.
  - Desktop: bound `bursaOpenExternal` and a safe OS opener (`xdg-open`/`open`/`rundll32`) with strict `http/https` validation; never navigates the embedded webview.
  - Added tests for URL mapping and click behavior across screens; light styling for the external-link affordance.

<sup>Written for commit 7f9765650798fff4ea389e95350df5ae4be5ef92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



