### PR TITLE
feat(ui): idle auto-lock timeout setting

### DIFF
--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -149,8 +149,9 @@ func WithLegacyKeystore(ks LegacyKeystore) HandlerOption {
 // SettingsController is the user-facing app-settings surface. It exposes the
 // persisted lean-node (history-expiry) profile and whether a node restart is
 // still needed for the persisted value to take effect (history expiry is a
-// node-construction option, applied only at node start). It is decoupled from
-// the storage and supervisor packages so the API can be tested with a fake.
+// node-construction option, applied only at node start), plus the idle
+// auto-lock timeout. It is decoupled from the storage and supervisor packages
+// so the API can be tested with a fake.
 type SettingsController interface {
 	HistoryExpiry() bool
 	SetHistoryExpiry(enabled bool) error
@@ -158,7 +159,25 @@ type SettingsController interface {
 	// with a different history-expiry value than what is now persisted (so the
 	// change has not taken effect yet).
 	HistoryExpiryRestartRequired() bool
+	// AutoLockMinutes reports the persisted idle auto-lock timeout in minutes;
+	// 0 means "Off" (auto-lock disabled). It is a pure client-side/UI setting —
+	// no node behaviour depends on it — so unlike history-expiry it never needs
+	// a restart to take effect.
+	AutoLockMinutes() int
+	// SetAutoLockMinutes persists the idle auto-lock timeout. It rejects any
+	// value outside the offered set (see settings.AutoLockOptions).
+	SetAutoLockMinutes(minutes int) error
 }
+
+// autoLockOptions are the only accepted auto-lock timeouts (minutes; 0 = Off).
+// Mirrors settings.AutoLockOptions — duplicated here (like the frontend's
+// MIN_PASSWORD_LEN mirroring keystore.MinPasswordLen) so this package stays
+// decoupled from the settings package and can be exercised with a fake. Also
+// mirrored a third time in the frontend's AUTO_LOCK_OPTIONS
+// (web/src/screens/Settings.tsx). TestAutoLockOptionsMatchesSettingsPackage in
+// api_test.go guards this set against settings.AutoLockOptions drifting apart;
+// keep the frontend list in sync by hand.
+var autoLockOptions = map[int]bool{0: true, 1: true, 5: true, 15: true, 30: true}
 
 // PoolOps is the Stake Pool Operations surface the API exposes. Credential
 // generation and seed-derived certificate/opcert building need the active
@@ -689,6 +708,36 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 			"enabled":          settings.HistoryExpiry(),
 			"restart_required": settings.HistoryExpiryRestartRequired(),
 		})
+	})
+
+	// App settings: the idle auto-lock timeout. Ungated for the same reason as
+	// history-expiry — it is a local UI preference, not a node query. Unlike
+	// history-expiry it takes effect immediately (the frontend's idle timer
+	// reads it directly), so there is no restart_required field.
+	mux.HandleFunc("GET /wallet/settings/auto-lock", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]int{"minutes": settings.AutoLockMinutes()})
+	})
+	mux.HandleFunc("PUT /wallet/settings/auto-lock", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Minutes *int `json:"minutes"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+			return
+		}
+		if req.Minutes == nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "minutes is required"})
+			return
+		}
+		if !autoLockOptions[*req.Minutes] {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid auto-lock timeout"})
+			return
+		}
+		if err := settings.SetAutoLockMinutes(*req.Minutes); err != nil {
+			writeJSON(w, http.StatusInternalServerError, errBody(err))
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]int{"minutes": settings.AutoLockMinutes()})
 	})
 
 	// CIP-8 / CIP-30 message verification — the inverse of sign-data. Pure

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/blinklabs-io/bursa/ui/internal/chain"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/poolops"
+	"github.com/blinklabs-io/bursa/ui/internal/settings"
 	"github.com/blinklabs-io/bursa/ui/internal/spend"
 	"github.com/blinklabs-io/bursa/ui/internal/supervisor"
 	"github.com/blinklabs-io/bursa/ui/internal/vault"
@@ -218,6 +219,11 @@ type fakeSettings struct {
 	setErr          error
 	setCalledWith   bool
 	setCalled       bool
+
+	autoLockMinutes       int
+	setAutoLockErr        error
+	setAutoLockCalled     bool
+	setAutoLockCalledWith int
 }
 
 func (f *fakeSettings) HistoryExpiry() bool { return f.enabled }
@@ -233,6 +239,18 @@ func (f *fakeSettings) SetHistoryExpiry(enabled bool) error {
 }
 
 func (f *fakeSettings) HistoryExpiryRestartRequired() bool { return f.restartRequired }
+
+func (f *fakeSettings) AutoLockMinutes() int { return f.autoLockMinutes }
+
+func (f *fakeSettings) SetAutoLockMinutes(minutes int) error {
+	f.setAutoLockCalled = true
+	f.setAutoLockCalledWith = minutes
+	if f.setAutoLockErr != nil {
+		return f.setAutoLockErr
+	}
+	f.autoLockMinutes = minutes
+	return nil
+}
 
 func (f *fakeVault) TPMStatus() vault.TPMStatusInfo { return f.tpmStatus }
 
@@ -1499,6 +1517,148 @@ func TestPutHistoryExpiryPersistError(t *testing.T) {
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("PUT history-expiry with persist error = %d, want 500", rec.Code)
+	}
+}
+
+func decodeAutoLock(t *testing.T, body *bytes.Buffer) int {
+	t.Helper()
+	var got struct {
+		Minutes *int `json:"minutes"`
+	}
+	if err := json.NewDecoder(body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Minutes == nil {
+		t.Fatal("response missing minutes")
+	}
+	return *got.Minutes
+}
+
+func TestGetAutoLockReturnsPersistedValue(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStopped}}
+	set := &fakeSettings{autoLockMinutes: 30}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/settings/auto-lock", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET auto-lock = %d, want 200", rec.Code)
+	}
+	if got := decodeAutoLock(t, rec.Body); got != 30 {
+		t.Fatalf("GET auto-lock minutes = %d, want 30", got)
+	}
+}
+
+func TestPutAutoLockPersists(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	set := &fakeSettings{autoLockMinutes: 15}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"minutes":5}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT auto-lock = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if !set.setAutoLockCalled || set.setAutoLockCalledWith != 5 {
+		t.Fatalf("SetAutoLockMinutes not called with 5: called=%v with=%v", set.setAutoLockCalled, set.setAutoLockCalledWith)
+	}
+	if got := decodeAutoLock(t, rec.Body); got != 5 {
+		t.Fatalf("PUT auto-lock response minutes = %d, want 5", got)
+	}
+}
+
+func TestPutAutoLockAcceptsOff(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	set := &fakeSettings{autoLockMinutes: 15}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"minutes":0}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT auto-lock 0 (Off) = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if got := decodeAutoLock(t, rec.Body); got != 0 {
+		t.Fatalf("PUT auto-lock response minutes = %d, want 0", got)
+	}
+}
+
+func TestPutAutoLockInvalidJSON(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	set := &fakeSettings{}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{not json`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("PUT auto-lock with bad JSON = %d, want 400", rec.Code)
+	}
+	if set.setAutoLockCalled {
+		t.Fatal("SetAutoLockMinutes must not be called on a bad request body")
+	}
+}
+
+func TestPutAutoLockRequiresExplicitMinutes(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	set := &fakeSettings{}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("PUT auto-lock with no minutes = %d, want 400", rec.Code)
+	}
+	if set.setAutoLockCalled {
+		t.Fatal("SetAutoLockMinutes must not be called without an explicit minutes value")
+	}
+}
+
+func TestPutAutoLockRejectsOutOfSetValue(t *testing.T) {
+	for _, bad := range []int{-1, 2, 60} {
+		st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+		set := &fakeSettings{}
+		h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
+		rec := httptest.NewRecorder()
+		body := bytes.NewBufferString(fmt.Sprintf(`{"minutes":%d}`, bad))
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("PUT auto-lock with %d = %d, want 400", bad, rec.Code)
+		}
+		if set.setAutoLockCalled {
+			t.Fatalf("SetAutoLockMinutes must not be called for out-of-set value %d", bad)
+		}
+	}
+}
+
+func TestPutAutoLockPersistError(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	set := &fakeSettings{setAutoLockErr: errors.New("disk full")}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, nil, &fakePoolOps{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"minutes":5}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("PUT auto-lock with persist error = %d, want 500", rec.Code)
+	}
+}
+
+// TestAutoLockOptionsMatchesSettingsPackage guards against the api-layer's
+// autoLockOptions (duplicated for decoupling, see its doc comment) silently
+// drifting from settings.AutoLockOptions — the two must always accept exactly
+// the same set of timeouts. The frontend's AUTO_LOCK_OPTIONS
+// (web/src/screens/Settings.tsx) duplicates the same set again for the <Select>
+// and is guarded only by a cross-referencing comment, since it lives outside
+// the Go module.
+func TestAutoLockOptionsMatchesSettingsPackage(t *testing.T) {
+	want := make(map[int]bool, len(settings.AutoLockOptions))
+	for _, v := range settings.AutoLockOptions {
+		want[v] = true
+	}
+	if len(autoLockOptions) != len(want) {
+		t.Fatalf("autoLockOptions has %d entries, settings.AutoLockOptions has %d: %v vs %v", len(autoLockOptions), len(want), autoLockOptions, want)
+	}
+	for v := range want {
+		if !autoLockOptions[v] {
+			t.Fatalf("autoLockOptions is missing %d, present in settings.AutoLockOptions", v)
+		}
 	}
 }
 

--- a/ui/internal/boot/boot.go
+++ b/ui/internal/boot/boot.go
@@ -393,6 +393,15 @@ func (c *settingsController) HistoryExpiryRestartRequired() bool {
 	return applied != c.store.HistoryExpiry()
 }
 
