### PR TITLE
feat(ui): Ledger hardware-wallet support (WebHID connect, xpub accounts, on-device signing)

### DIFF
--- a/bip32/bip32.go
+++ b/bip32/bip32.go
@@ -32,6 +32,7 @@ import (
 	"crypto/sha512"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"strings"
 
 	"filippo.io/edwards25519"
@@ -505,6 +506,80 @@ func (key XPrv) Derive(index uint32) XPrv {
 	copy(child[64:], childChain)
 
 	return child
+}
+
+// Derive derives a child extended public key from the parent using the given index.
+// Only non-hardened derivation (index < 0x80000000) is supported; hardened indices
+// require the private key and will return an error.
+//
+// Follows BIP32-Ed25519 (Khovratovich–Law V2) public-child derivation:
+//
+//	Z = HMAC-SHA512(chainCode, 0x02 || pubKey || LE32(index))
+//	ZL = Z[0:28]
+//	childPoint = parentPoint + (8·ZL)·B   (Edwards25519 scalar-base-mul + point add)
+//	childChain = HMAC-SHA512(chainCode, 0x03 || pubKey || LE32(index))[32:64]
+func (x XPub) Derive(index uint32) (XPub, error) {
+	if len(x) != 64 {
+		panic("XPub must be 64 bytes")
+	}
+	if hardened(index) {
+		return XPub{}, fmt.Errorf(
+			"bip32: cannot derive hardened index %d from a public key", index,
+		)
+	}
+
+	pubKey := []byte(x[:32])
+	chainCode := x[32:]
+
+	serializedIndex := make([]byte, 4)
+	binary.LittleEndian.PutUint32(serializedIndex, index)
+
+	// Z = HMAC-SHA512(chainCode, 0x02 || pubKey || LE32(index))
+	keyHmac := hmac.New(sha512.New, chainCode)
+	keyHmac.Write([]byte{0x02})
+	keyHmac.Write(pubKey)
+	keyHmac.Write(serializedIndex)
+	z := keyHmac.Sum(nil)
+
+	// child chain code = HMAC-SHA512(chainCode, 0x03 || pubKey || LE32(index))[32:64]
+	chainHmac := hmac.New(sha512.New, chainCode)
+	chainHmac.Write([]byte{0x03})
+	chainHmac.Write(pubKey)
+	chainHmac.Write(serializedIndex)
+	iout := chainHmac.Sum(nil)
+	childChain := iout[32:]
+
+	// ZL = Z[0:28]; compute tweak scalar = 8 * ZL (as little-endian 32-byte integer)
+	// add28mul8 with a zero base gives us exactly 8*ZL[0:28] in 32-byte LE form.
+	zeroBase := make([]byte, 32)
+	tweakLE := add28mul8(zeroBase, z[:32]) // uses only z[0:28] internally
+
+	// Interpret tweakLE as a scalar via SetUniformBytes (zero-padded to 64 bytes),
+	// matching the same approach makePublicKey uses for kL.
+	tweakPadded := make([]byte, 64)
+	copy(tweakPadded[:32], tweakLE)
+	tweakScalar, err := edwards25519.NewScalar().SetUniformBytes(tweakPadded)
+	if err != nil {
+		return XPub{}, fmt.Errorf("bip32: XPub.Derive scalar error: %w", err)
+	}
+
+	// tweakPoint = tweakScalar * B
+	tweakPoint := edwards25519.NewIdentityPoint().ScalarBaseMult(tweakScalar)
+
+	// parentPoint = decode A from compressed Edwards25519 encoding
+	parentPoint, err := edwards25519.NewIdentityPoint().SetBytes(pubKey)
+	if err != nil {
+		return XPub{}, fmt.Errorf("bip32: XPub.Derive: invalid parent public key: %w", err)
+	}
+
+	// childPoint = parentPoint + tweakPoint
+	childPoint := edwards25519.NewIdentityPoint().Add(parentPoint, tweakPoint)
+	childPubKey := childPoint.Bytes()
+
+	child := make([]byte, 64)
+	copy(child[:32], childPubKey)
+	copy(child[32:], childChain)
+	return XPub(child), nil
 }
 
 func hardened(index uint32) bool {

--- a/bip32/bip32_test.go
+++ b/bip32/bip32_test.go
@@ -618,6 +618,49 @@ func TestLenientBech32Decode(t *testing.T) {
 	}
 }
 
+// testAccountXPrv returns a known account XPrv (m/1852'/1815'/0') derived from a fixed entropy.
+// Uses the same zero-entropy test vector already used by TestCardanoWalletVectors.
+func testAccountXPrv(t *testing.T) XPrv {
+	t.Helper()
+	entropy := make([]byte, 32) // 32 bytes of zeros — same as TestCardanoWalletVectors
+	root := FromBip39Entropy(entropy, []byte{})
+	return root.
+		Derive(HardenedIndex(1852)).
+		Derive(HardenedIndex(1815)).
+		Derive(HardenedIndex(0))
+}
+
+// TestXPubDeriveMatchesXPrvPublic verifies that public-key child derivation produces
+// the same result as private-key child derivation followed by extraction of the public key.
+func TestXPubDeriveMatchesXPrvPublic(t *testing.T) {
+	acct := testAccountXPrv(t)
+	xpub := acct.Public()
+	for _, i := range []uint32{0, 1, 2, 5, 100} {
+		childPrv := acct.Derive(i)
+		childPubViaPrv := childPrv.Public().PublicKey()
+		childPubViaPub, err := xpub.Derive(i)
+		if err != nil {
+			t.Fatalf("XPub.Derive(%d): %v", i, err)
+		}
+		if !bytes.Equal(childPubViaPub.PublicKey(), childPubViaPrv) {
+			t.Fatalf("index %d: XPub.Derive pubkey %x != XPrv.Derive pubkey %x",
+				i, childPubViaPub.PublicKey(), childPubViaPrv)
+		}
+		if !bytes.Equal(childPubViaPub.ChainCode(), childPrv.Public().ChainCode()) {
+			t.Fatalf("index %d: chain code mismatch: got %x, want %x",
+				i, childPubViaPub.ChainCode(), childPrv.Public().ChainCode())
+		}
+	}
+}
+
+// TestXPubDeriveRejectsHardened verifies that hardened index derivation from XPub returns an error.
+func TestXPubDeriveRejectsHardened(t *testing.T) {
+	xpub := testAccountXPrv(t).Public()
+	if _, err := xpub.Derive(0x80000000); err == nil {
+		t.Fatal("hardened index must return an error")
+	}
+}
+
 // TestCIP3IcarusTestVectors validates CIP-3 Icarus master key derivation against
 // official test vectors from https://cips.cardano.org/cip/CIP-0003
 func TestCIP3IcarusTestVectors(t *testing.T) {

--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -78,6 +78,7 @@ type Spender interface {
 	SignTx(unsignedTxCBOR, password string, requiredSigners []string) (spend.Witness, error)
 	SubmitSigned(ctx context.Context, unsignedTxCBOR, witnessCBOR string) (spend.TxResult, error)
 	BuildDelegation(ctx context.Context, req spend.DelegationRequest) (spend.DelegationPreview, error)
+	HardwareSignRequest(pendingID string) (spend.HardwareSignRequest, error)
 }
 
 // NodeLookup is the node-backed verification/lookup surface the wallet uses to
@@ -109,6 +110,7 @@ type Vault interface {
 	AddWallet(name, mnemonic, network, vaultPassword, spendPassword string, windowN int) (vault.WalletMeta, error)
 	ImportWallet(name, mnemonic, network, vaultPassword, spendPassword string, windowN int) (vault.WalletMeta, error)
 	ImportWalletMnemonicBytes(name string, mnemonic []byte, network, vaultPassword, spendPassword string, windowN int) (vault.WalletMeta, error)
+	AddHardwareWallet(name, accountXpubBech32, network, vaultPassword string, accountIndex uint32, windowN int) (vault.WalletMeta, error)
 	RemoveWallet(id, vaultPassword string) error
 	SetActive(id string) (vault.WalletMeta, error)
 	Active() (vault.WalletMeta, error)
@@ -343,20 +345,31 @@ type vaultStatus struct {
 // walletView is the API representation of a vault wallet: the read-only fields a
 // client needs to list and bind wallets. The encrypted seed is never exposed.
 type walletView struct {
-	ID           string   `json:"id"`
-	Name         string   `json:"name"`
-	Network      string   `json:"network"`
-	StakeAddress string   `json:"stake_address"`
-	Addresses    []string `json:"addresses"`
-	Active       bool     `json:"active"`
+	ID           string           `json:"id"`
+	Name         string           `json:"name"`
+	Network      string           `json:"network"`
+	StakeAddress string           `json:"stake_address"`
+	Addresses    []string         `json:"addresses"`
+	Active       bool             `json:"active"`
+	Type         vault.WalletType `json:"type"`
 }
 
 func toWalletView(w vault.WalletMeta, activeID string) walletView {
+	// Wallet records persisted before hardware-wallet support carry no type.
+	// The vault only ever creates full or hardware wallets (both set the type
+	// explicitly), so an absent type is always a legacy full (seed-backed)
+	// wallet. Normalize it here — the single point where wallet metadata
+	// becomes SPA-facing — so upgraded vaults keep Send/Sign enabled.
+	walletType := w.Type
+	if walletType == "" {
+		walletType = vault.WalletTypeFull
+	}
 	v := walletView{
 		ID:      w.ID,
 		Name:    w.Name,
 		Network: w.Network,
 		Active:  w.ID == activeID,
+		Type:    walletType,
 	}
 	if w.Account != nil {
 		v.StakeAddress = w.Account.StakeAddress
@@ -635,6 +648,51 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 			return
 		}
 		writeJSON(w, http.StatusOK, map[string]string{"mnemonic": m})
+	})
+
+	// POST /wallet/hardware adds a hardware-backed (watch-only) wallet derived
+	// from an account-level xpub supplied by the device. No mnemonic or spending
+	// password is required — the hardware device holds the private key. The new
+	// wallet becomes active.
+	mux.HandleFunc("POST /wallet/hardware", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Name          string `json:"name"`
+			AccountXpub   string `json:"account_xpub"`
+			AccountIndex  uint32 `json:"account_index"`
+			Network       string `json:"network"`
+			VaultPassword string `json:"vault_password"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+			return
+		}
+		if strings.TrimSpace(req.Name) == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
+			return
+		}
+		if strings.TrimSpace(req.AccountXpub) == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "account_xpub is required"})
+			return
+		}
+		if req.VaultPassword == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "vault_password is required"})
+			return
+		}
+		if req.AccountIndex >= 1<<31 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "account_index must be less than 2147483648"})
+			return
+		}
+		net, ok := resolveNetwork(w, req.Network, network)
+		if !ok {
+			return
+		}
+		meta, err := vlt.AddHardwareWallet(req.Name, req.AccountXpub, net, req.VaultPassword, req.AccountIndex, defaultWindow)
+		if err != nil {
+			serve(w, struct{}{}, err)
+			return
+		}
+		bindActive(meta)
+		writeJSON(w, http.StatusOK, toWalletView(meta, meta.ID))
 	})
 
 	mux.HandleFunc("POST /wallet/{id}/activate", func(w http.ResponseWriter, r *http.Request) {
@@ -981,6 +1039,33 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 		}
 		res, err := sp.Confirm(r.Context(), r.PathValue("id"), req.Password)
 		serve(w, res, err)
+	}))
+
+	// GET /wallet/send/{id}/hardware-sign-request — structured signing request for Ledger.
+	// The pending entry is NOT consumed — the user can still confirm online instead.
+	mux.HandleFunc("GET /wallet/send/{id}/hardware-sign-request", readyGate(st, func(w http.ResponseWriter, r *http.Request) {
+		v, err := sp.HardwareSignRequest(r.PathValue("id"))
+		serve(w, v, err)
+	}))
+
+	// POST /wallet/send/{id}/submit-hardware — attach hardware (Ledger) witness and broadcast.
+	// The witness CBOR is produced by the device; the unsigned tx comes from the pending entry.
+	mux.HandleFunc("POST /wallet/send/{id}/submit-hardware", readyGate(st, func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			WitnessCBOR string `json:"witness_cbor"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+			return
+		}
+		// Fetch the unsigned tx CBOR from the pending entry.
+		unsigned, err := sp.ExportUnsigned(r.PathValue("id"))
+		if err != nil {
+			serve(w, spend.TxResult{}, err)
+			return
+		}
+		v, err := sp.SubmitSigned(r.Context(), unsigned.UnsignedTxCBOR, req.WitnessCBOR)
+		serve(w, v, err)
 	}))
 
 	if po != nil {

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -70,6 +70,12 @@ type fakeVault struct {
 	enableTPMPassword  string
 	enableTPMPCRBound  bool
 	disableTPMPassword string
+
+	// hardware wallet
+	hwErr           error
+	hwCalled        bool
+	gotXpub         string
+	gotAccountIndex uint32
 }
 
 type fakeLegacyKeystore struct {
@@ -354,6 +360,23 @@ func (f *fakeLookup) Asset(_ context.Context, unit string) (chain.AssetInfo, err
 	return f.asset, f.assetErr
 }
 
+func (f *fakeVault) AddHardwareWallet(name, accountXpubBech32, network, vaultPw string, accountIndex uint32, _ int) (vault.WalletMeta, error) {
+	if f.hwErr != nil {
+		return vault.WalletMeta{}, f.hwErr
+	}
+	f.hwCalled = true
+	f.gotName = name
+	f.gotXpub = accountXpubBech32
+	f.gotAccountIndex = accountIndex
+	f.gotVault = vaultPw
+	acct := sampleAccount(network)
+	acct.AccountIndex = accountIndex
+	meta := vault.WalletMeta{ID: "hw1", Name: name, Network: network, Account: acct, Type: vault.WalletTypeHardware}
+	f.wallets = append(f.wallets, meta)
+	f.activeID = meta.ID
+	return meta, nil
+}
+
 func TestHealthAlwaysOK(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
@@ -552,6 +575,35 @@ func TestVaultUnlockBindsSoleWalletAndReads(t *testing.T) {
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/balance", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /wallet/balance after unlock = %d, want 200", rec.Code)
+	}
+}
+
+func TestVaultUnlockLegacyWalletDefaultsToFullType(t *testing.T) {
+	// A wallet record persisted before hardware-wallet support carries no type.
+	// It must surface as a full (seed-backed) wallet so the SPA keeps Send/Sign
+	// enabled — an empty type would disable both for an otherwise normal wallet.
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	fv := &fakeVault{
+		exists:  true,
+		locked:  true,
+		wallets: []vault.WalletMeta{{ID: "legacy", Name: "old", Network: "preview", Account: sampleAccount("preview")}},
+	}
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /vault/unlock = %d, want 200", rec.Code)
+	}
+	var list []walletView
+	if err := json.NewDecoder(rec.Body).Decode(&list); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("unlock list = %+v, want one wallet", list)
+	}
+	if list[0].Type != vault.WalletTypeFull {
+		t.Fatalf("legacy wallet type = %q, want %q", list[0].Type, vault.WalletTypeFull)
 	}
 }
 
@@ -980,6 +1032,11 @@ type fakeSpender struct {
 	submitErr     error
 	gotSubmitTx   string
 	gotSubmitWit  string
+
+	// hardware signing
+	hwSignReq    spend.HardwareSignRequest
+	hwSignReqErr error
+	gotHWSignID  string
 }
 
 func (f *fakeSpender) SetAccount(id string, acct *wallet.Account) {
@@ -1048,6 +1105,14 @@ func (f *fakeSpender) SubmitSigned(_ context.Context, unsignedTxCBOR, witnessCBO
 		return spend.TxResult{}, f.submitErr
 	}
 	return f.submitResult, nil
+}
+
+func (f *fakeSpender) HardwareSignRequest(pendingID string) (spend.HardwareSignRequest, error) {
+	f.gotHWSignID = pendingID
+	if f.hwSignReqErr != nil {
+		return spend.HardwareSignRequest{}, f.hwSignReqErr
+	}
+	return f.hwSignReq, nil
 }
 
 func (f *fakeSpender) BuildDelegation(_ context.Context, _ spend.DelegationRequest) (spend.DelegationPreview, error) {
@@ -3036,5 +3101,196 @@ func TestDexQuoteErrorMapping(t *testing.T) {
 				t.Fatalf("POST /wallet/dex/quote with %s = %d, want %d: %s", tc.name, rec.Code, tc.want, rec.Body.String())
 			}
 		})
