### PR TITLE
feat(ui): derive network from the node (remove network selector)

### DIFF
--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -334,6 +334,14 @@ type handleInfo struct {
 
 const defaultWindow = 20
 
+// statusResponse is the GET /status response: the supervisor's node snapshot
+// plus the network the embedded node runs on. The node runs exactly one
+// network, so the SPA sources it from here rather than letting the user pick.
+type statusResponse struct {
+	supervisor.Status
+	Network string `json:"network"`
+}
+
 // vaultStatus is the GET /vault/status response.
 type vaultStatus struct {
 	Exists         bool `json:"exists"`
@@ -402,7 +410,7 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 		_, _ = w.Write([]byte("ok"))
 	})
 	mux.HandleFunc("/status", func(w http.ResponseWriter, _ *http.Request) {
-		writeJSON(w, http.StatusOK, st.Status())
+		writeJSON(w, http.StatusOK, statusResponse{Status: st.Status(), Network: network})
 	})
 
 	// bindActive pushes the active wallet's read-only account onto the read and

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -394,12 +394,18 @@ func TestStatusReturnsSnapshot(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("/status = %d, want 200", rec.Code)
 	}
-	var got supervisor.Status
+	var got struct {
+		supervisor.Status
+		Network string `json:"network"`
+	}
 	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	if got.State != want.State || got.Tip != want.Tip || got.CaughtUp != want.CaughtUp {
-		t.Fatalf("got %+v, want %+v", got, want)
+		t.Fatalf("got %+v, want %+v", got.Status, want)
+	}
+	if got.Network != "preview" {
+		t.Fatalf("network = %q, want %q", got.Network, "preview")
 	}
 }
 

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -22,6 +22,9 @@ export interface Status {
   caughtUp: boolean;
   bootstrap?: BootstrapProgress;
   error?: string;
+  // The network the embedded node runs on ("preview" | "preprod" | "mainnet").
+  // The node runs exactly one network; wallet flows derive it from here.
+  network: string;
 }
 
 export interface Account {

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -190,7 +190,10 @@ export function App() {
   }
 
   const vault = vaultStatus.data;
-  const network = "preview";
+  // The embedded node runs exactly one network; the create/add-wallet flows
+  // derive it from the live node status rather than letting the user pick a
+  // network that would never match the node (the backend rejects a mismatch).
+  const network = status.data?.network ?? "";
 
   if (!vault) {
     return (

--- a/ui/web/src/components/components.test.tsx
+++ b/ui/web/src/components/components.test.tsx
@@ -21,7 +21,7 @@ const mobileWallet: WalletView = {
 
 function renderMobileNav(overrides: Partial<MobileNavProps> = {}) {
   const props: MobileNavProps = {
-    status: { state: "ready", tip: 0, caughtUp: true },
+    status: { state: "ready", tip: 0, caughtUp: true, network: "preview" },
     activeWallet: mobileWallet,
     wallets: [mobileWallet],
     activeId: mobileWallet.id,
@@ -85,6 +85,7 @@ test("SyncBanner shows error detail ahead of retained bootstrap diagnostics", ()
         state: "error",
         tip: 0,
         caughtUp: false,
+        network: "preview",
         error: "mithril bootstrap: download failed",
         bootstrap: { phase: "bootstrap", percent: 40 },
       }}

--- a/ui/web/src/screens/AddWallet.test.tsx
+++ b/ui/web/src/screens/AddWallet.test.tsx
@@ -76,6 +76,18 @@ test("with a known vault password the vault field is hidden and add sends all fi
   await waitFor(() => expect(onAdded).toHaveBeenCalledWith(created));
 });
 
+test("the network is shown read-only (no selector) and taken from the node", () => {
+  render(<AddWallet network="preprod" knownVaultPassword="vault-password-xyz" onAdded={vi.fn()} />);
+  goToRestore();
+
+  // The old network <Select> is gone: there is no network combobox to pick a
+  // network the node isn't running.
+  expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+
+  // The node's network is shown read-only for context.
+  expect(screen.getByTestId("wallet-network")).toHaveTextContent(/Preprod/i);
+});
+
 test("without a known vault password the vault field is shown and required", async () => {
   const spy = vi.spyOn(client, "addWallet").mockResolvedValue(created);
   const onAdded = vi.fn();

--- a/ui/web/src/screens/AddWallet.tsx
+++ b/ui/web/src/screens/AddWallet.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import type { FormEvent } from "react";
 import { Card } from "../components/Card";
 import { Input } from "../components/Input";
-import { Select } from "../components/Select";
 import { Button } from "../components/Button";
 import { CopyButton } from "../components/CopyButton";
 import { addWallet, addHardwareWallet, generateMnemonic, ApiError } from "../api/client";
@@ -12,11 +11,29 @@ import type { WalletView } from "../api/types";
 import { MIN_PASSWORD_LEN, passwordLength } from "../password";
 import { CHALLENGE_WORD_COUNT, isChallengeAnswerCorrect, pickChallengeIndices, validateChallenge } from "../phraseChallenge";
 
-const NETWORK_OPTIONS = [
-  { value: "preview", label: "Preview" },
-  { value: "preprod", label: "Preprod" },
-  { value: "mainnet", label: "Mainnet" },
-];
+const NETWORK_LABELS: Record<string, string> = {
+  preview: "Preview",
+  preprod: "Preprod",
+  mainnet: "Mainnet",
+};
+
+function networkLabel(network: string): string {
+  return NETWORK_LABELS[network] ?? network ?? "";
+}
+
+// NetworkDisplay shows the network the wallet will be created on, read-only.
+// The embedded node runs exactly one network and the backend rejects any
+// mismatch, so there is nothing to choose — the value is shown for context.
+function NetworkDisplay({ network }: { network: string }) {
+  return (
+    <div className="field-group">
+      <label>Network</label>
+      <p className="helper-text" data-testid="wallet-network">
+        {networkLabel(network)} — set by the connected node
+      </p>
+    </div>
+  );
+}
 
 interface AddWalletProps {
   network: string;
@@ -56,7 +73,6 @@ export function AddWallet({
   // Shared form state
   const [name, setName] = useState("");
   const [mnemonic, setMnemonic] = useState("");
-  const [selectedNetwork, setSelectedNetwork] = useState(network);
   const [spendPassword, setSpendPassword] = useState("");
   const [vaultPassword, setVaultPassword] = useState("");
   const [ledgerAccountIndex, setLedgerAccountIndex] = useState("0");
@@ -133,7 +149,7 @@ export function AddWallet({
       const wallet = await addWallet({
         name: name.trim() || "Wallet",
         mnemonic: mnemonicToUse,
-        network: selectedNetwork,
+        network,
         vault_password: vaultPw,
         spend_password: spendPassword,
       });
@@ -183,7 +199,7 @@ export function AddWallet({
         name.trim() || "Ledger Wallet",
         xpub,
         accountIndex,
-        selectedNetwork,
+        network,
         vaultPw,
       );
       onAdded(wallet);
@@ -355,15 +371,7 @@ export function AddWallet({
             />
           </div>
 
-          <div className="field-group">
-            <label htmlFor="create-network">Network</label>
-            <Select
-              id="create-network"
-              options={NETWORK_OPTIONS}
-              value={selectedNetwork}
-              onChange={(e) => setSelectedNetwork(e.target.value)}
-            />
-          </div>
+          <NetworkDisplay network={network} />
 
           <div className="field-group">
             <label htmlFor="create-spend-password">Spending Password</label>
@@ -442,15 +450,7 @@ export function AddWallet({
             />
           </div>
 
-          <div className="field-group">
-            <label htmlFor="ledger-network">Network</label>
-            <Select
-              id="ledger-network"
-              options={NETWORK_OPTIONS}
-              value={selectedNetwork}
-              onChange={(e) => setSelectedNetwork(e.target.value)}
-            />
-          </div>
+          <NetworkDisplay network={network} />
 
           <div className="field-group">
             <label htmlFor="ledger-account-index">Account Index</label>
@@ -531,15 +531,7 @@ export function AddWallet({
           />
         </div>
 
-        <div className="field-group">
-          <label htmlFor="add-network">Network</label>
-          <Select
-            id="add-network"
-            options={NETWORK_OPTIONS}
-            value={selectedNetwork}
-            onChange={(e) => setSelectedNetwork(e.target.value)}
-          />
-        </div>
+        <NetworkDisplay network={network} />
 
         <div className="field-group">
           <label htmlFor="add-mnemonic">Recovery Phrase</label>

--- a/ui/web/src/screens/Syncing.test.tsx
+++ b/ui/web/src/screens/Syncing.test.tsx
@@ -10,6 +10,7 @@ test("(a) bootstrap download phase shows bytes, ETA, percent and the progress ba
         state: "bootstrapping",
         tip: 0,
         caughtUp: false,
+        network: "preview",
         bootstrap: {
           phase: "bootstrap",
           percent: 42.5,
@@ -34,6 +35,7 @@ test("(b) block-replay phase shows block count, slot range and the era label", (
         state: "bootstrapping",
         tip: 0,
         caughtUp: false,
+        network: "preview",
         bootstrap: {
           phase: "backfill",
           percent: 71,
@@ -59,6 +61,7 @@ test("(c) the phase stepper marks earlier phases done and the current one active
         state: "bootstrapping",
         tip: 0,
         caughtUp: false,
+        network: "preview",
         bootstrap: { phase: "immutable_copy", percent: 10 },
       }}
       onLoadAnyway={noop}
@@ -76,7 +79,7 @@ test("(d) chain sync shows how far behind the tip and the block slot", () => {
   const threeDaysAgo = new Date(Date.now() - 3 * 86400 * 1000).toISOString();
   render(
     <Syncing
-      status={{ state: "syncing", tip: 115748244, caughtUp: false, latestBlockTime: threeDaysAgo }}
+      status={{ state: "syncing", tip: 115748244, caughtUp: false, network: "preview", latestBlockTime: threeDaysAgo }}
       onLoadAnyway={noop}
     />,
   );
@@ -87,7 +90,7 @@ test("(d) chain sync shows how far behind the tip and the block slot", () => {
 test("(e) indeterminate sync progress is announced to assistive technology", () => {
   render(
     <Syncing
-      status={{ state: "starting", tip: 0, caughtUp: false }}
+      status={{ state: "starting", tip: 0, caughtUp: false, network: "preview" }}
       onLoadAnyway={noop}
     />,
   );
@@ -98,7 +101,7 @@ test("(e) indeterminate sync progress is announced to assistive technology", () 
 test("(f) error state surfaces the node error in an alert", () => {
   render(
     <Syncing
-      status={{ state: "error", tip: 0, caughtUp: false, error: "genesis import failed" }}
+      status={{ state: "error", tip: 0, caughtUp: false, network: "preview", error: "genesis import failed" }}
       onLoadAnyway={noop}
     />,
   );
@@ -112,6 +115,7 @@ test("(g) retained bootstrap diagnostics do not override an error state", () => 
         state: "error",
         tip: 0,
         caughtUp: false,
+        network: "preview",
         error: "mithril bootstrap: download failed",
         bootstrap: { phase: "bootstrap", percent: 40 },
       }}
@@ -126,7 +130,7 @@ test("(g) retained bootstrap diagnostics do not override an error state", () => 
 test("(h) the escape hatch invokes onLoadAnyway", () => {
   const onLoadAnyway = vi.fn();
   render(
-    <Syncing status={{ state: "syncing", tip: 0, caughtUp: false }} onLoadAnyway={onLoadAnyway} />,
+    <Syncing status={{ state: "syncing", tip: 0, caughtUp: false, network: "preview" }} onLoadAnyway={onLoadAnyway} />,
   );
   fireEvent.click(screen.getByRole("button", { name: /load wallet anyway/i }));
   expect(onLoadAnyway).toHaveBeenCalled();


### PR DESCRIPTION
## The footgun

`app.tsx` hardcoded `const network = "preview"`, which seeded a 3-option network `<Select>` (Preview / Preprod / Mainnet) in the create-vault and add-wallet flows. But the embedded node runs **exactly one** network, and the backend's `resolveNetwork` already returns **400** on any mismatch. So on a preprod or mainnet node the selector let the user pick a network that would never match — a guaranteed, confusing error with no valid alternative. The network **must** match the node; there is nothing to choose.

## The fix

**Backend** — add a `network` field to the `GET /status` response, populated from the node's network (the same value already passed into `NewHandler`, i.e. `cfg.Network`). JSON stays consistent with the existing `/status` fields.

**Frontend**
- `Status` interface gains `network: string`.
- `app.tsx` sources the network from the live `/status` (`status.data?.network ?? ""`) instead of the hardcoded `"preview"`. An empty string is a safe default — the backend treats empty as "use the node network".
- `AddWallet.tsx`: the network `<Select>` and its `selectedNetwork` state are removed entirely. The node's network is shown **read-only** for context (via a small `NetworkDisplay`) across the create-confirm, restore, and Ledger flows, and sent on submit.
- `CreateVault.tsx` forwards the node network through to `AddWallet` unchanged (it never had its own selector).

## Tests
- Backend: `/status` handler test now asserts the `network` field is returned.
- Frontend: new test asserts there is no network combobox and the node network renders read-only; existing tests updated for the required `network` field.

## Verification
- `ui/web`: `npm install`, `npm run lint` (0 errors), `npm run test` (400 passed), `npm run build` — all pass.
- `ui` (Go, mirroring CI scope): `go build ./cmd/bursa-wallet`, `go vet ./cmd/... ./internal/...`, `go test ./cmd/... ./internal/...` — all pass.

## Coordination note
`AddWallet.tsx` is being concurrently refactored on `feat/hw-signer-trezor` to add a hardware-device picker. Edits here are surgical — only the network selector/state was removed and the node network wired in; the Ledger/`hw/` device logic was left untouched to minimize merge overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derive the wallet network from the connected node and remove the network selector in add-wallet flows to prevent mismatch errors. Backend exposes the node’s `network` via `GET /status`; the UI reads it and shows it read-only.

- **Bug Fixes**
  - Backend: `GET /status` now includes `network` from the embedded node.
  - Frontend: `app.tsx` uses `status.network`; removed the network `<Select>` in `AddWallet` (create/restore/Ledger) and show a read-only network label; submits pass the node network.
  - Tests updated to assert `network` in `/status` and verify the selector is removed.

<sup>Written for commit 5b2471b4f1d7d1a98d3b9da584e6e0139f8e719b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Screenshots

Real browser captures (Playwright, 1280×800) against a mock node reporting network `preview`. The old Preview/Preprod/Mainnet `<Select>` is gone; the create-vault / add-wallet flow now shows the node's network read-only.

**Add-wallet (restore) step in the first-run flow — network shown read-only:**

![Add-wallet network read-only](https://raw.githubusercontent.com/blinklabs-io/bursa/ci/screenshots/screenshots/pr-611/pr611-addwallet-network-readonly.png)

**Create-vault → "Set Up Your New Wallet" confirm step — same read-only `NetworkDisplay`:**

![Create-vault confirm network read-only](https://raw.githubusercontent.com/blinklabs-io/bursa/ci/screenshots/screenshots/pr-611/pr611-createvault-confirm-network-readonly.png)