+// AutoLockMinutes and SetAutoLockMinutes pass straight through to the
+// persisted settings store: unlike history-expiry, the idle auto-lock timeout
+// is pure frontend behaviour with no node-construction dependency.
+func (c *settingsController) AutoLockMinutes() int { return c.store.AutoLockMinutes() }
+
+func (c *settingsController) SetAutoLockMinutes(minutes int) error {
+	return c.store.SetAutoLockMinutes(minutes)
+}
+
 // genesisAdapter adapts the loopback Blockfrost chain client to the genesis
 // subset the SPO toolkit's KES-period math needs.
 type genesisAdapter struct{ c *chain.Client }

--- a/ui/internal/settings/settings.go
+++ b/ui/internal/settings/settings.go
@@ -37,12 +37,42 @@ const settingsVersion = 1
 // a few hundred bytes; anything larger is not one of ours.
 const maxSettingsLen = 64 * 1024
 
+// defaultAutoLockMinutes is the idle auto-lock timeout used until the user
+// persists a choice: a sensible middle ground between "never" (0, i.e. Off)
+// and the shortest offered timeout.
+const defaultAutoLockMinutes = 15
+
+// AutoLockOptions are the only accepted auto-lock timeouts, in minutes. 0 means
+// "Off" (idle auto-lock disabled). Exported so the API layer and its tests can
+// validate against the same set without duplicating the literal values. The API
+// package still keeps its own copy (internal/api/api.go's autoLockOptions) to
+// stay decoupled — internal/api/api_test.go's
+// TestAutoLockOptionsMatchesSettingsPackage asserts the two stay equal. The
+// frontend's AUTO_LOCK_OPTIONS (web/src/screens/Settings.tsx) is a third copy,
+// kept in sync by hand.
+var AutoLockOptions = []int{0, 1, 5, 15, 30}
+
+// ErrInvalidAutoLockMinutes is returned by SetAutoLockMinutes for any value not
+// in AutoLockOptions.
+var ErrInvalidAutoLockMinutes = errors.New("invalid auto-lock timeout")
+
+func isValidAutoLockMinutes(m int) bool {
+	for _, v := range AutoLockOptions {
+		if v == m {
+			return true
+		}
+	}
+	return false
+}
+
 // data is the on-disk shape. Booleans use a pointer so a missing key (absent
 // field) is distinguishable from an explicit false — only a present value counts
-// as "persisted" for seeding purposes.
+// as "persisted" for seeding purposes. AutoLockMinutes uses a pointer for the
+// same reason: nil (absent) means "no choice persisted yet, use the default".
 type data struct {
-	Version       int   `json:"version"`
-	HistoryExpiry *bool `json:"history_expiry,omitempty"`
+	Version         int   `json:"version"`
+	HistoryExpiry   *bool `json:"history_expiry,omitempty"`
+	AutoLockMinutes *int  `json:"auto_lock_minutes,omitempty"`
 }
 
 // Store is a settings file at Path. It is safe for concurrent use: every method
