### PR TITLE
fix(cli): emit canonical NodeOperationalCertificate CBOR envelope (#592)

### DIFF
--- a/bursa.go
+++ b/bursa.go
@@ -1377,6 +1377,7 @@ type OperationalCertificate struct {
 	IssueNumber   uint64 // Certificate sequence/issue number
 	KesPeriod     uint64 // KES period at certificate creation
 	ColdSignature []byte // Cold key signature (64 bytes)
+	ColdVkey      []byte // Cold (pool) verification key (32 bytes)
 }
 
 // CreateOperationalCertificate creates a new operational certificate by signing
@@ -1407,11 +1408,34 @@ func CreateOperationalCertificate(
 			err,
 		)
 	}
+
+	// Derive the cold (pool) verification key from the cold signing key so
+	// the canonical NodeOperationalCertificate envelope can carry it. A real
+	// node cert is a 2-element structure [inner_cert, cold_vkey]; without the
+	// cold vkey the certificate cannot be verified or round-tripped.
+	var coldVkey ed25519.PublicKey
+	switch len(coldSkey) {
+	case ed25519.SeedSize:
+		coldVkey = ed25519.NewKeyFromSeed(coldSkey).
+			Public().(ed25519.PublicKey)
+	case ed25519.PrivateKeySize:
+		coldVkey = ed25519.PrivateKey(coldSkey).
+			Public().(ed25519.PublicKey)
+	default:
+		return nil, fmt.Errorf(
+			"cold signing key must be %d or %d bytes, got %d",
+			ed25519.SeedSize,
+			ed25519.PrivateKeySize,
+			len(coldSkey),
+		)
+	}
+
 	return &OperationalCertificate{
 		KesVkey:       opCert.KesVkey,
 		IssueNumber:   opCert.IssueNumber,
 		KesPeriod:     opCert.KesPeriod,
 		ColdSignature: opCert.ColdSignature,
+		ColdVkey:      coldVkey,
 	}, nil
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1612,16 +1612,35 @@ func parseSigningKey(data []byte) ([]byte, error) {
 	)
 }
 
