### PR TITLE
feat(ui): on-chain native-token metadata + Portfolio search/filter

### DIFF
--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -79,15 +79,19 @@ type Spender interface {
 	BuildDelegation(ctx context.Context, req spend.DelegationRequest) (spend.DelegationPreview, error)
 }
 
-// NodeLookup is the node-backed verification surface the staking and send
-// screens use: confirming a pasted pool or DRep ID exists, and resolving an
-// ADA Handle ($name) to its current holding address (consent law: the
-// embedded node is the only thing that touches the network). *chain.Client
-// satisfies it.
+// NodeLookup is the node-backed verification/lookup surface the wallet uses to
+// confirm a pasted pool or DRep ID exists, resolve ADA Handles, and read native
+// asset identity/metadata. The embedded node is the only component that
+// touches the network; *chain.Client satisfies this interface.
 type NodeLookup interface {
 	Pool(ctx context.Context, poolID string) (chain.PoolInfo, error)
 	DRep(ctx context.Context, drepID string) (chain.DRepInfo, error)
 	AssetAddresses(ctx context.Context, asset string) ([]chain.AssetAddress, error)
+	// Asset returns on-chain identity/metadata for a native asset (unit =
+	// policy ID + hex asset name). Most assets have no indexed on-chain
+	// metadata today (see chain.AssetInfo) — the Portfolio screen falls back
+	// to the raw unit/quantity when it is absent.
+	Asset(ctx context.Context, unit string) (chain.AssetInfo, error)
 }
 
 // Vault is the encrypted multi-wallet store the API drives. It owns the wallet
@@ -356,8 +360,9 @@ func toWalletView(w vault.WalletMeta, activeID string) walletView {
 // the encrypted multi-wallet store; the API pushes the active wallet onto wl/sp
 // whenever the selection changes. settings exposes user-facing app settings
 // (the lean-node profile). cb is the local-only address-book store. lookup
-// verifies pasted pool/DRep IDs and resolves ADA Handles through the node (may
-// be nil, in which case those endpoints report unavailable). po is the Stake
+// verifies pasted pool/DRep IDs, resolves ADA Handles, and reads native-asset
+// metadata through the node (may be nil, in which case those endpoints report
+// unavailable). po is the Stake
 // Pool Operations surface. dx optionally enables node-local DEX routes. ms is
 // the native multi-signature surface (may be nil, in which case the multi-sig
 // routes are not registered). spa is the embedded SPA, registered as the
@@ -926,6 +931,20 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 		serveLookup(w, handleInfo{Handle: bare, Address: addr}, err)
 	}))
 