@@ -115,6 +145,45 @@ func (s *Store) SeedDefault(enabled bool) error {
 	old := s.d
 	v := enabled
 	s.d.HistoryExpiry = &v
+	if committed, err := s.writeLocked(); err != nil {
+		if !committed {
+			s.d = old
+		}
+		return err
+	}
+	return nil
+}
+
+// AutoLockMinutes reports the persisted idle auto-lock timeout, in minutes,
+// defaulting to defaultAutoLockMinutes when no value has ever been persisted
+// OR when the persisted value is no longer one of AutoLockOptions (e.g. a
+// hand-edited or older/newer-version settings file) — an invalid value must
+// never propagate out as a lock timeout. 0 means auto-lock is off.
+func (s *Store) AutoLockMinutes() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.d.AutoLockMinutes == nil {
+		return defaultAutoLockMinutes
+	}
+	v := *s.d.AutoLockMinutes
+	if !isValidAutoLockMinutes(v) {
+		return defaultAutoLockMinutes
+	}
+	return v
+}
+
+// SetAutoLockMinutes persists the idle auto-lock timeout and atomically writes
+// the file. minutes must be one of AutoLockOptions (0 disables auto-lock);
+// anything else returns ErrInvalidAutoLockMinutes without touching the store.
+func (s *Store) SetAutoLockMinutes(minutes int) error {
+	if !isValidAutoLockMinutes(minutes) {
+		return fmt.Errorf("%w: %d", ErrInvalidAutoLockMinutes, minutes)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	old := s.d
+	v := minutes
+	s.d.AutoLockMinutes = &v
 	if committed, err := s.writeLocked(); err != nil {
 		if !committed {
 			s.d = old

--- a/ui/internal/settings/settings_test.go
+++ b/ui/internal/settings/settings_test.go
@@ -214,6 +214,134 @@ func TestSetHistoryExpiryDoesNotRollBackAfterRename(t *testing.T) {
 	}
 }
 
+// TestAutoLockDefaultsWhenAbsent: a missing settings file yields the
+// documented default timeout (15 minutes), not "Off".
+func TestAutoLockDefaultsWhenAbsent(t *testing.T) {
+	s, err := Load(tmpPath(t))
+	if err != nil {
+		t.Fatalf("Load with no file: %v", err)
+	}
+	if got := s.AutoLockMinutes(); got != defaultAutoLockMinutes {
+		t.Fatalf("AutoLockMinutes() = %d, want default %d", got, defaultAutoLockMinutes)
+	}
+}
+
+// TestAutoLockSetPersistsRoundTrip: setting the value writes the file, and a
+// fresh Load reads it back — including "Off" (0), which must survive the
+// round trip distinctly from "never persisted" (which also reads back as a
+// non-zero default, so this specifically exercises the persisted-zero path).
+func TestAutoLockSetPersistsRoundTrip(t *testing.T) {
+	path := tmpPath(t)
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := s.SetAutoLockMinutes(5); err != nil {
+		t.Fatalf("SetAutoLockMinutes(5): %v", err)
+	}
+	if got := s.AutoLockMinutes(); got != 5 {
+		t.Fatalf("in-memory AutoLockMinutes() = %d, want 5", got)
+	}
+
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got := reloaded.AutoLockMinutes(); got != 5 {
+		t.Fatalf("reloaded AutoLockMinutes() = %d, want persisted 5", got)
+	}
+
+	// Explicitly persisting "Off" (0) must survive reload as 0, not fall back
+	// to the default.
+	if err := reloaded.SetAutoLockMinutes(0); err != nil {
+		t.Fatalf("SetAutoLockMinutes(0): %v", err)
+	}
+	again, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload after off: %v", err)
+	}
+	if got := again.AutoLockMinutes(); got != 0 {
+		t.Fatalf("reloaded AutoLockMinutes() = %d, want persisted 0 (Off)", got)
+	}
+}
+
+// TestAutoLockRejectsInvalidValues: only the documented options are accepted;
+// an out-of-set value is rejected without mutating the in-memory value or
+// touching disk.
+func TestAutoLockRejectsInvalidValues(t *testing.T) {
+	for _, bad := range []int{-1, 2, 10, 60, 1000} {
+		path := tmpPath(t)
+		s, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if err := s.SetAutoLockMinutes(bad); !errors.Is(err, ErrInvalidAutoLockMinutes) {
+			t.Fatalf("SetAutoLockMinutes(%d) error = %v, want ErrInvalidAutoLockMinutes", bad, err)
+		}
+		if got := s.AutoLockMinutes(); got != defaultAutoLockMinutes {
+			t.Fatalf("rejected SetAutoLockMinutes(%d) must leave the default in place, got %d", bad, got)
+		}
+		if _, err := os.Stat(path); err == nil {
+			t.Fatalf("rejected SetAutoLockMinutes(%d) must not write a settings file", bad)
+		}
+	}
+}
+
+// TestAutoLockAllOptionsAccepted: every documented option round-trips.
+func TestAutoLockAllOptionsAccepted(t *testing.T) {
+	for _, v := range AutoLockOptions {
+		path := tmpPath(t)
+		s, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if err := s.SetAutoLockMinutes(v); err != nil {
+			t.Fatalf("SetAutoLockMinutes(%d): %v", v, err)
+		}
+		if got := s.AutoLockMinutes(); got != v {
+			t.Fatalf("AutoLockMinutes() = %d, want %d", got, v)
+		}
+	}
+}
+
+// TestAutoLockMinutesFallsBackOnInvalidPersistedValue: a settings file that
+// was hand-edited (or written by an older/newer version with a different
+// option set) can contain an auto_lock_minutes value outside AutoLockOptions.
+// AutoLockMinutes must not pass such a value through as-is — it must fall
+// back to the default, the same as an absent value.
+func TestAutoLockMinutesFallsBackOnInvalidPersistedValue(t *testing.T) {
+	for _, bad := range []int{-1, 2, 10, 60, 1000} {
+		v := bad
+		s := &Store{
+			d: data{
+				Version:         settingsVersion,
+				AutoLockMinutes: &v,
+			},
+		}
+		if got := s.AutoLockMinutes(); got != defaultAutoLockMinutes {
+			t.Fatalf("AutoLockMinutes() with invalid persisted %d = %d, want default %d", bad, got, defaultAutoLockMinutes)
+		}
+	}
+}
+
+func TestSetAutoLockMinutesRollsBackOnPersistError(t *testing.T) {
+	initial := 5
+	s := &Store{
+		path: filepath.Join(t.TempDir(), "missing-parent", "settings.json"),
+		d: data{
+			Version:         settingsVersion,
+			AutoLockMinutes: &initial,
+		},
+	}
+
+	if err := s.SetAutoLockMinutes(30); err == nil {
+		t.Fatal("SetAutoLockMinutes should fail when the settings directory is missing")
+	}
+	if got := s.AutoLockMinutes(); got != initial {
+		t.Fatalf("failed SetAutoLockMinutes must leave the in-memory setting unchanged, got %d", got)
+	}
+}
+
 // TestSeedDefaultFalseStillPersistsFirstRun: seeding false on first run records
 // an explicit value (so a later env flip to true is correctly ignored). i.e.
 // the absence-vs-explicit-false distinction is preserved.

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -157,7 +157,7 @@ export const getHistoryExpiry = () =>
 export const setHistoryExpiry = (enabled: boolean) =>
   apiPut<HistoryExpirySetting>("/wallet/settings/history-expiry", { enabled });
 export const getAutoLock = () => apiGet<AutoLockSetting>("/wallet/settings/auto-lock");
-export const setAutoLock = (minutes: number) =>
+export const setAutoLock = (minutes: AutoLockSetting["minutes"]) =>
   apiPut<AutoLockSetting>("/wallet/settings/auto-lock", { minutes });
 export const verifyData = (req: VerifyDataRequest) =>
   apiPost<VerifyDataResult>("/wallet/verify-data", req);

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -17,6 +17,7 @@ import type {
   AddWalletRequest,
   MigrateLegacyKeystoreRequest,
   HistoryExpirySetting,
+  AutoLockSetting,
   VerifyDataRequest,
   VerifyDataResult,
   UnsignedTx,
@@ -155,6 +156,9 @@ export const getHistoryExpiry = () =>
   apiGet<HistoryExpirySetting>("/wallet/settings/history-expiry");
 export const setHistoryExpiry = (enabled: boolean) =>
   apiPut<HistoryExpirySetting>("/wallet/settings/history-expiry", { enabled });
+export const getAutoLock = () => apiGet<AutoLockSetting>("/wallet/settings/auto-lock");
+export const setAutoLock = (minutes: number) =>
+  apiPut<AutoLockSetting>("/wallet/settings/auto-lock", { minutes });
 export const verifyData = (req: VerifyDataRequest) =>
   apiPost<VerifyDataResult>("/wallet/verify-data", req);
 export const exportUnsigned = (id: string) =>

--- a/ui/web/src/api/hooks.ts
+++ b/ui/web/src/api/hooks.ts
@@ -7,6 +7,7 @@ import type {
   DelegationView,
   VaultStatus,
   HistoryExpirySetting,
+  AutoLockSetting,
   TPMStatus,
 } from "./types";
 import {
@@ -17,6 +18,7 @@ import {
   getTransactions,
   getDelegation,
   getHistoryExpiry,
+  getAutoLock,
   getTPMStatus,
 } from "./client";
 
@@ -112,4 +114,5 @@ export const useAddresses = (): AsyncState<AddressView> => useAsync(getAddresses
 export const useTransactions = (): AsyncState<Tx[]> => useAsync(getTransactions);
 export const useDelegation = (): AsyncState<DelegationView> => useAsync(getDelegation);
 export const useHistoryExpiry = (): AsyncState<HistoryExpirySetting> => useAsync(getHistoryExpiry);
+export const useAutoLock = (): AsyncState<AutoLockSetting> => useAsync(getAutoLock);
 export const useTPMStatus = (): AsyncState<TPMStatus> => useAsync(getTPMStatus);

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -171,6 +171,12 @@ export interface HistoryExpirySetting {
   restart_required: boolean;
 }
 
+// App setting: the idle auto-lock timeout, in minutes. 0 means "Off" (never
+// auto-lock). Takes effect immediately client-side — no restart_required.
+export interface AutoLockSetting {
+  minutes: 0 | 1 | 5 | 15 | 30;
+}
+
 // CIP-8/CIP-30 verification: the inverse of signData. expected_address is
 // optional; when set, a signature whose signer differs is reported invalid.
 export interface VerifyDataRequest {

--- a/ui/web/src/app.test.tsx
+++ b/ui/web/src/app.test.tsx
@@ -40,14 +40,37 @@ function stubVault(data: { exists: boolean; locked: boolean; wallet_count: numbe
   } as never);
 }
 
+// The idle auto-lock timer reads useAutoLock; default it to Off so existing
+// tests (none of which exercise the idle-lock feature) never have a real
+// setInterval running against them, and never fire an unmocked fetch.
+function stubAutoLock(minutes = 0) {
+  vi.spyOn(hooks, "useAutoLock").mockReturnValue({
+    data: { minutes },
+    error: null,
+    loading: false,
+    refresh: vi.fn(),
+    setData: vi.fn(),
+  } as never);
+}
+
 // Keep Portfolio's data hooks quiet so it renders without firing real fetches.
 function quietPortfolio() {
   vi.spyOn(hooks, "useBalance").mockReturnValue({ data: { lovelace: "1000000", assets: [] }, error: null, loading: false, refresh: vi.fn() } as never);
   vi.spyOn(hooks, "useDelegation").mockReturnValue({ data: null, error: null, loading: false, refresh: vi.fn() } as never);
 }
 
+beforeEach(() => {
+  stubAutoLock(0);
+});
+
 afterEach(() => {
   vi.restoreAllMocks();
+  // Belt-and-suspenders: the idle auto-lock tests below call vi.useFakeTimers()
+  // and normally switch back with vi.useRealTimers() at the end, but if such a
+  // test fails/throws before reaching that line, fake timers would otherwise
+  // stay installed and cascade into unrelated tests. useRealTimers() is a
+  // harmless no-op when real timers are already active.
+  vi.useRealTimers();
   window.location.hash = "";
 });
 
@@ -334,4 +357,150 @@ test("offline banner can be dismissed by the user", async () => {
 
   fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
   expect(screen.queryByRole("alert", { name: /offline/i })).not.toBeInTheDocument();
+});
+
+// -------------------------------------------------------- idle auto-lock ---
+
+test("idle auto-lock locks the vault after the persisted timeout with no activity", async () => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  stubStatus("ready");
+  stubVault({ exists: true, locked: true, wallet_count: 1 });
+  stubAutoLock(1); // 1 minute
+  quietPortfolio();
+  vi.spyOn(client, "unlockVault").mockResolvedValue([walletA]);
+  const lockSpy = vi.spyOn(client, "lockVault").mockResolvedValue({
+    exists: true,
+    locked: true,
+    wallet_count: 1,
+  });
+
+  render(<App />);
+  fireEvent.change(screen.getByLabelText(/vault password/i), { target: { value: "vault-password-xyz" } });
+  fireEvent.click(screen.getByRole("button", { name: /^unlock$/i }));
+  await waitFor(() => expect(screen.getAllByText("Main").length).toBeGreaterThan(0));
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(60_000);
+  });
+
+  await waitFor(() => expect(lockSpy).toHaveBeenCalled());
+  // Locking clears the unlocked shell and returns to the unlock screen.
+  await waitFor(() => expect(screen.getByRole("button", { name: /^unlock$/i })).toBeInTheDocument());
+  vi.useRealTimers();
+});
+
+test("idle auto-lock does not fire when the setting is Off", async () => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  stubStatus("ready");
+  stubVault({ exists: true, locked: true, wallet_count: 1 });
+  stubAutoLock(0); // Off
+  quietPortfolio();
+  vi.spyOn(client, "unlockVault").mockResolvedValue([walletA]);
+  const lockSpy = vi.spyOn(client, "lockVault");
+
+  render(<App />);
+  fireEvent.change(screen.getByLabelText(/vault password/i), { target: { value: "vault-password-xyz" } });
+  fireEvent.click(screen.getByRole("button", { name: /^unlock$/i }));
+  await waitFor(() => expect(screen.getAllByText("Main").length).toBeGreaterThan(0));
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(30 * 60_000);
+  });
+
+  expect(lockSpy).not.toHaveBeenCalled();
+  expect(screen.getAllByText("Main").length).toBeGreaterThan(0);
+  vi.useRealTimers();
+});
+
+test("activity before the idle timeout elapses prevents the auto-lock", async () => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  stubStatus("ready");
+  stubVault({ exists: true, locked: true, wallet_count: 1 });
+  stubAutoLock(1); // 1 minute
+  quietPortfolio();
+  vi.spyOn(client, "unlockVault").mockResolvedValue([walletA]);
+  const lockSpy = vi.spyOn(client, "lockVault").mockResolvedValue({
+    exists: true,
+    locked: true,
+    wallet_count: 1,
+  });
+
+  render(<App />);
+  fireEvent.change(screen.getByLabelText(/vault password/i), { target: { value: "vault-password-xyz" } });
+  fireEvent.click(screen.getByRole("button", { name: /^unlock$/i }));
+  await waitFor(() => expect(screen.getAllByText("Main").length).toBeGreaterThan(0));
+
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(50_000);
+  });
+  act(() => {
+    window.dispatchEvent(new Event("pointerdown"));
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(50_000); // 100s total, but only 50s since activity
+  });
+
+  expect(lockSpy).not.toHaveBeenCalled();
+  expect(screen.getAllByText("Main").length).toBeGreaterThan(0);
+  vi.useRealTimers();
+});
+
+// Regression test for Fix 1: App's useIdleLock and Settings' AutoLockCard used
+// to each hold their own useAutoLock() instance (useAsync/useState has no
+// shared cache — see api/hooks.ts), so a save made in Settings never reached
+// the copy App actually feeds into useIdleLock; changing the timeout (or
+// turning it Off) silently had no effect until a full reload. This test does
+// NOT stub useAutoLock (unlike the other idle-lock tests above, which
+// deliberately do to keep them focused) — it only mocks the fetch/client
+// layer, so both the App-level read and the Settings-level save go through
+// the real, shared hook instance and would fail here if the state were split
+// again.
+test("[Fix 1] changing the auto-lock timeout in Settings propagates to the idle timer in the same session (no reload)", async () => {
+  // Undo this file's beforeEach stubAutoLock(0), which mocks hooks.useAutoLock
+  // directly — this test deliberately exercises the REAL useAutoLock() hook
+  // (shared, per Fix 1) in both App and Settings; only the fetch/client layer
+  // below is mocked.
+  vi.restoreAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  stubStatus("ready");
+  stubVault({ exists: true, locked: true, wallet_count: 1 });
+  quietPortfolio();
+  vi.spyOn(client, "unlockVault").mockResolvedValue([walletA]);
+  vi.spyOn(client, "getAutoLock").mockResolvedValue({ minutes: 1 });
+  const setAutoLockSpy = vi.spyOn(client, "setAutoLock").mockResolvedValue({ minutes: 0 });
+  const lockSpy = vi.spyOn(client, "lockVault").mockResolvedValue({
+    exists: true,
+    locked: true,
+    wallet_count: 1,
+  });
+
+  render(<App />);
+  fireEvent.change(screen.getByLabelText(/vault password/i), { target: { value: "vault-password-xyz" } });
+  fireEvent.click(screen.getByRole("button", { name: /^unlock$/i }));
+  await waitFor(() => expect(screen.getAllByText("Main").length).toBeGreaterThan(0));
+
+  // Navigate to Settings within the SAME App instance (no remount, no reload)
+  // and wait for the real useAutoLock() fetch to resolve to the persisted
+  // 1-minute timeout.
+  fireEvent.click(screen.getAllByRole("button", { name: "Settings" })[0]);
+  const select = await screen.findByRole("combobox", { name: /lock after inactivity/i });
+  await waitFor(() => expect(select).toHaveValue("1"));
+
+  // Switch to Off through the real Settings control.
+  fireEvent.change(select, { target: { value: "0" } });
+  await waitFor(() => expect(setAutoLockSpy).toHaveBeenCalledWith(0));
+  await waitFor(() => expect(select).toHaveValue("0"));
+
+  // Advance well past the original 1-minute timeout with no activity. If the
+  // Settings save had not propagated to App's copy of the setting (the bug),
+  // useIdleLock would still be running with the stale 1-minute value and
+  // lockVault would fire around the 60s mark. With the fix, App's shared
+  // AsyncState now reports minutes: 0, so useIdleLock is disabled and never
+  // locks the vault.
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(3 * 60_000);
+  });
+
+  expect(lockSpy).not.toHaveBeenCalled();
+  vi.useRealTimers();
 });

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from "react";
 import type { ReactElement } from "react";
 import type { Account, WalletView } from "./api/types";