+	}
+}
+
+// --- Hardware wallet --------------------------------------------------------
+
+func TestHardwareWalletRoute(t *testing.T) {
+	t.Run("valid body returns active wallet view with addresses", func(t *testing.T) {
+		st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+		fv := &fakeVault{exists: true, locked: false}
+		fw := &fakeWallet{}
+		sp := &fakeSpender{}
+		h := NewHandler(st, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+
+		body := `{"name":"Ledger","account_xpub":"acct_xvk1test","account_index":7,"network":"preview","vault_password":"valid-vault-password"}`
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("POST /wallet/hardware = %d, want 200: %s", rec.Code, rec.Body.String())
+		}
+		if !fv.hwCalled {
+			t.Fatal("AddHardwareWallet should have been called")
+		}
+		if fv.gotName != "Ledger" || fv.gotXpub != "acct_xvk1test" || fv.gotVault != "valid-vault-password" {
+			t.Fatalf("unexpected vault args: name=%q xpub=%q vault=%q", fv.gotName, fv.gotXpub, fv.gotVault)
+		}
+		if fv.gotAccountIndex != 7 {
+			t.Fatalf("account index = %d, want 7", fv.gotAccountIndex)
+		}
+		var got walletView
+		if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if got.ID != "hw1" || !got.Active || got.Type != vault.WalletTypeHardware {
+			t.Fatalf("response = %+v, want active hardware wallet hw1", got)
+		}
+		if len(got.Addresses) == 0 {
+			t.Fatal("response should include receive addresses")
+		}
+		if !fw.setAccountCalled || !sp.setAccountCalled {
+			t.Fatal("hardware wallet should be bound to read and spend services")
+		}
+	})
+
+	t.Run("hardened account index returns 400", func(t *testing.T) {
+		fv := &fakeVault{exists: true, locked: false}
+		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+		rec := httptest.NewRecorder()
+		body := `{"name":"Ledger","account_xpub":"acct_xvk1test","account_index":2147483648,"network":"preview","vault_password":"valid-vault-password"}`
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("hardened account index = %d, want 400", rec.Code)
+		}
+		if fv.hwCalled {
+			t.Fatal("AddHardwareWallet should not be called")
+		}
+	})
+
+	t.Run("malformed JSON returns 400", func(t *testing.T) {
+		fv := &fakeVault{exists: true, locked: false}
+		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(`{bad json`)))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("malformed JSON = %d, want 400", rec.Code)
+		}
+		if fv.hwCalled {
+			t.Fatal("AddHardwareWallet should not be called with malformed JSON")
+		}
+	})
+
+	t.Run("empty xpub returns 400", func(t *testing.T) {
+		fv := &fakeVault{exists: true, locked: false}
+		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+		rec := httptest.NewRecorder()
+		body := `{"name":"Ledger","account_xpub":"","network":"preview","vault_password":"valid-vault-password"}`
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("empty xpub = %d, want 400", rec.Code)
+		}
+	})
+
+	t.Run("empty name returns 400", func(t *testing.T) {
+		fv := &fakeVault{exists: true, locked: false}
+		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+		rec := httptest.NewRecorder()
+		body := `{"name":"","account_xpub":"acct_xvk1test","network":"preview","vault_password":"valid-vault-password"}`
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("empty name = %d, want 400", rec.Code)
+		}
+	})
+
+	t.Run("missing vault_password returns 400", func(t *testing.T) {
+		fv := &fakeVault{exists: true, locked: false}
+		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+		rec := httptest.NewRecorder()
+		body := `{"name":"Ledger","account_xpub":"acct_xvk1test","network":"preview"}`
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("missing vault_password = %d, want 400", rec.Code)
+		}
+	})
+
+	t.Run("duplicate hardware wallet returns 409", func(t *testing.T) {
+		fv := &fakeVault{exists: true, locked: false, hwErr: vault.ErrDuplicateWallet}
+		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+		rec := httptest.NewRecorder()
+		body := `{"name":"Ledger","account_xpub":"acct_xvk1test","network":"preview","vault_password":"valid-vault-password"}`
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
+		if rec.Code != http.StatusConflict {
+			t.Fatalf("duplicate hardware wallet = %d, want 409", rec.Code)
+		}
+	})
+
+	t.Run("network mismatch returns 400", func(t *testing.T) {
+		fv := &fakeVault{exists: true, locked: false}
+		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+		rec := httptest.NewRecorder()
+		body := `{"name":"Ledger","account_xpub":"acct_xvk1test","network":"mainnet","vault_password":"valid-vault-password"}`
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("network mismatch = %d, want 400", rec.Code)
+		}
+	})
+}
+
+func TestHardwareSignRequestRoute(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	sp := &fakeSpender{hwSignReq: spend.HardwareSignRequest{
+		Network:       "preview",
+		NetworkID:     0,
+		ProtocolMagic: 2,
+		Inputs: []spend.HWInput{
+			{TxHashHex: "deadbeef", OutputIndex: 0, Path: "1852'/1815'/0'/0/0"},
+		},
+		Outputs: []spend.HWOutput{
+			{AddressHex: "60aabb", AddressBech32: "addr_test1...", Lovelace: "1000000"},
+		},
+		Fee:             "170000",
+		RequiredSigners: []string{"aabbccdd"},
+		UnsignedTxCBOR:  "84a4deadbeef",
+	}}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/send/pending-123/hardware-sign-request", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /hardware-sign-request = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var got spend.HardwareSignRequest
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if sp.gotHWSignID != "pending-123" {
+		t.Fatalf("gotHWSignID = %q, want pending-123", sp.gotHWSignID)
+	}
+	if got.NetworkID != 0 || got.ProtocolMagic != 2 {
+		t.Fatalf("network fields wrong: %+v", got)
+	}
+	if len(got.Inputs) != 1 || got.Inputs[0].Path != "1852'/1815'/0'/0/0" {
+		t.Fatalf("inputs wrong: %+v", got.Inputs)
+	}
+	if len(got.RequiredSigners) != 1 || got.RequiredSigners[0] != "aabbccdd" {
+		t.Fatalf("required signers wrong: %+v", got.RequiredSigners)
+	}
+}
+
+func TestSubmitHardwareRoute(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	sp := &fakeSpender{
+		unsigned:     spend.UnsignedTx{UnsignedTxCBOR: "84a400deadbeef", RequiredSigners: []string{"aabb"}},
+		submitResult: spend.TxResult{TxHash: "cafebabe"},
+	}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+
+	body := `{"witness_cbor":"81825820"}`
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pending-123/submit-hardware",
+		strings.NewReader(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /submit-hardware = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var got spend.TxResult
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.TxHash != "cafebabe" {
+		t.Fatalf("tx_hash = %q, want cafebabe", got.TxHash)
+	}
+	if sp.gotSubmitTx != "84a400deadbeef" || sp.gotSubmitWit != "81825820" {
+		t.Fatalf("SubmitSigned called with wrong args: tx=%q wit=%q", sp.gotSubmitTx, sp.gotSubmitWit)
 	}
 }

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -1690,6 +1690,266 @@ func (s *Service) WitnessTx(
 	return wsCbor, nil
 }
 
+// HardwareSignRequest is the structured signing request the SPA passes to the
+// Ledger device (via ledgerjs). It contains decoded tx fields (NOT raw CBOR)
+// so the device can display them to the user and sign without parsing CBOR.
+//
+// Scope: payment transactions (inputs/outputs/fee/ttl/change) only.
+// Certificates and withdrawals are guarded — the caller must check Unsupported
+// before constructing a SignTransactionRequest.
+type HardwareSignRequest struct {
+	// Network: "mainnet", "preprod", or "preview".
+	Network string `json:"network"`
+	// NetworkID: 1 for mainnet, 0 for testnet.
+	NetworkID int `json:"network_id"`
+	// ProtocolMagic: 764824073 for mainnet, 1 for preprod, 2 for preview.
+	ProtocolMagic uint32 `json:"protocol_magic"`
+	// Inputs: one entry per tx input the wallet owns.
+	Inputs []HWInput `json:"inputs"`
+	// Outputs: all tx outputs.
+	Outputs []HWOutput `json:"outputs"`
+	// Fee: lovelace as decimal string.
+	Fee string `json:"fee"`
+	// TTL: slot number as decimal string, empty if absent.
+	TTL string `json:"ttl,omitempty"`
+	// RequiredSigners are the key hashes embedded in the transaction body. The
+	// Ledger request must include the identical set or it will sign a different
+	// body from UnsignedTxCBOR.
+	RequiredSigners []string `json:"required_signers"`
+	// IncludeNetworkID preserves body key 15 when it was present in the pending
+	// transaction, so Ledger reconstructs and signs the identical body.
+	IncludeNetworkID bool `json:"include_network_id,omitempty"`
+	// UnsignedTxCBOR: the raw tx hex, used by SubmitSigned.
+	UnsignedTxCBOR string `json:"unsigned_tx_cbor"`
+	// Unsupported: non-empty means this tx cannot be signed on hardware yet.
+	// The SPA MUST show this message and refuse to sign.
+	Unsupported string `json:"unsupported,omitempty"`
+}
+
+// HWInput is one transaction input in the hardware sign request.
+type HWInput struct {
+	TxHashHex   string `json:"tx_hash_hex"`
+	OutputIndex uint32 `json:"output_index"`
+	// Path is the CIP-1852 derivation path ("1852'/1815'/0'/0/3") for the
+	// payment key that must sign this input, or "" if the input is not ours.
+	Path string `json:"path,omitempty"`
+}
+
+// HWOutput is one transaction output in the hardware sign request.
+type HWOutput struct {
+	// AddressHex is the hex-encoded address bytes. It is used by the SPA for
+	// third-party outputs; device-owned outputs are reconstructed from paths.
+	AddressHex string `json:"address_hex"`
+	// AddressBech32 for display.
+	AddressBech32 string `json:"address_bech32"`
+	// Lovelace as decimal string.
+	Lovelace string `json:"lovelace"`
+	// PaymentPath and StakePath identify an output owned by this wallet. They
+	// are both set for our base addresses and omitted for third-party outputs.
+	PaymentPath string `json:"payment_path,omitempty"`
+	StakePath   string `json:"stake_path,omitempty"`
+	// Assets: native assets (NOT SUPPORTED yet — guard triggers if non-empty).
+	Assets []HWAsset `json:"assets,omitempty"`
+}
+
+// HWAsset is a native asset within an output.
+type HWAsset struct {
+	PolicyIDHex  string `json:"policy_id_hex"`
+	AssetNameHex string `json:"asset_name_hex"`
+	Amount       string `json:"amount"` // decimal string
+}
+
+// HardwareSignRequest returns the structured signing request the SPA passes to
+// the Ledger device. It decodes the pending transaction into discrete fields so
+// the device can display and sign them without parsing raw CBOR.
+//
+// Unlike Confirm it does NOT consume the pending entry — it is subject to the
+// same TTL. When an unsupported feature is detected the struct is still returned
+// with Unsupported set (and UnsignedTxCBOR populated) so the SPA can show the
+// user what was attempted.
+func (s *Service) HardwareSignRequest(pendingID string) (HardwareSignRequest, error) {
+	// Held for the whole function (like ExportUnsigned) so every structured
+	// field and UnsignedTxCBOR are read from the same consistent snapshot of
+	// the pending entry - not released partway through and re-read after a
+	// concurrent Confirm/sweep could touch it.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.pending[pendingID]
+	expired := ok && s.now().Sub(p.created) > pendingTTL
+	if !ok {
+		return HardwareSignRequest{}, fmt.Errorf("%w: %q", ErrUnknownPending, pendingID)
+	}
+	if expired {
+		return HardwareSignRequest{}, fmt.Errorf("%w: %q", ErrExpiredPending, pendingID)
+	}
+
+	tx := p.tx.GetTx()
+	if tx == nil {
+		return HardwareSignRequest{}, errors.New("pending tx is nil")
+	}
+
+	cborBytes, err := p.tx.GetTxCbor()
+	if err != nil {
+		return HardwareSignRequest{}, fmt.Errorf("encode unsigned tx: %w", err)
+	}
+	unsignedTxCBOR := hex.EncodeToString(cborBytes)
+
+	// Determine network parameters.
+	acct := p.account
+	if acct == nil {
+		return HardwareSignRequest{}, ErrNoWallet
+	}
+	networkName := acct.Network
+	networkID := 0
+	var protocolMagic uint32
+	switch networkName {
+	case "mainnet":
+		networkID = 1
+		protocolMagic = 764824073
+	case "preprod":
+		protocolMagic = 1
+	default: // preview; the account network is validated when it is derived.
+		protocolMagic = 2
+	}
+
+	result := HardwareSignRequest{
+		Network:          networkName,
+		NetworkID:        networkID,
+		ProtocolMagic:    protocolMagic,
+		RequiredSigners:  keyHashesHex(tx.Body.RequiredSigners()),
+		UnsignedTxCBOR:   unsignedTxCBOR,
+		IncludeNetworkID: tx.Body.TxNetworkId != nil,
+	}
+	if tx.Body.TxNetworkId != nil && int(*tx.Body.TxNetworkId) != networkID {
+		result.Unsupported = "transaction network id does not match the active wallet"
+		return result, nil
+	}
+
+	// Guard unsupported features — still populate UnsignedTxCBOR so the SPA can
+	// show the user what was attempted.
+	if len(tx.Body.TxCertificates) > 0 {
+		result.Unsupported = "certificates are not supported on hardware yet"
+		return result, nil
+	}
+	if len(tx.Body.TxWithdrawals) > 0 {
+		result.Unsupported = "withdrawals are not supported on hardware yet"
+		return result, nil
+	}
+	// Note: TxWithdrawals is a map[*Address]uint64; len works on nil maps (returns 0).
+	var unsupportedBodyFeature string
+	switch {
+	case tx.Body.Update != nil:
+		unsupportedBodyFeature = "protocol update"
+	case tx.Body.TxAuxDataHash != nil:
+		unsupportedBodyFeature = "auxiliary data"
+	case tx.Body.TxValidityIntervalStart != 0:
+		unsupportedBodyFeature = "validity interval start"
+	case tx.Body.TxMint != nil:
+		unsupportedBodyFeature = "minting"
+	case tx.Body.TxScriptDataHash != nil:
+		unsupportedBodyFeature = "script data"
+	case len(tx.Body.TxCollateral.Items()) > 0:
+		unsupportedBodyFeature = "collateral inputs"
+	case tx.Body.TxCollateralReturn != nil:
+		unsupportedBodyFeature = "collateral return"
+	case tx.Body.TxTotalCollateral != 0:
+		unsupportedBodyFeature = "total collateral"
+	case len(tx.Body.TxReferenceInputs.Items()) > 0:
+		unsupportedBodyFeature = "reference inputs"
+	case len(tx.Body.TxVotingProcedures) > 0:
+		unsupportedBodyFeature = "voting procedures"
+	case len(tx.Body.TxProposalProcedures) > 0:
+		unsupportedBodyFeature = "proposal procedures"
+	case tx.Body.TxCurrentTreasuryValue != 0:
+		unsupportedBodyFeature = "current treasury value"
+	case tx.Body.TxDonation != 0:
+		unsupportedBodyFeature = "treasury donation"
+	}
+	if unsupportedBodyFeature != "" {
+		result.Unsupported = unsupportedBodyFeature + " is not supported on hardware yet"
+		return result, nil
+	}
+
+	// Guard: native assets in outputs are not supported yet. Check before
+	// building inputs so no signing paths are leaked (symmetric with the cert
+	// and withdrawal guards above).
+	for _, out := range tx.Body.TxOutputs {
+		if out.OutputAmount.Assets != nil {
+			result.Unsupported = "outputs with native assets are not supported on hardware yet"
+			return result, nil
+		}
+		if out.DatumOption != nil || out.TxOutScriptRef != nil {
+			result.Unsupported = "outputs with datum or script references are not supported on hardware yet"
+			return result, nil
+		}
+	}
+
+	// Build address → derivation path lookups for input signing and owned
+	// outputs. Although Build currently sends change to receive address 0, keep
+	// both roles here so future change-address selection remains correctly
+	// represented to the device.
+	accountNum := acct.AccountIndex
+	idxOf := make(map[string]int, len(acct.ReceiveAddresses))
+	pathOf := make(map[string]string, len(acct.ReceiveAddresses)+len(acct.ChangeAddresses))
+	for i, addr := range acct.ReceiveAddresses {
+		idxOf[addr] = i
+		pathOf[addr] = fmt.Sprintf("1852'/%d'/%d'/0/%d", 1815, accountNum, i)
+	}
+	for i, addr := range acct.ChangeAddresses {
+		pathOf[addr] = fmt.Sprintf("1852'/%d'/%d'/1/%d", 1815, accountNum, i)
+	}
+	stakePath := fmt.Sprintf("1852'/%d'/%d'/2/0", 1815, accountNum)
+
+	// Build inputs with paths.
+	// Every owned input gets its correct derivation path; the Ledger tolerates
+	// repeated paths. Dedup of witnessPathsNumeric happens on the SPA side.
+	inputs := make([]HWInput, 0, len(tx.Body.TxInputs.Items()))
+	for _, inp := range tx.Body.TxInputs.Items() {
+		ref := hex.EncodeToString(inp.TxId.Bytes()) + "#" + strconv.Itoa(int(inp.OutputIndex))
+		hwInp := HWInput{
+			TxHashHex:   hex.EncodeToString(inp.TxId.Bytes()),
+			OutputIndex: inp.OutputIndex,
+		}
+		addrStr, found := p.utxoAddr[ref]
+		if found {
+			if idx, owned := idxOf[addrStr]; owned {
+				hwInp.Path = fmt.Sprintf("1852'/%d'/%d'/0/%d", 1815, accountNum, idx)
+			}
+		}
+		inputs = append(inputs, hwInp)
+	}
+	result.Inputs = inputs
+
+	// Build outputs.
+	outputs := make([]HWOutput, 0, len(tx.Body.TxOutputs))
+	for _, out := range tx.Body.TxOutputs {
+		addr := out.OutputAddress
+		addrBytes, bytesErr := addr.Bytes()
+		if bytesErr != nil {
+			return HardwareSignRequest{}, fmt.Errorf("output address bytes: %w", bytesErr)
+		}
+		hwOut := HWOutput{
+			AddressHex:    hex.EncodeToString(addrBytes),
+			AddressBech32: addr.String(),
+			Lovelace:      strconv.FormatUint(out.OutputAmount.Amount, 10),
+		}
+		if paymentPath, owned := pathOf[addr.String()]; owned {
+			hwOut.PaymentPath = paymentPath
+			hwOut.StakePath = stakePath
+		}
+		outputs = append(outputs, hwOut)
+	}
+	result.Outputs = outputs
+
+	// Fee and TTL.
+	result.Fee = strconv.FormatUint(tx.Body.TxFee, 10)
+	if tx.Body.Ttl > 0 {
+		result.TTL = strconv.FormatUint(tx.Body.Ttl, 10)
+	}
+
+	return result, nil
+}
+
 // randID generates a 16-byte random hex string for pending IDs.
 func randID() string {
 	b := make([]byte, 16)

--- a/ui/internal/spend/spend_test.go
+++ b/ui/internal/spend/spend_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	apollo "github.com/blinklabs-io/apollo/v2"
 	"github.com/blinklabs-io/apollo/v2/backend"
 	"github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/bursa/bip32"
@@ -18,6 +19,7 @@ import (
 	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
@@ -132,6 +134,31 @@ func (o *fakeOutput) Utxorpc() (*utxorpc.TxOutput, error) { return nil, nil }
 func (o *fakeOutput) ScriptRef() lcommon.Script           { return nil }
 func (o *fakeOutput) ToPlutusData() data.PlutusData       { return nil }
 func (o *fakeOutput) String() string                      { return o.address.String() }
+
+// fakeOutputWithAssets is like fakeOutput but also carries native assets — used
+// to construct test UTxOs that contain native tokens so apollo can forward them.
+type fakeOutputWithAssets struct {
+	fakeOutput
+	assets *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput]
+}
+
+func (o *fakeOutputWithAssets) Assets() *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput] {
+	return o.assets
+}
+
+// newFakeMultiAsset creates a minimal MultiAsset with one policy/asset entry.
+func newFakeMultiAsset(policyHex, assetNameHex string, qty int64) *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput] {
+	policyBytes, _ := hex.DecodeString(policyHex)
+	assetBytes, _ := hex.DecodeString(assetNameHex)
+	var policyID lcommon.Blake2b224
+	copy(policyID[:], policyBytes)
+	assetName := cbor.NewByteString(assetBytes)
+	data := map[lcommon.Blake2b224]map[cbor.ByteString]lcommon.MultiAssetTypeOutput{
+		policyID: {assetName: new(big.Int).SetInt64(qty)},
+	}
+	ma := lcommon.NewMultiAsset(data)
+	return &ma
+}
 
 // backend.ChainContext implementation for fakeChain.
 func (fc *fakeChain) ProtocolParams(_ context.Context) (backend.ProtocolParameters, error) {
@@ -1760,6 +1787,17 @@ func TestWitnessTxRejectsWalletChanged(t *testing.T) {
 	}
 }
 
+// mustNewAddress is a test helper that converts a bech32 address string and
+// fails the test if it cannot be parsed.
+func mustNewAddress(t *testing.T, addr string) lcommon.Address {
+	t.Helper()
+	a, err := lcommon.NewAddress(addr)
+	if err != nil {
+		t.Fatalf("lcommon.NewAddress(%q): %v", addr, err)
+	}
+	return a
+}
+
 // TestSetWalletCreatesKeystoreAndEnablesBuild exercises the SetWallet lifecycle
 // against a real keystore: before SetWallet, Build reports ErrNoWallet; after,
 // the keystore exists and Build works; re-attaching needs the correct password.
