### PR TITLE
build(deps): switch to a pinned bursa commit

### DIFF
--- a/ui/go.mod
+++ b/ui/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/blinklabs-io/apollo/v2 v2.0.0-20260625155554-2c0d64b7d8e9
-	github.com/blinklabs-io/bursa v0.16.1-0.20260624233607-e1d8912f7e08
+	github.com/blinklabs-io/bursa v0.16.1-0.20260723122856-2f8b123a98ae
 	github.com/blinklabs-io/dingo v0.58.0
 	github.com/blinklabs-io/go-bip39 v0.2.0
 	github.com/blinklabs-io/gouroboros v0.186.0
@@ -18,12 +18,6 @@ require (
 	github.com/webview/webview_go v0.0.0-20240831120633-6173450d4dd6
 	golang.org/x/crypto v0.53.0
 )
-
-// The wallet UI ships together with the bursa keys layer it embeds: CIP-8
-// verification (bursa.VerifyDataWithAddress) and air-gap signing reuse the
-// parent module's COSE/BIP32 code, so build against the local source rather
-// than a published tag.
-replace github.com/blinklabs-io/bursa => ../
 
 require (
 	cel.dev/expr v0.25.1 // indirect

--- a/ui/go.sum
+++ b/ui/go.sum
@@ -133,6 +133,8 @@ github.com/blinklabs-io/apollo/v2 v2.0.0-20260625155554-2c0d64b7d8e9 h1:XFQMZ9Fc
 github.com/blinklabs-io/apollo/v2 v2.0.0-20260625155554-2c0d64b7d8e9/go.mod h1:2V+ozsEcpAYykzUlTBBdMW7+aQTVJSbizRjXli3D92s=
 github.com/blinklabs-io/bark v0.0.2 h1:YcwhDfKu8QuPGjKcaV9/J4Vq+0kYMWMo8C08FW2akeI=
 github.com/blinklabs-io/bark v0.0.2/go.mod h1:+ufcuLfDoj8yXktYHQSffle/gaCJnJWqL/31PnAP3dc=
+github.com/blinklabs-io/bursa v0.16.1-0.20260723122856-2f8b123a98ae h1:QtuiW1YnvpMfp28liHcTPb2A/UUP4HeZDWpC6QP5XmM=
+github.com/blinklabs-io/bursa v0.16.1-0.20260723122856-2f8b123a98ae/go.mod h1:mcUIQifk8bNmCZ1tgh2IbxJa1GmRoDu6De5WUiboDHs=
 github.com/blinklabs-io/dingo v0.58.0 h1:8sUWR3n8kq9E5PMht4mCLr7pZKJjOdliqTdJoV2vkhw=
 github.com/blinklabs-io/dingo v0.58.0/go.mod h1:LzAKimQlrjizKI72xMxP6P2ZfEpd3Vat0Lc6D5c9jQw=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=

--- a/ui/internal/connector/service_test.go
+++ b/ui/internal/connector/service_test.go
@@ -344,19 +344,25 @@ func TestServiceSubscribe(t *testing.T) {
 	}()
 
 	// enable will enqueue a request; the subscriber should see it.
-	done := make(chan struct{})
+	handleDone := make(chan error, 1)
+	handleCtx := ctx(t)
 	go func() {
-		_, _ = s.Handle(ctx(t), "https://f.io", "enable", nil)
+		_, err := s.Handle(handleCtx, "https://f.io", "enable", nil)
+		handleDone <- err
 	}()
-	go func() {
-		select {
-		case <-ch:
-		case <-time.After(3 * time.Second):
-			t.Errorf("subscriber did not receive request")
-		}
-		close(done)
-	}()
-	<-done
+
+	select {
+	case <-ch:
+	case <-time.After(3 * time.Second):
+		t.Fatal("subscriber did not receive request")
+	}
+
+	// Wait for Handle to finish writing the grant before t.TempDir cleanup.
+	// Returning immediately after the notification races the atomic grant-file
+	// rename with removal of the temporary directory.
+	if err := <-handleDone; err != nil {
+		t.Fatalf("enable: %v", err)
+	}
 }
 
 // TestServiceUnpair verifies Unpair clears the token.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `github.com/blinklabs-io/bursa` in the `ui` module for reproducible builds and remove the local replace. Also stabilize the connector subscription test by waiting for request completion to avoid a race.

- **Dependencies**
  - Pinned `github.com/blinklabs-io/bursa` to a specific pseudo-version.
  - Removed `replace github.com/blinklabs-io/bursa => ../`.
  - Updated `go.sum`.

- **Bug Fixes**
  - `TestServiceSubscribe`: wait for `Handle` to finish before cleanup to prevent a race and flakiness.

<sup>Written for commit bed2d59680b855cb1d337f019c482f9160c1c955. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Bursa dependency to a newer version.
  * Builds now use the published dependency instead of a local directory reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->