-import { useStatus, useVaultStatus } from "./api/hooks";
+import { useStatus, useVaultStatus, useAutoLock } from "./api/hooks";
 import { lockVault, ApiError } from "./api/client";
+import { useIdleLock } from "./useIdleLock";
 import { Button } from "./components/Button";
 import { SyncBanner } from "./components/SyncBanner";
 import { WalletSwitcher } from "./components/WalletSwitcher";
@@ -61,6 +62,14 @@ function toAccount(w: WalletView): Account {
 export function App() {
   const status = useStatus();
   const vaultStatus = useVaultStatus();
+  // Lifted here (rather than called again inside Settings/AutoLockCard) so
+  // there is a single shared copy of the auto-lock setting: useIdleLock below
+  // reads autoLock.data directly, and Settings is handed this same AsyncState
+  // (autoLock.setData) so a save there updates the value useIdleLock sees in
+  // this same session, with no reload. A second independent useAutoLock()
+  // instance inside Settings would have its own useState and never be seen by
+  // the idle timer here (see useAsync in api/hooks.ts: no shared cache).
+  const autoLock = useAutoLock();
   const route = useHashRoute();
 
   // Vault session state, established after create/unlock and kept in memory.
@@ -127,6 +136,15 @@ export function App() {
       vaultStatus.refresh();
     }
   }
+
+  // Idle auto-lock: re-locks the vault after the persisted timeout elapses
+  // with no pointer/keyboard/visibility activity (see useIdleLock). Only runs
+  // once the vault is actually unlocked — locking an already-locked vault is
+  // harmless but pointless. Default to Off (0) only while the setting is
+  // still loading (nothing is known yet); if loading finishes and the fetch
+  // failed (autoLock.data stays null), fail SAFE by assuming the default
+  // timeout rather than fail OPEN by leaving auto-lock permanently disabled.
+  useIdleLock(autoLock.loading ? 0 : (autoLock.data?.minutes ?? 15), () => void handleLock(), unlocked);
 
   // --- Pre-unlock flows: render full-screen, no sidebar -------------------
 
@@ -239,7 +257,7 @@ export function App() {
       </section>
     );
   } else if (route === "settings") {
-    content = <Settings account={toAccount(activeWallet)} spendingEnabled />;
+    content = <Settings account={toAccount(activeWallet)} spendingEnabled autoLock={autoLock} />;
   } else if (route === "send" && !canSend) {
     content = <Portfolio />;
   } else if (route === "staking") {

--- a/ui/web/src/idle.test.ts
+++ b/ui/web/src/idle.test.ts
@@ -1,0 +1,32 @@
+import { isIdleTimeoutElapsed } from "./idle";
+
+test("Off (0) never elapses regardless of how much time has passed", () => {
+  expect(isIdleTimeoutElapsed(0, 10_000_000, 0)).toBe(false);
+});
+
+test("a negative timeout is treated as Off", () => {
+  expect(isIdleTimeoutElapsed(0, 10_000_000, -5)).toBe(false);
+});
+
+test("elapses exactly at the boundary", () => {
+  const timeoutMinutes = 5;
+  const last = 0;
+  const now = timeoutMinutes * 60_000;
+  expect(isIdleTimeoutElapsed(last, now, timeoutMinutes)).toBe(true);
+});
+
+test("does not elapse just before the boundary", () => {
+  const timeoutMinutes = 5;
+  const last = 0;
+  const now = timeoutMinutes * 60_000 - 1;
+  expect(isIdleTimeoutElapsed(last, now, timeoutMinutes)).toBe(false);
+});
+
+test("does not elapse immediately after activity", () => {
+  const last = 1_000_000;
+  expect(isIdleTimeoutElapsed(last, last + 1, 15)).toBe(false);
+});
+
+test("elapses well past the boundary", () => {
+  expect(isIdleTimeoutElapsed(0, 999_999_999, 1)).toBe(true);
+});

--- a/ui/web/src/idle.ts
+++ b/ui/web/src/idle.ts
@@ -1,0 +1,23 @@
+// Pure decision logic for the idle auto-lock feature. Kept separate from the
+// DOM-attached hook (useIdleLock.ts) so the "should we lock now?" question can
+// be unit-tested without simulating browser events or timers.
+
+// How often useIdleLock polls the clock against the last-activity timestamp.
+// Small enough that the lock fires promptly after the timeout elapses; large
+// enough to be a non-issue for battery/CPU.
+export const AUTO_LOCK_CHECK_INTERVAL_MS = 1000;
+
+/**
+ * isIdleTimeoutElapsed reports whether at least `timeoutMinutes` have passed
+ * since `lastActivityMs`, as of `nowMs`. A `timeoutMinutes` of 0 or less means
+ * auto-lock is "Off" and this always returns false, regardless of how much
+ * time has passed.
+ */
+export function isIdleTimeoutElapsed(
+  lastActivityMs: number,
+  nowMs: number,
+  timeoutMinutes: number,
+): boolean {
+  if (timeoutMinutes <= 0) return false;
+  return nowMs - lastActivityMs >= timeoutMinutes * 60_000;
+}

--- a/ui/web/src/screens/Settings.test.tsx
+++ b/ui/web/src/screens/Settings.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { Settings } from "./Settings";
 import * as hooks from "../api/hooks";
+import type { AsyncState } from "../api/hooks";
 import * as client from "../api/client";
-import type { Account, HistoryExpirySetting, TPMStatus } from "../api/types";
+import type { Account, HistoryExpirySetting, AutoLockSetting, TPMStatus } from "../api/types";
 
 const mockAccount: Account = {
   network: "preview",
@@ -30,6 +31,36 @@ function mockHistoryExpiry(setting: HistoryExpirySetting | null, loading = false
   } as never);
 }
 