@@ -1804,5 +1842,498 @@ func TestSetWalletCreatesKeystoreAndEnablesBuild(t *testing.T) {
 	}
 	if _, err := s.SetWallet(differentMnemonic, "preview", "spend-password-1"); err == nil {
 		t.Fatal("SetWallet re-attach with different mnemonic should fail")
+	}
+}
+
+func TestHardwareSignRequest(t *testing.T) {
+	acct := mustDeriveTestAccount(t)
+	addr0 := acct.ReceiveAddresses[0]
+	recipientAcct, err := wallet.Derive(differentMnemonic, "preview", 1)
+	if err != nil {
+		t.Fatalf("derive recipient account: %v", err)
+	}
+	recipientAddr := recipientAcct.ReceiveAddresses[0]
+
+	fc := newFakeChain(10_000_000, addr0)
+	s := NewService(fc, nil, acct)
+
+	// Build a pending transaction.
+	pv, err := s.Build(context.Background(), SendRequest{To: recipientAddr, Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	// Get the hardware sign request.
+	req, err := s.HardwareSignRequest(pv.PendingID)
+	if err != nil {
+		t.Fatalf("HardwareSignRequest: %v", err)
+	}
+
+	// Verify basic fields.
+	if req.Network != "preview" {
+		t.Fatalf("Network = %q, want preview", req.Network)
+	}
+	if req.NetworkID != 0 {
+		t.Fatalf("NetworkID = %d, want 0", req.NetworkID)
+	}
+	if req.ProtocolMagic != 2 {
+		t.Fatalf("ProtocolMagic = %d, want 2", req.ProtocolMagic)
+	}
+	if !req.IncludeNetworkID {
+		t.Fatal("IncludeNetworkID must preserve the network-id field from the payment body")
+	}
+	if req.Unsupported != "" {
+		t.Fatalf("Unsupported must be empty for simple payment, got %q", req.Unsupported)
+	}
+	if req.Fee == "" || req.Fee == "0" {
+		t.Fatalf("Fee = %q, want non-zero", req.Fee)
+	}
+	if req.UnsignedTxCBOR == "" {
+		t.Fatal("UnsignedTxCBOR must not be empty")
+	}
+	wantRequired := keyHashesHex(bodyRequiredSigners(t, req.UnsignedTxCBOR))
+	if !equalStringSets(req.RequiredSigners, wantRequired) || len(req.RequiredSigners) == 0 {
+		t.Fatalf("RequiredSigners = %v, want body required signers %v", req.RequiredSigners, wantRequired)
+	}
+
+	// Verify inputs have paths (payment tx funds from addr0 at index 0).
+	if len(req.Inputs) == 0 {
+		t.Fatal("expected at least one input")
+	}
+	hasPath := false
+	for _, inp := range req.Inputs {
+		if inp.Path != "" {
+			hasPath = true
+			// Path must follow CIP-1852 format.
+			if inp.Path != "1852'/1815'/0'/0/0" {
+				t.Fatalf("unexpected path %q for index 0 payment key", inp.Path)
+			}
+		}
+	}
+	if !hasPath {
+		t.Fatal("at least one input should have a derivation path")
+	}
+
+	// Verify outputs are present with lovelace.
+	if len(req.Outputs) == 0 {
+		t.Fatal("expected at least one output")
+	}
+	sawRecipient := false
+	sawChange := false
+	for _, out := range req.Outputs {
+		if out.Lovelace == "" || out.Lovelace == "0" {
+			t.Fatalf("output lovelace must be non-zero: %+v", out)
+		}
+		if out.AddressHex == "" {
+			t.Fatalf("output AddressHex must not be empty: %+v", out)
+		}
+		if out.AddressBech32 == "" {
+			t.Fatalf("output AddressBech32 must not be empty: %+v", out)
+		}
+		switch out.AddressBech32 {
+		case recipientAddr:
+			sawRecipient = true
+			if out.PaymentPath != "" || out.StakePath != "" {
+				t.Fatalf("third-party recipient must not have device paths: %+v", out)
+			}
+		case addr0:
+			sawChange = true
+			if out.PaymentPath != "1852'/1815'/0'/0/0" {
+				t.Fatalf("change payment path = %q, want account 0 external index 0", out.PaymentPath)
+			}
+			if out.StakePath != "1852'/1815'/0'/2/0" {
+				t.Fatalf("change stake path = %q, want account 0 stake index 0", out.StakePath)
+			}
+		}
+	}
+	if !sawRecipient || !sawChange {
+		t.Fatalf("outputs must include recipient and change: %+v", req.Outputs)
+	}
+}
+
+func TestHardwareSignRequestPreprodProtocolMagic(t *testing.T) {
+	acct, err := wallet.Derive(testMnemonic, "preprod", 2)
+	if err != nil {
+		t.Fatalf("derive preprod account: %v", err)
+	}
+	fc := newFakeChain(10_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, nil, acct)
+
+	pv, err := s.Build(context.Background(), SendRequest{
+		To:       acct.ReceiveAddresses[1],
+		Lovelace: "1000000",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	req, err := s.HardwareSignRequest(pv.PendingID)
+	if err != nil {
+		t.Fatalf("HardwareSignRequest: %v", err)
+	}
+
+	if req.NetworkID != 0 {
+		t.Fatalf("NetworkID = %d, want 0", req.NetworkID)
+	}
+	if req.ProtocolMagic != 1 {
+		t.Fatalf("ProtocolMagic = %d, want 1", req.ProtocolMagic)
+	}
+}
+
+func TestHardwareSignRequestUsesAccountIndex(t *testing.T) {
+	root, err := bursa.GetRootKeyFromMnemonic(testMnemonic, "")
+	if err != nil {
+		t.Fatalf("root key: %v", err)
+	}
+	accountKey, err := bursa.GetAccountKey(root, 2)
+	if err != nil {
+		t.Fatalf("account key: %v", err)
+	}
+	acct, err := wallet.DeriveFromAccountXpub(accountKey.Public().String(), "preview", 2, 3)
+	if err != nil {
+		t.Fatalf("derive account 2: %v", err)
+	}
+	fc := newFakeChain(10_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, nil, acct)
+	pv, err := s.Build(context.Background(), SendRequest{
+		To: acct.ReceiveAddresses[1], Lovelace: "1000000",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	req, err := s.HardwareSignRequest(pv.PendingID)
+	if err != nil {
+		t.Fatalf("HardwareSignRequest: %v", err)
+	}
+	if got := req.Inputs[0].Path; got != "1852'/1815'/2'/0/0" {
+		t.Fatalf("input path = %q, want account 2", got)
+	}
+	for _, out := range req.Outputs {
+		if out.PaymentPath != "" && !strings.HasPrefix(out.PaymentPath, "1852'/1815'/2'/") {
+			t.Fatalf("owned output payment path = %q, want account 2", out.PaymentPath)
+		}
+		if out.StakePath != "" && out.StakePath != "1852'/1815'/2'/2/0" {
+			t.Fatalf("owned output stake path = %q, want account 2", out.StakePath)
+		}
+	}
+}
+
+func TestHardwareSignRequestUnknownPending(t *testing.T) {
+	acct := mustDeriveTestAccount(t)
+	fc := newFakeChain(10_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, nil, acct)
+
+	_, err := s.HardwareSignRequest("does-not-exist")
+	if err == nil {
+		t.Fatal("expected error for unknown pending id")
+	}
+	if !errors.Is(err, ErrUnknownPending) {
+		t.Fatalf("expected ErrUnknownPending, got %v", err)
+	}
+}
+
+// TestHardwareSignRequestGuard verifies the safety property: txs with
+// certificates, withdrawals, or native-asset outputs set Unsupported and do
+// NOT leak signing inputs/paths for the certificate and withdrawal cases
+// (where the guard fires before inputs are built).
+func TestHardwareSignRequestGuard(t *testing.T) {
+	acct, err := wallet.Derive(testMnemonic, "preview", 5)
+	if err != nil {
+		t.Fatalf("wallet.Derive: %v", err)
+	}
+	addr0 := acct.ReceiveAddresses[0]
+	addr3 := acct.ReceiveAddresses[3]
+	recvAddr := acct.ReceiveAddresses[4]
+
+	t.Run("certificate tx is rejected", func(t *testing.T) {
+		fc := newFakeChain(5_000_000, addr0)
+		fc.addUTxO(5_000_000, addr3, "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc03", 0)
+		s := NewService(fc, nil, acct)
+
+		// Build an initial pending, then replace the builder with one that
+		// includes a stake-registration certificate.
+		pv, err := s.Build(context.Background(), SendRequest{To: recvAddr, Lovelace: "4000000"})
+		if err != nil {
+			t.Fatalf("Build: %v", err)
+		}
+		s.mu.Lock()
+		p := s.pending[pv.PendingID]
+		s.mu.Unlock()
+
+		changeAddr, _ := lcommon.NewAddress(addr0)
+		a := apollo.New(fc).
+			SetWallet(apollo.NewExternalWallet(changeAddr)).
+			SetChangeAddress(changeAddr).
+			SetFeePadding(feePaddingLovelace).
+			AddLoadedUTxOs(fc.utxos[addr0]...).
+			AddLoadedUTxOs(fc.utxos[addr3]...).
+			PayToAddress(mustNewAddress(t, recvAddr), 1_000_000)
+		a, err = a.RegisterStake(acct.StakeAddress)
+		if err != nil {
+			t.Fatalf("RegisterStake: %v", err)
+		}
+		a, err = a.CompleteContext(context.Background())
+		if err != nil {
+			t.Fatalf("Complete with cert: %v", err)
+		}
+		utxoAddr := make(map[string]string)
+		for _, u := range fc.utxos[addr0] {
+			utxoAddr[makeUtxoRef(u)] = addr0
+		}
+		for _, u := range fc.utxos[addr3] {
+			utxoAddr[makeUtxoRef(u)] = addr3
+		}
+		s.mu.Lock()
+		s.pending[pv.PendingID] = &pending{
+			tx:       a,
+			utxoAddr: utxoAddr,
+			created:  p.created,
+			walletID: p.walletID,
+			account:  p.account,
+		}
+		s.mu.Unlock()
+
+		req, err := s.HardwareSignRequest(pv.PendingID)
+		if err != nil {
+			t.Fatalf("HardwareSignRequest: %v", err)
+		}
+		if req.Unsupported == "" {
+			t.Fatal("expected Unsupported to be set for a cert tx")
+		}
+		// Guard fires before inputs are built: no paths should leak.
+		for _, inp := range req.Inputs {
+			if inp.Path != "" {
+				t.Fatalf("cert guard leaked a signing path: %q", inp.Path)
+			}
+		}
+		if len(req.Inputs) > 0 {
+			t.Fatalf("cert guard: expected no inputs in result, got %d", len(req.Inputs))
+		}
+	})
+
+	t.Run("withdrawal tx is rejected", func(t *testing.T) {
+		fc := newFakeChain(5_000_000, addr0)
+		s := NewService(fc, nil, acct)
+
+		pv, err := s.Build(context.Background(), SendRequest{To: recvAddr, Lovelace: "1000000"})
+		if err != nil {
+			t.Fatalf("Build: %v", err)
+		}
+		s.mu.Lock()
+		p := s.pending[pv.PendingID]
+		s.mu.Unlock()
+
+		stakeAddr, err := lcommon.NewAddress(acct.StakeAddress)
+		if err != nil {
+			t.Fatalf("NewAddress(stake): %v", err)
+		}
+		changeAddr, _ := lcommon.NewAddress(addr0)
+		a := apollo.New(fc).
+			SetWallet(apollo.NewExternalWallet(changeAddr)).
+			SetChangeAddress(changeAddr).
+			SetFeePadding(feePaddingLovelace).
+			AddLoadedUTxOs(fc.utxos[addr0]...).
+			PayToAddress(mustNewAddress(t, recvAddr), 1_000_000).
+			AddWithdrawal(stakeAddr, 500_000, nil, nil)
+		a, err = a.CompleteContext(context.Background())
+		if err != nil {
+			t.Fatalf("Complete with withdrawal: %v", err)
+		}
+		utxoAddr := make(map[string]string)
+		for _, u := range fc.utxos[addr0] {
+			utxoAddr[makeUtxoRef(u)] = addr0
+		}
+		s.mu.Lock()
+		s.pending[pv.PendingID] = &pending{
+			tx:       a,
+			utxoAddr: utxoAddr,
+			created:  p.created,
+			walletID: p.walletID,
+			account:  p.account,
+		}
+		s.mu.Unlock()
+
+		req, err := s.HardwareSignRequest(pv.PendingID)
+		if err != nil {
+			t.Fatalf("HardwareSignRequest: %v", err)
+		}
+		if req.Unsupported == "" {
+			t.Fatal("expected Unsupported to be set for a withdrawal tx")
+		}
+		// Guard fires before inputs are built: no inputs should leak.
+		if len(req.Inputs) > 0 {
+			t.Fatalf("withdrawal guard: expected no inputs in result, got %d", len(req.Inputs))
+		}
+	})
+
+	t.Run("native-asset output is rejected", func(t *testing.T) {
+		// Fund addr0 with 5 ADA + 1 native token. Apollo needs the token in the
+		// input UTxO before it can route it to an output (coin selection enforces
+		// asset conservation). We inject a fakeOutputWithAssets for that UTxO so
+		// the builder can construct a tx whose outputs carry the native asset.
+		const (
+			policyHex    = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 28 bytes
+			assetNameHex = "74657374"                                                 // "test"
+		)
+		nativeAssets := newFakeMultiAsset(policyHex, assetNameHex, 1) //nolint:gomnd
+		nativeToken := apollo.NewUnit(policyHex, assetNameHex, 1)
+
+		// Build the input UTxO manually with native assets.
+		var txIDBytes lcommon.Blake2b256
+		copy(txIDBytes[:], make([]byte, 32)) // all-zero hash
+		inputID := shelley.ShelleyTransactionInput{TxId: txIDBytes, OutputIndex: 0}
+		addr0Parsed, _ := lcommon.NewAddress(addr0)
+		inputOutput := &fakeOutputWithAssets{
+			fakeOutput: fakeOutput{address: addr0Parsed, lovelace: 5_000_000},
+			assets:     nativeAssets,
+		}
+		inputUTxO := lcommon.Utxo{Id: inputID, Output: inputOutput}
+
+		// Construct a fakeChain with the asset-bearing UTxO.
+		fc := &fakeChain{utxos: map[string][]lcommon.Utxo{addr0: {inputUTxO}}}
+		s := NewService(fc, nil, acct)
+
+		pv, err := s.Build(context.Background(), SendRequest{To: recvAddr, Lovelace: "1000000"})
+		if err != nil {
+			t.Fatalf("Build: %v", err)
+		}
+		s.mu.Lock()
+		p := s.pending[pv.PendingID]
+		s.mu.Unlock()
+
+		changeAddr, _ := lcommon.NewAddress(addr0)
+		// Build a tx that sends 2 ADA + the native token to recvAddr.
+		a := apollo.New(fc).
+			SetWallet(apollo.NewExternalWallet(changeAddr)).
+			SetChangeAddress(changeAddr).
+			SetFeePadding(feePaddingLovelace).
+			AddLoadedUTxOs(inputUTxO).
+			PayToAddress(mustNewAddress(t, recvAddr), 2_000_000, nativeToken)
+		a, err = a.CompleteContext(context.Background())
+		if err != nil {
+			t.Fatalf("Complete with native asset: %v", err)
+		}
+		ref := hex.EncodeToString(txIDBytes.Bytes()) + "#0"
+		utxoAddr := map[string]string{ref: addr0}
+		s.mu.Lock()
+		s.pending[pv.PendingID] = &pending{
+			tx:       a,
+			utxoAddr: utxoAddr,
+			created:  p.created,
+			walletID: p.walletID,
+			account:  p.account,
+		}
+		s.mu.Unlock()
+
+		req, err := s.HardwareSignRequest(pv.PendingID)
+		if err != nil {
+			t.Fatalf("HardwareSignRequest: %v", err)
+		}
+		if req.Unsupported == "" {
+			t.Fatal("expected Unsupported to be set for a native-asset output tx")
+		}
+		// Guard fires before inputs are built: no inputs should leak.
+		if len(req.Inputs) > 0 {
+			t.Fatalf("native-asset guard: expected no inputs in result, got %d", len(req.Inputs))
+		}
+	})
+}
+
+func TestHardwareSignRequestRejectsOtherConwayFeatures(t *testing.T) {
+	type mutateBody func(*conway.ConwayTransactionBody)
+	var hash lcommon.Blake2b256
+	hash[0] = 1
+	networkID := uint8(1)
+	tests := []struct {
+		name   string
+		mutate mutateBody
+	}{
+		{"protocol update", func(b *conway.ConwayTransactionBody) { b.Update = &conway.ConwayTransactionPparamUpdate{} }},
+		{"auxiliary data hash", func(b *conway.ConwayTransactionBody) { b.TxAuxDataHash = &hash }},
+		{"validity interval start", func(b *conway.ConwayTransactionBody) { b.TxValidityIntervalStart = 1 }},
+		{"mint", func(b *conway.ConwayTransactionBody) { b.TxMint = &lcommon.MultiAsset[lcommon.MultiAssetTypeMint]{} }},
+		{"script data hash", func(b *conway.ConwayTransactionBody) { b.TxScriptDataHash = &hash }},
+		{"collateral", func(b *conway.ConwayTransactionBody) { b.TxCollateral = cbor.NewSetType(b.TxInputs.Items(), true) }},
+		{"mismatched network id", func(b *conway.ConwayTransactionBody) { b.TxNetworkId = &networkID }},
+		{"collateral return", func(b *conway.ConwayTransactionBody) { out := b.TxOutputs[0]; b.TxCollateralReturn = &out }},
+		{"total collateral", func(b *conway.ConwayTransactionBody) { b.TxTotalCollateral = 1 }},
+		{"reference inputs", func(b *conway.ConwayTransactionBody) { b.TxReferenceInputs = cbor.NewSetType(b.TxInputs.Items(), true) }},
+		{"voting procedures", func(b *conway.ConwayTransactionBody) {
+			b.TxVotingProcedures = lcommon.VotingProcedures{new(lcommon.Voter): {new(lcommon.GovActionId): {}}}
+		}},
+		{"proposal procedures", func(b *conway.ConwayTransactionBody) { b.TxProposalProcedures = []conway.ConwayProposalProcedure{{}} }},
+		{"current treasury value", func(b *conway.ConwayTransactionBody) { b.TxCurrentTreasuryValue = 1 }},
+		{"donation", func(b *conway.ConwayTransactionBody) { b.TxDonation = 1 }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			acct := mustDeriveTestAccount(t)
+			fc := newFakeChain(10_000_000, acct.ReceiveAddresses[0])
+			s := NewService(fc, nil, acct)
+			pv, err := s.Build(context.Background(), SendRequest{To: acct.ReceiveAddresses[1], Lovelace: "1000000"})
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+			tx := s.pending[pv.PendingID].tx.GetTx()
+			tt.mutate(&tx.Body)
+
+			req, err := s.HardwareSignRequest(pv.PendingID)
+			if err != nil {
+				t.Fatalf("HardwareSignRequest: %v", err)
+			}
+			if req.Unsupported == "" {
+				t.Fatal("expected unsupported body feature to be rejected")
+			}
+			if len(req.Inputs) != 0 {
+				t.Fatalf("guard returned %d signing inputs", len(req.Inputs))
+			}
+		})
+	}
+
+	datumOptionCBOR, err := cbor.Encode([]any{babbage.DatumOptionTypeHash, hash})
+	if err != nil {
+		t.Fatalf("encode datum option: %v", err)
+	}
+	var datumOption babbage.BabbageTransactionOutputDatumOption
+	if _, err := cbor.Decode(datumOptionCBOR, &datumOption); err != nil {
+		t.Fatalf("decode datum option: %v", err)
+	}
+	outputTests := []struct {
+		name   string
+		mutate func(*babbage.BabbageTransactionOutput)
+	}{
+		{"output datum", func(out *babbage.BabbageTransactionOutput) {
+			out.DatumOption = &datumOption
+		}},
+		{"output script reference", func(out *babbage.BabbageTransactionOutput) {
+			out.TxOutScriptRef = &lcommon.ScriptRef{
+				Type:   lcommon.ScriptRefTypePlutusV1,
+				Script: lcommon.PlutusV1Script{0x01},
+			}
+		}},
+	}
+	for _, tt := range outputTests {
+		t.Run(tt.name, func(t *testing.T) {
+			acct := mustDeriveTestAccount(t)
+			fc := newFakeChain(10_000_000, acct.ReceiveAddresses[0])
+			s := NewService(fc, nil, acct)
+			pv, err := s.Build(context.Background(), SendRequest{To: acct.ReceiveAddresses[1], Lovelace: "1000000"})
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+			tx := s.pending[pv.PendingID].tx.GetTx()
+			tt.mutate(&tx.Body.TxOutputs[0])
+
+			req, err := s.HardwareSignRequest(pv.PendingID)
+			if err != nil {
+				t.Fatalf("HardwareSignRequest: %v", err)
+			}
+			if req.Unsupported == "" {
+				t.Fatal("expected unsupported output feature to be rejected")
+			}
+			if len(req.Inputs) != 0 {
+				t.Fatalf("guard returned %d signing inputs", len(req.Inputs))
+			}
+		})
 	}
 }

--- a/ui/internal/vault/migration_test.go
+++ b/ui/internal/vault/migration_test.go
@@ -16,6 +16,7 @@ package vault
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -199,5 +200,99 @@ func TestFormat1VaultWrongPasswordFails(t *testing.T) {
 	}
 	if string(probe["format"]) != "1" {
 		t.Fatalf("format after failed unlock = %s, want 1 (unchanged)", probe["format"])
+	}
+}
+
+func TestFormat1VaultMigrationWriteFailureAbortsUnlock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vault.json")
+	seal, open := keystore.CheapTestSealer()
+	idx := &index{Wallets: []WalletMeta{{
+		ID:      "legacy-wallet-1",
+		Name:    "legacy",
+		Network: "preview",
+	}}}
+	writeFormat1Vault(t, path, seal, idx, nil)
+
+	persistErr := errors.New("persist unavailable")
+	v := New(path)
+	v.SetCipher(func([]byte, string) ([]byte, error) {
+		return nil, persistErr
+	}, open)
+	if _, err := v.Unlock(vaultPw); !errors.Is(err, persistErr) {
+		t.Fatalf("Unlock error = %v, want migration persistence error", err)
+	}
+	if _, err := v.Wallets(); !errors.Is(err, ErrLocked) {
+		t.Fatalf("Wallets error = %v, want ErrLocked", err)
+	}
+}
+
+func TestFormat2WithoutWalletCountUnlocksReadOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vault.json")
+	seal, open := keystore.CheapTestSealer()
+
+	v1 := New(path)
+	v1.SetCipher(seal, open)
+	if err := v1.Create(vaultPw); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	meta, err := v1.AddWallet("main", mnemonicA, "preview", vaultPw, spendPwA, window)
+	if err != nil {
+		t.Fatalf("AddWallet: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read vault: %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatalf("unmarshal vault: %v", err)
+	}
+	delete(fields, "wallet_count")
+	withoutCount, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatalf("marshal vault without wallet_count: %v", err)
+	}
+	if err := os.WriteFile(path, withoutCount, 0o600); err != nil {
+		t.Fatalf("write vault without wallet_count: %v", err)
+	}
+
+	// Model a vault mounted read-only. Unlock only needs to read and decrypt this
+	// format-2 file; optional cleartext metadata is deferred to a future write.
+	if err := os.Chmod(path, 0o400); err != nil {
+		t.Fatalf("chmod vault: %v", err)
+	}
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod vault directory: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(dir, 0o700)
+		_ = os.Chmod(path, 0o600)
+	})
+
+	v2 := New(path)
+	v2.SetCipher(seal, open)
+	wallets, err := v2.Unlock(vaultPw)
+	if err != nil {
+		t.Fatalf("Unlock read-only format-2 vault: %v", err)
+	}
+	if len(wallets) != 1 || wallets[0].ID != meta.ID {
+		t.Fatalf("wallets = %+v, want wallet %q", wallets, meta.ID)
+	}
+	if v2.ActiveID() != meta.ID {
+		t.Fatalf("active wallet = %q, want %q", v2.ActiveID(), meta.ID)
+	}
+	afterUnlock, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read vault after unlock: %v", err)
+	}
+	var afterFields map[string]json.RawMessage
+	if err := json.Unmarshal(afterUnlock, &afterFields); err != nil {
+		t.Fatalf("unmarshal vault after unlock: %v", err)
+	}
+	if _, ok := afterFields["wallet_count"]; ok {
+		t.Fatal("Unlock unexpectedly rewrote optional wallet_count metadata")
 	}
 }

--- a/ui/internal/vault/vault.go
+++ b/ui/internal/vault/vault.go
@@ -39,6 +39,7 @@
 //	  "format": 2,
 //	  "key": { "password": <Container wrapping the VEK under the vault password> },
 //	  "index": <keystore Container, encrypted under the VEK>,
+//	  "wallet_count": 2,
 //	  "seeds": { "<wallet id>": <keystore Container, encrypted under spend pw> }
 //	}
 //