+	// GET /wallet/assets/{unit} reads a native asset's on-chain
+	// identity/metadata (unit = policy ID + hex asset name) through the node,
+	// for the Portfolio screen's token name/ticker/decimals display. Gated
+	// like the pool/DRep lookups above — it only needs the node serving
+	// queries, not a full sync.
+	mux.HandleFunc("GET /wallet/assets/{unit}", gated(st, func(w http.ResponseWriter, r *http.Request) {
+		if lookup == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "asset lookup unavailable"})
+			return
+		}
+		info, err := lookup.Asset(r.Context(), r.PathValue("unit"))
+		serveLookup(w, info, err)
+	}))
+
 	mux.HandleFunc("POST /wallet/delegation", readyGate(st, func(w http.ResponseWriter, r *http.Request) {
 		var req spend.DelegationRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -990,9 +1009,9 @@ func requirePassword(w http.ResponseWriter, password string) bool {
 	return true
 }
 
-// serveLookup writes a pool/DRep lookup result, mapping the node's not-found to
-// 404 (so the screen can show "not found by your node" inline) and other errors
-// to 502 (the node query failed).
+// serveLookup writes a pool/DRep/asset lookup result, mapping the node's
+// not-found to 404 (so the screen can show "not found by your node" inline)
+// and other errors to 502 (the node query failed).
 func serveLookup[T any](w http.ResponseWriter, v T, err error) {
 	switch {
 	case err == nil:

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -324,6 +324,36 @@ func (f *fakeVault) DisableTPM(password string) error {
 	return f.disableTPMErr
 }
 
+// fakeLookup implements the api.NodeLookup interface (pool/DRep/asset
+// node-verified lookups) for handler tests.
+type fakeLookup struct {
+	pool    chain.PoolInfo
+	poolErr error
+	drep    chain.DRepInfo
+	drepErr error
+
+	asset    chain.AssetInfo
+	assetErr error
+	gotUnit  string
+}
+
+func (f *fakeLookup) Pool(_ context.Context, _ string) (chain.PoolInfo, error) {
+	return f.pool, f.poolErr
+}
+
+func (f *fakeLookup) DRep(_ context.Context, _ string) (chain.DRepInfo, error) {
+	return f.drep, f.drepErr
+}
+
+func (f *fakeLookup) AssetAddresses(_ context.Context, _ string) ([]chain.AssetAddress, error) {
+	return nil, chain.ErrNotFound
+}
+
+func (f *fakeLookup) Asset(_ context.Context, unit string) (chain.AssetInfo, error) {
+	f.gotUnit = unit
+	return f.asset, f.assetErr
+}
+
 func TestHealthAlwaysOK(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
@@ -2149,6 +2179,68 @@ func readyStatuser() fakeStatuser {
 	return fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
 }
 
+func TestAssetLookupOK(t *testing.T) {
+	lookup := &fakeLookup{asset: chain.AssetInfo{
+		Asset:           "policy123746f6b656e",
+		PolicyID:        "policy123",
+		AssetName:       "746f6b656e",
+		AssetNameASCII:  "token",
+		Fingerprint:     "asset1xyz",
+		Quantity:        "1000000",
+		OnchainMetadata: json.RawMessage(`{"name":"Token","ticker":"TOK","decimals":6}`),
+	}}
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lookup, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/assets/policy123746f6b656e", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /wallet/assets/{unit} = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if lookup.gotUnit != "policy123746f6b656e" {
+		t.Fatalf("lookup.Asset called with unit %q, want policy123746f6b656e", lookup.gotUnit)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"ticker":"TOK"`) {
+		t.Fatalf("response missing onchain_metadata passthrough: %s", body)
+	}
+	var got chain.AssetInfo
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Asset != "policy123746f6b656e" || got.Fingerprint != "asset1xyz" {
+		t.Fatalf("unexpected response: %+v", got)
+	}
+}
+
+func TestAssetLookupNotFound(t *testing.T) {
+	lookup := &fakeLookup{assetErr: chain.ErrNotFound}
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lookup, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/assets/policymissing", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("GET /wallet/assets/{unit} (not found) = %d, want 404", rec.Code)
+	}
+}
+
+func TestAssetLookupUnavailableWhenNoLookup(t *testing.T) {
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/assets/policy123746f6b656e", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /wallet/assets/{unit} with nil lookup = %d, want 503", rec.Code)
+	}
+}
+
+func TestAssetLookupGatedWhileStarting(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
+	lookup := &fakeLookup{}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lookup, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/assets/policy123746f6b656e", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /wallet/assets/{unit} while starting = %d, want 503", rec.Code)
+	}
+}
+
 func TestPoolCredentialsReturnsCreds(t *testing.T) {
 	po := &fakePoolOps{creds: poolops.Credentials{PoolID: "pool1abc", Network: "preview"}}
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
@@ -2697,6 +2789,10 @@ func (f *fakeNodeLookup) DRep(_ context.Context, _ string) (chain.DRepInfo, erro
 func (f *fakeNodeLookup) AssetAddresses(_ context.Context, asset string) ([]chain.AssetAddress, error) {
 	f.gotAssetUnits = append(f.gotAssetUnits, asset)
 	return f.assetAddrs, f.assetErr
+}
+
+func (f *fakeNodeLookup) Asset(_ context.Context, _ string) (chain.AssetInfo, error) {
+	return chain.AssetInfo{}, chain.ErrNotFound
 }
 
 func TestHandleLookupUnavailableWithoutLookup(t *testing.T) {

--- a/ui/internal/chain/blockfrost.go
+++ b/ui/internal/chain/blockfrost.go
@@ -209,6 +209,27 @@ type AssetAddress struct {
 	Quantity string `json:"quantity"`
 }
 
+// AssetInfo mirrors GET /api/v0/assets/{asset}: a native asset's on-chain
+// identity, plus whatever CIP-25/68-style on-chain metadata the node has
+// indexed for it. OnchainMetadata is left as raw JSON (null when absent)
+// rather than a typed struct, since the standard defines no fixed schema
+// (name/image/decimals/etc. are all optional, standard-specific keys) —
+// callers parse the fields they need defensively.
+//
+// As of dingo's current adapter, OnchainMetadata is always null: dingo does
+// not yet parse mint-transaction metadata into this field. Callers must treat
+// name/ticker/decimals as best-effort and fall back to the raw unit/quantity
+// when they are absent, which today is effectively always.
+type AssetInfo struct {
+	Asset           string          `json:"asset"`
+	PolicyID        string          `json:"policy_id"`
+	AssetName       string          `json:"asset_name"`
+	AssetNameASCII  string          `json:"asset_name_ascii"`
+	Fingerprint     string          `json:"fingerprint"`
+	Quantity        string          `json:"quantity"`
+	OnchainMetadata json.RawMessage `json:"onchain_metadata"`
+}
+
 type accountAddress struct {
 	Address string `json:"address"`
 }
@@ -624,4 +645,15 @@ func (c *Client) LatestEpoch(ctx context.Context) (EpochInfo, error) {
 // name). An asset the node has not seen yields ErrNotFound.
 func (c *Client) AssetAddresses(ctx context.Context, asset string) ([]AssetAddress, error) {
 	return getAllPages[AssetAddress](ctx, c, "/api/v0/assets/"+asset+"/addresses")
+}
+
+// Asset fetches on-chain identity/metadata for a native asset — unit is the
+// policy ID concatenated with the hex-encoded asset name, the same "unit"
+// used in UTxO amounts — from the node's loopback Blockfrost-compatible API.
+// An asset the node has not indexed (never minted, as far as this node has
+// seen) yields ErrNotFound.
+func (c *Client) Asset(ctx context.Context, unit string) (AssetInfo, error) {
+	var out AssetInfo
+	err := c.get(ctx, "/api/v0/assets/"+url.PathEscape(unit), &out)
+	return out, err
 }

--- a/ui/internal/chain/blockfrost_test.go
+++ b/ui/internal/chain/blockfrost_test.go
@@ -479,6 +479,75 @@ func TestDRepNotFound(t *testing.T) {
 	}
 }
 
+func TestAsset(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != "/api/v0/assets/policy123746f6b656e" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"asset":"policy123746f6b656e","policy_id":"policy123","asset_name":"746f6b656e","asset_name_ascii":"token","fingerprint":"asset1xyz","quantity":"1000000","initial_mint_tx_hash":"aa","mint_or_burn_count":1,"onchain_metadata":{"name":"Token","ticker":"TOK","decimals":6}}`))
+	})
+	got, err := c.Asset(context.Background(), "policy123746f6b656e")
+	if err != nil {
+		t.Fatalf("Asset: %v", err)
+	}
+	if got.Asset != "policy123746f6b656e" || got.PolicyID != "policy123" || got.AssetName != "746f6b656e" {
+		t.Fatalf("unexpected asset: %+v", got)
+	}
+	if got.AssetNameASCII != "token" || got.Fingerprint != "asset1xyz" || got.Quantity != "1000000" {
+		t.Fatalf("unexpected asset: %+v", got)
+	}
+	if got.OnchainMetadata == nil {
+		t.Fatalf("OnchainMetadata = nil, want raw JSON")
+	}
+	var meta struct {
+		Name     string `json:"name"`
+		Ticker   string `json:"ticker"`
+		Decimals int    `json:"decimals"`
+	}
+	if err := json.Unmarshal(got.OnchainMetadata, &meta); err != nil {
+		t.Fatalf("unmarshal OnchainMetadata: %v", err)
+	}
+	if meta.Name != "Token" || meta.Ticker != "TOK" || meta.Decimals != 6 {
+		t.Fatalf("unexpected onchain metadata: %+v", meta)
+	}
+}
+
+func TestAssetNilMetadata(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"asset":"policy123746f6b656e","policy_id":"policy123","asset_name":"746f6b656e","asset_name_ascii":"token","fingerprint":"asset1xyz","quantity":"1000000","initial_mint_tx_hash":"","mint_or_burn_count":0,"onchain_metadata":null}`))
+	})
+	got, err := c.Asset(context.Background(), "policy123746f6b656e")
+	if err != nil {
+		t.Fatalf("Asset: %v", err)
+	}
+	// dingo's current adapter always reports onchain_metadata: null — this must
+	// decode cleanly (as the raw JSON literal "null", which the frontend reads
+	// as a falsy value) rather than erroring, since it is the common case today.
+	if string(got.OnchainMetadata) != "null" {
+		t.Fatalf("OnchainMetadata = %s, want the raw JSON null literal", got.OnchainMetadata)
+	}
+}
+
+func TestAssetNotFound(t *testing.T) {
+	t.Parallel()
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v0/assets/policymissing" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(blockfrostNotFoundJSON))
+	})
+	_, err := c.Asset(context.Background(), "policymissing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("404 should map to ErrNotFound, got %v", err)
+	}
+}
+
 func TestErrorStatus(t *testing.T) {
 	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -26,6 +26,7 @@ import type {
   SubmitSignedRequest,
   PoolInfo,
   DRepInfo,
+  AssetInfo,
   DelegationRequest,
   DelegationPreview,
   HandleInfo,
@@ -191,6 +192,11 @@ export const resolveHandle = (name: string) =>
 // through the same Confirm path the send flow uses.
 export const getPool = (id: string) => apiGet<PoolInfo>(`/wallet/pool/${encodeURIComponent(id)}`);
 export const getDRep = (id: string) => apiGet<DRepInfo>(`/wallet/drep/${encodeURIComponent(id)}`);
+
+// Native-asset on-chain metadata (node-only; see ../tokenMeta.ts for how the
+// Portfolio screen interprets it, with a fallback when it's absent).
+export const getAssetMetadata = (unit: string) =>
+  apiGet<AssetInfo>(`/wallet/assets/${encodeURIComponent(unit)}`);
 export const buildDelegation = (req: DelegationRequest) =>
   apiPost<DelegationPreview>("/wallet/delegation", req);
 export const confirmDelegation = (id: string, password: string) =>

--- a/ui/web/src/api/hooks.test.tsx
+++ b/ui/web/src/api/hooks.test.tsx
@@ -201,6 +201,24 @@ test("useAssetMetadata: a rejected lookup for one unit does not break the others
   expect(result.current.bad).toBeUndefined();
 });
 
+test("useAssetMetadata publishes fast lookups without waiting for slower units", async () => {
+  let resolveSlow!: (info: AssetInfo) => void;
+  const slow = new Promise<AssetInfo>((resolve) => {
+    resolveSlow = resolve;
+  });
+  vi.spyOn(client, "getAssetMetadata").mockImplementation((unit: string) => {
+    if (unit === "slow") return slow;
+    return Promise.resolve(fakeAssetInfo(unit, "Fast"));
+  });
+
+  const { result } = renderHook(() => useAssetMetadata(["slow", "fast"]));
+  await waitFor(() => expect(result.current.fast).toBeDefined());
+  expect(result.current.slow).toBeUndefined();
+
+  await act(async () => resolveSlow(fakeAssetInfo("slow", "Slow")));
+  await waitFor(() => expect(result.current.slow).toBeDefined());
+});
+
 test("useAssetMetadata: an empty unit list resolves to {} without calling the client", () => {
   const spy = vi.spyOn(client, "getAssetMetadata");
   const { result } = renderHook(() => useAssetMetadata([]));
@@ -222,4 +240,13 @@ test("useAssetMetadata: reordering the same units does not retrigger lookups", a
   // Give any (unwanted) effect re-run a tick to fire before asserting.
   await Promise.resolve();
   expect(spy).toHaveBeenCalledTimes(2);
+});
+
+test("useAssetMetadata: duplicate units trigger only one lookup", async () => {
+  const spy = vi
+    .spyOn(client, "getAssetMetadata")
+    .mockImplementation((unit: string) => Promise.resolve(fakeAssetInfo(unit, "Token")));
+  const { result } = renderHook(() => useAssetMetadata(["unitA", "unitA", "unitA"]));
+  await waitFor(() => expect(result.current.unitA).toBeDefined());
+  expect(spy).toHaveBeenCalledTimes(1);
 });

--- a/ui/web/src/api/hooks.test.tsx
+++ b/ui/web/src/api/hooks.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook, waitFor, act } from "@testing-library/react";
-import { useStatus, useAsync } from "./hooks";
+import { useStatus, useAsync, useAssetMetadata } from "./hooks";
 import * as client from "./client";
+import type { AssetInfo } from "./types";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -166,4 +167,59 @@ test("an 'online' window event triggers an immediate refetch", async () => {
   });
 
   await waitFor(() => expect(calls).toBeGreaterThan(callsAfterInit));
+});
+
+function fakeAssetInfo(unit: string, name: string): AssetInfo {
+  return {
+    asset: unit,
+    policy_id: unit.slice(0, 56),
+    asset_name: unit.slice(56),
+    asset_name_ascii: "",
+    fingerprint: "",
+    quantity: "0",
+    onchain_metadata: { name },
+  };
+}
+
+test("useAssetMetadata resolves metadata for every unit, keyed by unit", async () => {
+  vi.spyOn(client, "getAssetMetadata").mockImplementation((unit: string) =>
+    Promise.resolve(fakeAssetInfo(unit, `Name-${unit}`)),
+  );
+  const { result } = renderHook(() => useAssetMetadata(["unitA", "unitB"]));
+  await waitFor(() => expect(Object.keys(result.current)).toHaveLength(2));
+  expect(result.current.unitA?.onchain_metadata).toEqual({ name: "Name-unitA" });
+  expect(result.current.unitB?.onchain_metadata).toEqual({ name: "Name-unitB" });
+});
+
+test("useAssetMetadata: a rejected lookup for one unit does not break the others", async () => {
+  vi.spyOn(client, "getAssetMetadata").mockImplementation((unit: string) => {
+    if (unit === "bad") return Promise.reject(new Error("not found by your node"));
+    return Promise.resolve(fakeAssetInfo(unit, "Good"));
+  });
+  const { result } = renderHook(() => useAssetMetadata(["good", "bad"]));
+  await waitFor(() => expect(result.current.good).toBeDefined());
+  expect(result.current.bad).toBeUndefined();
+});
+
+test("useAssetMetadata: an empty unit list resolves to {} without calling the client", () => {
+  const spy = vi.spyOn(client, "getAssetMetadata");
+  const { result } = renderHook(() => useAssetMetadata([]));
+  expect(result.current).toEqual({});
+  expect(spy).not.toHaveBeenCalled();
+});
+
+test("useAssetMetadata: reordering the same units does not retrigger lookups", async () => {
+  const spy = vi
+    .spyOn(client, "getAssetMetadata")
+    .mockImplementation((unit: string) => Promise.resolve(fakeAssetInfo(unit, `Name-${unit}`)));
+  const { result, rerender } = renderHook(({ units }) => useAssetMetadata(units), {
+    initialProps: { units: ["unitA", "unitB"] },
+  });
+  await waitFor(() => expect(Object.keys(result.current)).toHaveLength(2));
+  expect(spy).toHaveBeenCalledTimes(2);
+
+  rerender({ units: ["unitB", "unitA"] });
+  // Give any (unwanted) effect re-run a tick to fire before asserting.
+  await Promise.resolve();
+  expect(spy).toHaveBeenCalledTimes(2);
 });

--- a/ui/web/src/api/hooks.ts
+++ b/ui/web/src/api/hooks.ts
@@ -11,6 +11,7 @@ import type {
   TPMStatus,
   Contact,
   DexPoolsResponse,
+  AssetInfo,
 } from "./types";
 import {
   getStatus,
@@ -24,6 +25,7 @@ import {
   getTPMStatus,
   getContacts,
   getDexPools,
+  getAssetMetadata,
 } from "./client";
 
 export interface AsyncState<T> {
@@ -123,3 +125,53 @@ export const useTPMStatus = (): AsyncState<TPMStatus> => useAsync(getTPMStatus);
 export const useContacts = (): AsyncState<Contact[]> => useAsync(getContacts);
 export const useDexPools = (): AsyncState<DexPoolsResponse> =>
   useAsync(getDexPools, { pollMs: 15000 });
+
+// useAssetMetadata looks up on-chain metadata for a set of native-asset units
+// (in parallel) and returns whatever resolved, keyed by unit. It is
+// deliberately NOT a single useAsync call: assets are looked up individually
+// against the node, and a lookup failing for one unit (not indexed, request
+// error, etc.) must not prevent the others from displaying — the Portfolio
+// screen falls back to the raw unit/quantity for any unit missing from the
+// returned map.
+export function useAssetMetadata(units: string[]): Record<string, AssetInfo> {
+  const [metadata, setMetadata] = useState<Record<string, AssetInfo>>({});
+  // Units are hex (policy id + asset name), so \0 can't collide with real
+  // content; this just gives useEffect a stable dependency for "same set".
+  // Dedupe + sort first so the key reflects set semantics — the caller only
+  // cares which units are present, not their order or repeat count — so a
+  // reorder (or a duplicate) of the same units doesn't retrigger lookups.
+  const key = [...new Set(units)].sort().join("\0");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (units.length === 0) {
+      setMetadata({});
+      return;
+    }
+
+    Promise.allSettled(
+      units.map((unit) => getAssetMetadata(unit).then((info) => [unit, info] as const)),
+    ).then((results) => {
+      if (cancelled) return;
+      const next: Record<string, AssetInfo> = {};
+      for (const result of results) {
+        if (result.status === "fulfilled") {
+          const [unit, info] = result.value;
+          next[unit] = info;
+        }
+        // A rejected result is silently skipped: the caller's fallback path
+        // (raw unit/quantity) covers it.
+      }
+      setMetadata(next);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+    // key summarizes `units` for this effect's purposes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  return metadata;
+}

--- a/ui/web/src/api/hooks.ts
+++ b/ui/web/src/api/hooks.ts
@@ -133,43 +133,42 @@ export const useDexPools = (): AsyncState<DexPoolsResponse> =>
 // error, etc.) must not prevent the others from displaying — the Portfolio
 // screen falls back to the raw unit/quantity for any unit missing from the
 // returned map.
-export function useAssetMetadata(units: string[]): Record<string, AssetInfo> {
-  const [metadata, setMetadata] = useState<Record<string, AssetInfo>>({});
+export function useAssetMetadata(units: string[]): Record<string, AssetInfo | undefined> {
+  const [metadata, setMetadata] = useState<Record<string, AssetInfo | undefined>>({});
   // Units are hex (policy id + asset name), so \0 can't collide with real
   // content; this just gives useEffect a stable dependency for "same set".
   // Dedupe + sort first so the key reflects set semantics — the caller only
   // cares which units are present, not their order or repeat count — so a
   // reorder (or a duplicate) of the same units doesn't retrigger lookups.
-  const key = [...new Set(units)].sort().join("\0");
+  const uniqueUnits = [...new Set(units)].sort();
+  const key = uniqueUnits.join("\0");
 
   useEffect(() => {
     let cancelled = false;
 
-    if (units.length === 0) {
-      setMetadata({});
-      return;
-    }
+    // Do not expose results for units from the previous request set while the
+    // new lookups are pending.
+    setMetadata({});
 
-    Promise.allSettled(
-      units.map((unit) => getAssetMetadata(unit).then((info) => [unit, info] as const)),
-    ).then((results) => {
-      if (cancelled) return;
-      const next: Record<string, AssetInfo> = {};
-      for (const result of results) {
-        if (result.status === "fulfilled") {
-          const [unit, info] = result.value;
-          next[unit] = info;
-        }
-        // A rejected result is silently skipped: the caller's fallback path
-        // (raw unit/quantity) covers it.
-      }
-      setMetadata(next);
-    });
+    // Publish each successful lookup immediately. A slow or rejected unit
+    // must not delay metadata that the node has already returned for another.
+    for (const unit of uniqueUnits) {
+      getAssetMetadata(unit)
+        .then((info) => {
+          if (!cancelled) {
+            setMetadata((current) => ({ ...current, [unit]: info }));
+          }
+        })
+        .catch(() => {
+          // Silently omit failures: callers fall back to the raw unit and
+          // quantity, and the return type makes that absence explicit.
+        });
+    }
 
     return () => {
       cancelled = true;
     };
-    // key summarizes `units` for this effect's purposes.
+    // key summarizes `uniqueUnits` for this effect's purposes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key]);
 

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -245,10 +245,10 @@ export interface DRepInfo {
 // identity, read from the embedded node (never an external token registry).
 // quantity here is the asset's total on-chain supply — NOT this wallet's
 // balance of it (see Balance/AssetBalance for that). onchain_metadata has no
-// fixed schema (CIP-25/68 define optional, standard-specific keys) and is
-// null on most assets today — the node does not yet index it for every
-// asset — so callers must read it defensively (see ../tokenMeta.ts) and fall
-// back to the raw unit/quantity when name/ticker/decimals are absent.
+// fixed schema (CIP-25/68 define optional, standard-specific keys). The
+// current dingo adapter always returns null; callers must read it defensively
+// (see ../tokenMeta.ts) and fall back to the raw unit/quantity until adapter
+// support lands.
 export interface AssetInfo {
   asset: string;
   policy_id: string;

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -241,6 +241,24 @@ export interface DRepInfo {
   live_stake: string;
 }
 
+// AssetInfo mirrors GET /wallet/assets/{unit}: a native asset's on-chain
+// identity, read from the embedded node (never an external token registry).
+// quantity here is the asset's total on-chain supply — NOT this wallet's
+// balance of it (see Balance/AssetBalance for that). onchain_metadata has no
+// fixed schema (CIP-25/68 define optional, standard-specific keys) and is
+// null on most assets today — the node does not yet index it for every
+// asset — so callers must read it defensively (see ../tokenMeta.ts) and fall
+// back to the raw unit/quantity when name/ticker/decimals are absent.
+export interface AssetInfo {
+  asset: string;
+  policy_id: string;
+  asset_name: string;
+  asset_name_ascii: string;
+  fingerprint: string;
+  quantity: string;
+  onchain_metadata: Record<string, unknown> | null;
+}
+
 export type VoteType = "abstain" | "no_confidence" | "drep" | "register_self";
 
 export interface VoteAnchor {

--- a/ui/web/src/format.test.ts
+++ b/ui/web/src/format.test.ts
@@ -1,4 +1,4 @@
-import { parseAda } from "./format";
+import { parseAda, formatTokenQuantity } from "./format";
 
 // --- parseAda tests ---
 
@@ -50,4 +50,55 @@ test("parseAda: rejects '' (empty string)", () => {
 
 test("parseAda: '0.0' is rejected (equals zero lovelace effectively? No, 0.0 = 0)", () => {
   expect(() => parseAda("0.0")).toThrow();
+});
+
+// --- formatTokenQuantity tests ---
+// The native-token generalization of formatAda (ADA is the 6-decimal special
+// case of lovelace); used once a native asset's decimals is known from its
+// on-chain metadata.
+
+test("formatTokenQuantity: applies 6 decimals like ADA", () => {
+  expect(formatTokenQuantity("4500000", 6)).toBe("4.5");
+});
+
+test("formatTokenQuantity: strips trailing zero fractional digits", () => {
+  expect(formatTokenQuantity("1000000", 6)).toBe("1");
+});
+
+test("formatTokenQuantity: keeps significant fractional digits", () => {
+  expect(formatTokenQuantity("1000001", 6)).toBe("1.000001");
+});
+
+test("formatTokenQuantity: works with 2 decimals", () => {
+  expect(formatTokenQuantity("150", 2)).toBe("1.5");
+});
+
+test("formatTokenQuantity: 0 decimals returns the raw integer unchanged", () => {
+  expect(formatTokenQuantity("12345", 0)).toBe("12345");
+});
+
+test("formatTokenQuantity: negative decimals is treated as no-op (returned unchanged)", () => {
+  expect(formatTokenQuantity("12345", -1)).toBe("12345");
+});
+
+test("formatTokenQuantity: a non-integer quantity string is returned unchanged", () => {
+  expect(formatTokenQuantity("abc", 6)).toBe("abc");
+});
+
+test("formatTokenQuantity: preserves values beyond 2^53 (no precision ceiling)", () => {
+  expect(formatTokenQuantity("9007199255000000", 6)).toBe("9007199255");
+});
+
+test("formatTokenQuantity: formats a negative quantity", () => {
+  expect(formatTokenQuantity("-1500000", 6)).toBe("-1.5");
+});
+
+test("formatTokenQuantity: decimals beyond the sane cap is returned unchanged (DoS guard)", () => {
+  // decimals comes from on-chain metadata anyone can mint arbitrary values
+  // into; an unbounded value must never reach BigInt exponentiation.
+  expect(formatTokenQuantity("12345", 1_000_000_000)).toBe("12345");
+});
+
+test("formatTokenQuantity: decimals at the cap boundary still formats normally", () => {
+  expect(formatTokenQuantity("1" + "0".repeat(18), 18)).toBe("1");
 });

--- a/ui/web/src/format.ts
+++ b/ui/web/src/format.ts
@@ -85,3 +85,46 @@ export function parseAda(ada: string): string {
 
   return lovelace.toString();
 }
+
+/**
+ * Convert a raw native-token quantity (decimal string, base units) to a
+ * display string using `decimals` fractional digits — the general form of
+ * formatAda (ADA/lovelace is simply the fixed 6-decimal case).
+ *
+ * Uses BigInt to avoid float precision loss on values beyond 2^53. Returns
+ * the input unchanged when it isn't a plain integer string, or when decimals
+ * is not a positive integer (nothing to apply) — so a malformed value or an
+ * asset with unknown decimals shows through rather than crashing the screen.
+ *
+ * `decimals` comes from on-chain asset metadata, which anyone can mint
+ * arbitrary values into (see tokenMeta.ts) — it is not trusted input. Values
+ * above MAX_TOKEN_DECIMALS are rejected (input returned unchanged) rather
+ * than fed to BigInt exponentiation, which would otherwise let an adversarial
+ * "decimals" value force an unbounded BigInt allocation and hang the tab.
+ *
+ * Examples:
+ *   formatTokenQuantity("4500000", 6) → "4.5"
+ *   formatTokenQuantity("150", 2)     → "1.5"
+ *   formatTokenQuantity("12345", 0)   → "12345"
+ */
+const MAX_TOKEN_DECIMALS = 18;
+
+export function formatTokenQuantity(quantity: string, decimals: number): string {
+  if (!Number.isInteger(decimals) || decimals <= 0 || decimals > MAX_TOKEN_DECIMALS) return quantity;
+  if (!/^-?\d+$/.test(quantity)) return quantity;
+
+  const base = BigInt(10) ** BigInt(decimals);
+  const raw = BigInt(quantity);
+  const isNegative = raw < BigInt(0);
+  const abs = isNegative ? -raw : raw;
+
+  const intPart = abs / base;
+  const fracPart = abs % base;
+
+  if (fracPart === BigInt(0)) {
+    return (isNegative ? "-" : "") + intPart.toString();
+  }
+
+  const fracStr = fracPart.toString().padStart(decimals, "0").replace(/0+$/, "");
+  return (isNegative ? "-" : "") + intPart.toString() + "." + fracStr;
+}

--- a/ui/web/src/screens/Portfolio.test.tsx
+++ b/ui/web/src/screens/Portfolio.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { Portfolio } from "./Portfolio";
 import * as hooks from "../api/hooks";
+import type { AssetInfo } from "../api/types";
 
 function mockBalance(lovelace: string, assets: { unit: string; quantity: string }[]) {
   vi.spyOn(hooks, "useBalance").mockReturnValue({
@@ -9,6 +10,10 @@ function mockBalance(lovelace: string, assets: { unit: string; quantity: string 
     loading: false,
     refresh: vi.fn(),
   } as never);
+}
+
+function mockAssetMetadata(byUnit: Record<string, Partial<AssetInfo>>) {
+  vi.spyOn(hooks, "useAssetMetadata").mockReturnValue(byUnit as never);
 }
 
 function mockDelegation(overrides: Partial<{
@@ -34,6 +39,12 @@ function mockDelegation(overrides: Partial<{
     refresh: vi.fn(),
   } as never);
 }
+
+beforeEach(() => {
+  // Default: no metadata resolved for any asset (the common case, since most
+  // assets have none on-chain). Individual tests override with mockAssetMetadata.
+  mockAssetMetadata({});
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -148,4 +159,101 @@ test("(h) fresh wallet with zero balance is valid — not an error", () => {
   // Should show "0 ADA" in the balance card without an error state.
   expect(screen.getByText(/^0 ADA$/)).toBeInTheDocument();
   expect(screen.queryByRole("alert")).toBeNull();
+});
+
+// --- on-chain token metadata + search/filter ---
+
+function makeAssetInfo(unit: string, metadata: Record<string, unknown> | null): AssetInfo {
+  return {
+    asset: unit,
+    policy_id: unit.slice(0, 56),
+    asset_name: unit.slice(56),
+    asset_name_ascii: "",
+    fingerprint: "",
+    quantity: "0",
+    onchain_metadata: metadata,
+  };
+}
+
+test("(i) shows on-chain name and decimals-applied quantity when metadata is available", () => {
+  const unit = "a".repeat(56) + "746f6b656e";
+  mockBalance("4500000", [{ unit, quantity: "1500000" }]);
+  mockDelegation();
+  mockAssetMetadata({
+    [unit]: makeAssetInfo(unit, { name: "Space Coin", ticker: "SPC", decimals: 6 }),
+  });
+
+  render(<Portfolio />);
+
+  expect(screen.getByText("Space Coin")).toBeInTheDocument();
+  expect(screen.getByText("1.5")).toBeInTheDocument();
+  expect(screen.queryByText(unit)).not.toBeInTheDocument();
+});
+
+test("(j) an asset with no resolved metadata falls back to its raw unit/quantity, even when a sibling asset has metadata", () => {
+  const known = "a".repeat(56) + "746f6b656e";
+  const unknown = "b".repeat(56) + "756e6b6e6f776e";
+  mockBalance("4500000", [
+    { unit: known, quantity: "1500000" },
+    { unit: unknown, quantity: "42" },
+  ]);
+  mockDelegation();
+  mockAssetMetadata({ [known]: makeAssetInfo(known, { name: "Space Coin", decimals: 6 }) });
+
+  render(<Portfolio />);
+
+  expect(screen.getByText("Space Coin")).toBeInTheDocument();
+  expect(screen.getByText(unknown)).toBeInTheDocument();
+  expect(screen.getByText("42")).toBeInTheDocument();
+});
+
+test("(k) search box filters the token list by on-chain name", () => {
+  const spc = "a".repeat(56) + "746f6b656e";
+  const other = "b".repeat(56) + "756e6b6e6f776e";
+  mockBalance("0", [
+    { unit: spc, quantity: "10" },
+    { unit: other, quantity: "20" },
+  ]);
+  mockDelegation();
+  mockAssetMetadata({ [spc]: makeAssetInfo(spc, { name: "Space Coin" }) });
+
+  render(<Portfolio />);
+
+  expect(screen.getByText("Space Coin")).toBeInTheDocument();
+  expect(screen.getByText(other)).toBeInTheDocument();
+
+  fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: "space" } });
+
+  expect(screen.getByText("Space Coin")).toBeInTheDocument();
+  expect(screen.queryByText(other)).not.toBeInTheDocument();
+});
+
+test("(k2) search box also matches on the raw unit when there is no metadata", () => {
+  mockBalance("0", [{ unit: "lovelace_unit.TokenA", quantity: "5" }]);
+  mockDelegation();
+
+  render(<Portfolio />);
+  fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: "tokena" } });
+
+  expect(screen.getByText("lovelace_unit.TokenA")).toBeInTheDocument();
+});
+
+test("(l) a search with no matches shows an empty-results message instead of the table", () => {
+  mockBalance("0", [{ unit: "lovelace_unit.TokenA", quantity: "5" }]);
+  mockDelegation();
+
+  render(<Portfolio />);
+  fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: "nomatch" } });
+
+  expect(screen.queryByText("lovelace_unit.TokenA")).not.toBeInTheDocument();
+  expect(screen.getByText(/no tokens match/i)).toBeInTheDocument();
+});
+
+test("(m) the search box is not rendered when there are no native tokens", () => {
+  mockBalance("0", []);
+  mockDelegation();
+
+  render(<Portfolio />);
+
+  expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
 });

--- a/ui/web/src/screens/Portfolio.tsx
+++ b/ui/web/src/screens/Portfolio.tsx
@@ -1,12 +1,23 @@
-import { useBalance, useDelegation } from "../api/hooks";
+import { useMemo, useState } from "react";
+import { useBalance, useDelegation, useAssetMetadata } from "../api/hooks";
 import { Card } from "../components/Card";
 import { Table } from "../components/Table";
 import { StatusPill } from "../components/StatusPill";
-import { formatAda } from "../format";
+import { Input } from "../components/Input";
+import { formatAda, formatTokenQuantity } from "../format";
+import { extractAssetMeta, assetDisplayName, assetMatchesQuery } from "../tokenMeta";
 
 export function Portfolio() {
   const balance = useBalance();
   const delegation = useDelegation();
+  const [query, setQuery] = useState("");
+
+  // Metadata is looked up per-asset through the node (node-only; see
+  // tokenMeta.ts) and applied on a best-effort basis below — a missing or
+  // failed lookup for one asset never blocks the rest of the portfolio.
+  const units = useMemo(() => (balance.data?.assets ?? []).map((a) => a.unit), [balance.data]);
+  const metadataByUnit = useAssetMetadata(units);
+  const assets = balance.data?.assets ?? [];
 
   // Show a single loading state if either hook is still loading.
   if (balance.loading || delegation.loading) {
@@ -21,18 +32,26 @@ export function Portfolio() {
     return <p role="alert" className="error-text">{delegation.error.message}</p>;
   }
 
-  const bal = balance.data;
   const del = delegation.data;
 
   // A fresh wallet returns zeros/empty — treat it as valid, not an error.
-  const lovelace = bal?.lovelace ?? "0";
-  const assets = bal?.assets ?? [];
+  const lovelace = balance.data?.lovelace ?? "0";
+
+  const visibleAssets = assets.filter((a) =>
+    assetMatchesQuery(a.unit, extractAssetMeta(metadataByUnit[a.unit]), query),
+  );
 
   const tokenColumns = [
-    { key: "unit", label: "Unit" },
+    { key: "unit", label: "Asset" },
     { key: "quantity", label: "Quantity" },
   ];
-  const tokenRows = assets.map((a) => ({ unit: a.unit, quantity: a.quantity }));
+  const tokenRows = visibleAssets.map((a) => {
+    const meta = extractAssetMeta(metadataByUnit[a.unit]);
+    return {
+      unit: assetDisplayName(a.unit, meta),
+      quantity: meta.decimals !== undefined ? formatTokenQuantity(a.quantity, meta.decimals) : a.quantity,
+    };
+  });
 
   return (
     <div className="portfolio">
@@ -44,7 +63,21 @@ export function Portfolio() {
         {assets.length === 0 ? (
           <p className="muted">No native tokens</p>
         ) : (
-          <Table columns={tokenColumns} rows={tokenRows} />
+          <>
+            <Input
+              type="text"
+              className="token-search"
+              placeholder="Search by name, ticker, policy, or unit…"
+              aria-label="Search native tokens"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+            {visibleAssets.length === 0 ? (
+              <p className="muted">No tokens match &ldquo;{query}&rdquo;</p>
+            ) : (
+              <Table columns={tokenColumns} rows={tokenRows} />
+            )}
+          </>
         )}
       </Card>
 

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -520,6 +520,11 @@ a:hover {
   margin-top: var(--space-3);
 }
 
+/* Native-token search/filter box (Portfolio). */
+.token-search {
+  margin-bottom: var(--space-3);
+}
+
 /* ---------------------------------------------------------------- tables -- */
 .table-wrap {
   overflow-x: auto;

--- a/ui/web/src/tokenMeta.test.ts
+++ b/ui/web/src/tokenMeta.test.ts
@@ -1,0 +1,100 @@
+import { extractAssetMeta, assetDisplayName, assetMatchesQuery, policyIdOf } from "./tokenMeta";
+import type { AssetInfo } from "./api/types";
+
+function makeInfo(onchainMetadata: unknown): AssetInfo {
+  return {
+    asset: "policy123746f6b656e",
+    policy_id: "policy123",
+    asset_name: "746f6b656e",
+    asset_name_ascii: "token",
+    fingerprint: "asset1xyz",
+    quantity: "1000000",
+    onchain_metadata: onchainMetadata as AssetInfo["onchain_metadata"],
+  };
+}
+
+// --- extractAssetMeta ---
+
+test("extractAssetMeta: reads name/ticker/decimals when present", () => {
+  const info = makeInfo({ name: "Token", ticker: "TOK", decimals: 6 });
+  expect(extractAssetMeta(info)).toEqual({ name: "Token", ticker: "TOK", decimals: 6 });
+});
+
+test("extractAssetMeta: falls back to symbol when ticker absent", () => {
+  const info = makeInfo({ name: "Token", symbol: "TOK" });
+  expect(extractAssetMeta(info)).toEqual({ name: "Token", ticker: "TOK" });
+});
+
+test("extractAssetMeta: returns {} when onchain_metadata is null (dingo's current default)", () => {
+  expect(extractAssetMeta(makeInfo(null))).toEqual({});
+});
+
+test("extractAssetMeta: returns {} when info is undefined (lookup not yet resolved / failed)", () => {
+  expect(extractAssetMeta(undefined)).toEqual({});
+});
+
+test("extractAssetMeta: ignores malformed fields (wrong types)", () => {
+  const info = makeInfo({ name: 123, ticker: [], decimals: "not-a-number" });
+  expect(extractAssetMeta(info)).toEqual({});
+});
+
+test("extractAssetMeta: accepts a numeric-string decimals", () => {
+  const info = makeInfo({ decimals: "6" });
+  expect(extractAssetMeta(info)).toEqual({ decimals: 6 });
+});
+
+test("extractAssetMeta: trims whitespace-only name/ticker to absent", () => {
+  const info = makeInfo({ name: "   ", ticker: "  " });
+  expect(extractAssetMeta(info)).toEqual({});
+});
+
+test("extractAssetMeta: rejects a negative decimals value", () => {
+  const info = makeInfo({ decimals: -1 });
+  expect(extractAssetMeta(info)).toEqual({});
+});
+
+// --- assetDisplayName ---
+
+test("assetDisplayName: prefers name, then ticker, then raw unit", () => {
+  expect(assetDisplayName("unit1", { name: "Token" })).toBe("Token");
+  expect(assetDisplayName("unit1", { ticker: "TOK" })).toBe("TOK");
+  expect(assetDisplayName("unit1", {})).toBe("unit1");
+});
+
+// --- policyIdOf ---
+
+test("policyIdOf: first 56 hex chars are the policy id", () => {
+  const policy = "a".repeat(56);
+  const unit = policy + "746f6b656e";
+  expect(policyIdOf(unit)).toBe(policy);
+});
+
+// --- assetMatchesQuery ---
+
+test("assetMatchesQuery: empty/whitespace query matches everything", () => {
+  expect(assetMatchesQuery("unit1", {}, "")).toBe(true);
+  expect(assetMatchesQuery("unit1", {}, "   ")).toBe(true);
+});
+
+test("assetMatchesQuery: matches by name (case-insensitive)", () => {
+  expect(assetMatchesQuery("unit1", { name: "SpaceCoin" }, "space")).toBe(true);
+  expect(assetMatchesQuery("unit1", { name: "SpaceCoin" }, "moon")).toBe(false);
+});
+
+test("assetMatchesQuery: matches by ticker", () => {
+  expect(assetMatchesQuery("unit1", { ticker: "SPC" }, "spc")).toBe(true);
+});
+
+test("assetMatchesQuery: matches by policy id", () => {
+  const policy = "b".repeat(56);
+  const unit = policy + "746f6b656e";
+  expect(assetMatchesQuery(unit, {}, policy.slice(0, 10))).toBe(true);
+});
+
+test("assetMatchesQuery: matches by raw unit substring when there is no metadata", () => {
+  expect(assetMatchesQuery("lovelace_unit.TokenA", {}, "tokena")).toBe(true);
+});
+
+test("assetMatchesQuery: no match returns false", () => {
+  expect(assetMatchesQuery("unit1", { name: "Token" }, "nomatch")).toBe(false);
+});

--- a/ui/web/src/tokenMeta.test.ts
+++ b/ui/web/src/tokenMeta.test.ts
@@ -1,4 +1,4 @@
-import { extractAssetMeta, assetDisplayName, assetMatchesQuery, policyIdOf } from "./tokenMeta";
+import { extractAssetMeta, assetDisplayName, assetMatchesQuery } from "./tokenMeta";
 import type { AssetInfo } from "./api/types";
 
 function makeInfo(onchainMetadata: unknown): AssetInfo {
@@ -23,6 +23,11 @@ test("extractAssetMeta: reads name/ticker/decimals when present", () => {
 test("extractAssetMeta: falls back to symbol when ticker absent", () => {
   const info = makeInfo({ name: "Token", symbol: "TOK" });
   expect(extractAssetMeta(info)).toEqual({ name: "Token", ticker: "TOK" });
+});
+
+test("extractAssetMeta: falls back to symbol when ticker is empty", () => {
+  const info = makeInfo({ ticker: "  ", symbol: "TOK" });
+  expect(extractAssetMeta(info)).toEqual({ ticker: "TOK" });
 });
 
 test("extractAssetMeta: returns {} when onchain_metadata is null (dingo's current default)", () => {
@@ -59,14 +64,6 @@ test("assetDisplayName: prefers name, then ticker, then raw unit", () => {
   expect(assetDisplayName("unit1", { name: "Token" })).toBe("Token");
   expect(assetDisplayName("unit1", { ticker: "TOK" })).toBe("TOK");
   expect(assetDisplayName("unit1", {})).toBe("unit1");
-});
-
-// --- policyIdOf ---
-
-test("policyIdOf: first 56 hex chars are the policy id", () => {
-  const policy = "a".repeat(56);
-  const unit = policy + "746f6b656e";
-  expect(policyIdOf(unit)).toBe(policy);
 });
 
 // --- assetMatchesQuery ---

--- a/ui/web/src/tokenMeta.ts
+++ b/ui/web/src/tokenMeta.ts
@@ -31,9 +31,11 @@ export function extractAssetMeta(info: AssetInfo | undefined): AssetDisplayMeta 
     result.name = name.trim();
   }
 
-  const ticker = meta.ticker ?? meta.symbol;
-  if (typeof ticker === "string" && ticker.trim() !== "") {
-    result.ticker = ticker.trim();
+  for (const ticker of [meta.ticker, meta.symbol]) {
+    if (typeof ticker === "string" && ticker.trim() !== "") {
+      result.ticker = ticker.trim();
+      break;
+    }
   }
 
   const decimalsRaw = meta.decimals;
@@ -49,13 +51,6 @@ export function extractAssetMeta(info: AssetInfo | undefined): AssetDisplayMeta 
 /** Display label for a native asset: metadata name, else ticker, else the raw unit (policy id + hex asset name). */
 export function assetDisplayName(unit: string, meta: AssetDisplayMeta): string {
   return meta.name || meta.ticker || unit;
-}
-
-/** A Cardano policy ID is 28 bytes = 56 hex chars; unit = policy ID + hex asset name. */
-const POLICY_ID_HEX_LENGTH = 56;
-
-export function policyIdOf(unit: string): string {
-  return unit.slice(0, POLICY_ID_HEX_LENGTH);
 }
 
 /**

--- a/ui/web/src/tokenMeta.ts
+++ b/ui/web/src/tokenMeta.ts
@@ -1,0 +1,76 @@
+import type { AssetInfo } from "./api/types";
+
+/**
+ * Best-effort display metadata for a native asset, extracted from its
+ * on-chain metadata (AssetInfo.onchain_metadata, from GET /wallet/assets/{unit}).
+ * All fields are optional: most assets have none today (dingo does not yet
+ * index on-chain asset metadata), and there is no single fixed schema even
+ * when it is present (CIP-25 targets NFTs; fungible-token conventions vary).
+ */
+export interface AssetDisplayMeta {
+  name?: string;
+  ticker?: string;
+  decimals?: number;
+}
+
+/**
+ * Reads a handful of commonly-used on-chain-metadata keys defensively:
+ * "name", "ticker" (or "symbol"), and "decimals" (number or numeric string).
+ * Anything missing, null, or the wrong shape is silently ignored — a
+ * malformed or absent metadata object must never break the Portfolio screen,
+ * it just yields {} and callers fall back to the raw unit/quantity.
+ */
+export function extractAssetMeta(info: AssetInfo | undefined): AssetDisplayMeta {
+  const meta = info?.onchain_metadata;
+  if (!meta || typeof meta !== "object") return {};
+
+  const result: AssetDisplayMeta = {};
+
+  const name = meta.name;
+  if (typeof name === "string" && name.trim() !== "") {
+    result.name = name.trim();
+  }
+
+  const ticker = meta.ticker ?? meta.symbol;
+  if (typeof ticker === "string" && ticker.trim() !== "") {
+    result.ticker = ticker.trim();
+  }
+
+  const decimalsRaw = meta.decimals;
+  if (typeof decimalsRaw === "number" && Number.isInteger(decimalsRaw) && decimalsRaw >= 0) {
+    result.decimals = decimalsRaw;
+  } else if (typeof decimalsRaw === "string" && /^\d+$/.test(decimalsRaw)) {
+    result.decimals = parseInt(decimalsRaw, 10);
+  }
+
+  return result;
+}
+
+/** Display label for a native asset: metadata name, else ticker, else the raw unit (policy id + hex asset name). */
+export function assetDisplayName(unit: string, meta: AssetDisplayMeta): string {
+  return meta.name || meta.ticker || unit;
+}
+
+/** A Cardano policy ID is 28 bytes = 56 hex chars; unit = policy ID + hex asset name. */
+const POLICY_ID_HEX_LENGTH = 56;
+
+export function policyIdOf(unit: string): string {
+  return unit.slice(0, POLICY_ID_HEX_LENGTH);
+}
+
+/**
+ * Whether a native asset row matches a search query: a case-insensitive
+ * substring match against its display name, ticker, and raw unit (which
+ * already covers the policy ID, since unit = policy ID + hex asset name —
+ * any substring match against the policy ID alone is also a substring match
+ * against unit). An empty/whitespace-only query matches everything.
+ */
+export function assetMatchesQuery(unit: string, meta: AssetDisplayMeta, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (q === "") return true;
+
+  const haystacks = [unit, meta.name, meta.ticker].filter(
+    (s): s is string => typeof s === "string" && s.length > 0,
+  );
+  return haystacks.some((s) => s.toLowerCase().includes(q));
+}


### PR DESCRIPTION
Shows on-chain native-token name/ticker and applies decimals in Portfolio, with search/filter; falls back to raw policy+hex when metadata is absent. Node-only. Dormant until dingo populates on-chain asset metadata (blinklabs-io/dingo#2485).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds node-backed on-chain native-token metadata and a Portfolio search/filter. The UI shows token name/ticker and formats quantities using on-chain decimals, falling back to raw unit/quantity; node-only and dormant until `blinklabs-io/dingo#2485` indexes metadata.

- **New Features**
  - Backend: `NodeLookup` adds `Asset(ctx, unit)`; new GET `/wallet/assets/{unit}` returns `AssetInfo` with raw `onchain_metadata`; 404 → not found, others → 502; gated (503) until the node serves queries.
  - Frontend: `getAssetMetadata()`/`useAssetMetadata()` fetch per-unit metadata in parallel, dedupe/order-safe, publish partial results, and skip failures; `tokenMeta` helpers (extract name/ticker/decimals, display name, match by name/ticker/policy/unit); `formatTokenQuantity()` uses BigInt, trims trailing zeros, caps decimals at 18; Portfolio shows name/ticker, applies decimals, adds a search box with empty-state, and falls back cleanly when metadata is missing.

<sup>Written for commit 9f955bfa977a115b88205bc05aa6055d14a24448. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