+// Settings no longer calls useAutoLock() itself — App owns the single shared
+// instance and passes its AsyncState down as the `autoLock` prop (see Fix 1:
+// a second independent useAutoLock() call inside Settings/AutoLockCard would
+// never see a save made through the other instance). Tests build that
+// AsyncState directly and pass it via the `autoLock` prop; default it to a
+// loaded state so existing Settings assertions are unaffected.
+let autoLockState: AsyncState<AutoLockSetting>;
+
+function mockAutoLock(setting: AutoLockSetting | null, loading = false) {
+  autoLockState = {
+    data: setting,
+    error: null,
+    loading,
+    refresh: vi.fn(),
+    setData: vi.fn(),
+  };
+}
+
+// renderSettings wraps render(<Settings .../>) with the module's current
+// autoLockState so every call site doesn't need to thread it explicitly.
+function renderSettings(props: Partial<Pick<Parameters<typeof Settings>[0], "account" | "spendingEnabled">> = {}) {
+  return render(
+    <Settings
+      account={props.account ?? mockAccount}
+      spendingEnabled={props.spendingEnabled ?? false}
+      autoLock={autoLockState}
+    />,
+  );
+}
+
 function mockTPMStatus(tpmStatus: TPMStatus) {
   vi.spyOn(hooks, "useTPMStatus").mockReturnValue({
     data: tpmStatus,
@@ -51,6 +82,7 @@ const tpmEnabledPCR: TPMStatus = { available: true, enabled: true, pcrBound: tru
 // Individual tests override as needed.
 beforeEach(() => {
   mockHistoryExpiry({ enabled: false, restart_required: false });
+  mockAutoLock({ minutes: 15 });
   mockTPMStatus(tpmUnavailable);
 });
 
@@ -60,7 +92,7 @@ afterEach(() => {
 
 test("(a) renders network from account prop", () => {
   mockStatus("ready", 12345, true);
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   expect(screen.getByText("preview")).toBeInTheDocument();
 });
 
@@ -69,7 +101,7 @@ test("(b) renders stake address in monospace and a CopyButton for it", async () 
   Object.assign(navigator, { clipboard: { writeText } });
   mockStatus("ready", 12345, true);
 
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
 
   // The stake address should appear in the document
   expect(screen.getByText(mockAccount.stake_address)).toBeInTheDocument();
@@ -81,38 +113,38 @@ test("(b) renders stake address in monospace and a CopyButton for it", async () 
 
 test("(c) renders sync state pill from useStatus", () => {
   mockStatus("syncing", 10000, false);
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   // The sync state must be visible
   expect(screen.getByText("syncing")).toBeInTheDocument();
 });
 
 test("(d) renders tip block number from useStatus", () => {
   mockStatus("ready", 99999, true);
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   expect(screen.getByText("99999")).toBeInTheDocument();
 });
 
 test("(e) caughtUp=true shows a caught-up indicator", () => {
   mockStatus("ready", 12345, true);
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   expect(screen.getByText(/caught.?up/i)).toBeInTheDocument();
 });
 
 test("(f) caughtUp=false does NOT show caught-up indicator", () => {
   mockStatus("syncing", 12345, false);
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   expect(screen.queryByText(/caught.?up/i)).toBeNull();
 });
 
 test("(g) spendingEnabled=true shows 'Spending enabled'", () => {
   mockStatus("ready", 12345, true);
-  render(<Settings account={mockAccount} spendingEnabled={true} />);
+  renderSettings({ spendingEnabled: true });
   expect(screen.getByText(/spending enabled/i)).toBeInTheDocument();
 });
 
 test("(h) spendingEnabled=false shows 'Read-only'", () => {
   mockStatus("ready", 12345, true);
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   expect(screen.getByText(/read.?only/i)).toBeInTheDocument();
 });
 
@@ -124,7 +156,7 @@ test("(i) loading state from useStatus renders gracefully", () => {
     refresh: vi.fn(),
     setData: vi.fn(),
   } as never);
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   // Should not crash; network card still shows
   expect(screen.getByText("preview")).toBeInTheDocument();
 });
@@ -134,7 +166,7 @@ test("(i) loading state from useStatus renders gracefully", () => {
 test("(j) lean storage toggle reflects the persisted enabled state", () => {
   mockStatus("ready", 12345, true);
   mockHistoryExpiry({ enabled: true, restart_required: false });
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   const toggle = screen.getByRole("switch", { name: /lean storage/i });
   expect(toggle).toBeChecked();
   expect(screen.getByText(/enabled/i)).toBeInTheDocument();
@@ -142,7 +174,7 @@ test("(j) lean storage toggle reflects the persisted enabled state", () => {
 
 test("(k) lean storage renders the tradeoff copy", () => {
   mockStatus("ready", 12345, true);
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   expect(screen.getByText(/saves significant disk space/i)).toBeInTheDocument();
   expect(screen.getByText(/your mithril snapshot is kept/i)).toBeInTheDocument();
   expect(screen.getByText(/one-way until re-sync/i)).toBeInTheDocument();
@@ -155,7 +187,7 @@ test("(l) toggling lean storage PUTs the new value and shows restart note", asyn
     .spyOn(client, "setHistoryExpiry")
     .mockResolvedValue({ enabled: true, restart_required: true });
 
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   const toggle = screen.getByRole("switch", { name: /lean storage/i });
   fireEvent.click(toggle);
 
@@ -176,7 +208,7 @@ test("(m) failed lean storage update rolls back and surfaces the error", async (
     .spyOn(client, "setHistoryExpiry")
     .mockRejectedValue(new client.ApiError(500, "disk full"));
 
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   const toggle = screen.getByRole("switch", { name: /lean storage/i });
   fireEvent.click(toggle);
 
@@ -196,7 +228,7 @@ test("(n) failed initial lean storage load renders unavailable", () => {
     setData: vi.fn(),
   } as never);
 
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   const toggle = screen.getByRole("switch", { name: /lean storage/i });
   expect(toggle).toBeDisabled();
   expect(screen.getByText(/^Unavailable$/)).toBeInTheDocument();
@@ -207,10 +239,76 @@ test("(n) failed initial lean storage load renders unavailable", () => {
 test("(o) a persisted restart_required surfaces the restart note", () => {
   mockStatus("ready", 12345, true);
   mockHistoryExpiry({ enabled: true, restart_required: true });
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   // The restart note appears both in the live status line (role=status) and as
   // the final bullet of the copy; assert the live status one specifically.
   expect(screen.getByRole("status")).toHaveTextContent(/takes effect after a node restart/i);
+});
+
+// ------------------------------------------------------------- auto-lock ---
+
+test("(al1) auto-lock select reflects the persisted timeout", () => {
+  mockStatus("ready", 12345, true);
+  mockAutoLock({ minutes: 30 });
+  renderSettings();
+  const select = screen.getByRole("combobox", { name: /lock after inactivity/i });
+  expect(select).toHaveValue("30");
+  expect(screen.getByText(/locks after 30 minutes/i)).toBeInTheDocument();
+});
+
+test("(al2) auto-lock 'Off' (0) is rendered distinctly", () => {
+  mockStatus("ready", 12345, true);
+  mockAutoLock({ minutes: 0 });
+  renderSettings();
+  const select = screen.getByRole("combobox", { name: /lock after inactivity/i });
+  expect(select).toHaveValue("0");
+  expect(screen.getByText(/the vault will not auto-lock/i)).toBeInTheDocument();
+});
+
+test("(al3) changing the auto-lock select PUTs the new value", async () => {
+  mockStatus("ready", 12345, true);
+  mockAutoLock({ minutes: 15 });
+  const spy = vi.spyOn(client, "setAutoLock").mockResolvedValue({ minutes: 5 });
+
+  renderSettings();
+  const select = screen.getByRole("combobox", { name: /lock after inactivity/i });
+  fireEvent.change(select, { target: { value: "5" } });
+
+  await waitFor(() => expect(spy).toHaveBeenCalledWith(5));
+  await waitFor(() => expect(select).toHaveValue("5"));
+  expect(screen.getByText(/locks after 5 minutes/i)).toBeInTheDocument();
+});
+
+test("(al4) failed auto-lock update rolls back and surfaces the error", async () => {
+  mockStatus("ready", 12345, true);
+  mockAutoLock({ minutes: 15 });
+  const spy = vi
+    .spyOn(client, "setAutoLock")
+    .mockRejectedValue(new client.ApiError(500, "disk full"));
+
+  renderSettings();
+  const select = screen.getByRole("combobox", { name: /lock after inactivity/i });
+  fireEvent.change(select, { target: { value: "5" } });
+
+  await waitFor(() => expect(spy).toHaveBeenCalledWith(5));
+  await waitFor(() => expect(select).toHaveValue("15"));
+  expect(screen.getByRole("alert")).toHaveTextContent(/disk full/i);
+});
+
+test("(al5) failed initial auto-lock load renders unavailable", () => {
+  mockStatus("ready", 12345, true);
+  autoLockState = {
+    data: null,
+    error: new Error("settings unavailable"),
+    loading: false,
+    refresh: vi.fn(),
+    setData: vi.fn(),
+  };
+
+  renderSettings();
+  const select = screen.getByRole("combobox", { name: /lock after inactivity/i });
+  expect(select).toBeDisabled();
+  expect(screen.getAllByText(/unavailable/i).length).toBeGreaterThan(0);
 });
 
 // --- Hardware security (TPM) card -----------------------------------------
@@ -224,7 +322,7 @@ test("(j0) TPM card renders a loading state while status is fetching", () => {
     refresh: vi.fn(),
     setData: vi.fn(),
   } as never);
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   // The card must still be present (not gated away) and show a loading hint.
   expect(screen.getByText("Hardware security")).toBeInTheDocument();
   const loadings = screen.getAllByText(/loading/i);
@@ -240,7 +338,7 @@ test("(j1) TPM card renders an error/unavailable state on status-fetch error", (
     refresh: vi.fn(),
     setData: vi.fn(),
   } as never);
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   // The card must remain present (not vanish) and surface the failure.
   expect(screen.getByText("Hardware security")).toBeInTheDocument();
   expect(screen.getByText(/unavailable/i)).toBeInTheDocument();
@@ -250,21 +348,21 @@ test("(j1) TPM card renders an error/unavailable state on status-fetch error", (
 test("(p) TPM card shows 'No TPM detected' message when unavailable", () => {
   mockStatus("ready");
   mockTPMStatus(tpmUnavailable);
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   expect(screen.getByText(/no tpm detected/i)).toBeInTheDocument();
 });
 
 test("(q) TPM card shows the unavailable reason text", () => {
   mockStatus("ready");
   mockTPMStatus({ available: false, reason: "tss group permission denied", enabled: false, pcrBound: false });
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   expect(screen.getByText(/tss group permission denied/i)).toBeInTheDocument();
 });
 
 test("(r) TPM card shows toggle when TPM is available and not enabled", () => {
   mockStatus("ready");
   mockTPMStatus(tpmAvailable);
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   // Toggle button / checkbox should be present to enable TPM
   expect(screen.getByRole("button", { name: /enable/i })).toBeInTheDocument();
 });
@@ -272,14 +370,14 @@ test("(r) TPM card shows toggle when TPM is available and not enabled", () => {
 test("(s) TPM card shows disable button when TPM is enabled", () => {
   mockStatus("ready");
   mockTPMStatus(tpmEnabled);
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   expect(screen.getByRole("button", { name: /disable/i })).toBeInTheDocument();
 });
 
 test("(s1) TPM-enabled vault can be disabled when TPM is unavailable", () => {
   mockStatus("ready");
   mockTPMStatus(tpmEnabledUnavailable);
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   expect(screen.getByRole("button", { name: /disable/i })).toBeInTheDocument();
   expect(screen.queryByText(/no tpm detected/i)).toBeNull();
 });
@@ -289,7 +387,7 @@ test("(t) enabling TPM calls enableTPM client function with password", async () 
   mockTPMStatus(tpmAvailable);
   const enableTPMSpy = vi.spyOn(client, "enableTPM").mockResolvedValue(tpmEnabled);
 
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   fireEvent.click(screen.getByRole("button", { name: /enable/i }));
 
   // Password prompt appears
@@ -309,7 +407,7 @@ test("(t1) failed TPM enable is announced as an alert", async () => {
   mockTPMStatus(tpmAvailable);
   vi.spyOn(client, "enableTPM").mockRejectedValue(new client.ApiError(500, "TPM seal failed"));
 
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   fireEvent.click(screen.getByRole("button", { name: /enable/i }));
 
   const pwInput = await screen.findByPlaceholderText(/vault password/i);
@@ -324,7 +422,7 @@ test("(u) disabling TPM calls disableTPM client function with password", async (
   mockTPMStatus(tpmEnabled);
   const disableTPMSpy = vi.spyOn(client, "disableTPM").mockResolvedValue(tpmAvailable);
 
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   fireEvent.click(screen.getByRole("button", { name: /disable/i }));
 
   const pwInput = await screen.findByPlaceholderText(/vault password/i);
@@ -341,7 +439,7 @@ test("(u1) failed TPM disable is announced as an alert", async () => {
   mockTPMStatus(tpmEnabled);
   vi.spyOn(client, "disableTPM").mockRejectedValue(new client.ApiError(500, "TPM disable failed"));
 
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   fireEvent.click(screen.getByRole("button", { name: /disable/i }));
 
   const pwInput = await screen.findByPlaceholderText(/vault password/i);
@@ -354,7 +452,7 @@ test("(u1) failed TPM disable is announced as an alert", async () => {
 test("(v) PCR advanced option shows brittleness warning when checked", async () => {
   mockStatus("ready");
   mockTPMStatus(tpmAvailable);
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   fireEvent.click(screen.getByRole("button", { name: /enable/i }));
 
   // Advanced PCR checkbox should appear in the enable dialog
@@ -368,6 +466,6 @@ test("(v) PCR advanced option shows brittleness warning when checked", async () 
 test("(w) TPM card shows PCR-bound status when enabled with PCR", () => {
   mockStatus("ready");
   mockTPMStatus(tpmEnabledPCR);
-  render(<Settings account={mockAccount} spendingEnabled={false} />);
+  renderSettings();
   expect(screen.getByText(/pcr/i)).toBeInTheDocument();
 });

--- a/ui/web/src/screens/Settings.test.tsx
+++ b/ui/web/src/screens/Settings.test.tsx
@@ -268,13 +268,15 @@ test("(al2) auto-lock 'Off' (0) is rendered distinctly", () => {
 test("(al3) changing the auto-lock select PUTs the new value", async () => {
   mockStatus("ready", 12345, true);
   mockAutoLock({ minutes: 15 });
-  const spy = vi.spyOn(client, "setAutoLock").mockResolvedValue({ minutes: 5 });
+  const saved = { minutes: 5 } as const;
+  const spy = vi.spyOn(client, "setAutoLock").mockResolvedValue(saved);
 
   renderSettings();
   const select = screen.getByRole("combobox", { name: /lock after inactivity/i });
   fireEvent.change(select, { target: { value: "5" } });
 
   await waitFor(() => expect(spy).toHaveBeenCalledWith(5));
+  await waitFor(() => expect(autoLockState.setData).toHaveBeenCalledWith(saved));
   await waitFor(() => expect(select).toHaveValue("5"));
   expect(screen.getByText(/locks after 5 minutes/i)).toBeInTheDocument();
 });

--- a/ui/web/src/screens/Settings.tsx
+++ b/ui/web/src/screens/Settings.tsx
@@ -4,13 +4,26 @@ import { StatusPill } from "../components/StatusPill";
 import { CopyButton } from "../components/CopyButton";
 import { Button } from "../components/Button";
 import { Input } from "../components/Input";
+import { Select } from "../components/Select";
 import { useStatus, useHistoryExpiry, useTPMStatus } from "../api/hooks";
-import { setHistoryExpiry as putHistoryExpiry, ApiError, enableTPM, disableTPM } from "../api/client";
-import type { Account, NodeState, TPMStatus } from "../api/types";
+import type { AsyncState } from "../api/hooks";
+import {
+  setHistoryExpiry as putHistoryExpiry,
+  setAutoLock as putAutoLock,
+  ApiError,
+  enableTPM,
+  disableTPM,
+} from "../api/client";
+import type { Account, AutoLockSetting, NodeState, TPMStatus } from "../api/types";
 
 interface SettingsProps {
   account: Account;
   spendingEnabled: boolean;
+  // The auto-lock AsyncState, lifted up to and owned by App (see app.tsx) so
+  // this screen's save path and App's useIdleLock share the same value — a
+  // change here must be visible to the idle timer in the same session, with
+  // no reload.
+  autoLock: AsyncState<AutoLockSetting>;
 }
 
 function syncTone(state: NodeState): "ok" | "warn" | "error" | "muted" {
@@ -146,6 +159,117 @@ function LeanStorageCard() {
             <strong>Takes effect after a node restart.</strong>
           </li>
         </ul>
+      </div>
+    </Card>
+  );
+}
+
+// Mirrors settings.AutoLockOptions (ui/internal/settings/settings.go) and
+// autoLockOptions (ui/internal/api/api.go) — those two are guarded against
+// drift by TestAutoLockOptionsMatchesSettingsPackage in ui/internal/api, but
+// this frontend copy lives outside the Go module and must be kept in sync by
+// hand.
+const AUTO_LOCK_OPTIONS = [
+  { value: "0", label: "Off" },
+  { value: "1", label: "1 minute" },
+  { value: "5", label: "5 minutes" },
+  { value: "15", label: "15 minutes" },
+  { value: "30", label: "30 minutes" },
+];
+
+// AutoLockCard is the user-facing control for the idle auto-lock timeout: how
+// long the app waits with no pointer/keyboard/visibility activity before
+// re-locking the vault (see useIdleLock, wired up in app.tsx). Mirrors
+// LeanStorageCard's optimistic-update pattern, minus the restart-required
+// concept — this setting is a pure frontend behaviour and takes effect on the
+// very next idle check.
+//
+// `setting` is App's useAutoLock() AsyncState, passed down rather than called
+// again here (compare TPMCard, which is handed tpmStatusQuery the same way).
+// A second independent useAutoLock() call here would have its own useState
+// (useAsync keeps no shared cache) and App's useIdleLock would never see a
+// save made through this card until a full reload.
+function AutoLockCard({ setting }: { setting: AsyncState<AutoLockSetting> }) {
+  const [minutes, setMinutes] = useState<number | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (setting.data) {
+      setMinutes(setting.data.minutes);
+    }
+  }, [setting.data]);
+
+  async function handleChange(next: number) {
+    if (minutes === null || saving || next === minutes) return;
+    const previous = minutes;
+    setError(null);
+    setSaving(true);
+    setMinutes(next); // optimistic
+    try {
+      const res = await putAutoLock(next);
+      setMinutes(res.minutes);
+      // Propagate the authoritative saved value into the shared AsyncState
+      // App reads for useIdleLock, so the new timeout (including Off) takes
+      // effect immediately in this session — not just in this card's local
+      // echo of it.
+      setting.setData(res);
+    } catch (e) {
+      // Roll back the optimistic change on failure.
+      setMinutes(previous);
+      setError(e instanceof ApiError ? e.message : "An unexpected error occurred");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const hasLoaded = minutes !== null;
+  const loading = setting.loading && !hasLoaded;
+  const unavailable = !loading && !hasLoaded;
+  const loadError = setting.error?.message ?? null;
+  const cardError = error ?? loadError;
+
+  return (
+    <Card title="Auto-Lock">
+      <div className="setting-toggle-row">
+        <label htmlFor="auto-lock" className="setting-toggle-label">
+          Lock after inactivity
+        </label>
+        <Select
+          id="auto-lock"
+          aria-label="Lock after inactivity"
+          options={AUTO_LOCK_OPTIONS}
+          value={String(minutes ?? 0)}
+          disabled={!hasLoaded || loading || saving}
+          onChange={(e) => handleChange(Number(e.target.value))}
+        />
+      </div>
+
+      {loading ? (
+        <p className="muted">Loading…</p>
+      ) : unavailable ? (
+        <p className="muted">Unavailable</p>
+      ) : (
+        <p className="setting-state">
+          {minutes === 0
+            ? "Off — the vault will not auto-lock"
+            : `Locks after ${minutes} minute${minutes === 1 ? "" : "s"} of inactivity`}
+          {saving && " · saving…"}
+        </p>
+      )}
+
+      {cardError && (
+        <p role="alert" className="error-text">
+          {cardError}
+        </p>
+      )}
+
+      <div className="setting-copy">
+        <p>
+          Automatically re-locks the vault after a period with no pointer,
+          keyboard, or tab activity — so a wallet left open and unattended
+          doesn&apos;t stay unlocked indefinitely.
+        </p>
       </div>
     </Card>
   );
@@ -313,7 +437,7 @@ function TPMCard({
   );
 }
 
-export function Settings({ account, spendingEnabled }: SettingsProps) {
+export function Settings({ account, spendingEnabled, autoLock }: SettingsProps) {
   const status = useStatus();
   const tpmStatusQuery = useTPMStatus();
 
@@ -356,6 +480,8 @@ export function Settings({ account, spendingEnabled }: SettingsProps) {
       </Card>
 
       <LeanStorageCard />
+
+      <AutoLockCard setting={autoLock} />
 
       <Card title="Keystore">
         <p>{spendingEnabled ? "Spending enabled" : "Read-only"}</p>

--- a/ui/web/src/screens/Settings.tsx
+++ b/ui/web/src/screens/Settings.tsx
@@ -190,7 +190,7 @@ const AUTO_LOCK_OPTIONS = [
 // (useAsync keeps no shared cache) and App's useIdleLock would never see a
 // save made through this card until a full reload.
 function AutoLockCard({ setting }: { setting: AsyncState<AutoLockSetting> }) {
-  const [minutes, setMinutes] = useState<number | null>(null);
+  const [minutes, setMinutes] = useState<AutoLockSetting["minutes"] | null>(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -200,7 +200,7 @@ function AutoLockCard({ setting }: { setting: AsyncState<AutoLockSetting> }) {
     }
   }, [setting.data]);
 
-  async function handleChange(next: number) {
+  async function handleChange(next: AutoLockSetting["minutes"]) {
     if (minutes === null || saving || next === minutes) return;
     const previous = minutes;
     setError(null);
@@ -241,7 +241,7 @@ function AutoLockCard({ setting }: { setting: AsyncState<AutoLockSetting> }) {
           options={AUTO_LOCK_OPTIONS}
           value={String(minutes ?? 0)}
           disabled={!hasLoaded || loading || saving}
-          onChange={(e) => handleChange(Number(e.target.value))}
+          onChange={(e) => handleChange(Number(e.target.value) as AutoLockSetting["minutes"])}
         />
       </div>
 

--- a/ui/web/src/useIdleLock.test.ts
+++ b/ui/web/src/useIdleLock.test.ts
@@ -1,8 +1,16 @@
 import { renderHook, act } from "@testing-library/react";
 import { useIdleLock } from "./useIdleLock";
 
+function setVisibilityState(value: "hidden" | "visible"): void {
+  Object.defineProperty(document, "visibilityState", {
+    value,
+    configurable: true,
+  });
+}
+
 afterEach(() => {
   vi.useRealTimers();
+  setVisibilityState("visible");
 });
 
 test("calls onIdle after the timeout elapses with no activity", () => {
@@ -69,6 +77,23 @@ test("visibilitychange resets the timer", () => {
   expect(onIdle).not.toHaveBeenCalled();
 });
 
+test("visibilitychange to visible fires immediately when already idle", () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  const onIdle = vi.fn();
+  renderHook(() => useIdleLock(1, onIdle, true));
+  act(() => {
+    setVisibilityState("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+  act(() => {
+    vi.setSystemTime(60_000);
+    setVisibilityState("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+  expect(onIdle).toHaveBeenCalledTimes(1);
+});
+
 // Regression test: visibilitychange used to reset the idle clock on EVERY
 // transition, including the tab becoming hidden. That let leaving the tab
 // erase idle time accrued beforehand instead of counting toward the lock,
@@ -78,31 +103,42 @@ test("visibilitychange resets the timer", () => {
 test("visibilitychange while the tab becomes hidden does NOT reset the timer", () => {
   vi.useFakeTimers();
   const onIdle = vi.fn();
-  Object.defineProperty(document, "visibilityState", {
-    value: "hidden",
-    configurable: true,
+  setVisibilityState("hidden");
+  renderHook(() => useIdleLock(1, onIdle, true)); // 1 minute
+  act(() => {
+    vi.advanceTimersByTime(50_000);
   });
-  try {
-    renderHook(() => useIdleLock(1, onIdle, true)); // 1 minute
-    act(() => {
-      vi.advanceTimersByTime(50_000);
-    });
-    act(() => {
-      document.dispatchEvent(new Event("visibilitychange"));
-    });
-    act(() => {
-      // 100s total: had the "hidden" visibilitychange reset the clock (the
-      // bug), only 50s would have elapsed since the reset and this would not
-      // fire yet.
-      vi.advanceTimersByTime(50_000);
-    });
-    expect(onIdle).toHaveBeenCalledTimes(1);
-  } finally {
-    Object.defineProperty(document, "visibilityState", {
-      value: "visible",
-      configurable: true,
-    });
-  }
+  act(() => {
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+  act(() => {
+    // 100s total: had the "hidden" visibilitychange reset the clock (the
+    // bug), only 50s would have elapsed since the reset and this would not
+    // fire yet.
+    vi.advanceTimersByTime(50_000);
+  });
+  expect(onIdle).toHaveBeenCalledTimes(1);
+});
+
+test("re-arms with the new timeout when timeoutMinutes changes", () => {
+  vi.useFakeTimers();
+  const onIdle = vi.fn();
+  const { rerender } = renderHook(
+    ({ timeoutMinutes }) => useIdleLock(timeoutMinutes, onIdle, true),
+    { initialProps: { timeoutMinutes: 1 } },
+  );
+  act(() => {
+    vi.advanceTimersByTime(30_000);
+  });
+  rerender({ timeoutMinutes: 2 });
+  act(() => {
+    vi.advanceTimersByTime(60_000);
+  });
+  expect(onIdle).not.toHaveBeenCalled();
+  act(() => {
+    vi.advanceTimersByTime(60_000);
+  });
+  expect(onIdle).toHaveBeenCalledTimes(1);
 });
 
 test("Off (0 minutes) never fires no matter how long idle", () => {

--- a/ui/web/src/useIdleLock.test.ts
+++ b/ui/web/src/useIdleLock.test.ts
@@ -1,0 +1,147 @@
+import { renderHook, act } from "@testing-library/react";
+import { useIdleLock } from "./useIdleLock";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test("calls onIdle after the timeout elapses with no activity", () => {
+  vi.useFakeTimers();
+  const onIdle = vi.fn();
+  renderHook(() => useIdleLock(1, onIdle, true)); // 1 minute
+  act(() => {
+    vi.advanceTimersByTime(60_000);
+  });
+  expect(onIdle).toHaveBeenCalledTimes(1);
+});
+
+test("pointer activity resets the timer", () => {
+  vi.useFakeTimers();
+  const onIdle = vi.fn();
+  renderHook(() => useIdleLock(1, onIdle, true));
+  act(() => {
+    vi.advanceTimersByTime(50_000);
+  });
+  act(() => {
+    window.dispatchEvent(new Event("pointerdown"));
+  });
+  // 50s more since the reset (100s total) must not fire — only 50s has
+  // elapsed since the last activity.
+  act(() => {
+    vi.advanceTimersByTime(50_000);
+  });
+  expect(onIdle).not.toHaveBeenCalled();
+  act(() => {
+    vi.advanceTimersByTime(10_000); // now 60s since the reset
+  });
+  expect(onIdle).toHaveBeenCalledTimes(1);
+});
+
+test("keyboard activity resets the timer", () => {
+  vi.useFakeTimers();
+  const onIdle = vi.fn();
+  renderHook(() => useIdleLock(1, onIdle, true));
+  act(() => {
+    vi.advanceTimersByTime(50_000);
+  });
+  act(() => {
+    window.dispatchEvent(new Event("keydown"));
+  });
+  act(() => {
+    vi.advanceTimersByTime(50_000);
+  });
+  expect(onIdle).not.toHaveBeenCalled();
+});
+
+test("visibilitychange resets the timer", () => {
+  vi.useFakeTimers();
+  const onIdle = vi.fn();
+  renderHook(() => useIdleLock(1, onIdle, true));
+  act(() => {
+    vi.advanceTimersByTime(50_000);
+  });
+  act(() => {
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+  act(() => {
+    vi.advanceTimersByTime(50_000);
+  });
+  expect(onIdle).not.toHaveBeenCalled();
+});
+
+// Regression test: visibilitychange used to reset the idle clock on EVERY
+// transition, including the tab becoming hidden. That let leaving the tab
+// erase idle time accrued beforehand instead of counting toward the lock,
+// so a user who walked away could never be auto-locked while gone — the
+// opposite of the intended behaviour. Only a transition back to "visible"
+// should count as activity.
+test("visibilitychange while the tab becomes hidden does NOT reset the timer", () => {
+  vi.useFakeTimers();
+  const onIdle = vi.fn();
+  Object.defineProperty(document, "visibilityState", {
+    value: "hidden",
+    configurable: true,
+  });
+  try {
+    renderHook(() => useIdleLock(1, onIdle, true)); // 1 minute
+    act(() => {
+      vi.advanceTimersByTime(50_000);
+    });
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    act(() => {
+      // 100s total: had the "hidden" visibilitychange reset the clock (the
+      // bug), only 50s would have elapsed since the reset and this would not
+      // fire yet.
+      vi.advanceTimersByTime(50_000);
+    });
+    expect(onIdle).toHaveBeenCalledTimes(1);
+  } finally {
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      configurable: true,
+    });
+  }
+});
+
+test("Off (0 minutes) never fires no matter how long idle", () => {
+  vi.useFakeTimers();
+  const onIdle = vi.fn();
+  renderHook(() => useIdleLock(0, onIdle, true));
+  act(() => {
+    vi.advanceTimersByTime(10 * 60_000);
+  });
+  expect(onIdle).not.toHaveBeenCalled();
+});
+
+test("disabled (enabled=false) never fires even past the timeout", () => {
+  vi.useFakeTimers();
+  const onIdle = vi.fn();
+  renderHook(() => useIdleLock(1, onIdle, false));
+  act(() => {
+    vi.advanceTimersByTime(2 * 60_000);
+  });
+  expect(onIdle).not.toHaveBeenCalled();
+});
+
+test("fires only once even if the interval keeps running", () => {
+  vi.useFakeTimers();
+  const onIdle = vi.fn();
+  renderHook(() => useIdleLock(1, onIdle, true));
+  act(() => {
+    vi.advanceTimersByTime(5 * 60_000); // well past the 1-minute timeout
+  });
+  expect(onIdle).toHaveBeenCalledTimes(1);
+});
+
+test("unmounting clears listeners and timer (no calls after unmount)", () => {
+  vi.useFakeTimers();
+  const onIdle = vi.fn();
+  const { unmount } = renderHook(() => useIdleLock(1, onIdle, true));
+  unmount();
+  act(() => {
+    vi.advanceTimersByTime(5 * 60_000);
+  });
+  expect(onIdle).not.toHaveBeenCalled();
+});

--- a/ui/web/src/useIdleLock.ts
+++ b/ui/web/src/useIdleLock.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from "react";
+import { AUTO_LOCK_CHECK_INTERVAL_MS, isIdleTimeoutElapsed } from "./idle";
+
+// Activity events that reset the idle timer. Pointer and keyboard input cover
+// mouse/touch/stylus and typing; visibilitychange additionally resets it on
+// tab/window focus changes (switching back to this tab counts as the user
+// having returned).
+const ACTIVITY_EVENTS: (keyof WindowEventMap)[] = ["pointerdown", "keydown"];
+
+/**
+ * useIdleLock calls `onIdle` once after `timeoutMinutes` of no user activity
+ * (pointer, keyboard, or the tab regaining visibility all count as activity
+ * and restart the countdown). It is a no-op — no listeners, no timer — when
+ * `enabled` is false or `timeoutMinutes` is 0 or less ("Off"), so callers can
+ * pass the raw persisted setting straight through.
+ *
+ * `onIdle` only ever fires once per idle period; activity after it fires
+ * re-arms it for the next period.
+ */
+export function useIdleLock(timeoutMinutes: number, onIdle: () => void, enabled: boolean): void {
+  const lastActivity = useRef(Date.now());
+  const fired = useRef(false);
+  // Keep the latest onIdle in a ref so the effect below doesn't need to
+  // re-subscribe every time the caller passes a new function identity.
+  const onIdleRef = useRef(onIdle);
+  onIdleRef.current = onIdle;
+
+  useEffect(() => {
+    if (!enabled || timeoutMinutes <= 0) return;
+
+    lastActivity.current = Date.now();
+    fired.current = false;
+
+    const markActive = () => {
+      lastActivity.current = Date.now();
+      fired.current = false;
+    };
+
+    // Only returning to the tab counts as activity. Gating on visibleState
+    // here (rather than reacting to every visibilitychange, hidden or
+    // visible) matters: without it, merely switching away re-armed the timer
+    // at the moment of leaving, so idle time accrued before the switch was
+    // discarded and a user who left the tab could never be auto-locked while
+    // away — the opposite of what a security timeout is for.
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") markActive();
+    };
+
+    ACTIVITY_EVENTS.forEach((evt) => window.addEventListener(evt, markActive));
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    const id = window.setInterval(() => {
+      if (fired.current) return;
+      if (isIdleTimeoutElapsed(lastActivity.current, Date.now(), timeoutMinutes)) {
+        fired.current = true;
+        onIdleRef.current();
+      }
+    }, AUTO_LOCK_CHECK_INTERVAL_MS);
+
+    return () => {
+      ACTIVITY_EVENTS.forEach((evt) => window.removeEventListener(evt, markActive));
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.clearInterval(id);
+    };
+  }, [timeoutMinutes, enabled]);
+}

--- a/ui/web/src/useIdleLock.ts
+++ b/ui/web/src/useIdleLock.ts
@@ -2,20 +2,21 @@ import { useEffect, useRef } from "react";
 import { AUTO_LOCK_CHECK_INTERVAL_MS, isIdleTimeoutElapsed } from "./idle";
 
 // Activity events that reset the idle timer. Pointer and keyboard input cover
-// mouse/touch/stylus and typing; visibilitychange additionally resets it on
-// tab/window focus changes (switching back to this tab counts as the user
-// having returned).
+// mouse/touch/stylus and typing. Visibility changes are handled separately
+// because returning to a long-idle tab must lock before it can count as
+// activity.
 const ACTIVITY_EVENTS: (keyof WindowEventMap)[] = ["pointerdown", "keydown"];
 
 /**
  * useIdleLock calls `onIdle` once after `timeoutMinutes` of no user activity
- * (pointer, keyboard, or the tab regaining visibility all count as activity
- * and restart the countdown). It is a no-op — no listeners, no timer — when
- * `enabled` is false or `timeoutMinutes` is 0 or less ("Off"), so callers can
- * pass the raw persisted setting straight through.
+ * (pointer and keyboard activity restart the countdown; the tab regaining
+ * visibility only restarts it if the idle timeout has not already elapsed). It
+ * is a no-op — no listeners, no timer — when `enabled` is false or
+ * `timeoutMinutes` is 0 or less ("Off"), so callers can pass the raw persisted
+ * setting straight through.
  *
- * `onIdle` only ever fires once per idle period; activity after it fires
- * re-arms it for the next period.
+ * `onIdle` only ever fires once per idle period; pointer or keyboard activity
+ * after it fires re-arms it for the next period.
  */
 export function useIdleLock(timeoutMinutes: number, onIdle: () => void, enabled: boolean): void {
   const lastActivity = useRef(Date.now());
@@ -36,25 +37,33 @@ export function useIdleLock(timeoutMinutes: number, onIdle: () => void, enabled:
       fired.current = false;
     };
 
-    // Only returning to the tab counts as activity. Gating on visibleState
-    // here (rather than reacting to every visibilitychange, hidden or
-    // visible) matters: without it, merely switching away re-armed the timer
-    // at the moment of leaving, so idle time accrued before the switch was
-    // discarded and a user who left the tab could never be auto-locked while
-    // away — the opposite of what a security timeout is for.
+    const fireIfIdle = (): boolean => {
+      if (fired.current) return true;
+      if (!isIdleTimeoutElapsed(lastActivity.current, Date.now(), timeoutMinutes)) {
+        return false;
+      }
+
+      fired.current = true;
+      onIdleRef.current();
+      return true;
+    };
+
+    // Only returning to the tab can count as activity. Gating on visibleState
+    // here (rather than reacting to every visibilitychange, hidden or visible)
+    // matters: without it, merely switching away re-armed the timer at the
+    // moment of leaving, so idle time accrued beforehand was discarded. On the
+    // return path we first check whether the idle period already elapsed while
+    // the tab was away; if so, lock immediately instead of erasing the timeout.
     const onVisibilityChange = () => {
-      if (document.visibilityState === "visible") markActive();
+      if (document.visibilityState !== "visible") return;
+      if (!fireIfIdle()) markActive();
     };
 
     ACTIVITY_EVENTS.forEach((evt) => window.addEventListener(evt, markActive));
     document.addEventListener("visibilitychange", onVisibilityChange);
 
     const id = window.setInterval(() => {
-      if (fired.current) return;
-      if (isIdleTimeoutElapsed(lastActivity.current, Date.now(), timeoutMinutes)) {
-        fired.current = true;
-        onIdleRef.current();
-      }
+      fireIfIdle();
     }, AUTO_LOCK_CHECK_INTERVAL_MS);
 
     return () => {


### PR DESCRIPTION
Adds an idle auto-lock setting (Off / 1 / 5 / 15 / 30 min, default 15) that locks the vault after inactivity. Local-only; mirrors the existing settings-store pattern.


<img width="1440" height="900" alt="pr573-auto-lock" src="https://github.com/user-attachments/assets/3fe4db4d-7d3b-4166-bf9a-72c9eccd7491" />






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an idle auto-lock that re-locks the vault after inactivity in minutes. Default is 15; users can choose Off, 1, 5, 15, or 30. Changes apply immediately and are validated end-to-end.

- **New Features**
  - Persisted setting with default 15; accepted values: 0, 1, 5, 15, 30. Invalid/missing values fall back to 15.
  - New API: GET/PUT `/wallet/settings/auto-lock` with a `minutes` field and server-side validation; no restart required.
  - Web: `useIdleLock` checks every 1s; resets on pointer/keyboard and only when the tab becomes visible. App runs it only when unlocked, with safe defaults (Off while loading; 15 if fetch fails).
  - Settings: select control saves optimistically and updates the App’s shared `useAutoLock` state so the timer reacts immediately. Tests cover storage, API, idle logic, and UI.

- **Bug Fixes**
  - Changing the timeout in Settings now updates the App’s idle timer in the same session (single shared `useAutoLock` state).
  - Leaving the tab no longer resets the idle clock; only returning to a visible tab counts as activity (and locks immediately if already idle).

<sup>Written for commit 38efb297b744b91017a6fc3211bb07677128ef62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an idle auto-lock setting, including a new settings option to choose when the app locks after inactivity.
  * The app now automatically locks after the selected period of inactivity, with support for turning auto-lock off.
  * Settings changes apply immediately during the current session.

* **Bug Fixes**
  * Improved handling of invalid or unsupported saved settings by falling back to a safe default.
  * Preserved auto-lock behavior across reloads and prevented unexpected timer resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->