@@ -110,13 +111,27 @@ var (
 // derived account (stake address + receive-address window) and the account
 // xpub. The seed itself lives in the separate, spend-password-encrypted seeds
 // map and is never part of this record.
+//
+// For hardware wallets (Type==WalletTypeHardware) no seed blob exists at all: the device
+// holds the private key. Only the account xpub and the derived addresses are
+// stored, so read-only views (balances, history) work without any secret.
 type WalletMeta struct {
 	ID          string          `json:"id"`
 	Name        string          `json:"name"`
 	Network     string          `json:"network"`
 	AccountXpub string          `json:"account_xpub"`
 	Account     *wallet.Account `json:"account"`
+	Type        WalletType      `json:"type"`
 }
+
+type WalletType string
+
+const (
+	WalletTypeFull           WalletType = "full"
+	WalletTypeReadOnly       WalletType = "read_only"
+	WalletTypeMultiSignature WalletType = "multi_signature"
+	WalletTypeHardware       WalletType = "hardware"
+)
 
 // index is the plaintext payload sealed under the vault password.
 type index struct {
@@ -143,10 +158,11 @@ type keySection struct {
 // per-wallet encrypted seed blobs keyed by wallet id. Format 1 envelopes have no
 // Key section; Key is omitted (omitempty) so a format-1 file round-trips cleanly.
 type envelope struct {
-	Format int                           `json:"format"`
-	Key    *keySection                   `json:"key,omitempty"`
-	Index  keystore.Container            `json:"index"`
-	Seeds  map[string]keystore.Container `json:"seeds"`
+	Format      int                           `json:"format"`
+	Key         *keySection                   `json:"key,omitempty"`
+	Index       keystore.Container            `json:"index"`
+	WalletCount int                           `json:"wallet_count,omitempty"`
+	Seeds       map[string]keystore.Container `json:"seeds"`
 }
 
 // Vault is a thread-safe handle to the on-disk vault file. When unlocked it
@@ -238,9 +254,10 @@ func (v *Vault) VerifyPassword(vaultPassword string) error {
 
 // WalletCount returns the number of wallets in the vault. It works whether the
 // vault is locked or unlocked: when unlocked it uses the cached index; when
-// locked it reads the envelope and counts the seed blobs (the index is
-// encrypted, but the seed map keys are wallet ids in cleartext, so a count is
-// available without the vault password). Returns 0 when no vault exists.
+// locked it reads the non-secret count persisted alongside the encrypted index.
+// Older envelopes did not carry that count, so their seed-blob count remains a
+// compatibility fallback until their next successful mutation refreshes it.
+// Returns 0 when no vault exists.
 func (v *Vault) WalletCount() int {
 	v.mu.RLock()
 	if v.idx != nil {
@@ -252,6 +269,9 @@ func (v *Vault) WalletCount() int {
 	env, err := v.readEnvelope()
 	if err != nil {
 		return 0
+	}
+	if env.WalletCount > 0 {
+		return env.WalletCount
 	}
 	return len(env.Seeds)
 }
@@ -295,17 +315,18 @@ func (v *Vault) Unlock(vaultPassword string) ([]WalletMeta, error) {
 		return nil, err
 	}
 	defer keystore.Zero(vek)
-	// Format-1 vaults have no key section: transparently re-key to format 2 so
-	// the next Unlock takes the modern path. If the rewrite fails (e.g. a
-	// read-only disk), abort the unlock and surface the error rather than caching
-	// an unlocked state over a file that is still legacy. The on-disk vault stays
-	// a valid format 1, so a later Unlock simply retries the upgrade — nothing is
-	// lost. Format-1 vaults never carry a TPM section, so persist with tpm=nil.
+	// Format-1 vaults must be transparently re-keyed to format 2 before they are
+	// considered unlocked. This migration is security-critical, so a failed
+	// persist must abort the unlock.
 	if env.Format == legacyFormatVersion {
-		if err := v.persistLocked(idx, env.Seeds, vek, vaultPassword, nil); err != nil {
-			return nil, fmt.Errorf("vault: upgrade format 1->2 failed: %w", err)
+		if err := v.persistLocked(idx, env.Seeds, vek, vaultPassword, tpmOf(env)); err != nil {
+			return nil, fmt.Errorf("vault: persist metadata failed: %w", err)
 		}
 	}
+	// wallet_count is only a cleartext status hint; the decrypted index above is
+	// authoritative. Older format-2 envelopes may omit it, and read-only vaults
+	// must still unlock when they cannot be rewritten. The next successful vault
+	// mutation goes through persistLocked and refreshes the count.
 	v.idx = idx
 	if len(idx.Wallets) == 1 {
 		v.activeID = idx.Wallets[0].ID
@@ -459,6 +480,63 @@ func (v *Vault) AddWallet(name, mnemonic, network, vaultPassword, spendPassword 
 	}
 	newIdx := &index{Wallets: append(cloneWallets(idx.Wallets), meta)}
 	seeds[meta.ID] = seed
+	if err := v.persistLocked(newIdx, seeds, vek, vaultPassword, tpmOf(env)); err != nil {
+		return WalletMeta{}, err
+	}
+	v.idx = newIdx
+	v.activeID = meta.ID
+	return meta, nil
+}
+
+// AddHardwareWallet adds a hardware-backed wallet to the vault. It derives the
+// read-only account from the account-level xpub (no mnemonic, no seed) and
+// stores it in the index under the vault password. No seed blob is written —
+// the hardware device holds the private key.
+//
+// The vault must be unlocked. A wallet whose xpub derives the same stake
+// address as an existing one is rejected (ErrDuplicateWallet). The added
+// wallet becomes active.
+func (v *Vault) AddHardwareWallet(name, accountXpubBech32, network, vaultPassword string, accountIndex uint32, windowN int) (WalletMeta, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.idx == nil {
+		return WalletMeta{}, ErrLocked
+	}
+
+	env, vek, idx, err := v.authenticatedEnvelopeLocked(vaultPassword)
+	if err != nil {
+		return WalletMeta{}, err
+	}
+	defer keystore.Zero(vek)
+
+	acct, err := wallet.DeriveFromAccountXpub(accountXpubBech32, network, accountIndex, windowN)
+	if err != nil {
+		return WalletMeta{}, fmt.Errorf("derive account from xpub: %w", err)
+	}
+
+	meta := WalletMeta{
+		ID:          newID(),
+		Name:        name,
+		Network:     network,
+		AccountXpub: accountXpubBech32,
+		Account:     acct,
+		Type:        WalletTypeHardware,
+	}
+
+	// Reject duplicate: same stake address means the same wallet.
+	for _, w := range idx.Wallets {
+		if w.Account != nil && meta.Account != nil && w.Account.StakeAddress == meta.Account.StakeAddress {
+			return WalletMeta{}, fmt.Errorf("%w: %q", ErrDuplicateWallet, w.Name)
+		}
+	}
+
+	// Re-seal the index with the new hardware wallet appended. The seeds map is
+	// unchanged — no seed blob is added for a hardware wallet.
+	seeds := env.Seeds
+	if seeds == nil {
+		seeds = map[string]keystore.Container{}
+	}
+	newIdx := &index{Wallets: append(cloneWallets(idx.Wallets), meta)}
 	if err := v.persistLocked(newIdx, seeds, vek, vaultPassword, tpmOf(env)); err != nil {
 		return WalletMeta{}, err
 	}
@@ -764,10 +842,11 @@ func (v *Vault) persistLocked(idx *index, seeds map[string]keystore.Container, v
 		return err
 	}
 	env := envelope{
-		Format: formatVersion,
-		Key:    &keySection{Password: wrapped, Tpm: tpm},
-		Index:  idxContainer,
-		Seeds:  seeds,
+		Format:      formatVersion,
+		Key:         &keySection{Password: wrapped, Tpm: tpm},
+		Index:       idxContainer,
+		WalletCount: len(idx.Wallets),
+		Seeds:       seeds,
 	}
 	out, err := json.Marshal(env)
 	if err != nil {
@@ -880,6 +959,7 @@ func (v *Vault) prepareWalletBytes(name string, mnemonic []byte, network, spendP
 		Network:     network,
 		AccountXpub: xpub,
 		Account:     acct,
+		Type:        WalletTypeFull,
 	}
 	return meta, seed, nil
 }

--- a/ui/internal/vault/vault_test.go
+++ b/ui/internal/vault/vault_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
+	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 )
 
 const (
@@ -597,5 +598,98 @@ func TestPersistenceAcrossHandles(t *testing.T) {
 	seed, err := v2.UnlockSeed(spendPwA)
 	if err != nil || string(seed) != mnemonicA {
 		t.Fatalf("fresh-handle seed unlock: err=%v", err)
+	}
+}
+
+// hasSeedBlob reads the raw on-disk envelope and returns true if a seed blob
+// entry exists for the given wallet id. Hardware wallets must have no such
+// entry.
+func hasSeedBlob(t *testing.T, v *Vault, id string) bool {
+	t.Helper()
+	blob, err := os.ReadFile(v.path)
+	if err != nil {
+		t.Fatalf("hasSeedBlob ReadFile: %v", err)
+	}
+	var env envelope
+	if err := json.Unmarshal(blob, &env); err != nil {
+		t.Fatalf("hasSeedBlob Unmarshal: %v", err)
+	}
+	_, ok := env.Seeds[id]
+	return ok
+}
+
+func TestAddHardwareWallet(t *testing.T) {
+	v := newTestVault(t)
+	if err := v.Create(vaultPw); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Derive a fixed bech32 account xpub from the known test mnemonic.
+	xpub, err := wallet.AccountXpubFromMnemonicBytes([]byte(mnemonicA))
+	if err != nil {
+		t.Fatalf("AccountXpubFromMnemonicBytes: %v", err)
+	}
+
+	const hwWindowN = 5
+	meta, err := v.AddHardwareWallet("My Ledger", xpub, "preview", vaultPw, 0, hwWindowN)
+	if err != nil {
+		t.Fatalf("AddHardwareWallet: %v", err)
+	}
+
+	if meta.Type != WalletTypeHardware {
+		t.Fatalf("wallet type = %q, want %q", meta.Type, WalletTypeHardware)
+	}
+	// The stored xpub must match.
+	if meta.AccountXpub != xpub {
+		t.Fatalf("AccountXpub = %q, want %q", meta.AccountXpub, xpub)
+	}
+	// The correct number of receive addresses must be derived.
+	if len(meta.Account.ReceiveAddresses) != hwWindowN {
+		t.Fatalf("ReceiveAddresses = %d, want %d", len(meta.Account.ReceiveAddresses), hwWindowN)
+	}
+	// The added wallet becomes active.
+	if v.ActiveID() != meta.ID {
+		t.Fatalf("active = %q, want %q", v.ActiveID(), meta.ID)
+	}
+
+	// Critical: no seed blob may be persisted for this wallet id.
+	if hasSeedBlob(t, v, meta.ID) {
+		t.Fatal("hardware wallet must persist NO seed material")
+	}
+	// The cleartext count metadata, rather than the seed map, must keep status
+	// accurate while the index is locked and after a process relaunch.
+	v.Lock()
+	if got := v.WalletCount(); got != 1 {
+		t.Fatalf("WalletCount after lock = %d, want 1", got)
+	}
+
+	// Reload via a fresh handle to confirm the Hardware flag and xpub survive
+	// an unlock/re-read cycle.
+	v2 := New(v.path)
+	seal, open := keystore.CheapTestSealer()
+	v2.SetCipher(seal, open)
+	if got := v2.WalletCount(); got != 1 {
+		t.Fatalf("fresh-handle WalletCount before unlock = %d, want 1", got)
+	}
+	wallets, err := v2.Unlock(vaultPw)
+	if err != nil {
+		t.Fatalf("Unlock on fresh handle: %v", err)
+	}
+	if len(wallets) != 1 {
+		t.Fatalf("fresh-handle wallets = %d, want 1", len(wallets))
+	}
+	reloaded := wallets[0]
+	if reloaded.Type != WalletTypeHardware {
+		t.Fatalf("wallet type after reload = %q, want %q", reloaded.Type, WalletTypeHardware)
+	}
+	if reloaded.AccountXpub != xpub {
+		t.Fatalf("AccountXpub after reload = %q, want %q", reloaded.AccountXpub, xpub)
+	}
+	if len(reloaded.Account.ReceiveAddresses) != hwWindowN {
+		t.Fatalf("ReceiveAddresses after reload = %d, want %d", len(reloaded.Account.ReceiveAddresses), hwWindowN)
+	}
+	// Still no seed blob after reload.
+	if hasSeedBlob(t, v2, meta.ID) {
+		t.Fatal("hardware wallet seed blob appeared after reload")
 	}
 }

--- a/ui/internal/wallet/account.go
+++ b/ui/internal/wallet/account.go
@@ -6,12 +6,14 @@ package wallet
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/bursa/bip32"
 	"github.com/blinklabs-io/bursa/ui/internal/cardanonet"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/btcsuite/btcd/btcutil/bech32"
 )
 
 // Account is a derived, read-only view of a wallet: its stake address (the
@@ -24,7 +26,10 @@ import (
 // self-DRep registration and self vote delegation, so those operations need no
 // password to learn the wallet's DRep identity. It is public material, not a key.
 type Account struct {
-	Network          string   `json:"network"`
+	Network string `json:"network"`
+	// AccountIndex is the hardened CIP-1852 account component used to derive
+	// this account-level key (m/1852'/1815'/<account>').
+	AccountIndex     uint32   `json:"account_index"`
 	StakeAddress     string   `json:"stake_address"`
 	ReceiveAddresses []string `json:"receive_addresses"`
 	DRepKeyHash      string   `json:"drep_key_hash,omitempty"`
@@ -166,6 +171,124 @@ func deriveFromRoot(root bip32.XPrv, network string, netID uint8, windowN int) (
 		DRepKeyHash:      drepHash,
 		ChangeAddresses:  change,
 	}, nil
+}
+
+// DeriveFromAccountXpub derives a read-only Account from an account-level
+// extended public key (Bech32-encoded, normally with the acct_xvk HRP; root_xvk
+// is also accepted for compatibility with AccountXpub). This is the
+// hardware-wallet path: no private key is required. The returned account is
+// byte-identical to one produced by DeriveFromMnemonicBytes for the same key.
+//
+// Role mapping (CIP-1852):
+//   - receive addresses: xpub.Derive(0).Derive(i) for i in 0..windowN-1
+//   - change addresses:  xpub.Derive(1).Derive(i) for i in 0..windowN-1
+//   - stake address:     xpub.Derive(2).Derive(0)
+//   - DRep key hash:     xpub.Derive(3).Derive(0)
+//
+// The parent CIP-1852 account index is recorded on the returned Account. It
+// cannot be recovered from the xpub itself, but is needed later to build the
+// derivation paths a hardware device signs with.
+func DeriveFromAccountXpub(accountXpubBech32, network string, accountIndex uint32, windowN int) (*Account, error) {
+	const hardenedKeyStart = uint32(1 << 31)
+	if accountIndex >= hardenedKeyStart {
+		return nil, fmt.Errorf("account index must be less than %d, got %d", hardenedKeyStart, accountIndex)
+	}
+	netID, err := validateDeriveInputs(network, windowN)
+	if err != nil {
+		return nil, err
+	}
+	acctXpub, err := parseAccountXpub(accountXpubBech32)
+	if err != nil {
+		return nil, fmt.Errorf("decode account xpub: %w", err)
+	}
+
+	// Stake address: role 2, index 0
+	stakeXpub, err := acctXpub.Derive(2)
+	if err != nil {
+		return nil, fmt.Errorf("derive stake role: %w", err)
+	}
+	stakeIndexXpub, err := stakeXpub.Derive(0)
+	if err != nil {
+		return nil, fmt.Errorf("derive stake index: %w", err)
+	}
+	stakeHash := stakeIndexXpub.PublicKey().Hash()
+
+	// DRep credential: role 3, index 0.
+	drepXpub, err := acctXpub.Derive(3)
+	if err != nil {
+		return nil, fmt.Errorf("derive DRep role: %w", err)
+	}
+	drepIndexXpub, err := drepXpub.Derive(0)
+	if err != nil {
+		return nil, fmt.Errorf("derive DRep index: %w", err)
+	}
+	drepHash := hex.EncodeToString(drepIndexXpub.PublicKey().Hash())
+
+	stakeAddr, err := lcommon.NewAddressFromParts(lcommon.AddressTypeNoneKey, netID, nil, stakeHash)
+	if err != nil {
+		return nil, fmt.Errorf("stake address: %w", err)
+	}
+
+	deriveAddresses := func(role uint32, label string) ([]string, error) {
+		roleXpub, err := acctXpub.Derive(role)
+		if err != nil {
+			return nil, fmt.Errorf("derive %s role: %w", label, err)
+		}
+		addresses := make([]string, 0, windowN)
+		for i := 0; i < windowN; i++ {
+			indexXpub, err := roleXpub.Derive(uint32(i)) //nolint:gosec // i is bounded by windowN < MaxInt32 in practice
+			if err != nil {
+				return nil, fmt.Errorf("derive %s index %d: %w", label, i, err)
+			}
+			payHash := indexXpub.PublicKey().Hash()
+			addr, err := lcommon.NewAddressFromParts(lcommon.AddressTypeKeyKey, netID, payHash, stakeHash)
+			if err != nil {
+				return nil, fmt.Errorf("%s address %d: %w", label, i, err)
+			}
+			addresses = append(addresses, addr.String())
+		}
+		return addresses, nil
+	}
+
+	receive, err := deriveAddresses(0, "receive")
+	if err != nil {
+		return nil, err
+	}
+	change, err := deriveAddresses(1, "change")
+	if err != nil {
+		return nil, err
+	}
+
+	return &Account{
+		Network:          network,
+		AccountIndex:     accountIndex,
+		StakeAddress:     stakeAddr.String(),
+		ReceiveAddresses: receive,
+		DRepKeyHash:      drepHash,
+		ChangeAddresses:  change,
+	}, nil
+}
+
+// parseAccountXpub accepts the standard account-key HRP emitted by hardware
+// wallets as well as the root_xvk label historically emitted by AccountXpub.
+// The HRP is only a Bech32 type label; both encodings carry the same 64-byte
+// extended public key payload.
+func parseAccountXpub(s string) (bip32.XPub, error) {
+	hrp, decoded, err := bip32.LenientBech32Decode(s)
+	if err != nil {
+		return nil, err
+	}
+	if hrp != "acct_xvk" && hrp != "root_xvk" {
+		return nil, errors.New("invalid HRP for account extended public key, expected acct_xvk or root_xvk")
+	}
+	converted, err := bech32.ConvertBits(decoded, 5, 8, false)
+	if err != nil {
+		return nil, err
+	}
+	if len(converted) != 64 {
+		return nil, errors.New("invalid length for account extended public key, expected 64 bytes")
+	}
+	return bip32.XPub(converted), nil
 }
 
 func zeroXPrv(key bip32.XPrv) {

--- a/ui/internal/wallet/account_test.go
+++ b/ui/internal/wallet/account_test.go
@@ -1,10 +1,13 @@
 package wallet
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/bursa/bip32"
+	"github.com/btcsuite/btcd/btcutil/bech32"
 )
 
 const testMnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
@@ -151,5 +154,48 @@ func TestDeriveInvalidWindow(t *testing.T) {
 		if _, err := Derive(testMnemonic, "preview", n); err == nil {
 			t.Fatalf("windowN=%d: expected error, got nil", n)
 		}
+	}
+}
+
+func TestDeriveFromAccountXpubMatchesMnemonic(t *testing.T) {
+	mnemonic := testMnemonic
+	fromMnem, err := DeriveFromMnemonicBytes([]byte(mnemonic), "preview", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	xpub, err := AccountXpubFromMnemonicBytes([]byte(mnemonic))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Hardware wallets use the standard acct_xvk HRP. AccountXpub currently
+	// emits root_xvk, so re-label the same payload to cover both accepted forms.
+	_, payload, err := bip32.LenientBech32Decode(xpub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	acctXpub, err := bech32.Encode("acct_xvk", payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, encoded := range []string{xpub, acctXpub} {
+		fromXpub, err := DeriveFromAccountXpub(encoded, "preview", 0, 5)
+		if err != nil {
+			t.Fatalf("DeriveFromAccountXpub(%q): %v", encoded[:8], err)
+		}
+		if !reflect.DeepEqual(fromXpub, fromMnem) {
+			t.Fatalf("account mismatch for %q HRP:\n xpub: %+v\n mnem: %+v", encoded[:8], fromXpub, fromMnem)
+		}
+	}
+}
+
+func TestDeriveFromAccountXpubRejectsHardenedAccountIndex(t *testing.T) {
+	xpub, err := AccountXpubFromMnemonicBytes([]byte(testMnemonic))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DeriveFromAccountXpub(xpub, "preview", 1<<31, 1); err == nil {
+		t.Fatal("expected hardened account index to be rejected")
 	}
 }

--- a/ui/web/package-lock.json
+++ b/ui/web/package-lock.json
@@ -6,6 +6,9 @@
     "": {
       "name": "bursa-wallet-ui",
       "dependencies": {
+        "@cardano-foundation/ledgerjs-hw-app-cardano": "^7.1.4",
+        "@ledgerhq/hw-transport-webhid": "^6.35.4",
+        "bech32": "^1.1.4",
         "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -343,6 +346,18 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cardano-foundation/ledgerjs-hw-app-cardano": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@cardano-foundation/ledgerjs-hw-app-cardano/-/ledgerjs-hw-app-cardano-7.1.4.tgz",
+      "integrity": "sha512-bkZ78H0m6E22Fe4nN+K0HY0O2lrPk9Pjs/gv0U5xvJyrMqwmR4wm9h8QXd/AwJ084KIhfpCSGDCQ0CN/K++vNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/hw-transport": "^6.31.2",
+        "base-x": "^3.0.5",
+        "bech32": "^1.1.4",
+        "int64-buffer": "^1.0.1"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1161,6 +1176,96 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@ledgerhq/devices": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.17.0.tgz",
+      "integrity": "sha512-l+rrVQEjR1hSWOLD00LFX4zbS8yB1M/Mb6UYPmSHGO7TmE1CFbZ4CmDJC/kZSl3hdrXCJ+YUNpvaLCcSWDwA+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "semver": "7.7.3"
+      }
+    },
+    "node_modules/@ledgerhq/devices/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@ledgerhq/errors": {
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.37.0.tgz",
+      "integrity": "sha512-T5yiKI5UX7ugeocdTF3TUsCIN2BH41Bio4ZeN410YFjFOf3es08n/5JyMzzKwzRgP0blG3HfBf7s7vJKqCSAeg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@ledgerhq/hw-transport": {
+      "version": "6.35.6",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.35.6.tgz",
+      "integrity": "sha512-Eg1SsOgY9jAVPTBfhCVzj5WvzqlYS08Ip+DMX33tG6rjcCibDVjwjU2LuxYmTawd4Jo83bYm+Fpg8hIwN+bBNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/devices": "8.17.0",
+        "@ledgerhq/errors": "^6.37.0",
+        "@ledgerhq/logs": "^6.17.0",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-webhid": {
+      "version": "6.36.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-6.36.0.tgz",
+      "integrity": "sha512-1mKWm3LyGOgmaYlAiqbmaGoupOZHbj2Kow5sXLxKZzQa4kFvQuUdinYOWhs7T8hqJyAkz9WlHYyKM7aIs8kjNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/devices": "8.16.0",
+        "@ledgerhq/errors": "^6.37.0",
+        "@ledgerhq/hw-transport": "6.35.5",
+        "@ledgerhq/logs": "^6.17.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-webhid/node_modules/@ledgerhq/devices": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.16.0.tgz",
+      "integrity": "sha512-brXLPzkvGM3D5YNsWQ25P5G4SmWdSNBed9W8wKoOIRLGdRfvE+bg9mzFty0iZ+aRLBkLoXwX7xKIL9zUi6LBKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "semver": "7.7.3"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-webhid/node_modules/@ledgerhq/hw-transport": {
+      "version": "6.35.5",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.35.5.tgz",
+      "integrity": "sha512-P4+wtLewLWgxPtIb90h5kjpzXVlC6f4IBQBmvowVFkInvZt34ffXkX7wa5KfMzu4l3cqCcpNSqtPSCMp+0vuqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/devices": "8.16.0",
+        "@ledgerhq/errors": "^6.37.0",
+        "@ledgerhq/logs": "^6.17.0",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-webhid/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@ledgerhq/logs": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.17.0.tgz",
+      "integrity": "sha512-yra33g5q/AU7+PwAws+GaVpQGUuxnDREjVBnviJjcaJLVKuLzI4pnj8Bd3nY3fypM5k1yZEYKEXfUuGFUjP2+w==",
+      "license": "Apache-2.0"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -2249,6 +2354,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.38",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
@@ -2261,6 +2375,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.15",
@@ -2920,6 +3040,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3302,6 +3431,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/int64-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.1.1.tgz",
+      "integrity": "sha512-xp/v0/im2q7n7ISFJXcYsr/aVsUdZKPUZS1uYtoM9I9Cfmm5YuAi7SQts2TrEXwAKIE0wyn3KxJbo35goJgvwQ==",
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -3983,6 +4118,26 @@
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
       "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/safer-buffer": {

--- a/ui/web/package.json
+++ b/ui/web/package.json
@@ -11,6 +11,9 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@cardano-foundation/ledgerjs-hw-app-cardano": "^7.1.4",
+    "@ledgerhq/hw-transport-webhid": "^6.35.4",
+    "bech32": "^1.1.4",
     "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -15,6 +15,7 @@ import type {
   CreateVaultRequest,
   UnlockVaultRequest,
   AddWalletRequest,
+  AddHardwareWalletRequest,
   MigrateLegacyKeystoreRequest,
   HistoryExpirySetting,
   AutoLockSetting,
@@ -55,6 +56,7 @@ import type {
   MultiSigUnsignedTx,
   MultiSigSignRequest,
   MultiSigSubmitRequest,
+  HardwareSignResponse,
 } from "./types";
 
 export class ApiError extends Error {
@@ -151,6 +153,20 @@ export const migrateLegacyKeystore = (req: MigrateLegacyKeystoreRequest) =>
 export const generateMnemonic = () =>
   apiGet<{ mnemonic: string }>("/wallet/mnemonic/generate").then((r) => r.mnemonic);
 export const addWallet = (req: AddWalletRequest) => apiPost<WalletView>("/wallet", req);
+export const addHardwareWallet = (
+  name: string,
+  accountXpub: string,
+  accountIndex: number,
+  network: string,
+  vaultPassword: string,
+) =>
+  apiPost<WalletView>("/wallet/hardware", {
+    name,
+    account_xpub: accountXpub,
+    account_index: accountIndex,
+    network,
+    vault_password: vaultPassword,
+  } satisfies AddHardwareWalletRequest);
 export const activateWallet = (id: string) =>
   apiPost<WalletView>(`/wallet/${encodeURIComponent(id)}/activate`);
 export const removeWallet = (id: string, vaultPassword: string) =>
@@ -180,6 +196,14 @@ export const exportUnsigned = (id: string) =>
 export const signTx = (req: SignTxRequest) => apiPost<WitnessResult>("/wallet/sign-tx", req);
 export const submitSigned = (req: SubmitSignedRequest) =>
   apiPost<TxResult>("/wallet/submit-signed", req);
+
+// Hardware (Ledger) confirm-on-device signing via the air-gap submit path:
+// fetch the structured signing request, then submit the device-produced
+// witness against the same pending send.
+export const getHardwareSignRequest = (id: string) =>
+  apiGet<HardwareSignResponse>(`/wallet/send/${encodeURIComponent(id)}/hardware-sign-request`);
+export const submitHardware = (id: string, witnessCbor: string) =>
+  apiPost<TxResult>(`/wallet/send/${encodeURIComponent(id)}/submit-hardware`, { witness_cbor: witnessCbor });
 
 // ADA Handle ($name) resolution for the Send screen: resolves the handle NFT
 // to its current holding address through the node. name may carry a leading

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -392,6 +392,8 @@ export interface PoolIDResult {
 
 // A wallet as listed by the vault: read-only fields plus whether it's active.
 // The encrypted seed is never exposed.
+export type WalletType = "full" | "read_only" | "multi_signature" | "hardware";
+
 export interface WalletView {
   id: string;
   name: string;
@@ -399,6 +401,39 @@ export interface WalletView {
   stake_address: string;
   addresses: string[];
   active: boolean;
+  type: WalletType;
+}
+
+// Hardware signing request — structured tx fields for the Ledger device.
+// The device uses these to display the transaction to the user and sign it
+// without parsing raw CBOR.
+export interface HWInput {
+  tx_hash_hex: string;
+  output_index: number;
+  path?: string; // CIP-1852 path, e.g. "1852'/1815'/0'/0/0"
+}
+
+export interface HWOutput {
+  address_hex: string;
+  address_bech32: string;
+  lovelace: string;
+  payment_path?: string; // present for a wallet-owned base address
+  stake_path?: string; // present with payment_path for a wallet-owned base address
+  assets?: { policy_id_hex: string; asset_name_hex: string; amount: string }[];
+}
+
+export interface HardwareSignResponse {
+  network: string;
+  network_id: number;
+  include_network_id?: boolean;
+  protocol_magic: number;
+  inputs: HWInput[];
+  outputs: HWOutput[];
+  fee: string;
+  ttl?: string;
+  required_signers: string[];
+  unsigned_tx_cbor: string;
+  unsupported?: string; // non-empty = this tx type cannot be signed on hardware yet
 }
 
 export interface CreateVaultRequest {
@@ -581,4 +616,14 @@ export interface ConnectorRequest {
 export interface PendingPairing {
   extension_id: string;
   code?: string;
+}
+
+// Adding a hardware wallet: the account xpub is derived from the device; no
+// spending password is needed (the device signs every transaction directly).
+export interface AddHardwareWalletRequest {
+  name: string;
+  account_xpub: string;
+  account_index: number;
+  network: string;
+  vault_password: string;
 }

--- a/ui/web/src/app.test.tsx
+++ b/ui/web/src/app.test.tsx
@@ -11,6 +11,7 @@ const walletA: WalletView = {
   stake_address: "stake_test1abc",
   addresses: ["addr_test1abc"],
   active: true,
+  type: "full",
 };
 
 const walletB: WalletView = {
@@ -20,6 +21,7 @@ const walletB: WalletView = {
   stake_address: "stake_test1def",
   addresses: ["addr_test1def"],
   active: false,
+  type: "full",
 };
 
 const mainnetWallet: WalletView = {
@@ -29,6 +31,17 @@ const mainnetWallet: WalletView = {
   stake_address: "stake1abc",
   addresses: ["addr1abc"],
   active: true,
+  type: "full",
+};
+
+const hardwareWallet: WalletView = {
+  id: "w-ledger",
+  name: "Ledger",
+  network: "preview",
+  stake_address: "stake_test1ledger",
+  addresses: ["addr_test1ledger"],
+  active: true,
+  type: "hardware",
 };
 
 function stubStatus(state: string) {
@@ -294,6 +307,88 @@ test("an active wallet on a ready node can reach Send", async () => {
   fireEvent.click(screen.getByRole("button", { name: /^unlock$/i }));
 
   await waitFor(() => expect(screen.getByText("Send ADA")).toBeInTheDocument());
+});
+
+test.each(["read_only", "multi_signature"] as const)(
+  "%s wallet cannot enter the regular Send flow",
+  async (type) => {
+    stubStatus("ready");
+    stubVault({ exists: true, locked: true, wallet_count: 1 });
+    quietPortfolio();
+    vi.spyOn(client, "unlockVault").mockResolvedValue([{ ...walletA, type }]);
+    window.location.hash = "#/send";
+
+    render(<App />);
+    fireEvent.change(screen.getByLabelText(/vault password/i), { target: { value: "vault-password-xyz" } });
+    fireEvent.click(screen.getByRole("button", { name: /^unlock$/i }));
+
+    await waitFor(() => expect(screen.getByText("Balance")).toBeInTheDocument());
+    expect(screen.queryByText("Send ADA")).not.toBeInTheDocument();
+  },
+);
+
+test("Settings identifies a hardware wallet as using on-device signing", async () => {
+  stubStatus("ready");
+  stubVault({ exists: true, locked: true, wallet_count: 1 });
+  vi.spyOn(client, "unlockVault").mockResolvedValue([hardwareWallet]);
+  window.location.hash = "#/settings";
+
+  render(<App />);
+  fireEvent.change(screen.getByLabelText(/vault password/i), { target: { value: "vault-password-xyz" } });
+  fireEvent.click(screen.getByRole("button", { name: /^unlock$/i }));
+
+  expect(await screen.findByText(/hardware wallet.*on-device signing/i)).toBeInTheDocument();
+  expect(screen.queryByText(/read.?only/i)).not.toBeInTheDocument();
+});
+
+test("a hardware wallet can submit a multi-sig spend with external witnesses but cannot sign locally", async () => {
+  stubStatus("ready");
+  stubVault({ exists: true, locked: true, wallet_count: 1 });
+  vi.spyOn(client, "unlockVault").mockResolvedValue([hardwareWallet]);
+  vi.spyOn(client, "listMultiSig").mockResolvedValue([{
+    id: "acct1",
+    label: "Treasury",
+    network: "preview",
+    policy: {
+      threshold: 1,
+      participants: [{ key_hash_hex: "a".repeat(56) }],
+    },
+    script_cbor: "8200",
+    script_address: "addr_test1wqscriptaddressxyz",
+  }]);
+  vi.spyOn(client, "multiSigBalance").mockResolvedValue({ lovelace: "0" });
+  vi.spyOn(client, "multiSigBuild").mockResolvedValue({
+    unsigned_tx_cbor: "84a400",
+    required_signers: ["a".repeat(56)],
+    threshold: 1,
+  });
+  const submit = vi.spyOn(client, "multiSigSubmit").mockResolvedValue({ tx_hash: "feedface" });
+  window.location.hash = "#/multisig";
+
+  render(<App />);
+  fireEvent.change(screen.getByLabelText(/vault password/i), { target: { value: "vault-password-xyz" } });
+  fireEvent.click(screen.getByRole("button", { name: /^unlock$/i }));
+
+  fireEvent.click(await screen.findByText("Treasury"));
+
+  fireEvent.change(await screen.findByLabelText(/recipient address/i), {
+    target: { value: "addr_test1recipient" },
+  });
+  fireEvent.change(screen.getByLabelText(/amount \(ada\)/i), { target: { value: "1" } });
+  fireEvent.click(screen.getByRole("button", { name: /build transaction/i }));
+
+  expect(await screen.findByText(/0 of 1 collected/i)).toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /sign here/i })).not.toBeInTheDocument();
+  fireEvent.change(screen.getByLabelText(/co-signer witness/i), { target: { value: "81a0external" } });
+  fireEvent.click(screen.getByRole("button", { name: /add witness/i }));
+  fireEvent.click(await screen.findByRole("button", { name: /^submit$/i }));
+
+  await waitFor(() =>
+    expect(submit).toHaveBeenCalledWith("acct1", {
+      unsigned_tx_cbor: "84a400",
+      witnesses: ["81a0external"],
+    }),
+  );
 });
 
 test("switching active wallets remounts routed content and refetches read state", async () => {

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -110,11 +110,21 @@ export function App() {
   const activeWallet = wallets.find((w) => w.id === activeId) ?? null;
   const isReady = status.data?.state === "ready";
   const canQueryNode = status.data?.state === "ready" || status.data?.state === "syncing";
-  // Sending requires a fully synced node AND an active wallet (every vault
-  // wallet has an encrypted seed, so any active wallet can spend with its
-  // spending password).
-  const canSend = isReady && activeWallet !== null;
-  const canSign = activeWallet !== null;
+  // Regular sends require a fully synced node and either a full wallet (local
+  // seed signing) or a hardware wallet (on-device signing). Read-only and
+  // multi-signature wallets use their own non-local signing flows.
+  const canSend = isReady && (
+    activeWallet?.type === "full" || activeWallet?.type === "hardware"
+  );
+  // Sign/Offline/Operate all need the wallet's seed (message signing, air-gap
+  // signing, and cold/VRF/KES key derivation respectively). Hardware wallets
+  // are seedless (xpub-only) and sign only via the on-device path Send uses,
+  // so these flows must stay off for them.
+  const canSign = activeWallet?.type === "full";
+  // Multi-sig build/collect/submit only needs the same synced-node access as a
+  // regular send. Its optional "Sign here" and participant-key reveal actions
+  // derive CIP-1854 keys from the local seed, so those actions remain gated by
+  // canSign until Ledger multi-sig signing is available.
   // Swap shows node-local DEX prices/quotes (no spending, no signing), but
   // the DEX pool locators are mainnet-only. On preview/preprod the backend
   // returns ErrNotMainnet, so do not expose the route for testnet wallets.
@@ -239,8 +249,9 @@ export function App() {
 
   // Staking/governance is gated identically to send: a fully synced node AND an
   // active (spending-capable) wallet. A read-only or unsynced wallet falls back
-  // to Portfolio.
-  const canStake = isReady && activeWallet !== null;
+  // to Portfolio. Certificates also aren't supported on hardware yet (see
+  // spend.HardwareSignRequest), so hardware wallets are excluded too.
+  const canStake = isReady && activeWallet?.type === "full";
 
   // --- Unlocked: the normal wallet UI bound to the active wallet ----------
 
@@ -284,9 +295,17 @@ export function App() {
       </section>
     );
   } else if (route === "settings") {
-    content = <Settings account={toAccount(activeWallet)} spendingEnabled autoLock={autoLock} />;
+    content = (
+      <Settings
+        account={toAccount(activeWallet)}
+        walletType={activeWallet.type}
+        autoLock={autoLock}
+      />
+    );
   } else if (route === "send" && !canSend) {
     content = <Portfolio />;
+  } else if (route === "send" && canSend) {
+    content = <Send isHardware={activeWallet.type === "hardware"} />;
   } else if (route === "swap" && !canSwap) {
     // Guard deep-links (#/swap): DEX quotes need a queryable mainnet node, so
     // fall back to Portfolio while the node or active wallet cannot support it.
@@ -314,9 +333,9 @@ export function App() {
     content = canSign ? <Operate account={toAccount(activeWallet)} /> : <Portfolio />;
   } else if (route === "multisig") {
     // Managing multi-sig accounts (list/create/view) is local state and works on
-    // any active wallet; the spend sub-flow gates itself on canSend (synced node
-    // + spending-enabled wallet).
-    content = <MultiSig canSpend={canSend} />;
+    // any active wallet. Building and submitting spends requires a synced node;
+    // only local CIP-1854 key derivation/signing additionally requires a seed.
+    content = <MultiSig canSpend={canSend} canSign={canSign} />;
   } else if (route === "receive") {
     // Explorer links on each address need the active wallet's real network
     // (preview/preprod/mainnet), which the generic ROUTES map (no props)

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -335,7 +335,7 @@ export function App() {
     // Managing multi-sig accounts (list/create/view) is local state and works on
     // any active wallet. Building and submitting spends requires a synced node;
     // only local CIP-1854 key derivation/signing additionally requires a seed.
-    content = <MultiSig canSpend={canSend} canSign={canSign} />;
+    content = <MultiSig canSpend={isReady} canSign={canSign} />;
   } else if (route === "receive") {
     // Explorer links on each address need the active wallet's real network
     // (preview/preprod/mainnet), which the generic ROUTES map (no props)

--- a/ui/web/src/components/components.test.tsx
+++ b/ui/web/src/components/components.test.tsx
@@ -16,6 +16,7 @@ const mobileWallet: WalletView = {
   stake_address: "stake_test1abc",
   addresses: ["addr_test1abc"],
   active: true,
+  type: "full",
 };
 
 function renderMobileNav(overrides: Partial<MobileNavProps> = {}) {

--- a/ui/web/src/hw/ledger.test.ts
+++ b/ui/web/src/hw/ledger.test.ts
@@ -1,0 +1,220 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ── Hoisted mock state (must be declared before vi.mock factories run) ────────
+const {
+  mockTransport,
+  mockCreate,
+  mockGetExtendedPublicKey,
+  mockSignTransaction,
+  mockAdaConstructor,
+} = vi.hoisted(() => {
+  const mockTransport = { close: vi.fn().mockResolvedValue(undefined) };
+  const mockCreate = vi.fn().mockResolvedValue(mockTransport);
+
+  const HARDENED = 0x80000000;
+  const ACCT0_PATH = [1852 + HARDENED, 1815 + HARDENED, 0 + HARDENED];
+
+  const mockGetExtendedPublicKey = vi.fn().mockResolvedValue({
+    publicKeyHex: "beb7e770b3d0f1932b0a2f3a63285bf9ef7d3e461d55446d6a3911d8f0ee55c0",
+    chainCodeHex: "b0e2df16538508046649d0e6d5b32969555a23f2f1ebf2db2819359b0d88bd16",
+  });
+
+  const mockSignTransaction = vi.fn().mockResolvedValue({
+    txHashHex: "cafebabe01020304",
+    witnesses: [{ path: ACCT0_PATH, witnessSignatureHex: "aabbccdd".repeat(16) }],
+    auxiliaryDataSupplement: null,
+  });
+
+  const mockAdaInstance = {
+    getExtendedPublicKey: mockGetExtendedPublicKey,
+    signTransaction: mockSignTransaction,
+  };
+  const mockAdaConstructor = vi.fn().mockImplementation(() => mockAdaInstance);
+
+  return { mockTransport, mockCreate, mockGetExtendedPublicKey, mockSignTransaction, mockAdaConstructor };
+});
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+vi.mock("@ledgerhq/hw-transport-webhid", () => ({
+  default: { create: mockCreate },
+}));
+
+vi.mock("@cardano-foundation/ledgerjs-hw-app-cardano", () => ({
+  default: mockAdaConstructor,
+  Ada: mockAdaConstructor,
+}));
+
+// ── Test constants ────────────────────────────────────────────────────────────
+//
+// Test vector derived from the Go side for mnemonic:
+//   "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+// Go: wallet.AccountXpub(mnemonic) at account index 0 (m/1852'/1815'/0')
+//
+//   publicKey  (32 bytes, hex): beb7e770b3d0f1932b0a2f3a63285bf9ef7d3e461d55446d6a3911d8f0ee55c0
+//   chainCode  (32 bytes, hex): b0e2df16538508046649d0e6d5b32969555a23f2f1ebf2db2819359b0d88bd16
+//   bech32 xpub (HRP=root_xvk): root_xvk1h6m7wu9n6rcex2c29uaxx2zml8hh60jxr425gmt28yga3u8w2hqtpcklzefc2zqyveyapek4kv5kj426y0e0r6ljmv5pjdvmpkyt69s8fpd2x
+//
+// Verified: Go bip32.XPub.String() produces the identical encoding from the
+// same 64-byte payload (pubkey || chainCode) using bech32 with HRP "root_xvk".
+const TEST_PUB_KEY_HEX = "beb7e770b3d0f1932b0a2f3a63285bf9ef7d3e461d55446d6a3911d8f0ee55c0";
+const TEST_CHAIN_CODE_HEX = "b0e2df16538508046649d0e6d5b32969555a23f2f1ebf2db2819359b0d88bd16";
+const TEST_XPUB_BECH32 =
+  "root_xvk1h6m7wu9n6rcex2c29uaxx2zml8hh60jxr425gmt28yga3u8w2hqtpcklzefc2zqyveyapek4kv5kj426y0e0r6ljmv5pjdvmpkyt69s8fpd2x";
+
+const HARDENED = 0x80000000;
+// m/1852'/1815'/0'
+const ACCT0_PATH = [1852 + HARDENED, 1815 + HARDENED, 0 + HARDENED];
+
+// Mock witness data: one witness with a known pubkey+sig pair
+// Raw CBOR vkey-witness array: [[pubkey32, sig64], ...]
+// Using 32-byte pubkey and 64-byte sig for test
+const MOCK_WITNESS_PUB_HEX = TEST_PUB_KEY_HEX;
+const MOCK_WITNESS_SIG_HEX = "aabbccdd".repeat(16); // 64 bytes
+
+// ── Import SUT after mocks ────────────────────────────────────────────────────
+import { connectLedger } from "./ledger";
+import type { SignTransactionRequest } from "@cardano-foundation/ledgerjs-hw-app-cardano";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function setWebHID(available: boolean) {
+  Object.defineProperty(globalThis.navigator ?? (globalThis.navigator = {} as Navigator), "hid", {
+    value: available ? {} : undefined,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe("connectLedger", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreate.mockResolvedValue(mockTransport);
+    mockGetExtendedPublicKey.mockResolvedValue({
+      publicKeyHex: TEST_PUB_KEY_HEX,
+      chainCodeHex: TEST_CHAIN_CODE_HEX,
+    });
+    mockSignTransaction.mockResolvedValue({
+      txHashHex: "cafebabe01020304",
+      witnesses: [{ path: ACCT0_PATH, witnessSignatureHex: MOCK_WITNESS_SIG_HEX }],
+      auxiliaryDataSupplement: null,
+    });
+    mockTransport.close.mockResolvedValue(undefined);
+    // mockAdaConstructor still returns the hoisted mockAdaInstance with the
+    // now-cleared fns; restore default mock returns set above via the fns.
+    mockAdaConstructor.mockImplementation(() => ({
+      getExtendedPublicKey: mockGetExtendedPublicKey,
+      signTransaction: mockSignTransaction,
+    }));
+    setWebHID(true);
+  });
+
+  afterEach(() => {
+    setWebHID(false);
+  });
+
+  test("throws clear error when navigator.hid is undefined", async () => {
+    setWebHID(false);
+    await expect(connectLedger()).rejects.toThrow(
+      "WebHID not available — open this in a Chromium browser",
+    );
+  });
+
+  test("calls TransportWebHID.create() and constructs Ada app", async () => {
+    const session = await connectLedger();
+    expect(mockCreate).toHaveBeenCalledOnce();
+    expect(mockAdaConstructor).toHaveBeenCalledWith(mockTransport);
+    await session.close();
+  });
+
+  describe("getAccountXpub", () => {
+    test("calls getExtendedPublicKey with correct CIP-1852 path for account 0", async () => {
+      const session = await connectLedger();
+      await session.getAccountXpub(0);
+      expect(mockGetExtendedPublicKey).toHaveBeenCalledWith({ path: ACCT0_PATH });
+      await session.close();
+    });
+
+    test("calls getExtendedPublicKey with correct path for account 2", async () => {
+      const session = await connectLedger();
+      await session.getAccountXpub(2);
+      expect(mockGetExtendedPublicKey).toHaveBeenCalledWith({
+        path: [1852 + HARDENED, 1815 + HARDENED, 2 + HARDENED],
+      });
+      await session.close();
+    });
+
+    test("returns parity-correct bech32 xpub matching Go canonical vector", async () => {
+      // This is the KEY PARITY TEST.
+      // The mock returns the raw {publicKeyHex, chainCodeHex} that the Ledger
+      // device would return for the test mnemonic account 0.
+      // getAccountXpub MUST produce the IDENTICAL bech32 that Go's
+      // bip32.XPub.String() / wallet.AccountXpub() produces.
+      const session = await connectLedger();
+      const xpub = await session.getAccountXpub(0);
+      expect(xpub).toBe(TEST_XPUB_BECH32);
+      await session.close();
+    });
+  });
+
+  describe("signTx", () => {
+    test("calls signTransaction with the request and returns a raw CBOR witness array", async () => {
+      const session = await connectLedger();
+
+      const txReq: SignTransactionRequest = {
+        tx: {
+          network: { protocolMagic: 764824073, networkId: 1 },
+          inputs: [],
+          outputs: [],
+          fee: 200000,
+        },
+        signingMode: "ordinary_transaction" as const,
+      } as SignTransactionRequest;
+
+      const result = await session.signTx(txReq);
+
+      expect(mockSignTransaction).toHaveBeenCalledOnce();
+      // The request object must be passed through to the device unchanged.
+      expect(mockSignTransaction).toHaveBeenCalledWith(txReq);
+      // Result is CBOR hex: [[pubkey, sig], ...]
+      // Must be a non-empty hex string
+      expect(result).toMatch(/^[0-9a-f]+$/);
+      // One outer witness array followed by one two-element witness tuple.
+      expect(result.startsWith("8182")).toBe(true);
+      await session.close();
+    });
+
+    test("witness CBOR contains the pubkey and signature bytes from the device", async () => {
+      const session = await connectLedger();
+
+      // Prime getExtendedPublicKey to return our test pubkey for the signing path
+      mockGetExtendedPublicKey.mockResolvedValue({
+        publicKeyHex: MOCK_WITNESS_PUB_HEX,
+        chainCodeHex: TEST_CHAIN_CODE_HEX,
+      });
+
+      const txReq: SignTransactionRequest = {
+        tx: {
+          network: { protocolMagic: 764824073, networkId: 1 },
+          inputs: [],
+          outputs: [],
+          fee: 200000,
+        },
+        signingMode: "ordinary_transaction" as const,
+      } as SignTransactionRequest;
+
+      const result = await session.signTx(txReq);
+
+      // The CBOR hex must contain both the pubkey and the sig as substrings
+      expect(result).toContain(MOCK_WITNESS_PUB_HEX);
+      expect(result).toContain(MOCK_WITNESS_SIG_HEX);
+      await session.close();
+    });
+  });
+
+  describe("close", () => {
+    test("close() calls transport.close()", async () => {
+      const session = await connectLedger();
+      await session.close();
+      expect(mockTransport.close).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/ui/web/src/hw/ledger.ts
+++ b/ui/web/src/hw/ledger.ts
@@ -1,0 +1,185 @@
+/**
+ * hw/ledger.ts — Thin WebHID wrapper for the Cardano Ledger app.
+ *
+ * Cloud-free: uses only @ledgerhq/hw-transport-webhid,
+ * @cardano-foundation/ledgerjs-hw-app-cardano, and bech32.
+ * No network calls are made beyond the HID transport.
+ *
+ * Xpub encoding parity with Go:
+ *   bip32.XPub.String() encodes 64 bytes (publicKey || chainCode) as bech32
+ *   with HRP "root_xvk" — exactly what getAccountXpub produces here.
+ *   Verified against the Go canonical vector for the "abandon ×11 about"
+ *   test mnemonic at account 0 (see ledger.test.ts).
+ */
+
+import TransportWebHID from "@ledgerhq/hw-transport-webhid";
+import Ada from "@cardano-foundation/ledgerjs-hw-app-cardano";
+import type { SignTransactionRequest } from "@cardano-foundation/ledgerjs-hw-app-cardano";
+import { encode as bech32Encode, toWords as bech32ToWords } from "bech32";
+
+// ── CBOR helpers (minimal, covers only the witness-set structure) ─────────────
+
+/**
+ * Encode a small non-negative integer as CBOR unsigned int.
+ * This is only ever called with small witness-array cardinalities (the count of
+ * distinct signers in a transaction), NOT with lovelace amounts (those go
+ * through ledgerjs BigInt). The 65535 cap is therefore never reached in practice.
+ */
+function cborUint(n: number): number[] {
+  if (n < 24) return [n];
+  if (n < 256) return [0x18, n];
+  if (n < 65536) return [0x19, n >> 8, n & 0xff];
+  throw new RangeError(`cborUint: ${n} is too large`);
+}
+
+/** Encode a byte array as a CBOR byte string. */
+function cborBytes(hex: string): number[] {
+  const bytes = hexToBytes(hex);
+  const hdr = cborUint(bytes.length);
+  hdr[0] |= 0x40; // major type 2 = byte string
+  return [...hdr, ...Array.from(bytes)];
+}
+
+/** Encode a fixed-size array of already-encoded CBOR items. */
+function cborArray(items: number[][]): number[] {
+  const hdr = cborUint(items.length);
+  hdr[0] |= 0x80; // major type 4 = array
+  return [...hdr, ...items.flat()];
+}
+
+/** Encode a hex string as Uint8Array. */
+function hexToBytes(hex: string): Uint8Array {
+  const len = hex.length;
+  const out = new Uint8Array(len / 2);
+  for (let i = 0; i < len; i += 2) {
+    out[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return out;
+}
+
+/** Encode bytes as lowercase hex string. */
+function bytesToHex(bytes: number[]): string {
+  return bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+// ── BIP32 path ───────────────────────────────────────────────────────────────
+
+const HARDENED = 0x80000000;
+
+/** Convert account index to the CIP-1852 account-level path array. */
+function accountPath(account: number): number[] {
+  return [1852 + HARDENED, 1815 + HARDENED, account + HARDENED];
+}
+
+// ── Bech32 xpub encoding ─────────────────────────────────────────────────────
+
+/**
+ * Encode a raw {publicKeyHex, chainCodeHex} pair as a bech32 xpub with HRP
+ * "root_xvk". This matches Go's bip32.XPub.String() exactly:
+ *   data = publicKey(32 bytes) || chainCode(32 bytes)  →  bech32(root_xvk, data)
+ *
+ * The bech32 package's 90-char default limit is bypassed by passing limit=1000.
+ */
+function encodeXpub(publicKeyHex: string, chainCodeHex: string): string {
+  const pubBytes = Array.from(hexToBytes(publicKeyHex));
+  const ccBytes = Array.from(hexToBytes(chainCodeHex));
+  const data = new Uint8Array([...pubBytes, ...ccBytes]); // 64 bytes
+  const words = bech32ToWords(data);
+  return bech32Encode("root_xvk", words, 1000 /* no length limit */);
+}
+
+// ── Raw vkey-witness-array CBOR encoding ─────────────────────────────────────────────────
+
+/**
+ * Encode the raw vkey-witness array consumed by the backend's SubmitSigned.
+ *
+ * Format: [[pubkey_bytes, sig_bytes], ...]
+ *   - each witness = [32-byte Ed25519 pubkey, 64-byte Ed25519 signature]
+ */
+function encodeWitnessArray(witnesses: { pubKeyHex: string; sigHex: string }[]): string {
+  return bytesToHex(
+    cborArray(
+      witnesses.map(({ pubKeyHex, sigHex }) =>
+        cborArray([cborBytes(pubKeyHex), cborBytes(sigHex)]),
+      ),
+    ),
+  );
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/** A live session with a Ledger device running the Cardano app. */
+export interface LedgerSession {
+  /**
+   * Derive the account-level extended public key from the device.
+   * Calls getExtendedPublicKey(m/1852'/1815'/<account>') and encodes
+   * the result as a bech32 "root_xvk" string identical to what Go's
+   * bip32.XPub.String() / wallet.AccountXpub() produces.
+   */
+  getAccountXpub(account: number): Promise<string>;
+
+  /**
+   * Sign a transaction on the device.
+   * @param request - The full SignTransactionRequest for the Cardano Ledger app.
+   * @returns CBOR-encoded raw vkey-witness array hex string.
+   */
+  signTx(request: SignTransactionRequest): Promise<string>;
+
+  /** Close the underlying HID transport. */
+  close(): Promise<void>;
+}
+
+/**
+ * Open a connection to a Ledger device via WebHID and return a LedgerSession.
+ *
+ * @throws Error — "WebHID not available — open this in a Chromium browser"
+ *   if the browser does not support the WebHID API.
+ */
+export async function connectLedger(): Promise<LedgerSession> {
+  if (
+    typeof navigator === "undefined" ||
+    (navigator as Navigator & { hid?: unknown }).hid === undefined
+  ) {
+    throw new Error("WebHID not available — open this in a Chromium browser");
+  }
+
+  const transport = await TransportWebHID.create();
+  const cardano = new Ada(transport);
+
+  return {
+    async getAccountXpub(account: number): Promise<string> {
+      const path = accountPath(account);
+      const { publicKeyHex, chainCodeHex } = await cardano.getExtendedPublicKey({ path });
+      return encodeXpub(publicKeyHex, chainCodeHex);
+    },
+
+    async signTx(request: SignTransactionRequest): Promise<string> {
+      // 1. Ask the device to sign the transaction and collect witness signatures.
+      const { witnesses } = await cardano.signTransaction(request);
+
+      // 2. Resolve each signing path → public key (needed for each vkey witness).
+      //    We fetch the pubkey for each witness path returned by the device.
+      const resolved = await Promise.all(
+        witnesses.map(async (w) => {
+          // The device must return the path it signed with so we can fetch the
+          // matching public key. A positional fallback (e.g. [0]) would pair the
+          // signature with the wrong key when there is more than one signer.
+          if (!w.path) {
+            throw new Error(
+              "Ledger returned a witness without a derivation path; cannot resolve its public key",
+            );
+          }
+          const xpub = await cardano.getExtendedPublicKey({ path: w.path });
+          return { pubKeyHex: xpub.publicKeyHex, sigHex: w.witnessSignatureHex };
+        }),
+      );
+
+      // 3. Encode the raw witness array expected by SubmitSigned.
+      return encodeWitnessArray(resolved);
+    },
+
+    async close(): Promise<void> {
+      await transport.close();
+    },
+  };
+}

--- a/ui/web/src/screens/AddWallet.test.tsx
+++ b/ui/web/src/screens/AddWallet.test.tsx
@@ -3,6 +3,27 @@ import { AddWallet } from "./AddWallet";
 import * as client from "../api/client";
 import type { WalletView } from "../api/types";
 
+// ── Ledger mock ───────────────────────────────────────────────────────────────
+const FIXED_XPUB =
+  "root_xvk1qpxlt6hkndkymk3lgchrcgpjnkrxkutp6c4p0nwegwuhlhqmlkzjhxm7qhz8c7dw8qvpgm4y8ayjzce7hqjm0p7g4uh6ypmfmzrk4sv4k39n";
+
+// vi.hoisted creates variables that are available before vi.mock() factory runs.
+const { mockSession, mockConnectLedger } = vi.hoisted(() => {
+  const mockSession = {
+    getAccountXpub: vi.fn().mockResolvedValue(
+      "root_xvk1qpxlt6hkndkymk3lgchrcgpjnkrxkutp6c4p0nwegwuhlhqmlkzjhxm7qhz8c7dw8qvpgm4y8ayjzce7hqjm0p7g4uh6ypmfmzrk4sv4k39n",
+    ),
+    signTx: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  const mockConnectLedger = vi.fn().mockResolvedValue(mockSession);
+  return { mockSession, mockConnectLedger };
+});
+
+vi.mock("../hw/ledger", () => ({
+  connectLedger: mockConnectLedger,
+}));
+
 const created: WalletView = {
   id: "w2",
   name: "Savings",
@@ -10,6 +31,7 @@ const created: WalletView = {
   stake_address: "stake_test1xyz",
   addresses: ["addr_test1xyz"],
   active: true,
+  type: "full",
 };
 
 const MNEMONIC = "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12";
@@ -195,4 +217,114 @@ test("create-confirm: submit stays blocked while the challenge is unanswered or 
 
   // The button is disabled, so the click is a no-op — no request is sent.
   expect(spy).not.toHaveBeenCalled();
+});
+
+// ── Connect Ledger flow ───────────────────────────────────────────────────────
+
+const hwWallet: WalletView = {
+  id: "hw1",
+  name: "Ledger Main",
+  network: "preview",
+  stake_address: "stake_test1hw",
+  addresses: ["addr_test1hw"],
+  active: true,
+  type: "hardware",
+};
+
+// Helper: navigate from the "choose" screen to the "Connect Ledger" form.
+function goToLedger() {
+  fireEvent.click(screen.getByRole("button", { name: /connect ledger/i }));
+}
+
+// Re-arm the connectLedger mock before each Ledger test because
+// vi.restoreAllMocks() (called in afterEach above) clears vi.fn() implementations.
+beforeEach(() => {
+  mockSession.getAccountXpub.mockReset().mockResolvedValue(FIXED_XPUB);
+  mockSession.close.mockReset().mockResolvedValue(undefined);
+  mockConnectLedger.mockReset().mockResolvedValue(mockSession);
+});
+
+test("Connect Ledger: calls getAccountXpub(0) then addHardwareWallet, wallet added", async () => {
+  const hwSpy = vi.spyOn(client, "addHardwareWallet").mockResolvedValue(hwWallet);
+  const onAdded = vi.fn();
+
+  render(<AddWallet network="preview" knownVaultPassword="vault-pw" onAdded={onAdded} />);
+
+  // Navigate from the chooser to the Ledger form.
+  goToLedger();
+
+  // Fill in wallet name
+  fireEvent.change(screen.getByLabelText(/wallet name/i), { target: { value: "Ledger Main" } });
+
+  // Trigger connect
+  fireEvent.click(screen.getByRole("button", { name: /connect ledger/i }));
+
+  await waitFor(() => expect(mockSession.getAccountXpub).toHaveBeenCalledWith(0));
+  await waitFor(() =>
+    expect(hwSpy).toHaveBeenCalledWith("Ledger Main", FIXED_XPUB, 0, "preview", "vault-pw"),
+  );
+  await waitFor(() => expect(onAdded).toHaveBeenCalledWith(hwWallet));
+  expect(mockSession.close).toHaveBeenCalledOnce();
+});
+
+test("Connect Ledger: derives and stores the selected account index", async () => {
+  const hwSpy = vi.spyOn(client, "addHardwareWallet").mockResolvedValue(hwWallet);
+
+  render(<AddWallet network="preview" knownVaultPassword="vault-pw" onAdded={vi.fn()} />);
+  goToLedger();
+  fireEvent.change(screen.getByLabelText(/account index/i), { target: { value: "2" } });
+  fireEvent.click(screen.getByRole("button", { name: /connect ledger/i }));
+
+  await waitFor(() => expect(mockSession.getAccountXpub).toHaveBeenCalledWith(2));
+  expect(hwSpy).toHaveBeenCalledWith("Ledger Wallet", FIXED_XPUB, 2, "preview", "vault-pw");
+});
+
+test("Connect Ledger: an empty account index is rejected before touching the device", async () => {
+  // Number("") is 0, so an empty field must be caught explicitly — otherwise it
+  // would silently import account 0, a different Ledger account than intended.
+  const hwSpy = vi.spyOn(client, "addHardwareWallet");
+
+  render(<AddWallet network="preview" knownVaultPassword="vault-pw" onAdded={vi.fn()} />);
+  goToLedger();
+  fireEvent.change(screen.getByLabelText(/account index/i), { target: { value: "" } });
+  fireEvent.click(screen.getByRole("button", { name: /connect ledger/i }));
+
+  await waitFor(() => expect(screen.getByText(/account index must be an integer/i)).toBeInTheDocument());
+  expect(mockConnectLedger).not.toHaveBeenCalled();
+  expect(hwSpy).not.toHaveBeenCalled();
+});
+
+test("Connect Ledger: closes the session when reading the account xpub fails", async () => {
+  mockSession.getAccountXpub.mockRejectedValueOnce(new Error("Cardano app is not open"));
+  const hwSpy = vi.spyOn(client, "addHardwareWallet");
+
+  render(<AddWallet network="preview" knownVaultPassword="vault-pw" onAdded={vi.fn()} />);
+
+  goToLedger();
+  fireEvent.click(screen.getByRole("button", { name: /connect ledger/i }));
+
+  await waitFor(() =>
+    expect(screen.getByRole("alert")).toHaveTextContent("Cardano app is not open"),
+  );
+  expect(mockSession.close).toHaveBeenCalledOnce();
+  expect(hwSpy).not.toHaveBeenCalled();
+});
+
+test("Connect Ledger: WebHID unavailable error message is shown", async () => {
+  mockConnectLedger.mockRejectedValueOnce(
+    new Error("WebHID not available — open this in a Chromium browser"),
+  );
+  const onAdded = vi.fn();
+
+  render(<AddWallet network="preview" knownVaultPassword="vault-pw" onAdded={onAdded} />);
+
+  goToLedger();
+  fireEvent.click(screen.getByRole("button", { name: /connect ledger/i }));
+
+  await waitFor(() =>
+    expect(
+      screen.getByText(/open this in a chromium browser/i),
+    ).toBeInTheDocument(),
+  );
+  expect(onAdded).not.toHaveBeenCalled();
 });

--- a/ui/web/src/screens/AddWallet.tsx
+++ b/ui/web/src/screens/AddWallet.tsx
@@ -5,7 +5,9 @@ import { Input } from "../components/Input";
 import { Select } from "../components/Select";
 import { Button } from "../components/Button";
 import { CopyButton } from "../components/CopyButton";
-import { addWallet, generateMnemonic, ApiError } from "../api/client";
+import { addWallet, addHardwareWallet, generateMnemonic, ApiError } from "../api/client";
+import { connectLedger } from "../hw/ledger";
+import type { LedgerSession } from "../hw/ledger";
 import type { WalletView } from "../api/types";
 import { MIN_PASSWORD_LEN, passwordLength } from "../password";
 import { CHALLENGE_WORD_COUNT, isChallengeAnswerCorrect, pickChallengeIndices, validateChallenge } from "../phraseChallenge";
@@ -29,7 +31,7 @@ interface AddWalletProps {
 }
 
 // Mode within the Add Wallet flow.
-type Mode = "choose" | "create" | "create-confirm" | "restore";
+type Mode = "choose" | "create" | "create-confirm" | "restore" | "ledger";
 
 export function AddWallet({
   network,
@@ -57,6 +59,7 @@ export function AddWallet({
   const [selectedNetwork, setSelectedNetwork] = useState(network);
   const [spendPassword, setSpendPassword] = useState("");
   const [vaultPassword, setVaultPassword] = useState("");
+  const [ledgerAccountIndex, setLedgerAccountIndex] = useState("0");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -125,7 +128,6 @@ export function AddWallet({
       setError("Vault password is required");
       return;
     }
-
     setLoading(true);
     try {
       const wallet = await addWallet({
@@ -143,14 +145,65 @@ export function AddWallet({
     }
   }
 
+  // --- "Connect Ledger" path -----------------------------------------------
+  // No mnemonic and no spending password: the device holds the private key
+  // and signs every transaction directly. Only the account-level xpub is
+  // read from the device and stored (watch-only).
+
+  async function handleLedgerConnect(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const vaultPw = knownVaultPassword ?? vaultPassword;
+    if (vaultPw === "") {
+      setError("Vault password is required");
+      return;
+    }
+    // Reject an empty field explicitly: Number("") is 0, which would otherwise
+    // pass the integer/range check and silently import Ledger account 0 — a
+    // different account than a user who cleared the field may intend.
+    const trimmedIndex = ledgerAccountIndex.trim();
+    const accountIndex = Number(trimmedIndex);
+    if (
+      trimmedIndex === "" ||
+      !Number.isInteger(accountIndex) ||
+      accountIndex < 0 ||
+      accountIndex >= 0x80000000
+    ) {
+      setError("Account index must be an integer from 0 to 2147483647");
+      return;
+    }
+
+    setLoading(true);
+    let session: LedgerSession | null = null;
+    try {
+      session = await connectLedger();
+      const xpub = await session.getAccountXpub(accountIndex);
+      const wallet = await addHardwareWallet(
+        name.trim() || "Ledger Wallet",
+        xpub,
+        accountIndex,
+        selectedNetwork,
+        vaultPw,
+      );
+      onAdded(wallet);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An unexpected error occurred");
+    } finally {
+      if (session) await session.close().catch(() => {});
+      setLoading(false);
+    }
+  }
+
   // --- Mode: choose -------------------------------------------------------
 
   if (mode === "choose") {
     return (
       <Card title={title}>
         <p className="helper-text" style={{ marginBottom: "var(--space-3)" }}>
-          Create a brand-new wallet with a freshly generated recovery phrase, or
-          restore an existing one from a phrase you already have.
+          Create a brand-new wallet with a freshly generated recovery phrase,
+          restore an existing one from a phrase you already have, or connect a
+          Ledger hardware wallet.
         </p>
         <div className="preview-actions" style={{ flexDirection: "column" }}>
           <Button onClick={handleGenerate} disabled={generating}>
@@ -158,6 +211,9 @@ export function AddWallet({
           </Button>
           <Button variant="ghost" onClick={() => { setError(null); setMode("restore"); }} disabled={generating}>
             Restore from recovery phrase
+          </Button>
+          <Button variant="ghost" onClick={() => { setError(null); setMode("ledger"); }} disabled={generating}>
+            Connect Ledger
           </Button>
           {onCancel && (
             <Button type="button" variant="ghost" onClick={onCancel}>
@@ -363,6 +419,96 @@ export function AddWallet({
             >
               Back
             </Button>
+          </div>
+        </form>
+      </Card>
+    );
+  }
+
+  // --- Mode: ledger (Connect Ledger, no mnemonic or spending password) ----
+
+  if (mode === "ledger") {
+    return (
+      <Card title="Connect Ledger">
+        <form onSubmit={handleLedgerConnect}>
+          <div className="field-group">
+            <label htmlFor="ledger-name">Wallet Name</label>
+            <Input
+              id="ledger-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Ledger Main"
+              aria-label="Wallet Name"
+            />
+          </div>
+
+          <div className="field-group">
+            <label htmlFor="ledger-network">Network</label>
+            <Select
+              id="ledger-network"
+              options={NETWORK_OPTIONS}
+              value={selectedNetwork}
+              onChange={(e) => setSelectedNetwork(e.target.value)}
+            />
+          </div>
+
+          <div className="field-group">
+            <label htmlFor="ledger-account-index">Account Index</label>
+            <Input
+              id="ledger-account-index"
+              type="number"
+              min={0}
+              max={0x7fffffff}
+              step={1}
+              value={ledgerAccountIndex}
+              onChange={(e) => setLedgerAccountIndex(e.target.value)}
+              aria-label="Account Index"
+            />
+          </div>
+
+          {needsVaultPassword && (
+            <div className="field-group">
+              <label htmlFor="ledger-vault-password">Vault Password</label>
+              <Input
+                id="ledger-vault-password"
+                type="password"
+                value={vaultPassword}
+                onChange={(e) => setVaultPassword(e.target.value)}
+                placeholder="Your vault password"
+                aria-label="Vault Password"
+              />
+              <p className="helper-text">Confirms the change to your encrypted vault.</p>
+            </div>
+          )}
+
+          <p className="helper-text">
+            Connect your Ledger device, open the Cardano app, then click Connect Ledger.
+            No spending password is needed — the device signs every transaction.
+          </p>
+
+          {error && (
+            <p className="error-text" role="alert">
+              {error}
+            </p>
+          )}
+
+          <div className="preview-actions">
+            <Button type="submit" disabled={loading}>
+              {loading ? "Connecting…" : "Connect Ledger"}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => { setError(null); setMode("choose"); }}
+              disabled={loading}
+            >
+              Back
+            </Button>
+            {onCancel && (
+              <Button type="button" variant="ghost" onClick={onCancel} disabled={loading}>
+                Cancel
+              </Button>
+            )}
           </div>
         </form>
       </Card>

--- a/ui/web/src/screens/MultiSig.test.tsx
+++ b/ui/web/src/screens/MultiSig.test.tsx
@@ -28,7 +28,7 @@ const sampleAccount: MultiSigAccount = {
 test("lists saved multi-sig accounts with their policy summary", async () => {
   vi.spyOn(client, "listMultiSig").mockResolvedValue([sampleAccount]);
 
-  render(<MultiSig canSpend={true} />);
+  render(<MultiSig canSpend={true} canSign={true} />);
 
   expect(await screen.findByText("Treasury")).toBeInTheDocument();
   expect(screen.getByText(/2-of-2/)).toBeInTheDocument();
@@ -37,7 +37,7 @@ test("lists saved multi-sig accounts with their policy summary", async () => {
 test("shows a user-facing error when listing multi-sig accounts fails", async () => {
   vi.spyOn(client, "listMultiSig").mockRejectedValue(new Error("list failed"));
 
-  render(<MultiSig canSpend={true} />);
+  render(<MultiSig canSpend={true} canSign={true} />);
 
   expect(await screen.findByRole("alert")).toHaveTextContent("list failed");
 });
@@ -50,7 +50,7 @@ test("create flow: reveals my-key and creates an account", async () => {
   const create = vi.spyOn(client, "createMultiSig").mockResolvedValue(sampleAccount);
   vi.spyOn(client, "multiSigBalance").mockResolvedValue({ lovelace: "0" });
 
-  render(<MultiSig canSpend={true} />);
+  render(<MultiSig canSpend={true} canSign={true} />);
 
   fireEvent.click(await screen.findByRole("button", { name: /new multi-sig account/i }));
 
@@ -75,10 +75,21 @@ test("create flow: reveals my-key and creates an account", async () => {
   expect(arg.policy.participants).toHaveLength(2);
 });
 
+test("seedless wallet can add external participants without revealing a local key", async () => {
+  vi.spyOn(client, "listMultiSig").mockResolvedValue([]);
+
+  render(<MultiSig canSpend={true} canSign={false} />);
+  fireEvent.click(await screen.findByRole("button", { name: /new multi-sig account/i }));
+
+  expect(screen.queryByText("Your participant key (CIP-1854)")).not.toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /reveal my key/i })).not.toBeInTheDocument();
+  expect(screen.getByLabelText(/participant key hash/i)).toBeInTheDocument();
+});
+
 test("create rejects a malformed co-signer key hash", async () => {
   vi.spyOn(client, "listMultiSig").mockResolvedValue([]);
 
-  render(<MultiSig canSpend={true} />);
+  render(<MultiSig canSpend={true} canSign={true} />);
   fireEvent.click(await screen.findByRole("button", { name: /new multi-sig account/i }));
 
   fireEvent.change(screen.getByLabelText(/participant key hash/i), { target: { value: "xyz" } });
@@ -94,7 +105,7 @@ test("delete flow removes the selected account from the list", async () => {
   vi.spyOn(client, "multiSigBalance").mockResolvedValue({ lovelace: "0" });
   const del = vi.spyOn(client, "deleteMultiSig").mockResolvedValue({ status: "deleted" });
 
-  render(<MultiSig canSpend={true} />);
+  render(<MultiSig canSpend={true} canSign={true} />);
 
   fireEvent.click(await screen.findByText("Treasury"));
   fireEvent.click(await screen.findByRole("button", { name: /^delete$/i }));
@@ -117,7 +128,7 @@ test("spend flow: build then collect a threshold of witnesses and submit", async
   const sign = vi.spyOn(client, "multiSigSign").mockResolvedValue({ witness_cbor: "81a0sigA" });
   const submit = vi.spyOn(client, "multiSigSubmit").mockResolvedValue({ tx_hash: "feedface" });
 
-  render(<MultiSig canSpend={true} />);
+  render(<MultiSig canSpend={true} canSign={true} />);
 
   fireEvent.click(await screen.findByText("Treasury"));
 
@@ -155,12 +166,52 @@ test("spend flow: build then collect a threshold of witnesses and submit", async
   expect(await screen.findByText("7 ADA")).toBeInTheDocument();
 });
 
+test("seedless wallet can build, collect external witnesses, and submit without signing locally", async () => {
+  vi.spyOn(client, "listMultiSig").mockResolvedValue([sampleAccount]);
+  vi.spyOn(client, "multiSigBalance").mockResolvedValue({ lovelace: "10000000" });
+  const build = vi.spyOn(client, "multiSigBuild").mockResolvedValue({
+    unsigned_tx_cbor: "84a400",
+    required_signers: [KH_A, KH_B],
+    threshold: 2,
+  });
+  const sign = vi.spyOn(client, "multiSigSign");
+  const submit = vi.spyOn(client, "multiSigSubmit").mockResolvedValue({ tx_hash: "feedface" });
+
+  render(<MultiSig canSpend={true} canSign={false} />);
+  fireEvent.click(await screen.findByText("Treasury"));
+
+  fireEvent.change(await screen.findByLabelText(/recipient address/i), {
+    target: { value: "addr_test1recipient" },
+  });
+  fireEvent.change(screen.getByLabelText(/amount \(ada\)/i), { target: { value: "3" } });
+  fireEvent.click(screen.getByRole("button", { name: /build transaction/i }));
+  await waitFor(() => expect(build).toHaveBeenCalled());
+
+  expect(await screen.findByText(/0 of 2 collected/i)).toBeInTheDocument();
+  expect(screen.queryByLabelText(/sign with this wallet/i)).not.toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /sign here/i })).not.toBeInTheDocument();
+
+  for (const witness of ["81a0sigA", "81a0sigB"]) {
+    fireEvent.change(screen.getByLabelText(/co-signer witness/i), { target: { value: witness } });
+    fireEvent.click(screen.getByRole("button", { name: /add witness/i }));
+  }
+  fireEvent.click(await screen.findByRole("button", { name: /^submit$/i }));
+
+  await waitFor(() =>
+    expect(submit).toHaveBeenCalledWith("acct1", {
+      unsigned_tx_cbor: "84a400",
+      witnesses: ["81a0sigA", "81a0sigB"],
+    }),
+  );
+  expect(sign).not.toHaveBeenCalled();
+});
+
 test("shows a user-facing error when building a multi-sig spend fails", async () => {
   vi.spyOn(client, "listMultiSig").mockResolvedValue([sampleAccount]);
   vi.spyOn(client, "multiSigBalance").mockResolvedValue({ lovelace: "10000000" });
   vi.spyOn(client, "multiSigBuild").mockRejectedValue(new Error("build failed"));
 
-  render(<MultiSig canSpend={true} />);
+  render(<MultiSig canSpend={true} canSign={true} />);
 
   fireEvent.click(await screen.findByText("Treasury"));
   fireEvent.change(await screen.findByLabelText(/recipient address/i), {
@@ -181,7 +232,7 @@ test("submit is disabled until the threshold is met", async () => {
     threshold: 2,
   });
 
-  render(<MultiSig canSpend={true} />);
+  render(<MultiSig canSpend={true} canSign={true} />);
   fireEvent.click(await screen.findByText("Treasury"));
   fireEvent.change(await screen.findByLabelText(/recipient address/i), {
     target: { value: "addr_test1recipient" },
@@ -197,7 +248,7 @@ test("spend is unavailable when canSpend is false", async () => {
   vi.spyOn(client, "listMultiSig").mockResolvedValue([sampleAccount]);
   vi.spyOn(client, "multiSigBalance").mockResolvedValue({ lovelace: "0" });
 
-  render(<MultiSig canSpend={false} />);
+  render(<MultiSig canSpend={false} canSign={true} />);
   fireEvent.click(await screen.findByText("Treasury"));
 
   expect(

--- a/ui/web/src/screens/MultiSig.tsx
+++ b/ui/web/src/screens/MultiSig.tsx
@@ -96,11 +96,12 @@ function ListView({ accounts, onCreate, onOpen }: ListViewProps) {
 // ---------------------------------------------------------------------------
 
 interface CreateViewProps {
+  canSign: boolean;
   onCancel: () => void;
   onCreated: (acct: MultiSigAccount) => void;
 }
 
-function CreateView({ onCancel, onCreated }: CreateViewProps) {
+function CreateView({ canSign, onCancel, onCreated }: CreateViewProps) {
   const mounted = useMountedRef();
   const [label, setLabel] = useState("");
   const [threshold, setThreshold] = useState("2");
@@ -231,53 +232,55 @@ function CreateView({ onCancel, onCreated }: CreateViewProps) {
           disabled={loading}
         />
 
-        {/* Your own participant key, to share and to add to the policy. */}
-        <div className="ms-mykey">
-          <p className="field-label">Your participant key (CIP-1854)</p>
-          {myKeyHash ? (
-            <>
-              <p className="helper-text">Share this key-hash so others can include you.</p>
-              <div className="tx-hash-row">
-                <code className="tx-hash">{myKeyHash}</code>
-                <CopyButton value={myKeyHash} />
-              </div>
-              {myKeyVkey && (
+        {/* Your own participant key requires a seed-derived CIP-1854 key. */}
+        {canSign && (
+          <div className="ms-mykey">
+            <p className="field-label">Your participant key (CIP-1854)</p>
+            {myKeyHash ? (
+              <>
+                <p className="helper-text">Share this key-hash so others can include you.</p>
                 <div className="tx-hash-row">
-                  <code className="tx-hash">vkey: {myKeyVkey}</code>
-                  <CopyButton value={myKeyVkey} />
+                  <code className="tx-hash">{myKeyHash}</code>
+                  <CopyButton value={myKeyHash} />
                 </div>
-              )}
-              <Button
-                variant="ghost"
-                onClick={addMyself}
-                disabled={
-                  loading ||
-                  participants.some((p) => p.key_hash_hex.toLowerCase() === myKeyHash?.toLowerCase())
-                }
-              >
-                + Add myself
-              </Button>
-            </>
-          ) : (
-            <>
-              <p className="helper-text">
-                Enter your spending password to reveal your key-hash to share.
-              </p>
-              <Input
-                type="password"
-                placeholder="Spending password"
-                value={myKeyPassword}
-                onChange={(e) => setMyKeyPassword(e.target.value)}
-                disabled={loadingMyKey}
-                aria-label="Spending password"
-              />
-              {myKeyError && <ErrorText message={myKeyError} />}
-              <Button variant="ghost" onClick={handleRevealMyKey} disabled={loadingMyKey || !myKeyPassword}>
-                {loadingMyKey ? "Deriving…" : "Reveal my key"}
-              </Button>
-            </>
-          )}
-        </div>
+                {myKeyVkey && (
+                  <div className="tx-hash-row">
+                    <code className="tx-hash">vkey: {myKeyVkey}</code>
+                    <CopyButton value={myKeyVkey} />
+                  </div>
+                )}
+                <Button
+                  variant="ghost"
+                  onClick={addMyself}
+                  disabled={
+                    loading ||
+                    participants.some((p) => p.key_hash_hex.toLowerCase() === myKeyHash?.toLowerCase())
+                  }
+                >
+                  + Add myself
+                </Button>
+              </>
+            ) : (
+              <>
+                <p className="helper-text">
+                  Enter your spending password to reveal your key-hash to share.
+                </p>
+                <Input
+                  type="password"
+                  placeholder="Spending password"
+                  value={myKeyPassword}
+                  onChange={(e) => setMyKeyPassword(e.target.value)}
+                  disabled={loadingMyKey}
+                  aria-label="Spending password"
+                />
+                {myKeyError && <ErrorText message={myKeyError} />}
+                <Button variant="ghost" onClick={handleRevealMyKey} disabled={loadingMyKey || !myKeyPassword}>
+                  {loadingMyKey ? "Deriving…" : "Reveal my key"}
+                </Button>
+              </>
+            )}
+          </div>
+        )}
 
         {/* Co-signer participants. */}
         <p className="field-label">Participants ({participants.length})</p>
@@ -374,11 +377,12 @@ function CreateView({ onCancel, onCreated }: CreateViewProps) {
 interface DetailViewProps {
   account: MultiSigAccount;
   canSpend: boolean;
+  canSign: boolean;
   onBack: () => void;
   onDeleted: () => void;
 }
 
-function DetailView({ account, canSpend, onBack, onDeleted }: DetailViewProps) {
+function DetailView({ account, canSpend, canSign, onBack, onDeleted }: DetailViewProps) {
   const mounted = useMountedRef();
   const [balance, setBalance] = useState<string | null>(null);
   const [balanceError, setBalanceError] = useState<string | null>(null);
@@ -466,7 +470,12 @@ function DetailView({ account, canSpend, onBack, onDeleted }: DetailViewProps) {
         </div>
       </Card>
 
-      <SpendFlow account={account} canSpend={canSpend} onSpent={() => void loadBalance()} />
+      <SpendFlow
+        account={account}
+        canSpend={canSpend}
+        canSign={canSign}
+        onSpent={() => void loadBalance()}
+      />
     </div>
   );
 }
@@ -478,10 +487,11 @@ function DetailView({ account, canSpend, onBack, onDeleted }: DetailViewProps) {
 interface SpendFlowProps {
   account: MultiSigAccount;
   canSpend: boolean;
+  canSign: boolean;
   onSpent: () => void;
 }
 
-function SpendFlow({ account, canSpend, onSpent }: SpendFlowProps) {
+function SpendFlow({ account, canSpend, canSign, onSpent }: SpendFlowProps) {
   const [to, setTo] = useState("");
   const [ada, setAda] = useState("");
   const [built, setBuilt] = useState<MultiSigUnsignedTx | null>(null);
@@ -553,6 +563,7 @@ function SpendFlow({ account, canSpend, onSpent }: SpendFlowProps) {
         built={built}
         witnesses={witnesses}
         setWitnesses={setWitnesses}
+        canSign={canSign}
         onResult={setResult}
         onSpent={onSpent}
         onBack={reset}
@@ -595,15 +606,25 @@ interface CollectProps {
   built: MultiSigUnsignedTx;
   witnesses: string[];
   setWitnesses: Dispatch<SetStateAction<string[]>>;
+  canSign: boolean;
   onResult: (r: TxResult) => void;
   onSpent: () => void;
   onBack: () => void;
 }
 
-// CollectAndSubmit shows the unsigned tx for export, lets a co-signer on THIS
-// instance sign with their password, accepts pasted witnesses from other
-// co-signers, tracks "X of N collected", and submits once the threshold is met.
-function CollectAndSubmit({ accountId, built, witnesses, setWitnesses, onResult, onSpent, onBack }: CollectProps) {
+// CollectAndSubmit shows the unsigned tx for export, optionally lets a local
+// seed-backed co-signer sign with their password, accepts pasted witnesses from
+// other co-signers, tracks "X of N collected", and submits at the threshold.
+function CollectAndSubmit({
+  accountId,
+  built,
+  witnesses,
+  setWitnesses,
+  canSign,
+  onResult,
+  onSpent,
+  onBack,
+}: CollectProps) {
   const [password, setPassword] = useState("");
   const [pasteWitness, setPasteWitness] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -682,19 +703,23 @@ function CollectAndSubmit({ accountId, built, witnesses, setWitnesses, onResult,
           {collected > 0 && ` (${collected} witness${collected === 1 ? "" : "es"})`}
         </p>
 
-        {/* Sign on this instance. */}
-        <label htmlFor="ms-sign-pw">Sign with this wallet</label>
-        <Input
-          id="ms-sign-pw"
-          type="password"
-          placeholder="Spending password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          disabled={signing}
-        />
-        <Button variant="ghost" onClick={handleSignHere} disabled={signing || !password}>
-          {signing ? "Signing…" : "Sign here"}
-        </Button>
+        {/* Sign locally only when the seed-derived CIP-1854 key is available. */}
+        {canSign && (
+          <>
+            <label htmlFor="ms-sign-pw">Sign with this wallet</label>
+            <Input
+              id="ms-sign-pw"
+              type="password"
+              placeholder="Spending password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              disabled={signing}
+            />
+            <Button variant="ghost" onClick={handleSignHere} disabled={signing || !password}>
+              {signing ? "Signing…" : "Sign here"}
+            </Button>
+          </>
+        )}
 
         {/* Paste a witness from another co-signer. */}
         <label htmlFor="ms-paste">Add a co-signer's witness (CBOR)</label>
@@ -734,9 +759,10 @@ type View = "list" | "create" | "detail";
 
 interface MultiSigProps {
   canSpend: boolean;
+  canSign: boolean;
 }
 
-export function MultiSig({ canSpend }: MultiSigProps) {
+export function MultiSig({ canSpend, canSign }: MultiSigProps) {
   const mounted = useMountedRef();
   const [view, setView] = useState<View>("list");
   const [accounts, setAccounts] = useState<MultiSigAccount[]>([]);
@@ -766,6 +792,7 @@ export function MultiSig({ canSpend }: MultiSigProps) {
   if (view === "create") {
     return (
       <CreateView
+        canSign={canSign}
         onCancel={() => setView("list")}
         onCreated={(acct) => {
           setSelected(acct);
@@ -781,6 +808,7 @@ export function MultiSig({ canSpend }: MultiSigProps) {
       <DetailView
         account={selected}
         canSpend={canSpend}
+        canSign={canSign}
         onBack={() => {
           setSelected(null);
           void refresh();

--- a/ui/web/src/screens/Send.test.tsx
+++ b/ui/web/src/screens/Send.test.tsx
@@ -2,7 +2,13 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { Send } from "./Send";
 import * as client from "../api/client";
 import { mockContacts } from "../test/mockContacts";
-import type { Preview, TxResult, HandleInfo, Contact } from "../api/types";
+import type { Preview, TxResult, HandleInfo, Contact, HardwareSignResponse } from "../api/types";
+import type { LedgerSession } from "../hw/ledger";
+
+// Mock the ledger module so tests don't try to open WebHID.
+vi.mock("../hw/ledger", () => ({
+  connectLedger: vi.fn(),
+}));
 
 const MOCK_PREVIEW: Preview = {
   pending_id: "pending-abc-123",
@@ -358,6 +364,26 @@ test("(g) buildSend error shown inline on compose phase", async () => {
 // --- ADA Handle resolution ---
 
 const MOCK_HANDLE: HandleInfo = { handle: "chris", address: "addr1resolvedhandle" };
+const MOCK_HW_SIGN_RESP: HardwareSignResponse = {
+  network: "preview",
+  network_id: 0,
+  include_network_id: true,
+  protocol_magic: 2,
+  inputs: [{ tx_hash_hex: "deadbeef", output_index: 0, path: "1852'/1815'/0'/0/0" }],
+  outputs: [
+    { address_hex: "60aabb", address_bech32: "addr_test1recipient", lovelace: "1000000" },
+    {
+      address_hex: "60ccdd",
+      address_bech32: "addr_test1change",
+      lovelace: "3800000",
+      payment_path: "1852'/1815'/0'/0/0",
+      stake_path: "1852'/1815'/0'/2/0",
+    },
+  ],
+  fee: "170000",
+  required_signers: ["aabbccdd"],
+  unsigned_tx_cbor: "84a4deadbeef",
+};
 
 test("(k) $handle recipient resolves and buildSend uses the resolved address", async () => {
   const resolveHandle = vi.spyOn(client, "resolveHandle").mockResolvedValue(MOCK_HANDLE);
@@ -496,4 +522,139 @@ test("(q) the Address book picker closes on a second click of the toggle", () =>
 
   fireEvent.click(toggle);
   expect(screen.queryByText("Alice")).not.toBeInTheDocument();
+});
+
+// --- Hardware wallet tests ---
+
+test("(r) hardware account: preview shows 'Confirm on your Ledger' with no password input", async () => {
+  vi.spyOn(client, "buildSend").mockResolvedValue(MOCK_PREVIEW);
+
+  render(<Send isHardware />);
+
+  const inputs = screen.getAllByRole("textbox");
+  fireEvent.change(inputs[0], { target: { value: "addr_test1recipient" } });
+  fireEvent.change(inputs[1], { target: { value: "5" } });
+  fireEvent.click(screen.getByRole("button", { name: /review/i }));
+
+  await waitFor(() => {
+    expect(screen.getByText(/2 inputs/i)).toBeInTheDocument();
+  });
+
+  // Hardware: no password field, shows Ledger button.
+  expect(screen.queryByPlaceholderText(/spending password/i)).not.toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /confirm on.*ledger/i })).toBeInTheDocument();
+});
+
+test("(s) hardware account: confirm flow fetches sign request, calls signTx, submits hardware", async () => {
+  vi.spyOn(client, "buildSend").mockResolvedValue(MOCK_PREVIEW);
+  vi.spyOn(client, "getHardwareSignRequest").mockResolvedValue(MOCK_HW_SIGN_RESP);
+  vi.spyOn(client, "submitHardware").mockResolvedValue(MOCK_TX_RESULT);
+
+  const mockSignTx = vi.fn<LedgerSession["signTx"]>().mockResolvedValue("81825820aabb");
+  const mockClose = vi.fn().mockResolvedValue(undefined);
+  const { connectLedger } = await import("../hw/ledger");
+  vi.mocked(connectLedger).mockResolvedValue({
+    getAccountXpub: vi.fn(),
+    signTx: mockSignTx,
+    close: mockClose,
+  });
+
+  render(<Send isHardware />);
+
+  const inputs = screen.getAllByRole("textbox");
+  fireEvent.change(inputs[0], { target: { value: "addr_test1recipient" } });
+  fireEvent.change(inputs[1], { target: { value: "5" } });
+  fireEvent.click(screen.getByRole("button", { name: /review/i }));
+
+  await waitFor(() => {
+    expect(screen.getByText(/2 inputs/i)).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByRole("button", { name: /confirm on.*ledger/i }));
+
+  await waitFor(() => {
+    expect(client.getHardwareSignRequest).toHaveBeenCalledWith("pending-abc-123");
+    expect(mockSignTx).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tx: expect.objectContaining({
+          requiredSigners: [{ type: "required_signer_hash", hashHex: "aabbccdd" }],
+        }),
+      }),
+    );
+    expect(client.submitHardware).toHaveBeenCalledWith("pending-abc-123", "81825820aabb");
+  });
+
+  // The WebHID permission request must begin directly from the confirm click,
+  // before yielding to the backend signing-request fetch.
+  expect(vi.mocked(connectLedger).mock.invocationCallOrder[0]).toBeLessThan(
+    vi.mocked(client.getHardwareSignRequest).mock.invocationCallOrder[0],
+  );
+
+  const signRequest = mockSignTx.mock.calls[0][0];
+  expect(signRequest.tx.includeNetworkId).toBe(true);
+  expect(signRequest.tx.outputs).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ tokenBundle: [] }),
+    ]),
+  );
+  expect(signRequest.tx.outputs.every((output) => Array.isArray(output.tokenBundle))).toBe(true);
+  expect(signRequest.tx.outputs[0].destination).toEqual({
+    type: "third_party",
+    params: { addressHex: "60aabb" },
+  });
+  expect(signRequest.tx.outputs[1].destination).toEqual({
+    type: "device_owned",
+    params: {
+      type: 0,
+      params: {
+        spendingPath: [0x8000073c, 0x80000717, 0x80000000, 0, 0],
+        stakingPath: [0x8000073c, 0x80000717, 0x80000000, 2, 0],
+      },
+    },
+  });
+
+  await waitFor(() => {
+    expect(screen.getByText(new RegExp(MOCK_TX_RESULT.tx_hash))).toBeInTheDocument();
+    expect(mockClose).toHaveBeenCalledOnce();
+  });
+});
+
+test("(t) hardware account: unsupported tx closes the connected Ledger without signing", async () => {
+  vi.spyOn(client, "buildSend").mockResolvedValue(MOCK_PREVIEW);
+  vi.spyOn(client, "getHardwareSignRequest").mockResolvedValue({
+    ...MOCK_HW_SIGN_RESP,
+    unsupported: "certificates are not supported on hardware yet",
+  });
+
+  const { connectLedger } = await import("../hw/ledger");
+  const mockConnectLedger = vi.mocked(connectLedger);
+  const mockSignTx = vi.fn();
+  const mockClose = vi.fn().mockResolvedValue(undefined);
+  mockConnectLedger.mockClear();
+  mockConnectLedger.mockResolvedValue({
+    getAccountXpub: vi.fn(),
+    signTx: mockSignTx,
+    close: mockClose,
+  });
+
+  render(<Send isHardware />);
+
+  const inputs = screen.getAllByRole("textbox");
+  fireEvent.change(inputs[0], { target: { value: "addr_test1recipient" } });
+  fireEvent.change(inputs[1], { target: { value: "5" } });
+  fireEvent.click(screen.getByRole("button", { name: /review/i }));
+
+  await waitFor(() => {
+    expect(screen.getByText(/2 inputs/i)).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByRole("button", { name: /confirm on.*ledger/i }));
+
+  await waitFor(() => {
+    expect(screen.getByText(/cannot be signed on hardware/i)).toBeInTheDocument();
+  });
+
+  expect(mockConnectLedger).toHaveBeenCalledOnce();
+  expect(mockSignTx).not.toHaveBeenCalled();
+  expect(mockClose).toHaveBeenCalledOnce();
 });

--- a/ui/web/src/screens/Send.tsx
+++ b/ui/web/src/screens/Send.tsx
@@ -1,8 +1,26 @@
 import { useEffect, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
-import type { Preview, TxResult, SendAsset, UnsignedTx, HandleInfo } from "../api/types";
-import { buildSend, confirmSend, exportUnsigned, resolveHandle, ApiError } from "../api/client";
+import type { Preview, TxResult, SendAsset, UnsignedTx, HandleInfo, HardwareSignResponse } from "../api/types";
+import {
+  buildSend,
+  confirmSend,
+  exportUnsigned,
+  resolveHandle,
+  getHardwareSignRequest,
+  submitHardware,
+  ApiError,
+} from "../api/client";
 import { useContacts } from "../api/hooks";
+import { connectLedger } from "../hw/ledger";
+import type { LedgerSession } from "../hw/ledger";
+import type { SignTransactionRequest, TxInput, TxOutput } from "@cardano-foundation/ledgerjs-hw-app-cardano";
+import {
+  AddressType,
+  TransactionSigningMode,
+  TxOutputDestinationType,
+  TxOutputFormat,
+  TxRequiredSignerType,
+} from "@cardano-foundation/ledgerjs-hw-app-cardano";
 import { Card } from "../components/Card";
 import { Input } from "../components/Input";
 import { Button } from "../components/Button";
@@ -10,6 +28,72 @@ import { Table } from "../components/Table";
 import { CopyButton } from "../components/CopyButton";
 import { DownloadButton } from "../components/DownloadButton";
 import { formatAda, parseAda } from "../format";
+
+// parseBip32Path converts a CIP-1852 path string to a numeric array.
+// "1852'/1815'/0'/0/3" → [0x80000000+1852, 0x80000000+1815, 0x80000000+0, 0, 3]
+function parseBip32Path(pathStr: string): number[] {
+  const HARDENED = 0x80000000;
+  return pathStr.split("/").map((seg) => {
+    const hardened = seg.endsWith("'");
+    const n = parseInt(hardened ? seg.slice(0, -1) : seg, 10);
+    return hardened ? n + HARDENED : n;
+  });
+}
+
+// mapToSignRequest converts a HardwareSignResponse (from the backend) to the
+// SignTransactionRequest format that ledgerjs expects.
+function mapToSignRequest(resp: HardwareSignResponse): SignTransactionRequest {
+  const inputs: TxInput[] = resp.inputs.map((inp) => ({
+    txHashHex: inp.tx_hash_hex,
+    outputIndex: inp.output_index,
+    path: inp.path ? parseBip32Path(inp.path) : null,
+  }));
+
+  const outputs: TxOutput[] = resp.outputs.map((out) => {
+    const destination = out.payment_path && out.stake_path
+      ? {
+          type: TxOutputDestinationType.DEVICE_OWNED as const,
+          params: {
+            type: AddressType.BASE_PAYMENT_KEY_STAKE_KEY as const,
+            params: {
+              spendingPath: parseBip32Path(out.payment_path),
+              stakingPath: parseBip32Path(out.stake_path),
+            },
+          },
+        }
+      : {
+          type: TxOutputDestinationType.THIRD_PARTY as const,
+          params: { addressHex: out.address_hex },
+        };
+
+    return {
+      format: TxOutputFormat.ARRAY_LEGACY,
+      destination,
+      amount: BigInt(out.lovelace),
+      // ledgerjs iterates this field even when the output contains ADA only.
+      tokenBundle: [],
+    };
+  });
+
+  return {
+    tx: {
+      network: {
+        protocolMagic: resp.protocol_magic,
+        networkId: resp.network_id,
+      },
+      inputs,
+      outputs,
+      fee: BigInt(resp.fee),
+      ttl: resp.ttl ? BigInt(resp.ttl) : null,
+      requiredSigners: resp.required_signers.map((hashHex) => ({
+        type: TxRequiredSignerType.HASH,
+        hashHex,
+      })),
+      includeNetworkId: resp.include_network_id || null,
+    },
+    signingMode: TransactionSigningMode.ORDINARY_TRANSACTION,
+  };
+}
 
 type Phase = "compose" | "preview" | "done";
 
@@ -305,6 +389,7 @@ function Compose({ to, setTo, adaAmount, setAdaAmount, assetRows, setAssetRows, 
 
 interface PreviewPhaseProps {
   preview: Preview;
+  isHardware?: boolean;
   onBack: () => void;
   onDone: (result: TxResult) => void;
 }
@@ -315,7 +400,8 @@ const OUTPUT_COLUMNS = [
   { key: "assets", label: "Assets" },
 ];
 
-function PreviewPhase({ preview, onBack, onDone }: PreviewPhaseProps) {
+function PreviewPhase({ preview, isHardware, onBack, onDone }: PreviewPhaseProps) {
+  // password is only used in the software (!isHardware) confirm path; hooks cannot be conditional.
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -340,6 +426,40 @@ function PreviewPhase({ preview, onBack, onDone }: PreviewPhaseProps) {
     } catch (e) {
       setError(errorMessage(e));
     } finally {
+      setLoading(false);
+    }
+  }
+
+  // Hardware confirm flow: connect Ledger → fetch signing request → signTx → submit.
+  // WebHID's device chooser must be requested while the confirm click still
+  // carries transient user activation, before yielding to a backend request.
+  async function handleHardwareConfirm() {
+    setError(null);
+    setLoading(true);
+    let session: LedgerSession | null = null;
+    try {
+      // 1. Connect directly from the click handler so a first-time user can
+      // grant WebHID permission while browser user activation is still live.
+      session = await connectLedger();
+
+      // 2. Fetch the structured signing request once the device is connected.
+      const signResp = await getHardwareSignRequest(preview.pending_id);
+      if (signResp.unsupported) {
+        setError(`This transaction cannot be signed on hardware: ${signResp.unsupported}`);
+        return;
+      }
+      const request = mapToSignRequest(signResp);
+
+      // 3. Sign on the connected Ledger device.
+      const witnessCbor = await session.signTx(request);
+
+      // 4. Submit the signed transaction.
+      const result = await submitHardware(preview.pending_id, witnessCbor);
+      onDone(result);
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      if (session) await session.close().catch(() => {});
       setLoading(false);
     }
   }
@@ -382,14 +502,22 @@ function PreviewPhase({ preview, onBack, onDone }: PreviewPhaseProps) {
           </div>
         </dl>
 
-        <label htmlFor="spend-password">Spending password</label>
-        <Input
-          id="spend-password"
-          type="password"
-          placeholder="Spending password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
+        {isHardware ? (
+          <p className="helper-text">
+            Connect your Ledger and confirm the transaction on the device.
+          </p>
+        ) : (
+          <>
+            <label htmlFor="spend-password">Spending password</label>
+            <Input
+              id="spend-password"
+              type="password"
+              placeholder="Spending password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </>
+        )}
 
         {error && (
           <p role="alert" className="error-text">
@@ -401,46 +529,54 @@ function PreviewPhase({ preview, onBack, onDone }: PreviewPhaseProps) {
           <Button variant="ghost" onClick={onBack} disabled={loading || exporting}>
             Back
           </Button>
-          <Button onClick={handleConfirm} disabled={loading || exporting || !password}>
-            {loading ? "Submitting…" : "Confirm & send"}
-          </Button>
-        </div>
-
-        <div className="offline-export">
-          <Button variant="ghost" onClick={handleExport} disabled={loading || exporting}>
-            {exporting ? "Exporting…" : "Export for offline signing"}
-          </Button>
-          {exported && (
-            <div className="sign-result">
-              <p className="helper-text">
-                Carry this unsigned transaction to your offline instance, sign it
-                there, then bring the witness back to Submit signed.
-              </p>
-              <p className="field-label">Unsigned transaction (CBOR)</p>
-              <div className="tx-hash-row">
-                <code className="tx-hash">{exported.unsigned_tx_cbor}</code>
-                <CopyButton value={exported.unsigned_tx_cbor} />
-                <DownloadButton
-                  value={exported.unsigned_tx_cbor}
-                  filename="unsigned-tx.cbor"
-                  label="Download"
-                />
-              </div>
-              {exported.required_signers.length > 0 && (
-                <>
-                  <p className="field-label">Required signers</p>
-                  <ul className="signer-list">
-                    {exported.required_signers.map((s) => (
-                      <li key={s}>
-                        <code className="tx-hash">{s}</code>
-                      </li>
-                    ))}
-                  </ul>
-                </>
-              )}
-            </div>
+          {isHardware ? (
+            <Button onClick={handleHardwareConfirm} disabled={loading || exporting}>
+              {loading ? "Signing…" : "Confirm on Ledger"}
+            </Button>
+          ) : (
+            <Button onClick={handleConfirm} disabled={loading || exporting || !password}>
+              {loading ? "Submitting…" : "Confirm & send"}
+            </Button>
           )}
         </div>
+
+        {!isHardware && (
+          <div className="offline-export">
+            <Button variant="ghost" onClick={handleExport} disabled={loading || exporting}>
+              {exporting ? "Exporting…" : "Export for offline signing"}
+            </Button>
+            {exported && (
+              <div className="sign-result">
+                <p className="helper-text">
+                  Carry this unsigned transaction to your offline instance, sign it
+                  there, then bring the witness back to Submit signed.
+                </p>
+                <p className="field-label">Unsigned transaction (CBOR)</p>
+                <div className="tx-hash-row">
+                  <code className="tx-hash">{exported.unsigned_tx_cbor}</code>
+                  <CopyButton value={exported.unsigned_tx_cbor} />
+                  <DownloadButton
+                    value={exported.unsigned_tx_cbor}
+                    filename="unsigned-tx.cbor"
+                    label="Download"
+                  />
+                </div>
+                {exported.required_signers.length > 0 && (
+                  <>
+                    <p className="field-label">Required signers</p>
+                    <ul className="signer-list">
+                      {exported.required_signers.map((s) => (
+                        <li key={s}>
+                          <code className="tx-hash">{s}</code>
+                        </li>
+                      ))}
+                    </ul>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </Card>
   );
@@ -471,7 +607,7 @@ function DonePhase({ result, onReset }: DonePhaseProps) {
 
 // --- Top-level Send screen ---
 
-export function Send() {
+export function Send({ isHardware }: { isHardware?: boolean } = {}) {
   const [phase, setPhase] = useState<Phase>("compose");
   const [preview, setPreview] = useState<Preview | null>(null);
   const [txResult, setTxResult] = useState<TxResult | null>(null);
@@ -510,6 +646,7 @@ export function Send() {
     return (
       <PreviewPhase
         preview={preview}
+        isHardware={isHardware}
         onBack={() => setPhase("compose")}
         onDone={handleDone}
       />

--- a/ui/web/src/screens/Settings.test.tsx
+++ b/ui/web/src/screens/Settings.test.tsx
@@ -65,11 +65,11 @@ function mockAutoLock(setting: AutoLockSetting | null, loading = false) {
 
 // renderSettings wraps render(<Settings .../>) with the module's current
 // autoLockState so every call site doesn't need to thread it explicitly.
-function renderSettings(props: Partial<Pick<Parameters<typeof Settings>[0], "account" | "spendingEnabled">> = {}) {
+function renderSettings(props: Partial<Pick<Parameters<typeof Settings>[0], "account" | "walletType">> = {}) {
   return render(
     <Settings
       account={props.account ?? mockAccount}
-      spendingEnabled={props.spendingEnabled ?? false}
+      walletType={props.walletType ?? "read_only"}
       autoLock={autoLockState}
     />,
   );
@@ -160,16 +160,29 @@ test("(f) caughtUp=false does NOT show caught-up indicator", () => {
   expect(screen.queryByText(/caught.?up/i)).toBeNull();
 });
 
-test("(g) spendingEnabled=true shows 'Spending enabled'", () => {
+test("(g) full wallet type shows spending enabled", () => {
   mockStatus("ready", 12345, true);
-  renderSettings({ spendingEnabled: true });
-  expect(screen.getByText(/spending enabled/i)).toBeInTheDocument();
+  renderSettings({ walletType: "full" });
+  expect(screen.getByText(/full wallet.*spending enabled/i)).toBeInTheDocument();
 });
 
-test("(h) spendingEnabled=false shows 'Read-only'", () => {
+test("(h) read-only wallet type shows 'Read-only'", () => {
   mockStatus("ready", 12345, true);
   renderSettings();
   expect(screen.getByText(/read.?only/i)).toBeInTheDocument();
+});
+
+test("hardware wallet shows on-device signing instead of 'Read-only'", () => {
+  mockStatus("ready", 12345, true);
+  renderSettings({ walletType: "hardware" });
+  expect(screen.getByText(/hardware wallet.*on-device signing/i)).toBeInTheDocument();
+  expect(screen.queryByText(/read.?only/i)).not.toBeInTheDocument();
+});
+
+test("multi-signature wallet type is identified explicitly", () => {
+  mockStatus("ready", 12345, true);
+  renderSettings({ walletType: "multi_signature" });
+  expect(screen.getByText(/multi-signature wallet/i)).toBeInTheDocument();
 });
 
 test("(i) loading state from useStatus renders gracefully", () => {

--- a/ui/web/src/screens/Settings.tsx
+++ b/ui/web/src/screens/Settings.tsx
@@ -20,11 +20,11 @@ import {
   disableTPM,
 } from "../api/client";
 import { getConnectorState, revokeGrant, unpair, pendingPairings } from "../api/connector";
-import type { Account, AutoLockSetting, NodeState, TPMStatus } from "../api/types";
+import type { Account, AutoLockSetting, NodeState, TPMStatus, WalletType } from "../api/types";
 
 interface SettingsProps {
   account: Account;
-  spendingEnabled: boolean;
+  walletType: WalletType;
   // The auto-lock AsyncState, lifted up to and owned by App (see app.tsx) so
   // this screen's save path and App's useIdleLock share the same value — a
   // change here must be visible to the idle timer in the same session, with
@@ -37,6 +37,19 @@ function syncTone(state: NodeState): "ok" | "warn" | "error" | "muted" {
   if (state === "error") return "error";
   if (state === "stopped") return "muted";
   return "warn";
+}
+
+function walletTypeStatus(walletType: WalletType): string {
+  switch (walletType) {
+    case "full":
+      return "Full wallet · Spending enabled";
+    case "read_only":
+      return "Read-only wallet";
+    case "multi_signature":
+      return "Multi-signature wallet";
+    case "hardware":
+      return "Hardware wallet · On-device signing";
+  }
 }
 
 // LeanStorageCard is the user-facing control for the lean-node (history-expiry)
@@ -443,7 +456,7 @@ function TPMCard({
   );
 }
 
-export function Settings({ account, spendingEnabled, autoLock }: SettingsProps) {
+export function Settings({ account, walletType, autoLock }: SettingsProps) {
   const status = useStatus();
   const tpmStatusQuery = useTPMStatus();
   const [connectorMissing, setConnectorMissing] = useState(false);
@@ -579,8 +592,8 @@ export function Settings({ account, spendingEnabled, autoLock }: SettingsProps) 
 
       <AutoLockCard setting={autoLock} />
 
-      <Card title="Keystore">
-        <p>{spendingEnabled ? "Spending enabled" : "Read-only"}</p>
+      <Card title="Wallet">
+        <p>{walletTypeStatus(walletType)}</p>
       </Card>
 
       {tpmStatusQuery.data ? (

--- a/ui/web/src/screens/UnlockVault.test.tsx
+++ b/ui/web/src/screens/UnlockVault.test.tsx
@@ -4,7 +4,7 @@ import * as client from "../api/client";
 import type { WalletView } from "../api/types";
 
 const wallets: WalletView[] = [
-  { id: "w1", name: "Main", network: "preview", stake_address: "stake_test1", addresses: ["addr1"], active: true },
+  { id: "w1", name: "Main", network: "preview", stake_address: "stake_test1", addresses: ["addr1"], active: true, type: "full" },
 ];
 
 afterEach(() => vi.restoreAllMocks());

--- a/ui/web/src/smoke.test.tsx
+++ b/ui/web/src/smoke.test.tsx
@@ -11,6 +11,7 @@ const walletA: WalletView = {
   stake_address: "stake_test1abc",
   addresses: ["addr_test1abc"],
   active: true,
+  type: "full",
 };
 
 test("renders the app shell once a wallet is active", async () => {


### PR DESCRIPTION
Adds **Ledger hardware-wallet support** to the full-node wallet.

- `bip32`: non-hardened `XPub.Derive` (public-key child derivation)
- Seedless **xpub-only hardware accounts** in the vault + address derivation from the account xpub
- API: `POST /wallet/hardware` to add a Ledger account; `hardware-sign-request` + `submit-hardware` routes
- `spend`: CIP-1852 signing-path emission for hardware signing
- SPA: **Ledger WebHID** module (connect, xpub, signTx) + a **Connect-Ledger** add-wallet flow, with confirm-on-device signing routed through the existing air-gap submit path

**Consent law preserved** — signing is user-device-local (Ledger over WebHID) plus the wallet's existing node submit path; no new external network calls, and the `internal/boundary` denylist test stays green.

**Note:** Ledger connect uses **WebHID**, which is available in the browser-served mode (Chromium/Brave/Edge) — not the embedded desktop webview (documented design constraint).

Re-integrated onto current `main` as a single commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Ledger hardware-wallet support with WebHID connect, xpub-only accounts (tracks `account_index`), and on-device signing; also restores multi‑sig spending.

- **New Features**
  - `bip32`: public-child `XPub.Derive` (non‑hardened) with tests; wallet builds read‑only accounts from Bech32 `acct_xvk`/`root_xvk`.
  - Vault/API: hardware wallets (`type: "hardware"`); `AddHardwareWallet`/`POST /wallet/hardware` with `account_index`; vault envelope tracks `wallet_count`; `Account` includes `account_index`; no seed blob for hardware.
  - Spend/API: `HardwareSignRequest` (decoded tx fields) from `pending_id`; `hardware-sign-request` and `submit-hardware` accept Ledger witnesses and forward to node submit; payment‑only (certs/withdrawals blocked).
  - Web UI: `hw/ledger.ts` WebHID wrapper; Connect‑Ledger add‑wallet flow; Send signs on device using `@cardano-foundation/ledgerjs-hw-app-cardano`, `@ledgerhq/hw-transport-webhid`, and `bech32`; Settings shows wallet type; App enables Send for full/hardware.

- **Bug Fixes**
  - Multi‑sig spend restored (screen now receives `canSpend`/`canSign` as intended).
  - Disabled seed‑required flows (Sign/Offline/Operate) for hardware; clear errors for unsupported txs, invalid wallet details, and when WebHID is unavailable.
  - Vault migration: aborts format‑1 persistence failure and keeps the vault locked.

<sup>Written for commit 77fb262605b32e89d883389e439946e9cd605caf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Ledger hardware-wallet connection and account setup.
  - Added hardware-wallet indicators in wallet listings.
  - Added Ledger-based transaction signing and submission.
  - Added structured signing previews with transaction inputs, outputs, fees, and network details.
  - Added public-key child derivation for non-hardened paths.

- **Bug Fixes**
  - Corrected routing so hardware-wallet send flows open the Send screen.
  - Added validation and clear errors for unsupported transactions, invalid wallet details, and unavailable WebHID support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->