-// encodeOpCertCBOR encodes an operational certificate to CBOR hex
+// encodeOpCertCBOR encodes an operational certificate to CBOR hex.
+//
+// The canonical NodeOperationalCertificate is a 2-element structure:
+//
+//	[[kes_vkey, counter, kes_period, signature], cold_vkey]
+//
+// i.e. the inner 4-tuple wrapped in an outer array whose second element is
+// the pool cold verification key. This matches cardano-cli / node output and
+// is what bursa's own decodeOpCert expects, so the emitted cert round-trips.
 func encodeOpCertCBOR(
 	opCert *bursa.OperationalCertificate,
 ) (string, error) {
-	// OpCert CBOR: [kes_vkey, counter, kes_period, signature]
-	certData := []any{
+	if len(opCert.ColdVkey) != 32 {
+		return "", fmt.Errorf(
+			"invalid operational certificate: cold_vkey expected 32 bytes, got %d",
+			len(opCert.ColdVkey),
+		)
+	}
+	// Inner cert: [kes_vkey, counter, kes_period, signature]
+	innerCert := []any{
 		opCert.KesVkey,
 		opCert.IssueNumber,
 		opCert.KesPeriod,
 		opCert.ColdSignature,
+	}
+	// Outer envelope: [inner_cert, cold_vkey]
+	certData := []any{
+		innerCert,
+		opCert.ColdVkey,
 	}
 	cborBytes, err := cbor.Encode(certData)
 	if err != nil {

--- a/internal/cli/opcert_test.go
+++ b/internal/cli/opcert_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deterministic test material.
+var (
+	// 32-byte cold signing key seed.
+	testColdSkeySeed = mustHex(
+		"1111111111111111111111111111111111111111111111111111111111111111",
+	)
+	// 32-byte KES verification key.
+	testKESVkey = mustHex(
+		"2222222222222222222222222222222222222222222222222222222222222222",
+	)
+)
+
+func mustHex(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// TestEncodeOpCertCBORShape verifies that encodeOpCertCBOR emits the canonical
+// 2-element NodeOperationalCertificate structure:
+//
+//	[[kes_vkey, counter, kes_period, signature], cold_vkey]
+//
+// with a 32-byte cold verification key as the outer array's second element.
+func TestEncodeOpCertCBORShape(t *testing.T) {
+	opCert, err := bursa.CreateOperationalCertificate(
+		testKESVkey,
+		7,  // counter / issue number
+		42, // kes period
+		testColdSkeySeed,
+	)
+	require.NoError(t, err)
+
+	// The cold vkey must be carried on the certificate and be the correct
+	// public key derived from the cold seed.
+	expectedColdVkey := ed25519.NewKeyFromSeed(testColdSkeySeed).
+		Public().(ed25519.PublicKey)
+	assert.Equal(t, []byte(expectedColdVkey), opCert.ColdVkey)
+	require.Len(t, opCert.ColdVkey, 32)
+
+	cborHex, err := encodeOpCertCBOR(opCert)
+	require.NoError(t, err)
+
+	raw, err := hex.DecodeString(cborHex)
+	require.NoError(t, err)
+
+	var outer []any
+	_, err = cbor.Decode(raw, &outer)
+	require.NoError(t, err)
+
+	// Outer array: 2 elements.
+	require.Len(t, outer, 2, "outer array must have exactly 2 elements")
+
+	// Element 0: inner 4-element cert array.
+	inner, ok := outer[0].([]any)
+	require.True(t, ok, "outer[0] must be an array")
+	require.Len(t, inner, 4, "inner cert array must have 4 elements")
+
+	kesVkey, ok := inner[0].([]byte)
+	require.True(t, ok)
+	assert.Equal(t, testKESVkey, kesVkey)
+
+	// Element 1: 32-byte cold vkey.
+	coldVkey, ok := outer[1].([]byte)
+	require.True(t, ok, "outer[1] (cold_vkey) must be bytes")
+	require.Len(t, coldVkey, 32, "cold_vkey must be 32 bytes")
+	assert.Equal(t, []byte(expectedColdVkey), coldVkey)
+}
+
+// TestOpCertEncodeDecodeRoundTrip proves that a certificate emitted by
+// encodeOpCertCBOR (wrapped in the NodeOperationalCertificate text envelope)
+// can be decoded again by bursa's own decoder. This is the round-trip the bug
+// broke: the old bare 4-tuple failed bursa's 2-element outer-array requirement.
+func TestOpCertEncodeDecodeRoundTrip(t *testing.T) {
+	const (
+		counter   = uint64(3)
+		kesPeriod = uint64(100)
+	)
+	opCert, err := bursa.CreateOperationalCertificate(
+		testKESVkey,
+		counter,
+		kesPeriod,
+		testColdSkeySeed,
+	)
+	require.NoError(t, err)
+
+	cborHex, err := encodeOpCertCBOR(opCert)
+	require.NoError(t, err)
+
+	envelope := map[string]string{
+		"type":        "NodeOperationalCertificate",
+		"description": "Operational Certificate",
+		"cborHex":     cborHex,
+	}
+	data, err := json.Marshal(envelope)
+	require.NoError(t, err)
+
+	loaded, err := bursa.LoadKeyFromBytes(data)
+	require.NoError(t, err, "bursa must be able to decode its own op-cert output")
+
+	assert.Equal(t, testKESVkey, loaded.VKey)
+	assert.Equal(t, counter, loaded.OpCertIssueNumber)
+	assert.Equal(t, kesPeriod, loaded.OpCertKesPeriod)
+	assert.Equal(t, opCert.ColdSignature, loaded.OpCertSignature)
+	assert.Equal(t, opCert.ColdVkey, loaded.OpCertColdVKey)
+
+	expectedColdVkey := ed25519.NewKeyFromSeed(testColdSkeySeed).
+		Public().(ed25519.PublicKey)
+	assert.Equal(t, []byte(expectedColdVkey), loaded.OpCertColdVKey)
+}
+
+// TestRunCertOpCertRoundTrip drives the full CLI command end-to-end: it writes
+// KES vkey and cold skey input files, runs RunCertOpCert to produce the cert
+// file, then decodes that file with bursa.LoadKeyFromFile.
+func TestRunCertOpCertRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	kesVkeyFile := createTestVkeyFile(
+		t,
+		dir,
+		"kes.vkey",
+		"KesVerificationKey_ed25519_kes_2^6",
+		"KES Verification Key",
+		"5820"+hex.EncodeToString(testKESVkey),
+	)
+	coldSkeyFile := createTestVkeyFile(
+		t,
+		dir,
+		"cold.skey",
+		"StakePoolSigningKey_ed25519",
+		"Stake Pool Cold Signing Key",
+		"5820"+hex.EncodeToString(testColdSkeySeed),
+	)
+	outFile := filepath.Join(dir, "node.cert")
+
+	err := RunCertOpCert(kesVkeyFile, coldSkeyFile, outFile, 5, 250)
+	require.NoError(t, err)
+
+	// The emitted file must be a valid NodeOperationalCertificate envelope
+	// that bursa can load back.
+	raw, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+
+	var env struct {
+		Type    string `json:"type"`
+		CborHex string `json:"cborHex"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &env))
+	assert.Equal(t, "NodeOperationalCertificate", env.Type)
+
+	loaded, err := bursa.LoadKeyFromFile(outFile)
+	require.NoError(t, err)
+	assert.Equal(t, testKESVkey, loaded.VKey)
+	assert.Equal(t, uint64(5), loaded.OpCertIssueNumber)
+	assert.Equal(t, uint64(250), loaded.OpCertKesPeriod)
+	require.Len(t, loaded.OpCertColdVKey, 32)
+
+	expectedColdVkey := ed25519.NewKeyFromSeed(testColdSkeySeed).
+		Public().(ed25519.PublicKey)
+	assert.Equal(t, []byte(expectedColdVkey), loaded.OpCertColdVKey)
+}


### PR DESCRIPTION
## The bug

`bursa cert op-cert` emitted only the **bare inner 4-tuple**
`[kes_vkey, counter, kes_period, signature]` (`encodeOpCertCBOR`,
`internal/cli/cli.go`) and then wrapped it in the text-envelope type
`"NodeOperationalCertificate"` (`RunCertOpCert`).

But the canonical `NodeOperationalCertificate` is the **2-element** structure:

```
[[kes_vkey, counter, kes_period, sig], cold_vkey]
```

Bursa's own decoder proves it: `decodeOpCert` (`bursa.go`) requires a 2-element
outer array with a mandatory 32-byte `cold_vkey` at index 1, and is invoked from
`parseKeyEnvelope` under `case "NodeOperationalCertificate":`. Consequences:

- Bursa could **not round-trip its own `bursa cert op-cert` output** — feeding
  the emitted cert back through `LoadKeyFromFile`/`decodeOpCert` failed the
  "expected 2-element outer array, got 4" check.
- The emitted cert **omitted the cold vkey** a real node cert carries, so it did
  not match `cardano-cli`/node expectations.

Root cause: the `OperationalCertificate` struct had only 4 fields and no cold
vkey; `CreateOperationalCertificate` (wrapping gouroboros `ledger.CreateOpCert`,
which also does not return it) never captured it.

## The fix (issue #592 **Part A** only)

- Added `ColdVkey` to `OperationalCertificate` and derive it from the cold
  signing key in `CreateOperationalCertificate` (handles both the 32-byte seed
  and 64-byte Ed25519 private-key forms, matching gouroboros' own handling).
- `encodeOpCertCBOR` now emits the canonical 2-element envelope
  `[[kes_vkey, counter, kes_period, sig], cold_vkey]` and validates the 32-byte
  cold vkey.

## Round-trip proof

New tests in `internal/cli/opcert_test.go`:

- **`TestEncodeOpCertCBORShape`** — decodes the emitted CBOR and asserts the
  outer array has exactly 2 elements, the inner array has 4, and the second
  outer element is a 32-byte cold vkey equal to the public key derived from the
  cold seed.
- **`TestOpCertEncodeDecodeRoundTrip`** — encodes, wraps in the
  `NodeOperationalCertificate` envelope, and decodes again via
  `bursa.LoadKeyFromBytes` (which invokes `decodeOpCert`); asserts KES vkey,
  counter, KES period, signature, and cold vkey all survive the round trip.
- **`TestRunCertOpCertRoundTrip`** — drives the full CLI command end-to-end
  (writes KES vkey + cold skey input files, runs `RunCertOpCert`, then decodes
  the produced cert file with `bursa.LoadKeyFromFile`).

```
CGO_ENABLED=0 go build ./...     # clean
CGO_ENABLED=0 go test ./...      # all packages pass
golangci-lint run ./...          # 0 issues
```

## Follow-up (out of scope here)

Issue #592 **Part B** — a new external mTLS cold-signer *sign type* in the signer
service — is a separate feature and is intentionally **not** included in this PR
to keep it focused and unstacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix `bursa cert op-cert` to emit the canonical `NodeOperationalCertificate` CBOR envelope `[[kes_vkey, counter, kes_period, sig], cold_vkey]`. This restores round-trip decoding in `bursa` and matches cardano-node expectations. Addresses #592 (Part A).

- **Bug Fixes**
  - Added `ColdVkey` to `OperationalCertificate` and derive it from the cold signing key in `CreateOperationalCertificate` (supports 32-byte seed and 64-byte private key).
  - Updated `encodeOpCertCBOR` to output `[inner_cert, cold_vkey]` and validate a 32-byte `cold_vkey`.
  - Added tests for envelope shape and round-trips through the encoder, `RunCertOpCert`, and `bursa` decoders.

<sup>Written for commit a095feb9ab549d3d84babf6d9e348d777712d385. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

