### PR TITLE
feat(ui): HardwareSigner abstraction + Trezor support (send-parity, consent-gated)

### DIFF
--- a/ui/web/package-lock.json
+++ b/ui/web/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@cardano-foundation/ledgerjs-hw-app-cardano": "^7.1.4",
         "@ledgerhq/hw-transport-webhid": "^6.35.4",
+        "@trezor/connect-web": "^9.7.3",
         "bech32": "^1.1.4",
         "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
@@ -474,6 +475,18 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@emurgo/cardano-serialization-lib-browser": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-browser/-/cardano-serialization-lib-browser-13.2.1.tgz",
+      "integrity": "sha512-7RfX1gI16Vj2DgCp/ZoXqyLAakWo6+X95ku/rYGbVzuS/1etrlSiJmdbmdm+eYmszMlGQjrtOJQeVLXoj4L/Ag==",
+      "license": "MIT"
+    },
+    "node_modules/@emurgo/cardano-serialization-lib-nodejs": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-nodejs/-/cardano-serialization-lib-nodejs-13.2.0.tgz",
+      "integrity": "sha512-Bz1zLGEqBQ0BVkqt1OgMxdBOE3BdUWUd7Ly9Ecr/aUwkA8AV1w1XzBMe4xblmJHnB1XXNlPH4SraXCvO+q0Mig==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -1061,6 +1074,92 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@ethereumjs/common": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-10.1.2.tgz",
+      "integrity": "sha512-whWnhqAxwpDy4zWkM6rqMzb8nioZJpiys01N57+HDyanvK5IRzodV5tdMRDt66PD5vDjl2c9K5UcB039gU2Oyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ethereumjs/util": "^10.1.2",
+        "eventemitter3": "^5.0.1"
+      }
+    },
+    "node_modules/@ethereumjs/rlp": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-10.1.2.tgz",
+      "integrity": "sha512-T5Zt6C2pd02Wd88Q9A5/UX+He1Q2Y1LntHxz/038tfbUMiqby4fYSSTLEDx+TEfJqw1BsJSBY/TSu6goUzlk+w==",
+      "license": "MPL-2.0",
+      "bin": {
+        "rlp": "bin/rlp.cjs"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ethereumjs/tx": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-10.1.2.tgz",
+      "integrity": "sha512-bAYK3YaYkk+auzxGfZSRVDbLHvboJNTx8/tV6jaqgPVlrA1QKEEADDEp/EGz+KI4NQmTGxEtXZ8tV/WjniRNww==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@ethereumjs/common": "^10.1.2",
+        "@ethereumjs/rlp": "^10.1.2",
+        "@ethereumjs/util": "^10.1.2",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ethereumjs/tx/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@ethereumjs/util": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-10.1.2.tgz",
+      "integrity": "sha512-UPBgXtHHfQugoXOSAoeG3jdmPbl37cwV9y3XqTPAnw8tJj8np14TPV2uc5lOs7C2LMF9Ubn66zyaiYxgwGppng==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@ethereumjs/rlp": "^10.1.2",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ethereumjs/util/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@fivebinaries/coin-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@fivebinaries/coin-selection/-/coin-selection-3.0.0.tgz",
+      "integrity": "sha512-h25Pn1ZA7oqQBQDodGAgIsQt66T2wDge9onBKNqE66WNWL0KJiKJbpij8YOLo5AAlEIg5IS7EB1QjBgDOIg6DQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@emurgo/cardano-serialization-lib-browser": "^13.2.0",
+        "@emurgo/cardano-serialization-lib-nodejs": "13.2.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1266,6 +1365,117 @@
       "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.17.0.tgz",
       "integrity": "sha512-yra33g5q/AU7+PwAws+GaVpQGUuxnDREjVBnviJjcaJLVKuLzI4pnj8Bd3nY3fypM5k1yZEYKEXfUuGFUjP2+w==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@mobily/ts-belt": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@mobily/ts-belt/-/ts-belt-3.13.1.tgz",
+      "integrity": "sha512-K5KqIhPI/EoCTbA6CGbrenM9s41OouyK8A03fGJJcla/zKucsgLbz8HNbeseoLarRPgyWJsUyCYqFhI7t3Ra9Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.*"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -1624,6 +1834,844 @@
         "win32"
       ]
     },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.33.24",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.33.24.tgz",
+      "integrity": "sha512-91up4t0BLjfkCZ4Ap/BcgaPrMaX6n0I2YRu+kc03xGhLy9G3N05nbTpnK8q7GXdv0PxwUoxi67A8o3Wr5U7j3w==",
+      "license": "MIT"
+    },
+    "node_modules/@solana-program/compute-budget": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.8.0.tgz",
+      "integrity": "sha512-qPKxdxaEsFxebZ4K5RPuy7VQIm/tfJLa1+Nlt3KNA8EYQkz9Xm8htdoEaXVrer9kpgzzp9R3I3Bh6omwCM06tQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@solana-program/stake": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/stake/-/stake-0.2.1.tgz",
+      "integrity": "sha512-ssNPsJv9XHaA+L7ihzmWGYcm/+XYURQ8UA3wQMKf6ccEHyHOUgoglkkDU/BoA0+wul6HxZUN0tHFymC0qFw6sg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@solana-program/system": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.7.0.tgz",
+      "integrity": "sha512-FKTBsKHpvHHNc1ATRm7SlC5nF/VdJtOSjldhcyfMN9R7xo712Mo2jHIzvBgn8zQO5Kg0DcWuKB7268Kv1ocicw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@solana-program/token": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.5.1.tgz",
+      "integrity": "sha512-bJvynW5q9SFuVOZ5vqGVkmaPGA0MCC+m9jgJj1nk5m20I389/ms69ASnhWGoOPNcie7S9OwBX0gTj2fiyWpfag==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@solana-program/token-2022": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@solana-program/token-2022/-/token-2022-0.4.2.tgz",
+      "integrity": "sha512-zIpR5t4s9qEU3hZKupzIBxJ6nUV5/UVyIT400tu9vT1HMs5JHxaTTsb5GUhYjiiTvNwU0MQavbwc4Dl29L0Xvw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0",
+        "@solana/sysvars": "^2.1.0"
+      }
+    },
+    "node_modules/@solana/accounts": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.3.0.tgz",
+      "integrity": "sha512-QgQTj404Z6PXNOyzaOpSzjgMOuGwG8vC66jSDB+3zHaRcEPRVRd2sVSrd1U6sHtnV3aiaS6YyDuPQMheg4K2jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/addresses": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.3.0.tgz",
+      "integrity": "sha512-ypTNkY2ZaRFpHLnHAgaW8a83N0/WoqdFvCqf4CQmnMdFsZSdC7qOwcbd7YzdaQn9dy+P2hybewzB+KP7LutxGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/assertions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.3.0.tgz",
+      "integrity": "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/codecs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.3.0.tgz",
+      "integrity": "sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/options": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.3.0.tgz",
+      "integrity": "sha512-qvU5LE5DqEdYMYgELRHv+HMOx73sSoV1ZZkwIrclwUmwTbTaH8QAJURBj0RhQ/zCne7VuLLOZFFGv6jGigWhSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/codecs-strings": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.3.0.tgz",
+      "integrity": "sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/fast-stable-stringify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.3.0.tgz",
+      "integrity": "sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/functional": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.3.0.tgz",
+      "integrity": "sha512-AgsPh3W3tE+nK3eEw/W9qiSfTGwLYEvl0rWaxHht/lRcuDVwfKRzeSa5G79eioWFFqr+pTtoCr3D3OLkwKz02Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/instructions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.3.0.tgz",
+      "integrity": "sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/keys": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.3.0.tgz",
+      "integrity": "sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/kit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-2.3.0.tgz",
+      "integrity": "sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "2.3.0",
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/programs": "2.3.0",
+        "@solana/rpc": "2.3.0",
+        "@solana/rpc-parsed-types": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-subscriptions": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/signers": "2.3.0",
+        "@solana/sysvars": "2.3.0",
+        "@solana/transaction-confirmation": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/nominal-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-2.3.0.tgz",
+      "integrity": "sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/options": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.3.0.tgz",
+      "integrity": "sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/programs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.3.0.tgz",
+      "integrity": "sha512-UXKujV71VCI5uPs+cFdwxybtHZAIZyQkqDiDnmK+DawtOO9mBn4Nimdb/6RjR2CXT78mzO9ZCZ3qfyX+ydcB7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/promises": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.3.0.tgz",
+      "integrity": "sha512-GjVgutZKXVuojd9rWy1PuLnfcRfqsaCm7InCiZc8bqmJpoghlyluweNc7ml9Y5yQn1P2IOyzh9+p/77vIyNybQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/rpc": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.3.0.tgz",
+      "integrity": "sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/fast-stable-stringify": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/rpc-api": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-transport-http": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/rpc-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.3.0.tgz",
+      "integrity": "sha512-UUdiRfWoyYhJL9PPvFeJr4aJ554ob2jXcpn4vKmRVn9ire0sCbpQKYx6K8eEKHZWXKrDW8IDspgTl0gT/aJWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/rpc-parsed-types": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/rpc-parsed-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.3.0.tgz",
+      "integrity": "sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/rpc-spec": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.3.0.tgz",
+      "integrity": "sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/rpc-spec-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.3.0.tgz",
+      "integrity": "sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.3.0.tgz",
+      "integrity": "sha512-Uyr10nZKGVzvCOqwCZgwYrzuoDyUdwtgQRefh13pXIrdo4wYjVmoLykH49Omt6abwStB0a4UL5gX9V4mFdDJZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/fast-stable-stringify": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-subscriptions-api": "2.3.0",
+        "@solana/rpc-subscriptions-channel-websocket": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.3.0.tgz",
+      "integrity": "sha512-9mCjVbum2Hg9KGX3LKsrI5Xs0KX390lS+Z8qB80bxhar6MJPugqIPH8uRgLhCW9GN3JprAfjRNl7our8CPvsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-2.3.0.tgz",
+      "integrity": "sha512-2oL6ceFwejIgeWzbNiUHI2tZZnaOxNTSerszcin7wYQwijxtpVgUHiuItM/Y70DQmH9sKhmikQp+dqeGalaJxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.3.0.tgz",
+      "integrity": "sha512-rdmVcl4PvNKQeA2l8DorIeALCgJEMSu7U8AXJS1PICeb2lQuMeaR+6cs/iowjvIB0lMVjYN2sFf6Q3dJPu6wWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/rpc-transformers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.3.0.tgz",
+      "integrity": "sha512-UuHYK3XEpo9nMXdjyGKkPCOr7WsZsxs7zLYDO1A5ELH3P3JoehvrDegYRAGzBS2VKsfApZ86ZpJToP0K3PhmMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/rpc-transport-http": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.3.0.tgz",
+      "integrity": "sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "undici-types": "^7.11.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/rpc-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.3.0.tgz",
+      "integrity": "sha512-O09YX2hED2QUyGxrMOxQ9GzH1LlEwwZWu69QbL4oYmIf6P5dzEEHcqRY6L1LsDVqc/dzAdEs/E1FaPrcIaIIPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/signers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.3.0.tgz",
+      "integrity": "sha512-OSv6fGr/MFRx6J+ZChQMRqKNPGGmdjkqarKkRzkwmv7v8quWsIRnJT5EV8tBy3LI4DLO/A8vKiNSPzvm1TdaiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/subscribable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-2.3.0.tgz",
+      "integrity": "sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/sysvars": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.3.0.tgz",
+      "integrity": "sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "2.3.0",
+        "@solana/codecs": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/transaction-confirmation": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.3.0.tgz",
+      "integrity": "sha512-UiEuiHCfAAZEKdfne/XljFNJbsKAe701UQHKXEInYzIgBjRbvaeYZlBmkkqtxwcasgBTOmEaEKT44J14N9VZDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc": "2.3.0",
+        "@solana/rpc-subscriptions": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/transaction-messages": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.3.0.tgz",
+      "integrity": "sha512-bgqvWuy3MqKS5JdNLH649q+ngiyOu5rGS3DizSnWwYUd76RxZl1kN6CoqHSrrMzFMvis6sck/yPGG3wqrMlAww==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/transactions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.3.0.tgz",
+      "integrity": "sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@stellar/js-xdr": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
+      "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@stellar/stellar-base": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-14.1.0.tgz",
+      "integrity": "sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw==",
+      "deprecated": "This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.9.6",
+        "@stellar/js-xdr": "^3.1.2",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.3.1",
+        "buffer": "^6.0.3",
+        "sha.js": "^2.4.12"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stellar/stellar-base/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-14.2.0.tgz",
+      "integrity": "sha512-7nh2ogzLRMhfkIC0fGjn1LHUzk3jqVw8tjAuTt5ADWfL9CSGBL18ILucE9igz2L/RU2AZgeAvhujAnW91Ut/oQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stellar/stellar-base": "^14.0.1",
+        "axios": "^1.12.2",
+        "bignumber.js": "^9.3.1",
+        "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -1698,6 +2746,411 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@trezor/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-evILW5XJEmfPlf0TY1duOLtGJ47pdGeSKVE3P75ODEUsRNxtPVqlkOUBPmYpCxPnzS8XDmkatT8lf9/DF0G6nA==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@trezor/env-utils": "1.5.0",
+        "@trezor/utils": "9.5.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link/-/blockchain-link-2.6.2.tgz",
+      "integrity": "sha512-HMz+Dm6nMflqRkaebMqpv3uNnVkRrb6lD2HKTHNBGhjVbqf0wRzJ8JoQ08wn/sF00ljJZz8pGnpcMYHJNxE+wQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@solana-program/compute-budget": "^0.8.0",
+        "@solana-program/stake": "^0.2.1",
+        "@solana-program/token": "^0.5.1",
+        "@solana-program/token-2022": "^0.4.2",
+        "@solana/kit": "^2.3.0",
+        "@solana/rpc-types": "^2.3.0",
+        "@stellar/stellar-sdk": "14.2.0",
+        "@trezor/blockchain-link-types": "1.5.1",
+        "@trezor/blockchain-link-utils": "1.5.2",
+        "@trezor/env-utils": "1.5.0",
+        "@trezor/utils": "9.5.0",
+        "@trezor/utxo-lib": "2.5.0",
+        "@trezor/websocket-client": "1.3.0",
+        "@types/web": "^0.0.197",
+        "crypto-browserify": "3.12.0",
+        "socks-proxy-agent": "8.0.5",
+        "stream-browserify": "^3.0.0",
+        "xrpl": "4.4.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-types": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-types/-/blockchain-link-types-1.5.1.tgz",
+      "integrity": "sha512-Idavz6LwLBW8sXc69fh5AJEnl666EDl2Nt3io7updvBgOR0/P12I900DgjNhCKtiWuv66A33/5RE7zLcj3lfnw==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@trezor/utils": "9.5.0",
+        "@trezor/utxo-lib": "2.5.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-utils": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-utils/-/blockchain-link-utils-1.5.2.tgz",
+      "integrity": "sha512-OSS5OEE98FMnYfjoEALPjBt7ebjC/FKnq3HOolHdEWXBpVlXZNN2+Vo1R9J6WbZUU087sHuUTJJy/GJYWY13Tg==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@mobily/ts-belt": "^3.13.1",
+        "@stellar/stellar-sdk": "14.2.0",
+        "@trezor/env-utils": "1.5.0",
+        "@trezor/protobuf": "1.5.2",
+        "@trezor/utils": "9.5.0",
+        "xrpl": "4.4.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-utils/node_modules/@trezor/protobuf": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.5.2.tgz",
+      "integrity": "sha512-zViaL1jKue8DUTVEDg0C/lMipqNMd/Z3kr29/+MeZOoupjaXIQ2Lqp3WAMe8hvNTKKX8aNQH9JrbapJ6w9FMXw==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@trezor/schema-utils": "1.4.0",
+        "long": "5.2.5",
+        "protobufjs": "7.4.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-utils/node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@trezor/connect": {
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@trezor/connect/-/connect-9.7.3.tgz",
+      "integrity": "sha512-oAOfvJHT8tPqOXTmCOhn8uTZcoqSDuWAiWXQegx7C46tq+NLg+enkYXxUYEHq/9PmfZAOrUT9VMxZDsXM2thkA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ethereumjs/common": "^10.1.0",
+        "@ethereumjs/tx": "^10.1.0",
+        "@fivebinaries/coin-selection": "3.0.0",
+        "@mobily/ts-belt": "^3.13.1",
+        "@noble/hashes": "^1.6.1",
+        "@scure/bip39": "^1.5.1",
+        "@solana-program/compute-budget": "^0.8.0",
+        "@solana-program/system": "^0.7.0",
+        "@solana-program/token": "^0.5.1",
+        "@solana-program/token-2022": "^0.4.2",
+        "@solana/kit": "^2.3.0",
+        "@trezor/blockchain-link": "2.6.2",
+        "@trezor/blockchain-link-types": "1.5.1",
+        "@trezor/blockchain-link-utils": "1.5.2",
+        "@trezor/connect-analytics": "1.4.0",
+        "@trezor/connect-common": "0.5.1",
+        "@trezor/crypto-utils": "1.2.0",
+        "@trezor/device-authenticity": "1.1.2",
+        "@trezor/device-utils": "1.2.0",
+        "@trezor/env-utils": "^1.5.0",
+        "@trezor/protobuf": "1.5.3",
+        "@trezor/protocol": "1.3.1",
+        "@trezor/schema-utils": "1.4.0",
+        "@trezor/transport": "1.6.3",
+        "@trezor/type-utils": "1.2.0",
+        "@trezor/utils": "9.5.0",
+        "@trezor/utxo-lib": "2.5.0",
+        "blakejs": "^1.2.1",
+        "bs58": "^6.0.0",
+        "bs58check": "^4.0.0",
+        "cbor": "^10.0.10",
+        "cross-fetch": "^4.0.0",
+        "jws": "^4.0.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-analytics": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-analytics/-/connect-analytics-1.4.0.tgz",
+      "integrity": "sha512-hy2J2oeIhRC/e1bOWXo5dsVMVnDwO2UKnxhR6FD8PINR3jgM6PWAXc6k33WJsBcyiTzwMP7/xPysLcgNJH5o4w==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@trezor/analytics": "1.5.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-common": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-common/-/connect-common-0.5.1.tgz",
+      "integrity": "sha512-wdpVCwdylBh4SBO5Ys40tB/d59UlfjmxgBHDkkLgaR+JcqkthCfiw5VlUrV9wu65lquejAZhA5KQL4mUUUhCow==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@trezor/env-utils": "1.5.0",
+        "@trezor/type-utils": "1.2.0",
+        "@trezor/utils": "9.5.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web": {
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-web/-/connect-web-9.7.3.tgz",
+      "integrity": "sha512-oTI/v9sUJMvLZgLa0seSGyPaumXydRYeAT4OVTQxIaEiL1hOA0yH+UvEfT4WKwxbxOtOqWosD8chP3uuWSArcg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@trezor/connect": "9.7.3",
+        "@trezor/connect-common": "0.5.1",
+        "@trezor/utils": "9.5.0",
+        "@trezor/websocket-client": "1.3.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/crypto-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@trezor/crypto-utils/-/crypto-utils-1.2.0.tgz",
+      "integrity": "sha512-9i1NrfW1IE6JO910ut7xrx4u5LxE++GETbpJhWLj4P5xpuGDDSDLEn/MXaYisls2DpE897aOrGPaa1qyt8V6tw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/device-authenticity": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@trezor/device-authenticity/-/device-authenticity-1.1.2.tgz",
+      "integrity": "sha512-313uSXYR4XKDv3CjtCpgHA+yEe9xxqN7EFl/D68FEn70SPsuWI0+2zUvjPPh6TIOh/EcLv7hCO/QTHUAGd7ZWQ==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@noble/curves": "^2.0.1",
+        "@trezor/crypto-utils": "1.2.0",
+        "@trezor/protobuf": "1.5.2",
+        "@trezor/schema-utils": "1.4.0",
+        "@trezor/utils": "9.5.0"
+      }
+    },
+    "node_modules/@trezor/device-authenticity/node_modules/@trezor/protobuf": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.5.2.tgz",
+      "integrity": "sha512-zViaL1jKue8DUTVEDg0C/lMipqNMd/Z3kr29/+MeZOoupjaXIQ2Lqp3WAMe8hvNTKKX8aNQH9JrbapJ6w9FMXw==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@trezor/schema-utils": "1.4.0",
+        "long": "5.2.5",
+        "protobufjs": "7.4.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/device-authenticity/node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@trezor/device-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@trezor/device-utils/-/device-utils-1.2.0.tgz",
+      "integrity": "sha512-Aqp7pIooFTx21zRUtTI6i1AS4d9Lrx7cclvksh2nJQF9WJvbzuCXshEGkLoOsHwhQrCl3IXfbGuMdA12yDenPA==",
+      "license": "See LICENSE.md in repo root"
+    },
+    "node_modules/@trezor/env-utils": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.5.0.tgz",
+      "integrity": "sha512-u1TN7dMQ5Qhpbae08Z4JJmI9fQrbbJ4yj8eIAsuzMQn6vb+Sg9vbntl+IDsZ1G9WeI73uHTLu1wWMmAgiujH8w==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "ua-parser-js": "^2.0.4"
+      },
+      "peerDependencies": {
+        "expo-constants": "*",
+        "expo-localization": "*",
+        "react-native": "*",
+        "tslib": "^2.6.2"
+      },
+      "peerDependenciesMeta": {
+        "expo-constants": {
+          "optional": true
+        },
+        "expo-localization": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trezor/protobuf": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.5.3.tgz",
+      "integrity": "sha512-ZYQtapkT2NaiVrAgb91Zprnk3uhl2Wca0bsnJcWgE7vwzqKegjrSorRnkZLqLTKTbCaT6sgkCYtM2hPl4Hqw5Q==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@trezor/schema-utils": "1.4.0",
+        "long": "5.2.5",
+        "protobufjs": "7.5.5"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/protocol": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@trezor/protocol/-/protocol-1.3.1.tgz",
+      "integrity": "sha512-uNJ83n38+BM+AJKsWza1ocvQ206d6NXJQ8/g+DelPLTj5c37Rj6hFiY5Nb5zgM7DBnq6T8Aa2K8t4TVCzHT1qg==",
+      "license": "See LICENSE.md in repo root",
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/schema-utils": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@trezor/schema-utils/-/schema-utils-1.4.0.tgz",
+      "integrity": "sha512-K7upSeh7VDrORaIC4KAxYVW93XNlohmUnH5if/5GKYmTdQSRp1nBkO6Jm+Z4hzIthdnz/1aLgnbeN3bDxWLRxA==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@sinclair/typebox": "^0.33.7",
+        "ts-mixer": "^6.0.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/transport": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.6.3.tgz",
+      "integrity": "sha512-GEi9KfiJsBgT/MCGNDIn9RDeXceLaAPjJT/GCayirXaCr3KnlpZCs6LGYkrjqapxiBm73nxM+BctKBKhpUl2cQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@trezor/protobuf": "1.5.3",
+        "@trezor/protocol": "1.3.1",
+        "@trezor/type-utils": "1.2.0",
+        "@trezor/utils": "9.5.0",
+        "cross-fetch": "^4.0.0",
+        "usb": "^2.15.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/type-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@trezor/type-utils/-/type-utils-1.2.0.tgz",
+      "integrity": "sha512-+E2QntxkyQuYfQQyl8RvT01tq2i5Dp/LFUOXuizF+KVOqsZBjBY43j5hewcCO3+MokD7deDiPyekbUEN5/iVlw==",
+      "license": "See LICENSE.md in repo root"
+    },
+    "node_modules/@trezor/utils": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-9.5.0.tgz",
+      "integrity": "sha512-kdyMyDbxzvOZmwBNvTjAK+C/kzyOz8T4oUbFvq+KaXn5mBFf1uf8rq5X2HkxgdYRPArtHS3PxLKsfkNCdhCYtQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "bignumber.js": "^9.3.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/utxo-lib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/utxo-lib/-/utxo-lib-2.5.0.tgz",
+      "integrity": "sha512-Fa2cZh0037oX6AHNLfpFIj65UR/OoX0ZJTocFuQASe77/1PjZHysf6BvvGfmzuFToKfrAQ+DM/1Sx+P/vnyNmA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@trezor/utils": "9.5.0",
+        "bech32": "^2.0.0",
+        "bip66": "^2.0.0",
+        "bitcoin-ops": "^1.4.1",
+        "blake-hash": "^2.0.0",
+        "blakejs": "^1.2.1",
+        "bn.js": "^5.2.2",
+        "bs58": "^6.0.0",
+        "bs58check": "^4.0.0",
+        "cashaddrjs": "0.4.4",
+        "create-hmac": "^1.1.7",
+        "int64-buffer": "^1.1.0",
+        "pushdata-bitcoin": "^1.0.1",
+        "tiny-secp256k1": "^1.1.7",
+        "typeforce": "^1.18.0",
+        "varuint-bitcoin": "2.0.0",
+        "wif": "^5.0.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/utxo-lib/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+      "license": "MIT"
+    },
+    "node_modules/@trezor/websocket-client": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@trezor/websocket-client/-/websocket-client-1.3.0.tgz",
+      "integrity": "sha512-9KQSaVc3NtmM6rFFj1e+9bM0C5mVKVidbnxlfzuBJu7G2YMRdIdLPcAXhvmRZjs40uzDuBeApK+p547kODz2ug==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@trezor/utils": "9.5.0",
+        "ws": "^8.18.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@types/aria-query": {
@@ -1785,6 +3238,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -1804,6 +3272,18 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/w3c-web-usb": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.14.tgz",
+      "integrity": "sha512-Qu3Nn6JFuF4+sHKYl+IcX9vYiI40ogleXzFFSxoE1W94rG98o/kXs8uJ0QSfFzuwBCZWlGfUGpPkgwuuX4PchA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/web": {
+      "version": "0.0.197",
+      "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.197.tgz",
+      "integrity": "sha512-V4sOroWDADFx9dLodWpKm298NOJ1VJ6zoDVgaP+WBb/utWxqQ6gnMzd9lvVDAr/F3ibiKaxH9i45eS0gQPSTaQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.62.0",
@@ -2236,6 +3716,48 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xrplf/isomorphic": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@xrplf/isomorphic/-/isomorphic-1.0.2.tgz",
+      "integrity": "sha512-ncZUdMXr6VlSXtdoiDi0jTH+gBrgGxwVeEidhoegII3PmyErbQsyj6e+j7acmR4LW/lvBkPkzb9QzRfJH0n3rA==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1",
+        "eventemitter3": "5.0.1",
+        "ws": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@xrplf/isomorphic/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@xrplf/isomorphic/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/@xrplf/secret-numbers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@xrplf/secret-numbers/-/secret-numbers-2.0.0.tgz",
+      "integrity": "sha512-z3AOibRTE9E8MbjgzxqMpG1RNaBhQ1jnfhNCa1cGf2reZUJzPMYs4TggQTc7j8+0WyV3cr7y/U8Oz99SXIkN5Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@xrplf/isomorphic": "^1.0.1",
+        "ripple-keypairs": "^2.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -2263,7 +3785,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -2330,6 +3851,23 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2344,8 +3882,59 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2362,6 +3951,35 @@
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/base32.js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
+      "integrity": "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.38",
@@ -2382,6 +4000,72 @@
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
       "license": "MIT"
     },
+    "node_modules/big-integer": {
+      "version": "1.6.36",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
+      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bip66": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-2.0.0.tgz",
+      "integrity": "sha512-kBG+hSpgvZBrkIm9dt5T1Hd/7xGCPEX2npoxAWZfsK1FvjgaxySEh2WizjyIstWXriKo9K9uJ4u0OnsyLDUPXQ==",
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-ops": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
+      "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==",
+      "license": "MIT"
+    },
+    "node_modules/blake-hash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/blake-hash/-/blake-hash-2.0.0.tgz",
+      "integrity": "sha512-Igj8YowDu1PRkRsxZA7NVkdFNxH5rKv5cpLxQ0CVXSIA77pVYwCPRQJ2sMew/oneUpfuYRyjG6r8SmmmnbZb1w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "license": "MIT"
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
+      "integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.16",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
@@ -2392,6 +4076,125 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "license": "MIT"
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "node_modules/browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/browserify-rsa": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+      "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz",
+      "integrity": "sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^5.2.3",
+        "browserify-rsa": "^4.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.6.1",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.9",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/browserslist": {
       "version": "4.28.4",
@@ -2427,6 +4230,67 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "node_modules/bs58/node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
+    "node_modules/bs58check": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^6.0.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "license": "MIT"
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2437,11 +4301,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2449,6 +4330,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -2481,6 +4378,27 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cashaddrjs": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cashaddrjs/-/cashaddrjs-0.4.4.tgz",
+      "integrity": "sha512-xZkuWdNOh0uq/mxJIng6vYWfTowZLd9F4GMAlp2DwFHlcCqCm91NtuAc47RuV4L7r4PYcY5p6Cr2OKNb4hnkWA==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "1.6.36"
+      }
+    },
+    "node_modules/cbor": {
+      "version": "10.0.12",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-10.0.12.tgz",
+      "integrity": "sha512-exQDevYd7ZQLP4moMQcZkKCVZsXLAtUSflObr3xTh4xzFIv/xBCdvCd6L259kQOUP2kcTC0jvC6PpZIf/WmRXA==",
+      "license": "MIT",
+      "dependencies": {
+        "nofilter": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/chai": {
       "version": "5.3.3",
@@ -2526,6 +4444,20 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cipher-base": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2550,13 +4482,21 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/concat-map": {
@@ -2573,6 +4513,64 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      }
+    },
+    "node_modules/create-ecdh/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2586,6 +4584,28 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/css.escape": {
@@ -2641,7 +4661,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2679,11 +4698,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -2699,6 +4734,53 @@
         "node": ">=6"
       }
     },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/diffie-hellman/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -2711,7 +4793,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2722,12 +4803,42 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.377",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.377.tgz",
       "integrity": "sha512-cH1jZgJHoezfTnKfKwnScpHywTFVnJUNITDPREFdhNjiuD502+QFpG0Qk7G8jhsV/f+CEAFlIrzP1fT+IMb92g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -2746,7 +4857,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2756,7 +4866,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2773,7 +4882,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2786,7 +4894,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3040,6 +5147,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -3047,6 +5160,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/expect-type": {
@@ -3070,7 +5202,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -3079,6 +5210,13 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3098,6 +5236,15 @@
         }
       }
     },
+    "node_modules/feaxios": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
+      "integrity": "sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3110,6 +5257,12 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -3149,11 +5302,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
       "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -3185,7 +5372,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3205,7 +5391,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3230,7 +5415,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3270,7 +5454,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3289,11 +5472,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3306,7 +5500,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3318,17 +5511,94 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash-base": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/hash-base/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/hash-base/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/hash-base/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/hash-base/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/hash-base/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -3385,6 +5655,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3432,11 +5722,38 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/int64-buffer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.1.1.tgz",
       "integrity": "sha512-xp/v0/im2q7n7ISFJXcYsr/aVsUdZKPUZS1uYtoM9I9Cfmm5YuAi7SQts2TrEXwAKIE0wyn3KxJbo35goJgvwQ==",
       "license": "MIT"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -3466,6 +5783,59 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -3593,6 +5963,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3640,6 +6031,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.5.tgz",
+      "integrity": "sha512-e0r9YBBgNCq1D1o5Dp8FMH0N5hsFtXDBiVa0qoJPHpakvZkmDKPRoGffZJII/XsHvj9An9blm+cRJ01yQqU+Dw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -3682,17 +6079,45 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      }
+    },
+    "node_modules/miller-rabin/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3702,7 +6127,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -3721,6 +6145,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "license": "MIT"
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -3738,7 +6174,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3767,6 +6208,65 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.48",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
@@ -3775,6 +6275,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/nofilter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
+      "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.19"
       }
     },
     "node_modules/nwsapi": {
@@ -3847,6 +6356,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-asn1": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
+      "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^4.10.1",
+        "browserify-aes": "^1.2.0",
+        "evp_bytestokey": "^1.0.3",
+        "pbkdf2": "^3.1.5",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -3897,6 +6422,23 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pbkdf2": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.6.tgz",
+      "integrity": "sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==",
+      "license": "MIT",
+      "dependencies": {
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "^2.0.3",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.12",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3915,6 +6457,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -3986,6 +6537,65 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/public-encrypt/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3996,6 +6606,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/pushdata-bitcoin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
+      "integrity": "sha512-hw7rcYTJRAl4olM8Owe8x0fBuJJ+WGbMhQuLWOXEMN3PxPCKQHRkhfL+XG0+iXUmSHjkMmb3Ba55Mt21cZc9kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bitcoin-ops": "^1.3.0"
+      }
+    },
     "node_modules/qrcode.react": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
@@ -4003,6 +6622,25 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "license": "MIT",
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/react": {
@@ -4044,6 +6682,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -4066,6 +6718,90 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/ripemd160": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.1.2",
+        "inherits": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ripple-address-codec": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-5.0.1.tgz",
+      "integrity": "sha512-JQHLKuVJV8lv9Qobmn4aUM2Dpv9WRRLKnNWfM8tN02fAbUtG8mUPsu9q9UYX8P76G4qzytEc5ZKMp/3JggNYmw==",
+      "license": "ISC",
+      "dependencies": {
+        "@scure/base": "^2.0.0",
+        "@xrplf/isomorphic": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/ripple-address-codec/node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ripple-binary-codec": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-2.8.0.tgz",
+      "integrity": "sha512-+NKnOi3hdzjm5dDpoZLUEaYon1jahPlSGnp3YrDoNMSR09ICEqgupN5wpEkPuqJvV75PF/g+W1QUwIXVzbEe7w==",
+      "license": "ISC",
+      "dependencies": {
+        "@xrplf/isomorphic": "^1.0.2",
+        "bignumber.js": "^10.0.2",
+        "ripple-address-codec": "^5.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/ripple-binary-codec/node_modules/bignumber.js": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
+      "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
+      "license": "MIT"
+    },
+    "node_modules/ripple-keypairs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ripple-keypairs/-/ripple-keypairs-2.0.0.tgz",
+      "integrity": "sha512-b5rfL2EZiffmklqZk1W+dvSy97v3V/C7936WxCCgDynaGPp7GE6R2XO7EU9O2LlM/z95rj870IylYnOQs+1Rag==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/curves": "^1.0.0",
+        "@xrplf/isomorphic": "^1.0.0",
+        "ripple-address-codec": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/ripple-keypairs/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/rollup": {
@@ -4176,6 +6912,43 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4206,6 +6979,44 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4229,6 +7040,25 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -4294,6 +7124,29 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-secp256k1": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.7.tgz",
+      "integrity": "sha512-eb+F6NabSnjbLwNoC+2o5ItbmP1kg7HliWue71JgLegQt6A5mTN8YbvTLCazdlg6e5SV6A+r8OGvZYskdlmhqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.3.0",
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "nan": "^2.13.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/tiny-secp256k1/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -4377,6 +7230,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
+    },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -4416,6 +7289,19 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "peer": true
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4429,11 +7315,30 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typeforce": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -4466,6 +7371,72 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
+    },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ua-parser-js": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.10.tgz",
+      "integrity": "sha512-t+3Ktbq0Ies2vaSezfOaWiolH4OigQIO1dk+1xDpOydB1COVPocVYOrEV5rqZ0kFY9XYG1v9LutCyMgYBpABcw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "ua-is-frozen": "^0.1.2"
+      },
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/uint8array-tools": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
+      "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.28.0.tgz",
+      "integrity": "sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ==",
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -4506,6 +7477,51 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "license": "MIT"
+    },
+    "node_modules/usb": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.18.0.tgz",
+      "integrity": "sha512-klAJPUTaSxRvTgrIh7om6UTrgRxdzioD+rJc/MaoiN8+OGdqRzai39tR00asnoCesPNikItWB9zBZoo0pJsWaA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/w3c-web-usb": "^1.0.6",
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=12.22.0 <13.0 || >=14.17.0"
+      }
+    },
+    "node_modules/usb/node_modules/node-addon-api": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/varuint-bitcoin": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-2.0.0.tgz",
+      "integrity": "sha512-6QZbU/rHO2ZQYpWFDALCDSRsXbAs1VOEmXAxtbtjLtKuMJ/FQ8YbhfxlaiKv5nklci0M6lZtlZyxo9Q+qNnyog==",
+      "license": "MIT",
+      "dependencies": {
+        "uint8array-tools": "^0.0.8"
       }
     },
     "node_modules/vite": {
@@ -4756,6 +7772,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -4773,6 +7810,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/wif": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-5.0.0.tgz",
+      "integrity": "sha512-iFzrC/9ne740qFbNjTZ2FciSRJlHIXoxqk/Y5EnE08QOXu1WjJyCCswwDTYbohAOEnlCtLaAAQBhyaLRFh2hMA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58check": "^4.0.0"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4787,7 +7833,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -4821,6 +7866,27 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xrpl": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/xrpl/-/xrpl-4.4.3.tgz",
+      "integrity": "sha512-vi2OjuNkiaP8nv1j+nqHp8GZwwEjO6Y8+j/OuVMg6M4LwXEwyHdIj33dlg7cyY1Lw5+jb9HqFOQvABhaywVbTQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@scure/bip32": "^1.3.1",
+        "@scure/bip39": "^1.2.1",
+        "@xrplf/isomorphic": "^1.0.1",
+        "@xrplf/secret-numbers": "^2.0.0",
+        "bignumber.js": "^9.0.0",
+        "eventemitter3": "^5.0.1",
+        "fast-json-stable-stringify": "^2.1.0",
+        "ripple-address-codec": "^5.0.0",
+        "ripple-binary-codec": "^2.5.0",
+        "ripple-keypairs": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/ui/web/package.json
+++ b/ui/web/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@cardano-foundation/ledgerjs-hw-app-cardano": "^7.1.4",
     "@ledgerhq/hw-transport-webhid": "^6.35.4",
+    "@trezor/connect-web": "^9.7.3",
     "bech32": "^1.1.4",
     "qrcode.react": "^4.2.0",
     "react": "^19.0.0",

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -308,7 +308,7 @@ export function App() {
   } else if (route === "send" && !canSend) {
     content = <Portfolio />;
   } else if (route === "send" && canSend) {
-    content = <Send isHardware={activeWallet.type === "hardware"} />;
+    content = <Send isHardware={activeWallet.type === "hardware"} walletId={activeWallet.id} />;
   } else if (route === "swap" && !canSwap) {
     // Guard deep-links (#/swap): DEX quotes need a queryable mainnet node, so
     // fall back to Portfolio while the node or active wallet cannot support it.

--- a/ui/web/src/hw/deviceKind.test.ts
+++ b/ui/web/src/hw/deviceKind.test.ts
@@ -1,7 +1,5 @@
 import { describe, test, expect, beforeEach } from "vitest";
-import { setDeviceKind, getDeviceKind, getStoredDeviceKind } from "./deviceKind";
-
-const STORAGE_KEY = "bursa.hw.deviceKind";
+import { setDeviceKind, getDeviceKind, getStoredDeviceKind, STORAGE_KEY } from "./deviceKind";
 
 beforeEach(() => {
   localStorage.clear();

--- a/ui/web/src/hw/deviceKind.test.ts
+++ b/ui/web/src/hw/deviceKind.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import { setDeviceKind, getDeviceKind, getStoredDeviceKind } from "./deviceKind";
+
+const STORAGE_KEY = "bursa.hw.deviceKind";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("getStoredDeviceKind", () => {
+  test("returns undefined when nothing is stored", () => {
+    expect(getStoredDeviceKind("w1")).toBeUndefined();
+  });
+
+  test("round-trips ledger and trezor", () => {
+    setDeviceKind("w1", "ledger");
+    setDeviceKind("w2", "trezor");
+    expect(getStoredDeviceKind("w1")).toBe("ledger");
+    expect(getStoredDeviceKind("w2")).toBe("trezor");
+  });
+
+  test("rejects a stale keystone hint (disabled this phase)", () => {
+    // A "keystone" hint must NOT select an unsupported signer — the allowlist
+    // omits it, so a stored keystone value reads back as unknown.
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ w1: "keystone" }));
+    expect(getStoredDeviceKind("w1")).toBeUndefined();
+  });
+
+  test("rejects an unrecognised value", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ w1: "bogus" }));
+    expect(getStoredDeviceKind("w1")).toBeUndefined();
+  });
+});
+
+describe("getDeviceKind", () => {
+  test("defaults to ledger when nothing recognised is stored", () => {
+    expect(getDeviceKind("w1")).toBe("ledger");
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ w1: "keystone" }));
+    expect(getDeviceKind("w1")).toBe("ledger");
+  });
+
+  test("returns the stored recognised kind", () => {
+    setDeviceKind("w1", "trezor");
+    expect(getDeviceKind("w1")).toBe("trezor");
+  });
+});

--- a/ui/web/src/hw/deviceKind.ts
+++ b/ui/web/src/hw/deviceKind.ts
@@ -1,0 +1,74 @@
+/**
+ * hw/deviceKind.ts — Client-only record of which hardware device backs each
+ * hardware wallet.
+ *
+ * The backend's WalletView is device-agnostic (it stores only the account
+ * xpub, which is identical whatever device produced it), so it does NOT tell
+ * us whether a hardware wallet is a Ledger or a Trezor. Send needs that to
+ * reconnect the right device for on-device signing.
+ *
+ * This is a purely local hint, keyed by wallet id in localStorage. It carries
+ * no secret (the device kind is not sensitive) and is safe to lose: any
+ * hardware wallet with no stored hint — including every one added before this
+ * feature existed — defaults to "ledger" for backward compatibility.
+ *
+ * If device-kind ever needs to survive a browser-data wipe or move between
+ * machines, it should become a server-side WalletView field instead; see the
+ * design doc's "human follow-up" note.
+ */
+
+import type { HardwareKind } from "./types";
+
+const STORAGE_KEY = "bursa.hw.deviceKind";
+
+// Kinds we persist. Keystone is intentionally omitted until it is supported.
+const KNOWN_KINDS: readonly HardwareKind[] = ["ledger", "trezor", "keystone"];
+
+type DeviceKindMap = Record<string, HardwareKind>;
+
+function readMap(): DeviceKindMap {
+  if (typeof localStorage === "undefined") return {};
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object") {
+      return parsed as DeviceKindMap;
+    }
+    return {};
+  } catch {
+    // Corrupt/unavailable storage must never break the wallet — fall back to
+    // the empty map (every wallet then defaults to "ledger").
+    return {};
+  }
+}
+
+function writeMap(map: DeviceKindMap): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // Best-effort: a full/blocked localStorage just means the hint is not
+    // remembered; the wallet still works (defaults to "ledger" on read).
+  }
+}
+
+/**
+ * Record the device kind for a hardware wallet id. Call this right after a
+ * hardware wallet is added, before it is used for signing.
+ */
+export function setDeviceKind(walletId: string, kind: HardwareKind): void {
+  const map = readMap();
+  map[walletId] = kind;
+  writeMap(map);
+}
+
+/**
+ * Look up the device kind for a hardware wallet id. Defaults to "ledger" when
+ * no hint is stored (pre-existing hardware wallets predate this feature) or
+ * when the stored value is not a kind we recognise.
+ */
+export function getDeviceKind(walletId: string): HardwareKind {
+  const stored = readMap()[walletId];
+  return stored && KNOWN_KINDS.includes(stored) ? stored : "ledger";
+}

--- a/ui/web/src/hw/deviceKind.ts
+++ b/ui/web/src/hw/deviceKind.ts
@@ -21,8 +21,10 @@ import type { HardwareKind } from "./types";
 
 const STORAGE_KEY = "bursa.hw.deviceKind";
 
-// Kinds we persist. Keystone is intentionally omitted until it is supported.
-const KNOWN_KINDS: readonly HardwareKind[] = ["ledger", "trezor", "keystone"];
+// Kinds we accept from storage. Keystone is intentionally omitted: it is
+// disabled this phase, so a stale "keystone" hint must NOT select an
+// unsupported signer — it falls back to the documented "ledger" default.
+const KNOWN_KINDS: readonly HardwareKind[] = ["ledger", "trezor"];
 
 type DeviceKindMap = Record<string, HardwareKind>;
 
@@ -64,11 +66,25 @@ export function setDeviceKind(walletId: string, kind: HardwareKind): void {
 }
 
 /**
- * Look up the device kind for a hardware wallet id. Defaults to "ledger" when
- * no hint is stored (pre-existing hardware wallets predate this feature) or
- * when the stored value is not a kind we recognise.
+ * Look up the stored device-kind hint for a hardware wallet id, or `undefined`
+ * when no recognised hint is stored — e.g. after a browser-data wipe, on
+ * another browser, or for a wallet added before this feature existed.
+ *
+ * Callers MUST treat `undefined` as "unknown, ask the user which device backs
+ * this wallet" rather than silently assuming one: a wrong assumption would try
+ * to reconnect the wrong signer (e.g. open WebHID for what is really a Trezor).
+ */
+export function getStoredDeviceKind(walletId: string): HardwareKind | undefined {
+  const stored = readMap()[walletId];
+  return stored && KNOWN_KINDS.includes(stored) ? stored : undefined;
+}
+
+/**
+ * Look up the device kind for a hardware wallet id, defaulting to "ledger" when
+ * no recognised hint is stored. Prefer {@link getStoredDeviceKind} where the
+ * caller can prompt the user; this default exists only for non-interactive
+ * call sites that must pick something.
  */
 export function getDeviceKind(walletId: string): HardwareKind {
-  const stored = readMap()[walletId];
-  return stored && KNOWN_KINDS.includes(stored) ? stored : "ledger";
+  return getStoredDeviceKind(walletId) ?? "ledger";
 }

--- a/ui/web/src/hw/deviceKind.ts
+++ b/ui/web/src/hw/deviceKind.ts
@@ -8,9 +8,12 @@
  * reconnect the right device for on-device signing.
  *
  * This is a purely local hint, keyed by wallet id in localStorage. It carries
- * no secret (the device kind is not sensitive) and is safe to lose: any
- * hardware wallet with no stored hint — including every one added before this
- * feature existed — defaults to "ledger" for backward compatibility.
+ * no secret (the device kind is not sensitive) and is safe to lose. When no
+ * hint is stored, {@link getStoredDeviceKind} returns `undefined` so callers
+ * can PROMPT for the device; only the non-interactive {@link getDeviceKind}
+ * falls back to "ledger". The fallback belongs to that function alone — do NOT
+ * reintroduce it into the stored-hint read, or a Trezor wallet with a lost hint
+ * would silently reconnect as a Ledger (the wrong signer).
  *
  * If device-kind ever needs to survive a browser-data wipe or move between
  * machines, it should become a server-side WalletView field instead; see the
@@ -19,7 +22,9 @@
 
 import type { HardwareKind } from "./types";
 
-const STORAGE_KEY = "bursa.hw.deviceKind";
+// The localStorage key the device-kind hint map lives under. Exported so tests
+// read/write the SAME key as this module (one source of truth).
+export const STORAGE_KEY = "bursa.hw.deviceKind";
 
 // Kinds we accept from storage. Keystone is intentionally omitted: it is
 // disabled this phase, so a stale "keystone" hint must NOT select an

--- a/ui/web/src/hw/hex.test.ts
+++ b/ui/web/src/hw/hex.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect } from "vitest";
+import { hexToBytes, bytesToHex } from "./hex";
+
+describe("hexToBytes", () => {
+  test("decodes a valid even-length hex string", () => {
+    expect(Array.from(hexToBytes("deadbeef"))).toEqual([0xde, 0xad, 0xbe, 0xef]);
+  });
+
+  test("accepts an empty string", () => {
+    expect(hexToBytes("").length).toBe(0);
+  });
+
+  test("decodes uppercase hex", () => {
+    expect(Array.from(hexToBytes("AABB"))).toEqual([0xaa, 0xbb]);
+  });
+
+  test("rejects odd-length input instead of dropping the last nibble", () => {
+    expect(() => hexToBytes("abc")).toThrow(/odd-length/i);
+  });
+
+  test("rejects invalid pairs instead of zero-filling", () => {
+    expect(() => hexToBytes("zz")).toThrow(/non-hex/i);
+    // A single bad nibble in an otherwise even string must still be rejected
+    // (parseInt would silently accept "a" from "az").
+    expect(() => hexToBytes("aazz")).toThrow(/non-hex/i);
+    expect(() => hexToBytes("gg")).toThrow(/non-hex/i);
+  });
+});
+
+describe("bytesToHex", () => {
+  test("round-trips with hexToBytes", () => {
+    expect(bytesToHex(Array.from(hexToBytes("00ff10")))).toBe("00ff10");
+  });
+});

--- a/ui/web/src/hw/hex.ts
+++ b/ui/web/src/hw/hex.ts
@@ -1,0 +1,23 @@
+/**
+ * hw/hex.ts — Minimal hex ⇄ bytes helpers shared by the hardware-signer
+ * encoders (xpub bech32 and vkey-witness CBOR).
+ *
+ * Factored out so ledger.ts, trezor.ts, xpub.ts, and witness.ts all encode
+ * from the SAME primitives — the byte-for-byte parity of every device's xpub
+ * and witness output depends on there being exactly one implementation.
+ */
+
+/** Decode a lowercase/uppercase hex string to bytes. */
+export function hexToBytes(hex: string): Uint8Array {
+  const len = hex.length;
+  const out = new Uint8Array(len / 2);
+  for (let i = 0; i < len; i += 2) {
+    out[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return out;
+}
+
+/** Encode bytes as a lowercase hex string. */
+export function bytesToHex(bytes: number[]): string {
+  return bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
+}

--- a/ui/web/src/hw/hex.ts
+++ b/ui/web/src/hw/hex.ts
@@ -7,9 +7,22 @@
  * and witness output depends on there being exactly one implementation.
  */
 
-/** Decode a lowercase/uppercase hex string to bytes. */
+/**
+ * Decode a lowercase/uppercase hex string to bytes.
+ *
+ * Rejects malformed input rather than silently coercing it: an odd-length
+ * string or any non-hex character throws. This helper feeds xpub and
+ * witness encoding, so a silent zero-fill or dropped nibble would let
+ * corrupted device data be encoded as a DIFFERENT key or witness.
+ */
 export function hexToBytes(hex: string): Uint8Array {
   const len = hex.length;
+  if (len % 2 !== 0) {
+    throw new Error(`hexToBytes: odd-length hex string (${len} chars)`);
+  }
+  if (!/^[0-9a-fA-F]*$/.test(hex)) {
+    throw new Error("hexToBytes: string contains non-hex characters");
+  }
   const out = new Uint8Array(len / 2);
   for (let i = 0; i < len; i += 2) {
     out[i / 2] = parseInt(hex.slice(i, i + 2), 16);

--- a/ui/web/src/hw/index.test.ts
+++ b/ui/web/src/hw/index.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import type { HardwareSigner } from "./types";
+
+// Mock the concrete connectors so the factory can be exercised without opening
+// WebHID or loading connect.trezor.io.
+const { mockConnectLedger, mockConnectTrezor } = vi.hoisted(() => ({
+  mockConnectLedger: vi.fn(),
+  mockConnectTrezor: vi.fn(),
+}));
+
+vi.mock("./ledger", () => ({ connectLedger: mockConnectLedger }));
+vi.mock("./trezor", () => ({ connectTrezor: mockConnectTrezor }));
+
+import { connectDevice, connectHardware } from "./index";
+
+const fakeLedger = { kind: "ledger" } as unknown as HardwareSigner;
+const fakeTrezor = { kind: "trezor" } as unknown as HardwareSigner;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockConnectLedger.mockResolvedValue(fakeLedger);
+  mockConnectTrezor.mockResolvedValue(fakeTrezor);
+});
+
+describe("connectDevice factory", () => {
+  test("ledger dispatches to connectLedger and takes no consent options", async () => {
+    const session = await connectDevice("ledger");
+    expect(mockConnectLedger).toHaveBeenCalledOnce();
+    expect(mockConnectTrezor).not.toHaveBeenCalled();
+    expect(session).toBe(fakeLedger);
+  });
+
+  test("trezor dispatches to connectTrezor, forwarding the consent options", async () => {
+    const requestExternalConsent = async () => true;
+    const session = await connectDevice("trezor", { requestExternalConsent });
+    expect(mockConnectTrezor).toHaveBeenCalledWith({ requestExternalConsent });
+    expect(mockConnectLedger).not.toHaveBeenCalled();
+    expect(session).toBe(fakeTrezor);
+  });
+
+  test("keystone is not supported and throws", () => {
+    expect(() => connectDevice("keystone")).toThrow(/not yet supported/i);
+  });
+});
+
+describe("connectDevice option discrimination (compile-time)", () => {
+  test("options are tied to the device kind", async () => {
+    // Ledger is a LOCAL device: it must NOT accept a cloud-consent callback.
+    // @ts-expect-error requestExternalConsent is forbidden for a local device
+    await connectDevice("ledger", { requestExternalConsent: async () => true });
+
+    // Trezor is EXTERNAL: the consent options are REQUIRED, not optional.
+    // @ts-expect-error ExternalConnectOptions is mandatory for Trezor
+    await connectDevice("trezor");
+
+    // A well-typed call for each kind compiles cleanly.
+    await connectDevice("ledger");
+    await connectDevice("trezor", { requestExternalConsent: async () => true });
+  });
+});
+
+describe("connectHardware (dynamic kind)", () => {
+  test("ledger ignores the consent callback", async () => {
+    const consent = vi.fn().mockResolvedValue(true);
+    await connectHardware("ledger", consent);
+    expect(mockConnectLedger).toHaveBeenCalledOnce();
+    expect(mockConnectTrezor).not.toHaveBeenCalled();
+    // The consent callback is not consulted for a local device.
+    expect(consent).not.toHaveBeenCalled();
+  });
+
+  test("trezor wires the consent callback through as ExternalConnectOptions", async () => {
+    const consent = async () => true;
+    await connectHardware("trezor", consent);
+    expect(mockConnectTrezor).toHaveBeenCalledWith({ requestExternalConsent: consent });
+    expect(mockConnectLedger).not.toHaveBeenCalled();
+  });
+
+  test("keystone throws (unsupported this phase)", () => {
+    expect(() => connectHardware("keystone", async () => true)).toThrow(/not yet supported/i);
+  });
+});

--- a/ui/web/src/hw/index.ts
+++ b/ui/web/src/hw/index.ts
@@ -10,7 +10,14 @@ import type { ConnectOptions, HardwareKind, HardwareSigner } from "./types";
 import { connectLedger } from "./ledger";
 import { connectTrezor } from "./trezor";
 
-export type { HardwareKind, HardwareCapabilities, HardwareSigner, ConnectOptions } from "./types";
+export type {
+  HardwareKind,
+  HardwareCapabilities,
+  HardwareSigner,
+  ConnectOptions,
+  LocalConnectOptions,
+  ExternalConnectOptions,
+} from "./types";
 
 /**
  * Connect to a hardware device of the given kind.
@@ -26,8 +33,19 @@ export function connectDevice(
   switch (kind) {
     case "ledger":
       return connectLedger();
-    case "trezor":
-      return connectTrezor(opts);
+    case "trezor": {
+      // Trezor reaches connect.trezor.io: the consent callback is mandatory.
+      // Reject here (rather than defaulting to no consent) if it is missing.
+      const consent = opts?.requestExternalConsent;
+      if (typeof consent !== "function") {
+        return Promise.reject(
+          new Error(
+            "Connecting a Trezor contacts connect.trezor.io; a consent callback is required before proceeding.",
+          ),
+        );
+      }
+      return connectTrezor({ requestExternalConsent: consent });
+    }
     case "keystone":
       throw new Error("Keystone hardware wallets are not yet supported");
     default: {

--- a/ui/web/src/hw/index.ts
+++ b/ui/web/src/hw/index.ts
@@ -1,0 +1,39 @@
+/**
+ * hw/index.ts — Hardware-signer factory.
+ *
+ * The UI (AddWallet, Send) asks for a device by kind and gets back a neutral
+ * HardwareSigner; it never imports a device module directly. This is the one
+ * place that knows which concrete connector implements each kind.
+ */
+
+import type { ConnectOptions, HardwareKind, HardwareSigner } from "./types";
+import { connectLedger } from "./ledger";
+
+export type { HardwareKind, HardwareCapabilities, HardwareSigner, ConnectOptions } from "./types";
+
+/**
+ * Connect to a hardware device of the given kind.
+ *
+ * @param opts - forwarded to the connector; carries the external-connection
+ *   consent gate that cloud-reaching devices require.
+ * @throws Error for a kind whose connector is not implemented yet.
+ */
+export function connectDevice(
+  kind: HardwareKind,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- opts is used once Trezor lands
+  opts?: ConnectOptions,
+): Promise<HardwareSigner> {
+  switch (kind) {
+    case "ledger":
+      return connectLedger();
+    case "trezor":
+      throw new Error("Trezor hardware wallets are not yet supported");
+    case "keystone":
+      throw new Error("Keystone hardware wallets are not yet supported");
+    default: {
+      // Exhaustiveness guard: a new HardwareKind must add a case above.
+      const never: never = kind;
+      throw new Error(`Unknown hardware device kind: ${String(never)}`);
+    }
+  }
+}

--- a/ui/web/src/hw/index.ts
+++ b/ui/web/src/hw/index.ts
@@ -6,7 +6,13 @@
  * place that knows which concrete connector implements each kind.
  */
 
-import type { ConnectOptions, HardwareKind, HardwareSigner } from "./types";
+import type {
+  ConnectOptionsByKind,
+  ExternalConnectOptions,
+  HardwareKind,
+  HardwareSigner,
+  LocalConnectOptions,
+} from "./types";
 import { connectLedger } from "./ledger";
 import { connectTrezor } from "./trezor";
 
@@ -15,6 +21,7 @@ export type {
   HardwareCapabilities,
   HardwareSigner,
   ConnectOptions,
+  ConnectOptionsByKind,
   LocalConnectOptions,
   ExternalConnectOptions,
 } from "./types";
@@ -22,34 +29,74 @@ export type {
 /**
  * Connect to a hardware device of the given kind.
  *
- * @param opts - forwarded to the connector; carries the external-connection
- *   consent gate that cloud-reaching devices (Trezor) require.
+ * The kind-specific overloads discriminate the options at compile time:
+ *   - Ledger (local, WebHID) accepts only {@link LocalConnectOptions}, which
+ *     FORBIDS a consent callback — a local device can never be handed one.
+ *   - Trezor (reaches connect.trezor.io) REQUIRES {@link ExternalConnectOptions}
+ *     with the consent callback.
+ *
+ * The missing-consent runtime policy lives in exactly one place —
+ * {@link connectTrezor} — so this factory only narrows types and forwards; it
+ * does not re-implement the consent gate.
+ *
  * @throws Error for an unimplemented kind (Keystone is not supported yet).
  */
 export function connectDevice(
+  kind: "ledger",
+  opts?: ConnectOptionsByKind["ledger"],
+): Promise<HardwareSigner>;
+export function connectDevice(
+  kind: "trezor",
+  opts: ConnectOptionsByKind["trezor"],
+): Promise<HardwareSigner>;
+export function connectDevice(
+  kind: "keystone",
+  opts?: ConnectOptionsByKind["keystone"],
+): Promise<HardwareSigner>;
+export function connectDevice(
   kind: HardwareKind,
-  opts?: ConnectOptions,
+  opts?: LocalConnectOptions | ExternalConnectOptions,
 ): Promise<HardwareSigner> {
   switch (kind) {
     case "ledger":
       return connectLedger();
-    case "trezor": {
-      // Trezor reaches connect.trezor.io: the consent callback is mandatory.
-      // Reject here (rather than defaulting to no consent) if it is missing.
-      const consent = opts?.requestExternalConsent;
-      if (typeof consent !== "function") {
-        return Promise.reject(
-          new Error(
-            "Connecting a Trezor contacts connect.trezor.io; a consent callback is required before proceeding.",
-          ),
-        );
-      }
-      return connectTrezor({ requestExternalConsent: consent });
-    }
+    case "trezor":
+      // The consent gate (mandatory callback, must resolve true) is enforced
+      // once, inside connectTrezor; the overload above guarantees `opts` is
+      // present and typed here.
+      return connectTrezor(opts as ExternalConnectOptions);
     case "keystone":
       throw new Error("Keystone hardware wallets are not yet supported");
     default: {
       // Exhaustiveness guard: a new HardwareKind must add a case above.
+      const never: never = kind;
+      throw new Error(`Unknown hardware device kind: ${String(never)}`);
+    }
+  }
+}
+
+/**
+ * Connect a device whose kind is only known at runtime (driven by a picker or a
+ * stored hint), wiring the consent callback external-network devices require.
+ *
+ * This is the ONE boundary that narrows a dynamic {@link HardwareKind} to the
+ * typed {@link connectDevice} overloads, so a UI caller that legitimately
+ * cannot know the kind at compile time does not re-derive which kinds need
+ * consent. `requestExternalConsent` is consulted ONLY for external-network
+ * devices (Trezor); local devices (Ledger) ignore it.
+ */
+export function connectHardware(
+  kind: HardwareKind,
+  requestExternalConsent: () => Promise<boolean>,
+): Promise<HardwareSigner> {
+  switch (kind) {
+    case "ledger":
+      return connectDevice("ledger");
+    case "trezor":
+      return connectDevice("trezor", { requestExternalConsent });
+    case "keystone":
+      return connectDevice("keystone");
+    default: {
       const never: never = kind;
       throw new Error(`Unknown hardware device kind: ${String(never)}`);
     }

--- a/ui/web/src/hw/index.ts
+++ b/ui/web/src/hw/index.ts
@@ -8,6 +8,7 @@
 
 import type { ConnectOptions, HardwareKind, HardwareSigner } from "./types";
 import { connectLedger } from "./ledger";
+import { connectTrezor } from "./trezor";
 
 export type { HardwareKind, HardwareCapabilities, HardwareSigner, ConnectOptions } from "./types";
 
@@ -15,19 +16,18 @@ export type { HardwareKind, HardwareCapabilities, HardwareSigner, ConnectOptions
  * Connect to a hardware device of the given kind.
  *
  * @param opts - forwarded to the connector; carries the external-connection
- *   consent gate that cloud-reaching devices require.
- * @throws Error for a kind whose connector is not implemented yet.
+ *   consent gate that cloud-reaching devices (Trezor) require.
+ * @throws Error for an unimplemented kind (Keystone is not supported yet).
  */
 export function connectDevice(
   kind: HardwareKind,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- opts is used once Trezor lands
   opts?: ConnectOptions,
 ): Promise<HardwareSigner> {
   switch (kind) {
     case "ledger":
       return connectLedger();
     case "trezor":
-      throw new Error("Trezor hardware wallets are not yet supported");
+      return connectTrezor(opts);
     case "keystone":
       throw new Error("Keystone hardware wallets are not yet supported");
     default: {

--- a/ui/web/src/hw/ledger.test.ts
+++ b/ui/web/src/hw/ledger.test.ts
@@ -233,6 +233,49 @@ describe("connectLedger", () => {
       await session.close();
     });
 
+    test("maps native assets into the ledger token bundle grouped by policy id", async () => {
+      // A recipient output carrying two assets under one policy plus one under a
+      // second policy. The device MUST receive these grouped so it signs the
+      // same tx the backend built — an empty bundle would drop the tokens.
+      const MULTI_ASSET_REQ: HardwareSignResponse = {
+        ...NEUTRAL_REQ,
+        outputs: [
+          {
+            address_hex: "60aabb",
+            address_bech32: "addr1recipient",
+            lovelace: "1000000",
+            assets: [
+              { policy_id_hex: "aa".repeat(28), asset_name_hex: "544f4b454e31", amount: "5" },
+              { policy_id_hex: "aa".repeat(28), asset_name_hex: "544f4b454e32", amount: "7" },
+              { policy_id_hex: "bb".repeat(28), asset_name_hex: "", amount: "3" },
+            ],
+          },
+          NEUTRAL_REQ.outputs[1], // wallet-owned change, ADA-only
+        ],
+      };
+
+      const session = await connectLedger();
+      await session.signTx(MULTI_ASSET_REQ);
+
+      const request = mockSignTransaction.mock.calls[0][0];
+      expect(request.tx.outputs[0].tokenBundle).toEqual([
+        {
+          policyIdHex: "aa".repeat(28),
+          tokens: [
+            { assetNameHex: "544f4b454e31", amount: 5n },
+            { assetNameHex: "544f4b454e32", amount: 7n },
+          ],
+        },
+        {
+          policyIdHex: "bb".repeat(28),
+          tokens: [{ assetNameHex: "", amount: 3n }],
+        },
+      ]);
+      // The ADA-only change output keeps an empty bundle (ledgerjs iterates it).
+      expect(request.tx.outputs[1].tokenBundle).toEqual([]);
+      await session.close();
+    });
+
     test("returns a raw CBOR witness array", async () => {
       const session = await connectLedger();
       const result = await session.signTx(NEUTRAL_REQ);

--- a/ui/web/src/hw/ledger.test.ts
+++ b/ui/web/src/hw/ledger.test.ts
@@ -39,10 +39,12 @@ vi.mock("@ledgerhq/hw-transport-webhid", () => ({
   default: { create: mockCreate },
 }));
 
-vi.mock("@cardano-foundation/ledgerjs-hw-app-cardano", () => ({
-  default: mockAdaConstructor,
-  Ada: mockAdaConstructor,
-}));
+// Keep the real enum exports (TxOutputDestinationType, AddressType, …) that the
+// neutral→ledgerjs mapping in ledger.ts references; only the Ada class is mocked.
+vi.mock("@cardano-foundation/ledgerjs-hw-app-cardano", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@cardano-foundation/ledgerjs-hw-app-cardano")>();
+  return { ...actual, default: mockAdaConstructor, Ada: mockAdaConstructor };
+});
 
 // ── Test constants ────────────────────────────────────────────────────────────
 //
@@ -73,7 +75,31 @@ const MOCK_WITNESS_SIG_HEX = "aabbccdd".repeat(16); // 64 bytes
 
 // ── Import SUT after mocks ────────────────────────────────────────────────────
 import { connectLedger } from "./ledger";
-import type { SignTransactionRequest } from "@cardano-foundation/ledgerjs-hw-app-cardano";
+import type { HardwareSignResponse } from "../api/types";
+
+// A neutral backend signing request (device-agnostic). connectLedger's signTx
+// maps this to the ledgerjs SignTransactionRequest internally; the mapping
+// assertions below used to live in Send.test.tsx and moved here with the code.
+const NEUTRAL_REQ: HardwareSignResponse = {
+  network: "mainnet",
+  network_id: 1,
+  include_network_id: true,
+  protocol_magic: 764824073,
+  inputs: [{ tx_hash_hex: "deadbeef", output_index: 0, path: "1852'/1815'/0'/0/0" }],
+  outputs: [
+    { address_hex: "60aabb", address_bech32: "addr1recipient", lovelace: "1000000" },
+    {
+      address_hex: "60ccdd",
+      address_bech32: "addr1change",
+      lovelace: "3800000",
+      payment_path: "1852'/1815'/0'/0/0",
+      stake_path: "1852'/1815'/0'/2/0",
+    },
+  ],
+  fee: "200000",
+  required_signers: ["aabbccdd"],
+  unsigned_tx_cbor: "84a4deadbeef",
+};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 function setWebHID(available: boolean) {
@@ -125,6 +151,19 @@ describe("connectLedger", () => {
     await session.close();
   });
 
+  test("reports kind 'ledger' and send-only capabilities", async () => {
+    const session = await connectLedger();
+    expect(session.kind).toBe("ledger");
+    expect(session.capabilities).toEqual({
+      send: true,
+      staking: false,
+      governance: false,
+      multisig: false,
+      poolReg: false,
+    });
+    await session.close();
+  });
+
   describe("getAccountXpub", () => {
     test("calls getExtendedPublicKey with correct CIP-1852 path for account 0", async () => {
       const session = await connectLedger();
@@ -156,28 +195,50 @@ describe("connectLedger", () => {
   });
 
   describe("signTx", () => {
-    test("calls signTransaction with the request and returns a raw CBOR witness array", async () => {
+    test("maps the neutral request to a ledgerjs SignTransactionRequest", async () => {
       const session = await connectLedger();
 
-      const txReq: SignTransactionRequest = {
-        tx: {
-          network: { protocolMagic: 764824073, networkId: 1 },
-          inputs: [],
-          outputs: [],
-          fee: 200000,
-        },
-        signingMode: "ordinary_transaction" as const,
-      } as SignTransactionRequest;
-
-      const result = await session.signTx(txReq);
+      await session.signTx(NEUTRAL_REQ);
 
       expect(mockSignTransaction).toHaveBeenCalledOnce();
-      // The request object must be passed through to the device unchanged.
-      expect(mockSignTransaction).toHaveBeenCalledWith(txReq);
-      // Result is CBOR hex: [[pubkey, sig], ...]
-      // Must be a non-empty hex string
+      const request = mockSignTransaction.mock.calls[0][0];
+
+      // ORDINARY signing with the network + required-signer fields carried over.
+      expect(request.signingMode).toBe("ordinary_transaction");
+      expect(request.tx.network).toEqual({ protocolMagic: 764824073, networkId: 1 });
+      expect(request.tx.includeNetworkId).toBe(true);
+      expect(request.tx.requiredSigners).toEqual([
+        { type: "required_signer_hash", hashHex: "aabbccdd" },
+      ]);
+
+      // Third-party recipient by raw address hex; device-owned change by path.
+      expect(request.tx.outputs[0].destination).toEqual({
+        type: "third_party",
+        params: { addressHex: "60aabb" },
+      });
+      expect(request.tx.outputs[1].destination).toEqual({
+        type: "device_owned",
+        params: {
+          type: 0,
+          params: {
+            spendingPath: [0x8000073c, 0x80000717, 0x80000000, 0, 0],
+            stakingPath: [0x8000073c, 0x80000717, 0x80000000, 2, 0],
+          },
+        },
+      });
+      // ledgerjs iterates tokenBundle even for ADA-only outputs.
+      expect(request.tx.outputs.every((o: { tokenBundle: unknown[] }) => Array.isArray(o.tokenBundle))).toBe(
+        true,
+      );
+      await session.close();
+    });
+
+    test("returns a raw CBOR witness array", async () => {
+      const session = await connectLedger();
+      const result = await session.signTx(NEUTRAL_REQ);
+      // Result is CBOR hex: [[pubkey, sig], ...] — a non-empty hex string with
+      // one outer array followed by one two-element witness tuple.
       expect(result).toMatch(/^[0-9a-f]+$/);
-      // One outer witness array followed by one two-element witness tuple.
       expect(result.startsWith("8182")).toBe(true);
       await session.close();
     });
@@ -191,17 +252,7 @@ describe("connectLedger", () => {
         chainCodeHex: TEST_CHAIN_CODE_HEX,
       });
 
-      const txReq: SignTransactionRequest = {
-        tx: {
-          network: { protocolMagic: 764824073, networkId: 1 },
-          inputs: [],
-          outputs: [],
-          fee: 200000,
-        },
-        signingMode: "ordinary_transaction" as const,
-      } as SignTransactionRequest;
-
-      const result = await session.signTx(txReq);
+      const result = await session.signTx(NEUTRAL_REQ);
 
       // The CBOR hex must contain both the pubkey and the sig as substrings
       expect(result).toContain(MOCK_WITNESS_PUB_HEX);

--- a/ui/web/src/hw/ledger.ts
+++ b/ui/web/src/hw/ledger.ts
@@ -13,7 +13,9 @@
 import TransportWebHID from "@ledgerhq/hw-transport-webhid";
 import Ada from "@cardano-foundation/ledgerjs-hw-app-cardano";
 import type {
+  AssetGroup,
   SignTransactionRequest,
+  Token,
   TxInput,
   TxOutput,
 } from "@cardano-foundation/ledgerjs-hw-app-cardano";
@@ -50,6 +52,22 @@ function parseBip32Path(pathStr: string): number[] {
 
 // ── Neutral → ledgerjs mapping ────────────────────────────────────────────────
 
+// mapTokenBundle groups a neutral output's native assets by policy id and maps
+// them into the ledgerjs AssetGroup/Token shape. Without this, a multi-asset
+// send would reach the device with an empty bundle and the device would sign a
+// DIFFERENT transaction than the backend built (dropping the tokens entirely).
+function mapTokenBundle(
+  assets: NonNullable<HardwareSignResponse["outputs"][number]["assets"]>,
+): AssetGroup[] {
+  const byPolicy = new Map<string, Token[]>();
+  for (const a of assets) {
+    const tokens = byPolicy.get(a.policy_id_hex) ?? [];
+    tokens.push({ assetNameHex: a.asset_name_hex, amount: BigInt(a.amount) });
+    byPolicy.set(a.policy_id_hex, tokens);
+  }
+  return Array.from(byPolicy, ([policyIdHex, tokens]) => ({ policyIdHex, tokens }));
+}
+
 // mapToSignRequest converts a HardwareSignResponse (from the backend) to the
 // SignTransactionRequest format that ledgerjs expects. This lived in Send.tsx
 // as a device-specific leak; it now belongs to the Ledger signer, which is the
@@ -82,8 +100,10 @@ function mapToSignRequest(resp: HardwareSignResponse): SignTransactionRequest {
       format: TxOutputFormat.ARRAY_LEGACY,
       destination,
       amount: BigInt(out.lovelace),
-      // ledgerjs iterates this field even when the output contains ADA only.
-      tokenBundle: [],
+      // Carry any native assets grouped by policy so the device signs the same
+      // tx the backend built. ledgerjs iterates this field even when the output
+      // is ADA-only, so an empty array is the correct no-asset value.
+      tokenBundle: out.assets && out.assets.length > 0 ? mapTokenBundle(out.assets) : [],
     };
   });
 

--- a/ui/web/src/hw/ledger.ts
+++ b/ui/web/src/hw/ledger.ts
@@ -5,62 +5,29 @@
  * @cardano-foundation/ledgerjs-hw-app-cardano, and bech32.
  * No network calls are made beyond the HID transport.
  *
- * Xpub encoding parity with Go:
- *   bip32.XPub.String() encodes 64 bytes (publicKey || chainCode) as bech32
- *   with HRP "root_xvk" — exactly what getAccountXpub produces here.
- *   Verified against the Go canonical vector for the "abandon ×11 about"
- *   test mnemonic at account 0 (see ledger.test.ts).
+ * Xpub/witness encoding parity with Go lives in the shared hw/xpub.ts and
+ * hw/witness.ts helpers so every device (Ledger, Trezor, …) encodes from one
+ * implementation; the parity vector is exercised in ledger.test.ts.
  */
 
 import TransportWebHID from "@ledgerhq/hw-transport-webhid";
 import Ada from "@cardano-foundation/ledgerjs-hw-app-cardano";
-import type { SignTransactionRequest } from "@cardano-foundation/ledgerjs-hw-app-cardano";
-import { encode as bech32Encode, toWords as bech32ToWords } from "bech32";
-
-// ── CBOR helpers (minimal, covers only the witness-set structure) ─────────────
-
-/**
- * Encode a small non-negative integer as CBOR unsigned int.
- * This is only ever called with small witness-array cardinalities (the count of
- * distinct signers in a transaction), NOT with lovelace amounts (those go
- * through ledgerjs BigInt). The 65535 cap is therefore never reached in practice.
- */
-function cborUint(n: number): number[] {
-  if (n < 24) return [n];
-  if (n < 256) return [0x18, n];
-  if (n < 65536) return [0x19, n >> 8, n & 0xff];
-  throw new RangeError(`cborUint: ${n} is too large`);
-}
-
-/** Encode a byte array as a CBOR byte string. */
-function cborBytes(hex: string): number[] {
-  const bytes = hexToBytes(hex);
-  const hdr = cborUint(bytes.length);
-  hdr[0] |= 0x40; // major type 2 = byte string
-  return [...hdr, ...Array.from(bytes)];
-}
-
-/** Encode a fixed-size array of already-encoded CBOR items. */
-function cborArray(items: number[][]): number[] {
-  const hdr = cborUint(items.length);
-  hdr[0] |= 0x80; // major type 4 = array
-  return [...hdr, ...items.flat()];
-}
-
-/** Encode a hex string as Uint8Array. */
-function hexToBytes(hex: string): Uint8Array {
-  const len = hex.length;
-  const out = new Uint8Array(len / 2);
-  for (let i = 0; i < len; i += 2) {
-    out[i / 2] = parseInt(hex.slice(i, i + 2), 16);
-  }
-  return out;
-}
-
-/** Encode bytes as lowercase hex string. */
-function bytesToHex(bytes: number[]): string {
-  return bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
-}
+import type {
+  SignTransactionRequest,
+  TxInput,
+  TxOutput,
+} from "@cardano-foundation/ledgerjs-hw-app-cardano";
+import {
+  AddressType,
+  TransactionSigningMode,
+  TxOutputDestinationType,
+  TxOutputFormat,
+  TxRequiredSignerType,
+} from "@cardano-foundation/ledgerjs-hw-app-cardano";
+import type { HardwareSignResponse } from "../api/types";
+import type { HardwareCapabilities, HardwareSigner } from "./types";
+import { encodeXpub } from "./xpub";
+import { encodeWitnessArray } from "./witness";
 
 // ── BIP32 path ───────────────────────────────────────────────────────────────
 
@@ -71,71 +38,94 @@ function accountPath(account: number): number[] {
   return [1852 + HARDENED, 1815 + HARDENED, account + HARDENED];
 }
 
-// ── Bech32 xpub encoding ─────────────────────────────────────────────────────
-
-/**
- * Encode a raw {publicKeyHex, chainCodeHex} pair as a bech32 xpub with HRP
- * "root_xvk". This matches Go's bip32.XPub.String() exactly:
- *   data = publicKey(32 bytes) || chainCode(32 bytes)  →  bech32(root_xvk, data)
- *
- * The bech32 package's 90-char default limit is bypassed by passing limit=1000.
- */
-function encodeXpub(publicKeyHex: string, chainCodeHex: string): string {
-  const pubBytes = Array.from(hexToBytes(publicKeyHex));
-  const ccBytes = Array.from(hexToBytes(chainCodeHex));
-  const data = new Uint8Array([...pubBytes, ...ccBytes]); // 64 bytes
-  const words = bech32ToWords(data);
-  return bech32Encode("root_xvk", words, 1000 /* no length limit */);
+// parseBip32Path converts a CIP-1852 path string to a numeric array.
+// "1852'/1815'/0'/0/3" → [0x80000000+1852, 0x80000000+1815, 0x80000000+0, 0, 3]
+function parseBip32Path(pathStr: string): number[] {
+  return pathStr.split("/").map((seg) => {
+    const hardened = seg.endsWith("'");
+    const n = parseInt(hardened ? seg.slice(0, -1) : seg, 10);
+    return hardened ? n + HARDENED : n;
+  });
 }
 
-// ── Raw vkey-witness-array CBOR encoding ─────────────────────────────────────────────────
+// ── Neutral → ledgerjs mapping ────────────────────────────────────────────────
 
-/**
- * Encode the raw vkey-witness array consumed by the backend's SubmitSigned.
- *
- * Format: [[pubkey_bytes, sig_bytes], ...]
- *   - each witness = [32-byte Ed25519 pubkey, 64-byte Ed25519 signature]
- */
-function encodeWitnessArray(witnesses: { pubKeyHex: string; sigHex: string }[]): string {
-  return bytesToHex(
-    cborArray(
-      witnesses.map(({ pubKeyHex, sigHex }) =>
-        cborArray([cborBytes(pubKeyHex), cborBytes(sigHex)]),
-      ),
-    ),
-  );
+// mapToSignRequest converts a HardwareSignResponse (from the backend) to the
+// SignTransactionRequest format that ledgerjs expects. This lived in Send.tsx
+// as a device-specific leak; it now belongs to the Ledger signer, which is the
+// only code that knows the ledgerjs shape.
+function mapToSignRequest(resp: HardwareSignResponse): SignTransactionRequest {
+  const inputs: TxInput[] = resp.inputs.map((inp) => ({
+    txHashHex: inp.tx_hash_hex,
+    outputIndex: inp.output_index,
+    path: inp.path ? parseBip32Path(inp.path) : null,
+  }));
+
+  const outputs: TxOutput[] = resp.outputs.map((out) => {
+    const destination = out.payment_path && out.stake_path
+      ? {
+          type: TxOutputDestinationType.DEVICE_OWNED as const,
+          params: {
+            type: AddressType.BASE_PAYMENT_KEY_STAKE_KEY as const,
+            params: {
+              spendingPath: parseBip32Path(out.payment_path),
+              stakingPath: parseBip32Path(out.stake_path),
+            },
+          },
+        }
+      : {
+          type: TxOutputDestinationType.THIRD_PARTY as const,
+          params: { addressHex: out.address_hex },
+        };
+
+    return {
+      format: TxOutputFormat.ARRAY_LEGACY,
+      destination,
+      amount: BigInt(out.lovelace),
+      // ledgerjs iterates this field even when the output contains ADA only.
+      tokenBundle: [],
+    };
+  });
+
+  return {
+    tx: {
+      network: {
+        protocolMagic: resp.protocol_magic,
+        networkId: resp.network_id,
+      },
+      inputs,
+      outputs,
+      fee: BigInt(resp.fee),
+      ttl: resp.ttl ? BigInt(resp.ttl) : null,
+      requiredSigners: resp.required_signers.map((hashHex) => ({
+        type: TxRequiredSignerType.HASH,
+        hashHex,
+      })),
+      includeNetworkId: resp.include_network_id || null,
+    },
+    signingMode: TransactionSigningMode.ORDINARY_TRANSACTION,
+  };
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
-/** A live session with a Ledger device running the Cardano app. */
-export interface LedgerSession {
-  /**
-   * Derive the account-level extended public key from the device.
-   * Calls getExtendedPublicKey(m/1852'/1815'/<account>') and encodes
-   * the result as a bech32 "root_xvk" string identical to what Go's
-   * bip32.XPub.String() / wallet.AccountXpub() produces.
-   */
-  getAccountXpub(account: number): Promise<string>;
-
-  /**
-   * Sign a transaction on the device.
-   * @param request - The full SignTransactionRequest for the Cardano Ledger app.
-   * @returns CBOR-encoded raw vkey-witness array hex string.
-   */
-  signTx(request: SignTransactionRequest): Promise<string>;
-
-  /** Close the underlying HID transport. */
-  close(): Promise<void>;
-}
+// Ledger currently signs send (ordinary) transactions on-device; the other
+// flows are declared unsupported until their neutral→ledgerjs mappings land.
+const LEDGER_CAPABILITIES: HardwareCapabilities = {
+  send: true,
+  staking: false,
+  governance: false,
+  multisig: false,
+  poolReg: false,
+};
 
 /**
- * Open a connection to a Ledger device via WebHID and return a LedgerSession.
+ * Open a connection to a Ledger device via WebHID and return a HardwareSigner.
  *
  * @throws Error — "WebHID not available — open this in a Chromium browser"
  *   if the browser does not support the WebHID API.
  */
-export async function connectLedger(): Promise<LedgerSession> {
+export async function connectLedger(): Promise<HardwareSigner> {
   if (
     typeof navigator === "undefined" ||
     (navigator as Navigator & { hid?: unknown }).hid === undefined
@@ -147,13 +137,19 @@ export async function connectLedger(): Promise<LedgerSession> {
   const cardano = new Ada(transport);
 
   return {
+    kind: "ledger",
+    capabilities: LEDGER_CAPABILITIES,
+
     async getAccountXpub(account: number): Promise<string> {
       const path = accountPath(account);
       const { publicKeyHex, chainCodeHex } = await cardano.getExtendedPublicKey({ path });
       return encodeXpub(publicKeyHex, chainCodeHex);
     },
 
-    async signTx(request: SignTransactionRequest): Promise<string> {
+    async signTx(req: HardwareSignResponse): Promise<string> {
+      // 0. Shape the neutral request into what the Cardano Ledger app expects.
+      const request = mapToSignRequest(req);
+
       // 1. Ask the device to sign the transaction and collect witness signatures.
       const { witnesses } = await cardano.signTransaction(request);
 

--- a/ui/web/src/hw/trezor.test.ts
+++ b/ui/web/src/hw/trezor.test.ts
@@ -1,0 +1,198 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// ── Hoisted mock state (declared before the vi.mock factory runs) ─────────────
+const { mockInit, mockGetPublicKey, mockSignTransaction, mockDispose } = vi.hoisted(() => ({
+  mockInit: vi.fn().mockResolvedValue(undefined),
+  mockGetPublicKey: vi.fn(),
+  mockSignTransaction: vi.fn(),
+  mockDispose: vi.fn(),
+}));
+
+// Fully mock @trezor/connect-web — no real network, iframe, or popup is loaded.
+// trezor.ts imports this dynamically, but vi.mock still intercepts the import.
+vi.mock("@trezor/connect-web", () => ({
+  default: {
+    init: mockInit,
+    cardanoGetPublicKey: mockGetPublicKey,
+    cardanoSignTransaction: mockSignTransaction,
+    dispose: mockDispose,
+  },
+  PROTO: {
+    CardanoTxSigningMode: { ORDINARY_TRANSACTION: 0 },
+    CardanoAddressType: { BASE: 0 },
+  },
+}));
+
+import { connectTrezor } from "./trezor";
+import type { HardwareSignResponse } from "../api/types";
+
+// Xpub parity vector — identical key material to the Ledger canonical vector
+// (see ledger.test.ts) so both devices MUST produce the same bech32 string.
+const TEST_PUB_KEY_HEX = "beb7e770b3d0f1932b0a2f3a63285bf9ef7d3e461d55446d6a3911d8f0ee55c0";
+const TEST_CHAIN_CODE_HEX = "b0e2df16538508046649d0e6d5b32969555a23f2f1ebf2db2819359b0d88bd16";
+const TEST_XPUB_BECH32 =
+  "root_xvk1h6m7wu9n6rcex2c29uaxx2zml8hh60jxr425gmt28yga3u8w2hqtpcklzefc2zqyveyapek4kv5kj426y0e0r6ljmv5pjdvmpkyt69s8fpd2x";
+
+const HARDENED = 0x80000000;
+const ACCT0_PATH = [1852 + HARDENED, 1815 + HARDENED, 0 + HARDENED];
+
+const NEUTRAL_REQ: HardwareSignResponse = {
+  network: "mainnet",
+  network_id: 1,
+  include_network_id: true,
+  protocol_magic: 764824073,
+  inputs: [{ tx_hash_hex: "deadbeef", output_index: 0, path: "1852'/1815'/0'/0/0" }],
+  outputs: [
+    { address_hex: "60aabb", address_bech32: "addr1recipient", lovelace: "1000000" },
+    {
+      address_hex: "60ccdd",
+      address_bech32: "addr1change",
+      lovelace: "3800000",
+      payment_path: "1852'/1815'/0'/0/0",
+      stake_path: "1852'/1815'/0'/2/0",
+    },
+  ],
+  fee: "200000",
+  required_signers: ["aabbccdd"],
+  unsigned_tx_cbor: "84a4deadbeef",
+};
+
+// Always-approve consent callback for the tests that exercise past the gate.
+const approve = async () => true;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockInit.mockResolvedValue(undefined);
+  mockGetPublicKey.mockResolvedValue({
+    success: true,
+    payload: { node: { public_key: TEST_PUB_KEY_HEX, chain_code: TEST_CHAIN_CODE_HEX } },
+  });
+  mockSignTransaction.mockResolvedValue({
+    success: true,
+    payload: {
+      hash: "cafebabe",
+      witnesses: [{ type: 1, pubKey: TEST_PUB_KEY_HEX, signature: "aabbccdd".repeat(16) }],
+    },
+  });
+});
+
+describe("connectTrezor consent gate", () => {
+  test("does NOT init when consent is denied, and throws", async () => {
+    await expect(connectTrezor({ requestExternalConsent: async () => false })).rejects.toThrow(
+      /connect\.trezor\.io/i,
+    );
+    expect(mockInit).not.toHaveBeenCalled();
+  });
+
+  test("does NOT init when no consent callback is provided", async () => {
+    await expect(connectTrezor()).rejects.toThrow(/connect\.trezor\.io/i);
+    expect(mockInit).not.toHaveBeenCalled();
+  });
+
+  test("init is not called until approval resolves", async () => {
+    let resolveConsent: (ok: boolean) => void = () => {};
+    const consent = new Promise<boolean>((resolve) => {
+      resolveConsent = resolve;
+    });
+
+    const pending = connectTrezor({ requestExternalConsent: () => consent });
+
+    // Approval still pending → the external iframe must not have been loaded.
+    await Promise.resolve();
+    expect(mockInit).not.toHaveBeenCalled();
+
+    resolveConsent(true);
+    const session = await pending;
+
+    expect(mockInit).toHaveBeenCalledOnce();
+    // init carries the manifest + lazyLoad settings.
+    expect(mockInit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        manifest: expect.objectContaining({ email: expect.any(String), appUrl: expect.any(String) }),
+        lazyLoad: true,
+      }),
+    );
+    await session.close();
+  });
+});
+
+describe("connectTrezor session", () => {
+  test("reports kind 'trezor' and send-only capabilities", async () => {
+    const session = await connectTrezor({ requestExternalConsent: approve });
+    expect(session.kind).toBe("trezor");
+    expect(session.capabilities).toEqual({
+      send: true,
+      staking: false,
+      governance: false,
+      multisig: false,
+      poolReg: false,
+    });
+    await session.close();
+  });
+
+  test("getAccountXpub produces the SAME bech32 as the Ledger parity vector", async () => {
+    const session = await connectTrezor({ requestExternalConsent: approve });
+    const xpub = await session.getAccountXpub(0);
+
+    expect(mockGetPublicKey).toHaveBeenCalledWith({ path: ACCT0_PATH, showOnTrezor: false });
+    // Byte-for-byte identical to Ledger/Go for the same key material.
+    expect(xpub).toBe(TEST_XPUB_BECH32);
+    await session.close();
+  });
+
+  test("getAccountXpub throws on an unsuccessful device response", async () => {
+    mockGetPublicKey.mockResolvedValueOnce({ success: false, payload: { error: "device disconnected" } });
+    const session = await connectTrezor({ requestExternalConsent: approve });
+    await expect(session.getAccountXpub(0)).rejects.toThrow("device disconnected");
+    await session.close();
+  });
+
+  test("signTx maps the neutral request to ORDINARY Trezor params and returns witness CBOR", async () => {
+    const session = await connectTrezor({ requestExternalConsent: approve });
+    const result = await session.signTx(NEUTRAL_REQ);
+
+    expect(mockSignTransaction).toHaveBeenCalledOnce();
+    const params = mockSignTransaction.mock.calls[0][0];
+
+    expect(params.signingMode).toBe(0); // ORDINARY_TRANSACTION
+    expect(params.protocolMagic).toBe(764824073);
+    expect(params.networkId).toBe(1);
+    expect(params.includeNetworkId).toBe(true);
+    expect(params.fee).toBe("200000");
+
+    expect(params.inputs).toEqual([
+      { path: [0x8000073c, 0x80000717, 0x80000000, 0, 0], prev_hash: "deadbeef", prev_index: 0 },
+    ]);
+
+    // Third-party recipient by bech32 address; wallet-owned change by path.
+    expect(params.outputs[0]).toEqual({ address: "addr1recipient", amount: "1000000" });
+    expect(params.outputs[1]).toEqual({
+      addressParameters: {
+        addressType: 0, // BASE
+        path: [0x8000073c, 0x80000717, 0x80000000, 0, 0],
+        stakingPath: [0x8000073c, 0x80000717, 0x80000000, 2, 0],
+      },
+      amount: "3800000",
+    });
+
+    // Witness CBOR carries the device's pubkey + signature.
+    expect(result).toMatch(/^[0-9a-f]+$/);
+    expect(result.startsWith("8182")).toBe(true);
+    expect(result).toContain(TEST_PUB_KEY_HEX);
+    expect(result).toContain("aabbccdd".repeat(16));
+    await session.close();
+  });
+
+  test("signTx throws on an unsuccessful device response", async () => {
+    mockSignTransaction.mockResolvedValueOnce({ success: false, payload: { error: "user cancelled" } });
+    const session = await connectTrezor({ requestExternalConsent: approve });
+    await expect(session.signTx(NEUTRAL_REQ)).rejects.toThrow("user cancelled");
+    await session.close();
+  });
+
+  test("close disposes the Trezor transport", async () => {
+    const session = await connectTrezor({ requestExternalConsent: approve });
+    await session.close();
+    expect(mockDispose).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/web/src/hw/trezor.test.ts
+++ b/ui/web/src/hw/trezor.test.ts
@@ -257,4 +257,29 @@ describe("connectTrezor session", () => {
     await session.close();
     expect(mockDispose).toHaveBeenCalledOnce();
   });
+
+  test("closing one live signer keeps the other usable (ref-counted dispose)", async () => {
+    // Two live signers share the module-wide transport. Closing one must NOT
+    // tear it down while the other is still in use. (Connected sequentially so
+    // the shared init() runs once — b reuses a's in-flight init promise.)
+    const a = await connectTrezor({ requestExternalConsent: approve });
+    const b = await connectTrezor({ requestExternalConsent: approve });
+    expect(mockInit).toHaveBeenCalledOnce();
+
+    await a.close();
+    // The shared transport survives because b is still live.
+    expect(mockDispose).not.toHaveBeenCalled();
+
+    // b remains fully usable after a closed.
+    const xpub = await b.getAccountXpub(0);
+    expect(xpub).toBe(TEST_XPUB_BECH32);
+
+    // The LAST signer to close disposes the transport exactly once.
+    await b.close();
+    expect(mockDispose).toHaveBeenCalledOnce();
+
+    // A double close() on an already-closed signer is a no-op (no extra dispose).
+    await a.close();
+    expect(mockDispose).toHaveBeenCalledOnce();
+  });
 });

--- a/ui/web/src/hw/trezor.test.ts
+++ b/ui/web/src/hw/trezor.test.ts
@@ -24,6 +24,7 @@ vi.mock("@trezor/connect-web", () => ({
 }));
 
 import { connectTrezor } from "./trezor";
+import type { ExternalConnectOptions } from "./types";
 import type { HardwareSignResponse } from "../api/types";
 
 // Xpub parity vector — identical key material to the Ledger canonical vector
@@ -85,7 +86,13 @@ describe("connectTrezor consent gate", () => {
   });
 
   test("does NOT init when no consent callback is provided", async () => {
-    await expect(connectTrezor()).rejects.toThrow(/connect\.trezor\.io/i);
+    // The consent callback is mandatory for this external connector; an options
+    // object without it (an untyped/legacy caller) must be rejected, not
+    // treated as implicit approval. Cast bypasses the compile-time requirement
+    // to exercise the runtime guard.
+    await expect(connectTrezor({} as ExternalConnectOptions)).rejects.toThrow(
+      /connect\.trezor\.io/i,
+    );
     expect(mockInit).not.toHaveBeenCalled();
   });
 
@@ -181,6 +188,61 @@ describe("connectTrezor session", () => {
     expect(result).toContain(TEST_PUB_KEY_HEX);
     expect(result).toContain("aabbccdd".repeat(16));
     await session.close();
+  });
+
+  test("signTx maps native assets into the token bundle grouped by policy id", async () => {
+    // A recipient output carrying two assets under one policy plus one under a
+    // second policy. The device MUST receive these so it signs the same tx the
+    // backend built — an empty/absent bundle would drop the tokens silently.
+    const MULTI_ASSET_REQ: HardwareSignResponse = {
+      ...NEUTRAL_REQ,
+      outputs: [
+        {
+          address_hex: "60aabb",
+          address_bech32: "addr1recipient",
+          lovelace: "1000000",
+          assets: [
+            { policy_id_hex: "aa".repeat(28), asset_name_hex: "544f4b454e31", amount: "5" },
+            { policy_id_hex: "aa".repeat(28), asset_name_hex: "544f4b454e32", amount: "7" },
+            { policy_id_hex: "bb".repeat(28), asset_name_hex: "", amount: "3" },
+          ],
+        },
+        NEUTRAL_REQ.outputs[1], // wallet-owned change, ADA-only
+      ],
+    };
+
+    const session = await connectTrezor({ requestExternalConsent: approve });
+    await session.signTx(MULTI_ASSET_REQ);
+
+    const params = mockSignTransaction.mock.calls[0][0];
+    expect(params.outputs[0].tokenBundle).toEqual([
+      {
+        policyId: "aa".repeat(28),
+        tokenAmounts: [
+          { assetNameBytes: "544f4b454e31", amount: "5" },
+          { assetNameBytes: "544f4b454e32", amount: "7" },
+        ],
+      },
+      {
+        policyId: "bb".repeat(28),
+        tokenAmounts: [{ assetNameBytes: "", amount: "3" }],
+      },
+    ]);
+    // The ADA-only change output carries no bundle key.
+    expect(params.outputs[1].tokenBundle).toBeUndefined();
+    await session.close();
+  });
+
+  test("concurrent connects share a single init()", async () => {
+    // Two callers (e.g. a double-click) must not both race into init(); the
+    // shared init promise means only one init() call is made.
+    const [a, b] = await Promise.all([
+      connectTrezor({ requestExternalConsent: approve }),
+      connectTrezor({ requestExternalConsent: approve }),
+    ]);
+    expect(mockInit).toHaveBeenCalledOnce();
+    await a.close();
+    await b.close();
   });
 
   test("signTx throws on an unsuccessful device response", async () => {

--- a/ui/web/src/hw/trezor.ts
+++ b/ui/web/src/hw/trezor.ts
@@ -16,7 +16,7 @@
  */
 
 import type { HardwareSignResponse } from "../api/types";
-import type { ConnectOptions, HardwareCapabilities, HardwareSigner } from "./types";
+import type { ExternalConnectOptions, HardwareCapabilities, HardwareSigner } from "./types";
 import { encodeXpub } from "./xpub";
 import { encodeWitnessArray } from "./witness";
 
@@ -43,13 +43,17 @@ function parseBip32Path(pathStr: string): number[] {
 
 // ── Trezor Connect manifest / init ────────────────────────────────────────────
 
+// Placeholder contact advertised in the Trezor Connect manifest.
+// TODO: production contact — replace with the approved production
+// support/attribution address before shipping.
+const TREZOR_MANIFEST_CONTACT_EMAIL = "wallet@blinklabs.io";
+
 // Trezor requires a manifest identifying the calling app so it can reach out if
 // an integration misbehaves. This is the local Bursa wallet's identity; appUrl
 // is the wallet's own origin when running in a browser context.
-// NOTE (human follow-up): confirm the contact email before shipping.
 const TREZOR_MANIFEST = {
   appName: "Bursa Wallet",
-  email: "wallet@blinklabs.io",
+  email: TREZOR_MANIFEST_CONTACT_EMAIL,
   appUrl:
     typeof window !== "undefined" && window.location?.origin
       ? window.location.origin
@@ -57,9 +61,12 @@ const TREZOR_MANIFEST = {
 };
 
 // init() loads the connect.trezor.io iframe once per page; a second call throws
-// "already initialized". Track it so repeated connects (and reconnect after a
-// close/dispose) behave, without re-loading the iframe unnecessarily.
-let trezorInitialized = false;
+// "already initialized". A SHARED init promise makes the lifecycle safe under
+// concurrent connectTrezor() calls: two callers (e.g. a double-click) await the
+// same in-flight init instead of both racing to init(). A failed init clears
+// the promise so a later connect can retry; close() clears it so a fresh
+// connect re-inits after dispose.
+let trezorInitPromise: Promise<void> | null = null;
 
 // ── Capabilities ──────────────────────────────────────────────────────────────
 
@@ -73,18 +80,53 @@ const TREZOR_CAPABILITIES: HardwareCapabilities = {
   poolReg: false,
 };
 
+// ── Neutral → Trezor token-bundle mapping ─────────────────────────────────────
+
+// A Trezor cardanoSignTransaction output token bundle: assets grouped by policy
+// id, each carrying an asset-name + decimal amount (both hex/string). Typed
+// locally to avoid importing the SDK's schema types at module load.
+type TrezorAssetGroup = {
+  policyId: string;
+  tokenAmounts: { assetNameBytes: string; amount: string }[];
+};
+
+// mapTokenBundle groups a neutral output's native assets by policy id into the
+// Trezor token-bundle shape, or returns undefined for an ADA-only output.
+function mapTokenBundle(
+  assets: HardwareSignResponse["outputs"][number]["assets"],
+): TrezorAssetGroup[] | undefined {
+  if (!assets || assets.length === 0) return undefined;
+  const byPolicy = new Map<string, { assetNameBytes: string; amount: string }[]>();
+  for (const a of assets) {
+    const tokens = byPolicy.get(a.policy_id_hex) ?? [];
+    tokens.push({ assetNameBytes: a.asset_name_hex, amount: a.amount });
+    byPolicy.set(a.policy_id_hex, tokens);
+  }
+  return Array.from(byPolicy, ([policyId, tokenAmounts]) => ({ policyId, tokenAmounts }));
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
 
 /**
  * Connect to a Trezor device via Trezor Connect and return a HardwareSigner.
  *
- * @param opts.requestExternalConsent - REQUIRED in practice: it must resolve
- *   true before any connect.trezor.io contact is made. If it is absent or
- *   resolves false, no SDK is loaded, init() is never called, and this throws.
+ * @param opts.requestExternalConsent - MANDATORY (enforced by the type and at
+ *   runtime): it must resolve true before any connect.trezor.io contact is
+ *   made. If it is absent or resolves false, no SDK is loaded, init() is never
+ *   called, and this throws.
  */
-export async function connectTrezor(opts?: ConnectOptions): Promise<HardwareSigner> {
+export async function connectTrezor(opts: ExternalConnectOptions): Promise<HardwareSigner> {
   // CONSENT-LAW GATE — nothing external happens before this resolves true.
-  const approved = opts?.requestExternalConsent ? await opts.requestExternalConsent() : false;
+  // The consent callback is mandatory for this external-network connector; a
+  // missing callback (e.g. an untyped JS caller) is rejected, never treated as
+  // implicit approval.
+  const consent = opts?.requestExternalConsent;
+  if (typeof consent !== "function") {
+    throw new Error(
+      "Connecting a Trezor contacts connect.trezor.io; a consent callback is required before proceeding.",
+    );
+  }
+  const approved = await consent();
   if (!approved) {
     throw new Error(
       "Connecting a Trezor contacts connect.trezor.io; approval is required before proceeding.",
@@ -95,10 +137,18 @@ export async function connectTrezor(opts?: ConnectOptions): Promise<HardwareSign
   // initial load and makes it impossible to init() it before approval.
   const { default: TrezorConnect, PROTO } = await import("@trezor/connect-web");
 
-  if (!trezorInitialized) {
-    await TrezorConnect.init({ manifest: TREZOR_MANIFEST, lazyLoad: true });
-    trezorInitialized = true;
+  // Guard init with a shared promise so concurrent connects can't both init().
+  if (!trezorInitPromise) {
+    trezorInitPromise = TrezorConnect.init({ manifest: TREZOR_MANIFEST, lazyLoad: true }).catch(
+      (err: unknown) => {
+        // A failed init must not poison future attempts — clear the shared
+        // promise so a later connect can retry from a clean slate.
+        trezorInitPromise = null;
+        throw err;
+      },
+    );
   }
+  await trezorInitPromise;
 
   return {
     kind: "trezor",
@@ -128,8 +178,12 @@ export async function connectTrezor(opts?: ConnectOptions): Promise<HardwareSign
         prev_index: inp.output_index,
       }));
 
-      const outputs = req.outputs.map((out) =>
-        out.payment_path && out.stake_path
+      const outputs = req.outputs.map((out) => {
+        // Carry any native assets grouped by policy id so the device signs the
+        // same tx the backend built; without this a multi-asset send would sign
+        // an ADA-only output that drops the tokens.
+        const tokenBundle = mapTokenBundle(out.assets);
+        return out.payment_path && out.stake_path
           ? {
               // Wallet-owned change: describe it by path so the device can
               // recognise it as its own and not prompt as an external send.
@@ -139,13 +193,15 @@ export async function connectTrezor(opts?: ConnectOptions): Promise<HardwareSign
                 stakingPath: parseBip32Path(out.stake_path),
               },
               amount: out.lovelace,
+              ...(tokenBundle ? { tokenBundle } : {}),
             }
           : {
               // Third-party recipient: the bech32 address as displayed.
               address: out.address_bech32,
               amount: out.lovelace,
-            },
-      );
+              ...(tokenBundle ? { tokenBundle } : {}),
+            };
+      });
 
       const res = await TrezorConnect.cardanoSignTransaction({
         signingMode: PROTO.CardanoTxSigningMode.ORDINARY_TRANSACTION,
@@ -173,7 +229,7 @@ export async function connectTrezor(opts?: ConnectOptions): Promise<HardwareSign
     async close(): Promise<void> {
       // Release the iframe/popup transport. A fresh connect re-inits it.
       TrezorConnect.dispose();
-      trezorInitialized = false;
+      trezorInitPromise = null;
     },
   };
 }

--- a/ui/web/src/hw/trezor.ts
+++ b/ui/web/src/hw/trezor.ts
@@ -1,0 +1,179 @@
+/**
+ * hw/trezor.ts — Trezor Connect wrapper for the Cardano app (send-parity).
+ *
+ * CONSENT-LAW GATE: @trezor/connect-web talks to connect.trezor.io. Unlike the
+ * Ledger path (WebHID, fully local), a Trezor connection LEAVES the user's
+ * node. So:
+ *   - the SDK is imported dynamically, only inside connectTrezor(), never at
+ *     module load — importing it eagerly would pull the cloud bundle into the
+ *     initial page and is easy to accidentally init;
+ *   - TrezorConnect.init() (which loads the connect.trezor.io iframe) is called
+ *     ONLY after the caller's requestExternalConsent() resolves true.
+ *
+ * Xpub/witness encoding parity is guaranteed by reusing the shared hw/xpub.ts
+ * and hw/witness.ts encoders (identical output to the Ledger path for the same
+ * key material — see trezor.test.ts).
+ */
+
+import type { HardwareSignResponse } from "../api/types";
+import type { ConnectOptions, HardwareCapabilities, HardwareSigner } from "./types";
+import { encodeXpub } from "./xpub";
+import { encodeWitnessArray } from "./witness";
+
+// ── BIP32 path ───────────────────────────────────────────────────────────────
+
+const HARDENED = 0x80000000;
+
+/** Convert account index to the CIP-1852 account-level path array. */
+function accountPath(account: number): number[] {
+  return [1852 + HARDENED, 1815 + HARDENED, account + HARDENED];
+}
+
+// parseBip32Path converts a CIP-1852 path string to a numeric array.
+// "1852'/1815'/0'/0/3" → [0x80000000+1852, 0x80000000+1815, 0x80000000+0, 0, 3]
+// Passed to Trezor as an explicit number[] rather than the "m/…" string form so
+// the derivation is unambiguous regardless of the SDK's string-path parsing.
+function parseBip32Path(pathStr: string): number[] {
+  return pathStr.split("/").map((seg) => {
+    const hardened = seg.endsWith("'");
+    const n = parseInt(hardened ? seg.slice(0, -1) : seg, 10);
+    return hardened ? n + HARDENED : n;
+  });
+}
+
+// ── Trezor Connect manifest / init ────────────────────────────────────────────
+
+// Trezor requires a manifest identifying the calling app so it can reach out if
+// an integration misbehaves. This is the local Bursa wallet's identity; appUrl
+// is the wallet's own origin when running in a browser context.
+// NOTE (human follow-up): confirm the contact email before shipping.
+const TREZOR_MANIFEST = {
+  appName: "Bursa Wallet",
+  email: "wallet@blinklabs.io",
+  appUrl:
+    typeof window !== "undefined" && window.location?.origin
+      ? window.location.origin
+      : "https://blinklabs.io",
+};
+
+// init() loads the connect.trezor.io iframe once per page; a second call throws
+// "already initialized". Track it so repeated connects (and reconnect after a
+// close/dispose) behave, without re-loading the iframe unnecessarily.
+let trezorInitialized = false;
+
+// ── Capabilities ──────────────────────────────────────────────────────────────
+
+// Trezor currently signs send (ordinary) transactions on-device; the other
+// flows are declared unsupported until their neutral→Trezor mappings land.
+const TREZOR_CAPABILITIES: HardwareCapabilities = {
+  send: true,
+  staking: false,
+  governance: false,
+  multisig: false,
+  poolReg: false,
+};
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Connect to a Trezor device via Trezor Connect and return a HardwareSigner.
+ *
+ * @param opts.requestExternalConsent - REQUIRED in practice: it must resolve
+ *   true before any connect.trezor.io contact is made. If it is absent or
+ *   resolves false, no SDK is loaded, init() is never called, and this throws.
+ */
+export async function connectTrezor(opts?: ConnectOptions): Promise<HardwareSigner> {
+  // CONSENT-LAW GATE — nothing external happens before this resolves true.
+  const approved = opts?.requestExternalConsent ? await opts.requestExternalConsent() : false;
+  if (!approved) {
+    throw new Error(
+      "Connecting a Trezor contacts connect.trezor.io; approval is required before proceeding.",
+    );
+  }
+
+  // Import the SDK only now, after consent — keeps the cloud bundle out of the
+  // initial load and makes it impossible to init() it before approval.
+  const { default: TrezorConnect, PROTO } = await import("@trezor/connect-web");
+
+  if (!trezorInitialized) {
+    await TrezorConnect.init({ manifest: TREZOR_MANIFEST, lazyLoad: true });
+    trezorInitialized = true;
+  }
+
+  return {
+    kind: "trezor",
+    capabilities: TREZOR_CAPABILITIES,
+
+    async getAccountXpub(account: number): Promise<string> {
+      const res = await TrezorConnect.cardanoGetPublicKey({
+        path: accountPath(account),
+        showOnTrezor: false,
+      });
+      if (!res.success) {
+        throw new Error(res.payload.error);
+      }
+      // The extended public key is carried as node.public_key || node.chain_code
+      // (32 + 32 bytes). Re-encode through the shared helper so the bech32
+      // "root_xvk" string is byte-for-byte identical to the Ledger/Go output.
+      const { public_key, chain_code } = res.payload.node;
+      return encodeXpub(public_key, chain_code);
+    },
+
+    async signTx(req: HardwareSignResponse): Promise<string> {
+      // Map the neutral request to Trezor's ORDINARY signing shape. Only the
+      // payment inputs/outputs needed for send-parity are populated here.
+      const inputs = req.inputs.map((inp) => ({
+        path: inp.path ? parseBip32Path(inp.path) : undefined,
+        prev_hash: inp.tx_hash_hex,
+        prev_index: inp.output_index,
+      }));
+
+      const outputs = req.outputs.map((out) =>
+        out.payment_path && out.stake_path
+          ? {
+              // Wallet-owned change: describe it by path so the device can
+              // recognise it as its own and not prompt as an external send.
+              addressParameters: {
+                addressType: PROTO.CardanoAddressType.BASE,
+                path: parseBip32Path(out.payment_path),
+                stakingPath: parseBip32Path(out.stake_path),
+              },
+              amount: out.lovelace,
+            }
+          : {
+              // Third-party recipient: the bech32 address as displayed.
+              address: out.address_bech32,
+              amount: out.lovelace,
+            },
+      );
+
+      const res = await TrezorConnect.cardanoSignTransaction({
+        signingMode: PROTO.CardanoTxSigningMode.ORDINARY_TRANSACTION,
+        inputs,
+        outputs,
+        fee: req.fee,
+        ...(req.ttl ? { ttl: req.ttl } : {}),
+        protocolMagic: req.protocol_magic,
+        networkId: req.network_id,
+        ...(req.include_network_id ? { includeNetworkId: true } : {}),
+      });
+      if (!res.success) {
+        throw new Error(res.payload.error);
+      }
+
+      // Trezor returns one witness per signer as {pubKey, signature}; the shared
+      // encoder turns those into the canonical [[pubkey, sig], …] CBOR array.
+      const resolved = res.payload.witnesses.map((w) => ({
+        pubKeyHex: w.pubKey,
+        sigHex: w.signature,
+      }));
+      return encodeWitnessArray(resolved);
+    },
+
+    async close(): Promise<void> {
+      // Release the iframe/popup transport. A fresh connect re-inits it.
+      TrezorConnect.dispose();
+      trezorInitialized = false;
+    },
+  };
+}

--- a/ui/web/src/hw/trezor.ts
+++ b/ui/web/src/hw/trezor.ts
@@ -64,9 +64,15 @@ const TREZOR_MANIFEST = {
 // "already initialized". A SHARED init promise makes the lifecycle safe under
 // concurrent connectTrezor() calls: two callers (e.g. a double-click) await the
 // same in-flight init instead of both racing to init(). A failed init clears
-// the promise so a later connect can retry; close() clears it so a fresh
-// connect re-inits after dispose.
+// the promise so a later connect can retry.
 let trezorInitPromise: Promise<void> | null = null;
+
+// The connect.trezor.io transport is module-wide (one iframe per page), so it
+// is shared by every live signer. Reference-count the live signers and dispose
+// the transport (and clear the shared init) only when the LAST one closes —
+// otherwise closing one of two concurrent sessions would tear the transport out
+// from under the other, breaking its getAccountXpub/signTx.
+let activeSignerCount = 0;
 
 // ── Capabilities ──────────────────────────────────────────────────────────────
 
@@ -150,6 +156,13 @@ export async function connectTrezor(opts: ExternalConnectOptions): Promise<Hardw
   }
   await trezorInitPromise;
 
+  // Init succeeded: this signer now shares the module-wide transport. Counted
+  // here (after the await) so a failed init never leaves a phantom reference.
+  activeSignerCount += 1;
+
+  // Guards against a double close() double-decrementing the shared count.
+  let closed = false;
+
   return {
     kind: "trezor",
     capabilities: TREZOR_CAPABILITIES,
@@ -227,9 +240,18 @@ export async function connectTrezor(opts: ExternalConnectOptions): Promise<Hardw
     },
 
     async close(): Promise<void> {
-      // Release the iframe/popup transport. A fresh connect re-inits it.
-      TrezorConnect.dispose();
-      trezorInitPromise = null;
+      // Idempotent: a second close() on the same signer must not decrement the
+      // shared count again.
+      if (closed) return;
+      closed = true;
+      activeSignerCount -= 1;
+      // Only the LAST live signer tears down the shared transport, so a
+      // concurrent session stays usable. A fresh connect re-inits afterwards.
+      if (activeSignerCount <= 0) {
+        activeSignerCount = 0;
+        TrezorConnect.dispose();
+        trezorInitPromise = null;
+      }
     },
   };
 }

--- a/ui/web/src/hw/types.ts
+++ b/ui/web/src/hw/types.ts
@@ -56,13 +56,29 @@ export interface HardwareSigner {
 }
 
 /**
- * Options passed to a device connector.
- *
- * `requestExternalConsent` is the CONSENT-LAW gate for devices that reach a
- * cloud service (Trezor loads connect.trezor.io). The connector MUST await it
- * and only proceed with the external connection when it resolves `true`.
- * Fully-local devices (Ledger via WebHID) ignore it.
+ * Options for a fully-local connector (Ledger via WebHID). No external
+ * network is contacted, so no consent gate applies; the field is forbidden
+ * so a local connector is never accidentally handed a cloud consent callback.
  */
-export interface ConnectOptions {
-  requestExternalConsent?: () => Promise<boolean>;
+export interface LocalConnectOptions {
+  requestExternalConsent?: never;
 }
+
+/**
+ * Options for an external-network connector (Trezor loads connect.trezor.io).
+ *
+ * `requestExternalConsent` is the CONSENT-LAW gate: it is MANDATORY here so a
+ * cloud-reaching device can NEVER be connected without a consent callback.
+ * The connector MUST await it and only proceed once it resolves `true`,
+ * rejecting when it is absent or resolves `false`.
+ */
+export interface ExternalConnectOptions {
+  requestExternalConsent: () => Promise<boolean>;
+}
+
+/**
+ * Options passed to a device connector. A discriminated union: local devices
+ * (Ledger) take {@link LocalConnectOptions}; external-network devices (Trezor)
+ * take {@link ExternalConnectOptions}, which requires the consent callback.
+ */
+export type ConnectOptions = LocalConnectOptions | ExternalConnectOptions;

--- a/ui/web/src/hw/types.ts
+++ b/ui/web/src/hw/types.ts
@@ -1,0 +1,68 @@
+/**
+ * hw/types.ts — Device-agnostic hardware-signer abstraction.
+ *
+ * The backend already speaks in NEUTRAL, device-agnostic terms: it emits a
+ * `HardwareSignResponse` (structured tx fields, CIP-1852 paths) and accepts a
+ * standard vkey-witness-array CBOR back. This interface mirrors that contract
+ * on the client so the UI (AddWallet, Send) never names a specific device —
+ * each signer implementation owns its own neutral→device→neutral mapping.
+ */
+
+import type { HardwareSignResponse } from "../api/types";
+
+/** Which hardware device a signer talks to. */
+export type HardwareKind = "ledger" | "trezor" | "keystone";
+
+/**
+ * What a given device can sign today. Send-parity is the current baseline for
+ * every implemented device; staking/governance/multisig/poolReg are declared
+ * so the UI can gate those flows per-device as they land, without a new type.
+ */
+export interface HardwareCapabilities {
+  send: boolean;
+  staking: boolean;
+  governance: boolean;
+  multisig: boolean;
+  poolReg: boolean;
+}
+
+/**
+ * A live session with a connected hardware device.
+ *
+ * `signTx` takes the backend's neutral request and returns the standard
+ * witness-array CBOR hex the submit endpoint expects — the device-specific
+ * request/response shaping is entirely internal to each implementation.
+ */
+export interface HardwareSigner {
+  readonly kind: HardwareKind;
+  readonly capabilities: HardwareCapabilities;
+
+  /**
+   * Derive the account-level extended public key (m/1852'/1815'/<account>')
+   * from the device, encoded as the bech32 "root_xvk" string the backend
+   * accepts (see hw/xpub.ts for the canonical encoding).
+   */
+  getAccountXpub(account: number): Promise<string>;
+
+  /**
+   * Sign a transaction on the device.
+   * @param req - The backend's neutral HardwareSignResponse.
+   * @returns CBOR-encoded raw vkey-witness array hex string.
+   */
+  signTx(req: HardwareSignResponse): Promise<string>;
+
+  /** Release the device connection / dispose of any external transport. */
+  close(): Promise<void>;
+}
+
+/**
+ * Options passed to a device connector.
+ *
+ * `requestExternalConsent` is the CONSENT-LAW gate for devices that reach a
+ * cloud service (Trezor loads connect.trezor.io). The connector MUST await it
+ * and only proceed with the external connection when it resolves `true`.
+ * Fully-local devices (Ledger via WebHID) ignore it.
+ */
+export interface ConnectOptions {
+  requestExternalConsent?: () => Promise<boolean>;
+}

--- a/ui/web/src/hw/types.ts
+++ b/ui/web/src/hw/types.ts
@@ -77,8 +77,22 @@ export interface ExternalConnectOptions {
 }
 
 /**
- * Options passed to a device connector. A discriminated union: local devices
- * (Ledger) take {@link LocalConnectOptions}; external-network devices (Trezor)
- * take {@link ExternalConnectOptions}, which requires the consent callback.
+ * Options passed to a device connector. A union of the two option shapes; the
+ * per-kind contract is enforced by {@link ConnectOptionsByKind} at the
+ * connectDevice factory boundary, not by this union on its own.
  */
 export type ConnectOptions = LocalConnectOptions | ExternalConnectOptions;
+
+/**
+ * Ties each {@link HardwareKind} to the connect-options it accepts, so the
+ * factory can discriminate at compile time: a local device (Ledger) can NEVER
+ * be handed a cloud-consent callback, and an external device (Trezor) can NEVER
+ * be connected without one. Enforced via the kind-specific `connectDevice`
+ * overloads in hw/index.ts. (Keystone is unsupported this phase; it accepts the
+ * broad union and is rejected at runtime.)
+ */
+export interface ConnectOptionsByKind {
+  ledger: LocalConnectOptions;
+  trezor: ExternalConnectOptions;
+  keystone: ConnectOptions;
+}

--- a/ui/web/src/hw/witness.ts
+++ b/ui/web/src/hw/witness.ts
@@ -1,0 +1,64 @@
+/**
+ * hw/witness.ts — Raw vkey-witness-array CBOR encoding, shared by every
+ * hardware signer.
+ *
+ * The backend's SubmitSigned / submit-hardware endpoint consumes a standard
+ * witness array:
+ *   [[pubkey_bytes, sig_bytes], ...]
+ *     - each witness = [32-byte Ed25519 pubkey, 64-byte Ed25519 signature]
+ *
+ * Every device returns its witnesses in its own shape (Ledger: path→pubkey +
+ * signature; Trezor: pubKey + signature per witness); each maps them to the
+ * {pubKeyHex, sigHex} pairs this single encoder turns into the canonical CBOR.
+ */
+
+import { hexToBytes, bytesToHex } from "./hex";
+
+// ── CBOR helpers (minimal, covers only the witness-set structure) ─────────────
+
+/**
+ * Encode a small non-negative integer as CBOR unsigned int.
+ * This is only ever called with small witness-array cardinalities (the count of
+ * distinct signers in a transaction), NOT with lovelace amounts (those go
+ * through the device SDK's own encoders). The 65535 cap is therefore never
+ * reached in practice.
+ */
+function cborUint(n: number): number[] {
+  if (n < 24) return [n];
+  if (n < 256) return [0x18, n];
+  if (n < 65536) return [0x19, n >> 8, n & 0xff];
+  throw new RangeError(`cborUint: ${n} is too large`);
+}
+
+/** Encode a byte array as a CBOR byte string. */
+function cborBytes(hex: string): number[] {
+  const bytes = hexToBytes(hex);
+  const hdr = cborUint(bytes.length);
+  hdr[0] |= 0x40; // major type 2 = byte string
+  return [...hdr, ...Array.from(bytes)];
+}
+
+/** Encode a fixed-size array of already-encoded CBOR items. */
+function cborArray(items: number[][]): number[] {
+  const hdr = cborUint(items.length);
+  hdr[0] |= 0x80; // major type 4 = array
+  return [...hdr, ...items.flat()];
+}
+
+/**
+ * Encode the raw vkey-witness array consumed by the backend's SubmitSigned.
+ *
+ * Format: [[pubkey_bytes, sig_bytes], ...]
+ *   - each witness = [32-byte Ed25519 pubkey, 64-byte Ed25519 signature]
+ */
+export function encodeWitnessArray(
+  witnesses: { pubKeyHex: string; sigHex: string }[],
+): string {
+  return bytesToHex(
+    cborArray(
+      witnesses.map(({ pubKeyHex, sigHex }) =>
+        cborArray([cborBytes(pubKeyHex), cborBytes(sigHex)]),
+      ),
+    ),
+  );
+}

--- a/ui/web/src/hw/xpub.test.ts
+++ b/ui/web/src/hw/xpub.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "vitest";
+import { encodeXpub } from "./xpub";
+
+// Canonical 32-byte halves (same vector as ledger.test.ts / trezor.test.ts).
+const PUB = "beb7e770b3d0f1932b0a2f3a63285bf9ef7d3e461d55446d6a3911d8f0ee55c0";
+const CC = "b0e2df16538508046649d0e6d5b32969555a23f2f1ebf2db2819359b0d88bd16";
+const XPUB =
+  "root_xvk1h6m7wu9n6rcex2c29uaxx2zml8hh60jxr425gmt28yga3u8w2hqtpcklzefc2zqyveyapek4kv5kj426y0e0r6ljmv5pjdvmpkyt69s8fpd2x";
+
+describe("encodeXpub", () => {
+  test("encodes two 32-byte halves to the canonical bech32 xpub", () => {
+    expect(encodeXpub(PUB, CC)).toBe(XPUB);
+  });
+
+  test("rejects a public key that is not 32 bytes", () => {
+    expect(() => encodeXpub(PUB.slice(0, 62), CC)).toThrow(/public key must be 32 bytes/i);
+    expect(() => encodeXpub(PUB + "aa", CC)).toThrow(/public key must be 32 bytes/i);
+  });
+
+  test("rejects a chain code that is not 32 bytes", () => {
+    expect(() => encodeXpub(PUB, CC.slice(0, 62))).toThrow(/chain code must be 32 bytes/i);
+    expect(() => encodeXpub(PUB, CC + "aa")).toThrow(/chain code must be 32 bytes/i);
+  });
+
+  test("propagates malformed hex rejection", () => {
+    expect(() => encodeXpub("zz", CC)).toThrow(/non-hex/i);
+  });
+});

--- a/ui/web/src/hw/xpub.ts
+++ b/ui/web/src/hw/xpub.ts
@@ -1,0 +1,33 @@
+/**
+ * hw/xpub.ts — Account-level extended-public-key bech32 encoding, shared by
+ * every hardware signer (Ledger, Trezor, …).
+ *
+ * Xpub encoding parity with Go:
+ *   bip32.XPub.String() encodes 64 bytes (publicKey || chainCode) as bech32
+ *   with HRP "root_xvk". The backend's parseAccountXpub accepts that HRP (and
+ *   the account-key HRP), both carrying the same 64-byte pubkey||chaincode.
+ *   Verified against the Go canonical vector for the "abandon ×11 about"
+ *   test mnemonic at account 0 (see ledger.test.ts / trezor.test.ts).
+ *
+ * Every device MUST produce an identical xpub for identical key material, so
+ * this is the single encoder both ledger.ts and trezor.ts call — a per-device
+ * copy could drift and silently import a wallet the backend can't match.
+ */
+
+import { encode as bech32Encode, toWords as bech32ToWords } from "bech32";
+import { hexToBytes } from "./hex";
+
+/**
+ * Encode a raw {publicKeyHex, chainCodeHex} pair as a bech32 xpub with HRP
+ * "root_xvk". This matches Go's bip32.XPub.String() exactly:
+ *   data = publicKey(32 bytes) || chainCode(32 bytes)  →  bech32(root_xvk, data)
+ *
+ * The bech32 package's 90-char default limit is bypassed by passing limit=1000.
+ */
+export function encodeXpub(publicKeyHex: string, chainCodeHex: string): string {
+  const pubBytes = Array.from(hexToBytes(publicKeyHex));
+  const ccBytes = Array.from(hexToBytes(chainCodeHex));
+  const data = new Uint8Array([...pubBytes, ...ccBytes]); // 64 bytes
+  const words = bech32ToWords(data);
+  return bech32Encode("root_xvk", words, 1000 /* no length limit */);
+}

--- a/ui/web/src/hw/xpub.ts
+++ b/ui/web/src/hw/xpub.ts
@@ -25,8 +25,17 @@ import { hexToBytes } from "./hex";
  * The bech32 package's 90-char default limit is bypassed by passing limit=1000.
  */
 export function encodeXpub(publicKeyHex: string, chainCodeHex: string): string {
-  const pubBytes = Array.from(hexToBytes(publicKeyHex));
-  const ccBytes = Array.from(hexToBytes(chainCodeHex));
+  const pubBytes = hexToBytes(publicKeyHex);
+  const ccBytes = hexToBytes(chainCodeHex);
+  // Enforce the xpub layout locally: each half MUST be exactly 32 bytes.
+  // Concatenating a short/long half would silently produce a misaligned or
+  // invalid xpub that the backend cannot match — fail here instead.
+  if (pubBytes.length !== 32) {
+    throw new Error(`encodeXpub: public key must be 32 bytes, got ${pubBytes.length}`);
+  }
+  if (ccBytes.length !== 32) {
+    throw new Error(`encodeXpub: chain code must be 32 bytes, got ${ccBytes.length}`);
+  }
   const data = new Uint8Array([...pubBytes, ...ccBytes]); // 64 bytes
   const words = bech32ToWords(data);
   return bech32Encode("root_xvk", words, 1000 /* no length limit */);

--- a/ui/web/src/screens/AddWallet.test.tsx
+++ b/ui/web/src/screens/AddWallet.test.tsx
@@ -23,7 +23,7 @@ const { mockSession, mockConnectDevice } = vi.hoisted(() => {
 });
 
 vi.mock("../hw", () => ({
-  connectDevice: mockConnectDevice,
+  connectHardware: mockConnectDevice,
 }));
 
 const created: WalletView = {

--- a/ui/web/src/screens/AddWallet.test.tsx
+++ b/ui/web/src/screens/AddWallet.test.tsx
@@ -3,25 +3,27 @@ import { AddWallet } from "./AddWallet";
 import * as client from "../api/client";
 import type { WalletView } from "../api/types";
 
-// ── Ledger mock ───────────────────────────────────────────────────────────────
+// ── Hardware-device mock ────────────────────────────────────────────────────
 const FIXED_XPUB =
   "root_xvk1qpxlt6hkndkymk3lgchrcgpjnkrxkutp6c4p0nwegwuhlhqmlkzjhxm7qhz8c7dw8qvpgm4y8ayjzce7hqjm0p7g4uh6ypmfmzrk4sv4k39n";
 
 // vi.hoisted creates variables that are available before vi.mock() factory runs.
-const { mockSession, mockConnectLedger } = vi.hoisted(() => {
+const { mockSession, mockConnectDevice } = vi.hoisted(() => {
   const mockSession = {
+    kind: "ledger" as const,
+    capabilities: { send: true, staking: false, governance: false, multisig: false, poolReg: false },
     getAccountXpub: vi.fn().mockResolvedValue(
       "root_xvk1qpxlt6hkndkymk3lgchrcgpjnkrxkutp6c4p0nwegwuhlhqmlkzjhxm7qhz8c7dw8qvpgm4y8ayjzce7hqjm0p7g4uh6ypmfmzrk4sv4k39n",
     ),
     signTx: vi.fn(),
     close: vi.fn().mockResolvedValue(undefined),
   };
-  const mockConnectLedger = vi.fn().mockResolvedValue(mockSession);
-  return { mockSession, mockConnectLedger };
+  const mockConnectDevice = vi.fn().mockResolvedValue(mockSession);
+  return { mockSession, mockConnectDevice };
 });
 
-vi.mock("../hw/ledger", () => ({
-  connectLedger: mockConnectLedger,
+vi.mock("../hw", () => ({
+  connectDevice: mockConnectDevice,
 }));
 
 const created: WalletView = {
@@ -231,7 +233,7 @@ test("create-confirm: submit stays blocked while the challenge is unanswered or 
   expect(spy).not.toHaveBeenCalled();
 });
 
-// ── Connect Ledger flow ───────────────────────────────────────────────────────
+// ── Connect hardware wallet flow ────────────────────────────────────────────
 
 const hwWallet: WalletView = {
   id: "hw1",
@@ -243,27 +245,34 @@ const hwWallet: WalletView = {
   type: "hardware",
 };
 
-// Helper: navigate from the "choose" screen to the "Connect Ledger" form.
-function goToLedger() {
-  fireEvent.click(screen.getByRole("button", { name: /connect ledger/i }));
+// Helper: navigate from the "choose" screen to the "Connect hardware wallet" form.
+function goToHardware() {
+  fireEvent.click(screen.getByRole("button", { name: /connect hardware wallet/i }));
 }
 
-// Re-arm the connectLedger mock before each Ledger test because
+// Re-arm the connectDevice mock before each hardware test because
 // vi.restoreAllMocks() (called in afterEach above) clears vi.fn() implementations.
+// Also clear localStorage so the device-kind hint from a prior test never leaks.
 beforeEach(() => {
+  localStorage.clear();
   mockSession.getAccountXpub.mockReset().mockResolvedValue(FIXED_XPUB);
   mockSession.close.mockReset().mockResolvedValue(undefined);
-  mockConnectLedger.mockReset().mockResolvedValue(mockSession);
+  mockConnectDevice.mockReset().mockResolvedValue(mockSession);
 });
 
-test("Connect Ledger: calls getAccountXpub(0) then addHardwareWallet, wallet added", async () => {
+test("Connect hardware: Ledger is the default device; connects, adds wallet, stores kind", async () => {
   const hwSpy = vi.spyOn(client, "addHardwareWallet").mockResolvedValue(hwWallet);
   const onAdded = vi.fn();
 
   render(<AddWallet network="preview" knownVaultPassword="vault-pw" onAdded={onAdded} />);
 
-  // Navigate from the chooser to the Ledger form.
-  goToLedger();
+  // Navigate from the chooser to the hardware form.
+  goToHardware();
+
+  // Ledger radio is selected by default.
+  expect(screen.getByRole("radio", { name: /ledger/i })).toBeChecked();
+  // Keystone is listed but disabled (coming soon).
+  expect(screen.getByRole("radio", { name: /keystone/i })).toBeDisabled();
 
   // Fill in wallet name
   fireEvent.change(screen.getByLabelText(/wallet name/i), { target: { value: "Ledger Main" } });
@@ -271,19 +280,55 @@ test("Connect Ledger: calls getAccountXpub(0) then addHardwareWallet, wallet add
   // Trigger connect
   fireEvent.click(screen.getByRole("button", { name: /connect ledger/i }));
 
+  await waitFor(() => expect(mockConnectDevice).toHaveBeenCalled());
+  expect(mockConnectDevice.mock.calls[0][0]).toBe("ledger");
   await waitFor(() => expect(mockSession.getAccountXpub).toHaveBeenCalledWith(0));
   await waitFor(() =>
     expect(hwSpy).toHaveBeenCalledWith("Ledger Main", FIXED_XPUB, 0, "preview", "vault-pw"),
   );
   await waitFor(() => expect(onAdded).toHaveBeenCalledWith(hwWallet));
   expect(mockSession.close).toHaveBeenCalledOnce();
+  // The device-kind hint is persisted so Send reconnects a Ledger.
+  const { getDeviceKind } = await import("../hw/deviceKind");
+  expect(getDeviceKind("hw1")).toBe("ledger");
 });
 
-test("Connect Ledger: derives and stores the selected account index", async () => {
+test("Connect hardware: Trezor requires consent, then connects and stores the trezor kind", async () => {
+  const hwSpy = vi.spyOn(client, "addHardwareWallet").mockResolvedValue(hwWallet);
+  const onAdded = vi.fn();
+
+  render(<AddWallet network="preview" knownVaultPassword="vault-pw" onAdded={onAdded} />);
+  goToHardware();
+
+  // Pick Trezor.
+  fireEvent.click(screen.getByRole("radio", { name: /^trezor$/i }));
+
+  // The connect button is disabled until the external-connection consent is
+  // given (Trezor reaches connect.trezor.io — consent law).
+  const connectButton = screen.getByRole("button", { name: /connect trezor/i });
+  expect(connectButton).toBeDisabled();
+  expect(mockConnectDevice).not.toHaveBeenCalled();
+
+  fireEvent.click(screen.getByRole("checkbox", { name: /connect\.trezor\.io/i }));
+  expect(connectButton).toBeEnabled();
+
+  fireEvent.click(connectButton);
+
+  await waitFor(() => expect(mockConnectDevice).toHaveBeenCalled());
+  expect(mockConnectDevice.mock.calls[0][0]).toBe("trezor");
+  await waitFor(() =>
+    expect(hwSpy).toHaveBeenCalledWith("Trezor Wallet", FIXED_XPUB, 0, "preview", "vault-pw"),
+  );
+  await waitFor(() => expect(onAdded).toHaveBeenCalledWith(hwWallet));
+  const { getDeviceKind } = await import("../hw/deviceKind");
+  expect(getDeviceKind("hw1")).toBe("trezor");
+});
+
+test("Connect hardware: derives and stores the selected account index", async () => {
   const hwSpy = vi.spyOn(client, "addHardwareWallet").mockResolvedValue(hwWallet);
 
   render(<AddWallet network="preview" knownVaultPassword="vault-pw" onAdded={vi.fn()} />);
-  goToLedger();
+  goToHardware();
   fireEvent.change(screen.getByLabelText(/account index/i), { target: { value: "2" } });
   fireEvent.click(screen.getByRole("button", { name: /connect ledger/i }));
 
@@ -291,28 +336,28 @@ test("Connect Ledger: derives and stores the selected account index", async () =
   expect(hwSpy).toHaveBeenCalledWith("Ledger Wallet", FIXED_XPUB, 2, "preview", "vault-pw");
 });
 
-test("Connect Ledger: an empty account index is rejected before touching the device", async () => {
+test("Connect hardware: an empty account index is rejected before touching the device", async () => {
   // Number("") is 0, so an empty field must be caught explicitly — otherwise it
-  // would silently import account 0, a different Ledger account than intended.
+  // would silently import account 0, a different account than intended.
   const hwSpy = vi.spyOn(client, "addHardwareWallet");
 
   render(<AddWallet network="preview" knownVaultPassword="vault-pw" onAdded={vi.fn()} />);
-  goToLedger();
+  goToHardware();
   fireEvent.change(screen.getByLabelText(/account index/i), { target: { value: "" } });
   fireEvent.click(screen.getByRole("button", { name: /connect ledger/i }));
 
   await waitFor(() => expect(screen.getByText(/account index must be an integer/i)).toBeInTheDocument());
-  expect(mockConnectLedger).not.toHaveBeenCalled();
+  expect(mockConnectDevice).not.toHaveBeenCalled();
   expect(hwSpy).not.toHaveBeenCalled();
 });
 
-test("Connect Ledger: closes the session when reading the account xpub fails", async () => {
+test("Connect hardware: closes the session when reading the account xpub fails", async () => {
   mockSession.getAccountXpub.mockRejectedValueOnce(new Error("Cardano app is not open"));
   const hwSpy = vi.spyOn(client, "addHardwareWallet");
 
   render(<AddWallet network="preview" knownVaultPassword="vault-pw" onAdded={vi.fn()} />);
 
-  goToLedger();
+  goToHardware();
   fireEvent.click(screen.getByRole("button", { name: /connect ledger/i }));
 
   await waitFor(() =>
@@ -322,15 +367,15 @@ test("Connect Ledger: closes the session when reading the account xpub fails", a
   expect(hwSpy).not.toHaveBeenCalled();
 });
 
-test("Connect Ledger: WebHID unavailable error message is shown", async () => {
-  mockConnectLedger.mockRejectedValueOnce(
+test("Connect hardware: WebHID unavailable error message is shown", async () => {
+  mockConnectDevice.mockRejectedValueOnce(
     new Error("WebHID not available — open this in a Chromium browser"),
   );
   const onAdded = vi.fn();
 
   render(<AddWallet network="preview" knownVaultPassword="vault-pw" onAdded={onAdded} />);
 
-  goToLedger();
+  goToHardware();
   fireEvent.click(screen.getByRole("button", { name: /connect ledger/i }));
 
   await waitFor(() =>

--- a/ui/web/src/screens/AddWallet.tsx
+++ b/ui/web/src/screens/AddWallet.tsx
@@ -5,8 +5,9 @@ import { Input } from "../components/Input";
 import { Button } from "../components/Button";
 import { CopyButton } from "../components/CopyButton";
 import { addWallet, addHardwareWallet, generateMnemonic, ApiError } from "../api/client";
-import { connectLedger } from "../hw/ledger";
-import type { LedgerSession } from "../hw/ledger";
+import { connectDevice } from "../hw";
+import type { HardwareKind, HardwareSigner } from "../hw";
+import { setDeviceKind } from "../hw/deviceKind";
 import type { WalletView } from "../api/types";
 import { MIN_PASSWORD_LEN, passwordLength } from "../password";
 import { CHALLENGE_WORD_COUNT, isChallengeAnswerCorrect, pickChallengeIndices, validateChallenge } from "../phraseChallenge";
@@ -48,7 +49,21 @@ interface AddWalletProps {
 }
 
 // Mode within the Add Wallet flow.
-type Mode = "choose" | "create" | "create-confirm" | "restore" | "ledger";
+type Mode = "choose" | "create" | "create-confirm" | "restore" | "hardware";
+
+// Selectable hardware devices. Keystone is listed but disabled until its
+// signer lands, so users can see it is planned without being able to pick it.
+const DEVICE_OPTIONS: { kind: HardwareKind; label: string; disabled?: boolean }[] = [
+  { kind: "ledger", label: "Ledger" },
+  { kind: "trezor", label: "Trezor" },
+  { kind: "keystone", label: "Keystone (coming soon)", disabled: true },
+];
+
+const DEVICE_LABELS: Record<HardwareKind, string> = {
+  ledger: "Ledger",
+  trezor: "Trezor",
+  keystone: "Keystone",
+};
 
 export function AddWallet({
   network,
@@ -75,7 +90,13 @@ export function AddWallet({
   const [mnemonic, setMnemonic] = useState("");
   const [spendPassword, setSpendPassword] = useState("");
   const [vaultPassword, setVaultPassword] = useState("");
-  const [ledgerAccountIndex, setLedgerAccountIndex] = useState("0");
+
+  // Hardware-wallet state: which device, which account, and (for a
+  // cloud-reaching device like Trezor) the external-connection consent.
+  const [deviceKind, setDeviceKindState] = useState<HardwareKind>("ledger");
+  const [accountIndex, setAccountIndex] = useState("0");
+  const [externalConsent, setExternalConsent] = useState(false);
+
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -161,12 +182,13 @@ export function AddWallet({
     }
   }
 
-  // --- "Connect Ledger" path -----------------------------------------------
+  // --- Hardware-wallet path -------------------------------------------------
   // No mnemonic and no spending password: the device holds the private key
   // and signs every transaction directly. Only the account-level xpub is
-  // read from the device and stored (watch-only).
+  // read from the device and stored (watch-only). The chosen device kind is
+  // recorded client-side so Send later reconnects the same device.
 
-  async function handleLedgerConnect(e: FormEvent) {
+  async function handleHardwareConnect(e: FormEvent) {
     e.preventDefault();
     setError(null);
 
@@ -176,32 +198,40 @@ export function AddWallet({
       return;
     }
     // Reject an empty field explicitly: Number("") is 0, which would otherwise
-    // pass the integer/range check and silently import Ledger account 0 — a
-    // different account than a user who cleared the field may intend.
-    const trimmedIndex = ledgerAccountIndex.trim();
-    const accountIndex = Number(trimmedIndex);
+    // pass the integer/range check and silently import account 0 — a different
+    // account than a user who cleared the field may intend.
+    const trimmedIndex = accountIndex.trim();
+    const account = Number(trimmedIndex);
     if (
       trimmedIndex === "" ||
-      !Number.isInteger(accountIndex) ||
-      accountIndex < 0 ||
-      accountIndex >= 0x80000000
+      !Number.isInteger(account) ||
+      account < 0 ||
+      account >= 0x80000000
     ) {
       setError("Account index must be an integer from 0 to 2147483647");
       return;
     }
 
     setLoading(true);
-    let session: LedgerSession | null = null;
+    let session: HardwareSigner | null = null;
     try {
-      session = await connectLedger();
-      const xpub = await session.getAccountXpub(accountIndex);
+      // connectDevice dispatches to the right connector. For Trezor the
+      // consent box gates the connect button, so this reports the given
+      // approval; the real init() gate lives inside connectTrezor.
+      session = await connectDevice(deviceKind, {
+        requestExternalConsent: async () => externalConsent,
+      });
+      const xpub = await session.getAccountXpub(account);
+      const defaultName = `${DEVICE_LABELS[deviceKind]} Wallet`;
       const wallet = await addHardwareWallet(
-        name.trim() || "Ledger Wallet",
+        name.trim() || defaultName,
         xpub,
-        accountIndex,
+        account,
         network,
         vaultPw,
       );
+      // Remember which device backs this wallet so Send reconnects it.
+      setDeviceKind(wallet.id, deviceKind);
       onAdded(wallet);
     } catch (err) {
       setError(err instanceof Error ? err.message : "An unexpected error occurred");
@@ -219,7 +249,7 @@ export function AddWallet({
         <p className="helper-text" style={{ marginBottom: "var(--space-3)" }}>
           Create a brand-new wallet with a freshly generated recovery phrase,
           restore an existing one from a phrase you already have, or connect a
-          Ledger hardware wallet.
+          hardware wallet (Ledger or Trezor).
         </p>
         <div className="preview-actions" style={{ flexDirection: "column" }}>
           <Button onClick={handleGenerate} disabled={generating}>
@@ -228,8 +258,8 @@ export function AddWallet({
           <Button variant="ghost" onClick={() => { setError(null); setMode("restore"); }} disabled={generating}>
             Restore from recovery phrase
           </Button>
-          <Button variant="ghost" onClick={() => { setError(null); setMode("ledger"); }} disabled={generating}>
-            Connect Ledger
+          <Button variant="ghost" onClick={() => { setError(null); setMode("hardware"); }} disabled={generating}>
+            Connect hardware wallet
           </Button>
           {onCancel && (
             <Button type="button" variant="ghost" onClick={onCancel}>
@@ -433,19 +463,45 @@ export function AddWallet({
     );
   }
 
-  // --- Mode: ledger (Connect Ledger, no mnemonic or spending password) ----
+  // --- Mode: hardware (connect a device, no mnemonic or spending password) --
 
-  if (mode === "ledger") {
+  if (mode === "hardware") {
+    const deviceLabel = DEVICE_LABELS[deviceKind];
+    // Trezor reaches connect.trezor.io; its connect is gated on explicit
+    // acknowledgement (consent law). Ledger (WebHID) needs no such gate.
+    const needsExternalConsent = deviceKind === "trezor";
     return (
-      <Card title="Connect Ledger">
-        <form onSubmit={handleLedgerConnect}>
+      <Card title="Connect hardware wallet">
+        <form onSubmit={handleHardwareConnect}>
+          <fieldset className="field-group" style={{ border: "none", padding: 0, margin: 0 }}>
+            <legend className="field-label">Device</legend>
+            {DEVICE_OPTIONS.map((opt) => (
+              <label className="checkbox-row" key={opt.kind}>
+                <input
+                  type="radio"
+                  name="hw-device"
+                  value={opt.kind}
+                  checked={deviceKind === opt.kind}
+                  disabled={opt.disabled || loading}
+                  onChange={() => {
+                    setError(null);
+                    setExternalConsent(false);
+                    setDeviceKindState(opt.kind);
+                  }}
+                  aria-label={opt.label}
+                />
+                {opt.label}
+              </label>
+            ))}
+          </fieldset>
+
           <div className="field-group">
-            <label htmlFor="ledger-name">Wallet Name</label>
+            <label htmlFor="hw-name">Wallet Name</label>
             <Input
-              id="ledger-name"
+              id="hw-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              placeholder="e.g. Ledger Main"
+              placeholder={`e.g. ${deviceLabel} Main`}
               aria-label="Wallet Name"
             />
           </div>
@@ -453,24 +509,24 @@ export function AddWallet({
           <NetworkDisplay network={network} />
 
           <div className="field-group">
-            <label htmlFor="ledger-account-index">Account Index</label>
+            <label htmlFor="hw-account-index">Account Index</label>
             <Input
-              id="ledger-account-index"
+              id="hw-account-index"
               type="number"
               min={0}
               max={0x7fffffff}
               step={1}
-              value={ledgerAccountIndex}
-              onChange={(e) => setLedgerAccountIndex(e.target.value)}
+              value={accountIndex}
+              onChange={(e) => setAccountIndex(e.target.value)}
               aria-label="Account Index"
             />
           </div>
 
           {needsVaultPassword && (
             <div className="field-group">
-              <label htmlFor="ledger-vault-password">Vault Password</label>
+              <label htmlFor="hw-vault-password">Vault Password</label>
               <Input
-                id="ledger-vault-password"
+                id="hw-vault-password"
                 type="password"
                 value={vaultPassword}
                 onChange={(e) => setVaultPassword(e.target.value)}
@@ -481,8 +537,21 @@ export function AddWallet({
             </div>
           )}
 
+          {needsExternalConsent && (
+            <label className="checkbox-row">
+              <input
+                type="checkbox"
+                checked={externalConsent}
+                onChange={(e) => setExternalConsent(e.target.checked)}
+                aria-label="Approve contacting connect.trezor.io to reach the Trezor"
+              />
+              I understand this connects to connect.trezor.io to reach my {deviceLabel},
+              which leaves my node.
+            </label>
+          )}
+
           <p className="helper-text">
-            Connect your Ledger device, open the Cardano app, then click Connect Ledger.
+            Connect your {deviceLabel} device, open the Cardano app, then click Connect.
             No spending password is needed — the device signs every transaction.
           </p>
 
@@ -493,8 +562,11 @@ export function AddWallet({
           )}
 
           <div className="preview-actions">
-            <Button type="submit" disabled={loading}>
-              {loading ? "Connecting…" : "Connect Ledger"}
+            <Button
+              type="submit"
+              disabled={loading || (needsExternalConsent && !externalConsent)}
+            >
+              {loading ? "Connecting…" : `Connect ${deviceLabel}`}
             </Button>
             <Button
               type="button"

--- a/ui/web/src/screens/AddWallet.tsx
+++ b/ui/web/src/screens/AddWallet.tsx
@@ -5,7 +5,7 @@ import { Input } from "../components/Input";
 import { Button } from "../components/Button";
 import { CopyButton } from "../components/CopyButton";
 import { addWallet, addHardwareWallet, generateMnemonic, ApiError } from "../api/client";
-import { connectDevice } from "../hw";
+import { connectHardware } from "../hw";
 import type { HardwareKind, HardwareSigner } from "../hw";
 import { setDeviceKind } from "../hw/deviceKind";
 import type { WalletView } from "../api/types";
@@ -215,12 +215,11 @@ export function AddWallet({
     setLoading(true);
     let session: HardwareSigner | null = null;
     try {
-      // connectDevice dispatches to the right connector. For Trezor the
+      // connectHardware dispatches to the right connector. For Trezor the
       // consent box gates the connect button, so this reports the given
-      // approval; the real init() gate lives inside connectTrezor.
-      session = await connectDevice(deviceKind, {
-        requestExternalConsent: async () => externalConsent,
-      });
+      // approval; the real init() gate lives inside connectTrezor. For Ledger
+      // the callback is ignored.
+      session = await connectHardware(deviceKind, async () => externalConsent);
       const xpub = await session.getAccountXpub(account);
       const defaultName = `${DEVICE_LABELS[deviceKind]} Wallet`;
       const wallet = await addHardwareWallet(
@@ -231,6 +230,10 @@ export function AddWallet({
         vaultPw,
       );
       // Remember which device backs this wallet so Send reconnects it.
+      // TODO(follow-up): this hint is client-only (localStorage); persist the
+      // device kind on the server-side wallet record so it survives a browser
+      // wipe or another browser. Send's post-failure device picker mitigates
+      // the wrong-signer risk until then (see hw/deviceKind.ts).
       setDeviceKind(wallet.id, deviceKind);
       onAdded(wallet);
     } catch (err) {

--- a/ui/web/src/screens/Send.test.tsx
+++ b/ui/web/src/screens/Send.test.tsx
@@ -3,12 +3,15 @@ import { Send } from "./Send";
 import * as client from "../api/client";
 import { mockContacts } from "../test/mockContacts";
 import type { Preview, TxResult, HandleInfo, Contact, HardwareSignResponse } from "../api/types";
-import type { LedgerSession } from "../hw/ledger";
+import type { HardwareSigner } from "../hw";
 
-// Mock the ledger module so tests don't try to open WebHID.
-vi.mock("../hw/ledger", () => ({
-  connectLedger: vi.fn(),
+// Mock the hardware factory so tests don't try to open WebHID / a Trezor popup.
+vi.mock("../hw", () => ({
+  connectDevice: vi.fn(),
 }));
+
+// Send-parity capabilities shared by the mock signers below.
+const HW_CAPS = { send: true, staking: false, governance: false, multisig: false, poolReg: false };
 
 const MOCK_PREVIEW: Preview = {
   pending_id: "pending-abc-123",
@@ -545,15 +548,17 @@ test("(r) hardware account: preview shows 'Confirm on your Ledger' with no passw
   expect(screen.getByRole("button", { name: /confirm on.*ledger/i })).toBeInTheDocument();
 });
 
-test("(s) hardware account: confirm flow fetches sign request, calls signTx, submits hardware", async () => {
+test("(s) hardware account: confirm flow connects device, fetches sign request, signs, submits", async () => {
   vi.spyOn(client, "buildSend").mockResolvedValue(MOCK_PREVIEW);
   vi.spyOn(client, "getHardwareSignRequest").mockResolvedValue(MOCK_HW_SIGN_RESP);
   vi.spyOn(client, "submitHardware").mockResolvedValue(MOCK_TX_RESULT);
 
-  const mockSignTx = vi.fn<LedgerSession["signTx"]>().mockResolvedValue("81825820aabb");
+  const mockSignTx = vi.fn<HardwareSigner["signTx"]>().mockResolvedValue("81825820aabb");
   const mockClose = vi.fn().mockResolvedValue(undefined);
-  const { connectLedger } = await import("../hw/ledger");
-  vi.mocked(connectLedger).mockResolvedValue({
+  const { connectDevice } = await import("../hw");
+  vi.mocked(connectDevice).mockResolvedValue({
+    kind: "ledger",
+    capabilities: HW_CAPS,
     getAccountXpub: vi.fn(),
     signTx: mockSignTx,
     close: mockClose,
@@ -574,44 +579,20 @@ test("(s) hardware account: confirm flow fetches sign request, calls signTx, sub
 
   await waitFor(() => {
     expect(client.getHardwareSignRequest).toHaveBeenCalledWith("pending-abc-123");
-    expect(mockSignTx).toHaveBeenCalledWith(
-      expect.objectContaining({
-        tx: expect.objectContaining({
-          requiredSigners: [{ type: "required_signer_hash", hashHex: "aabbccdd" }],
-        }),
-      }),
-    );
+    // Send passes the NEUTRAL backend request straight to the signer; the
+    // device-specific mapping now lives inside the signer (see ledger.test.ts).
+    expect(mockSignTx).toHaveBeenCalledWith(MOCK_HW_SIGN_RESP);
     expect(client.submitHardware).toHaveBeenCalledWith("pending-abc-123", "81825820aabb");
   });
 
-  // The WebHID permission request must begin directly from the confirm click,
-  // before yielding to the backend signing-request fetch.
-  expect(vi.mocked(connectLedger).mock.invocationCallOrder[0]).toBeLessThan(
+  // With no stored device-kind hint, a hardware wallet defaults to Ledger.
+  expect(vi.mocked(connectDevice).mock.calls[0][0]).toBe("ledger");
+
+  // The device connect must begin directly from the confirm click, before
+  // yielding to the backend signing-request fetch (preserves user activation).
+  expect(vi.mocked(connectDevice).mock.invocationCallOrder[0]).toBeLessThan(
     vi.mocked(client.getHardwareSignRequest).mock.invocationCallOrder[0],
   );
-
-  const signRequest = mockSignTx.mock.calls[0][0];
-  expect(signRequest.tx.includeNetworkId).toBe(true);
-  expect(signRequest.tx.outputs).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({ tokenBundle: [] }),
-    ]),
-  );
-  expect(signRequest.tx.outputs.every((output) => Array.isArray(output.tokenBundle))).toBe(true);
-  expect(signRequest.tx.outputs[0].destination).toEqual({
-    type: "third_party",
-    params: { addressHex: "60aabb" },
-  });
-  expect(signRequest.tx.outputs[1].destination).toEqual({
-    type: "device_owned",
-    params: {
-      type: 0,
-      params: {
-        spendingPath: [0x8000073c, 0x80000717, 0x80000000, 0, 0],
-        stakingPath: [0x8000073c, 0x80000717, 0x80000000, 2, 0],
-      },
-    },
-  });
 
   await waitFor(() => {
     expect(screen.getByText(new RegExp(MOCK_TX_RESULT.tx_hash))).toBeInTheDocument();
@@ -619,19 +600,21 @@ test("(s) hardware account: confirm flow fetches sign request, calls signTx, sub
   });
 });
 
-test("(t) hardware account: unsupported tx closes the connected Ledger without signing", async () => {
+test("(t) hardware account: unsupported tx closes the connected device without signing", async () => {
   vi.spyOn(client, "buildSend").mockResolvedValue(MOCK_PREVIEW);
   vi.spyOn(client, "getHardwareSignRequest").mockResolvedValue({
     ...MOCK_HW_SIGN_RESP,
     unsupported: "certificates are not supported on hardware yet",
   });
 
-  const { connectLedger } = await import("../hw/ledger");
-  const mockConnectLedger = vi.mocked(connectLedger);
+  const { connectDevice } = await import("../hw");
+  const mockConnectDevice = vi.mocked(connectDevice);
   const mockSignTx = vi.fn();
   const mockClose = vi.fn().mockResolvedValue(undefined);
-  mockConnectLedger.mockClear();
-  mockConnectLedger.mockResolvedValue({
+  mockConnectDevice.mockClear();
+  mockConnectDevice.mockResolvedValue({
+    kind: "ledger",
+    capabilities: HW_CAPS,
     getAccountXpub: vi.fn(),
     signTx: mockSignTx,
     close: mockClose,
@@ -654,7 +637,7 @@ test("(t) hardware account: unsupported tx closes the connected Ledger without s
     expect(screen.getByText(/cannot be signed on hardware/i)).toBeInTheDocument();
   });
 
-  expect(mockConnectLedger).toHaveBeenCalledOnce();
+  expect(mockConnectDevice).toHaveBeenCalledOnce();
   expect(mockSignTx).not.toHaveBeenCalled();
   expect(mockClose).toHaveBeenCalledOnce();
 });

--- a/ui/web/src/screens/Send.test.tsx
+++ b/ui/web/src/screens/Send.test.tsx
@@ -543,9 +543,41 @@ test("(r) hardware account: preview shows 'Confirm on your Ledger' with no passw
     expect(screen.getByText(/2 inputs/i)).toBeInTheDocument();
   });
 
+  // With no stored device-kind hint, the wallet's device is unknown, so the
+  // preview prompts for it rather than silently defaulting to Ledger.
+  expect(screen.getByText(/which device backs this wallet/i)).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /choose a device/i })).toBeDisabled();
+
+  // Choosing Ledger reveals the Ledger confirm flow.
+  fireEvent.click(screen.getByRole("radio", { name: /ledger/i }));
+
   // Hardware: no password field, shows Ledger button.
   expect(screen.queryByPlaceholderText(/spending password/i)).not.toBeInTheDocument();
   expect(screen.getByRole("button", { name: /confirm on.*ledger/i })).toBeInTheDocument();
+});
+
+test("(r2) hardware account with unknown kind: choosing Trezor gates confirm on consent", async () => {
+  vi.spyOn(client, "buildSend").mockResolvedValue(MOCK_PREVIEW);
+
+  render(<Send isHardware />);
+
+  const inputs = screen.getAllByRole("textbox");
+  fireEvent.change(inputs[0], { target: { value: "addr_test1recipient" } });
+  fireEvent.change(inputs[1], { target: { value: "5" } });
+  fireEvent.click(screen.getByRole("button", { name: /review/i }));
+
+  await waitFor(() => {
+    expect(screen.getByText(/2 inputs/i)).toBeInTheDocument();
+  });
+
+  // Pick Trezor: the confirm button appears but stays disabled until the
+  // connect.trezor.io consent box is ticked (consent-law gate).
+  fireEvent.click(screen.getByRole("radio", { name: /trezor/i }));
+  const confirm = screen.getByRole("button", { name: /confirm on.*trezor/i });
+  expect(confirm).toBeDisabled();
+
+  fireEvent.click(screen.getByRole("checkbox", { name: /connect\.trezor\.io/i }));
+  expect(confirm).not.toBeDisabled();
 });
 
 test("(s) hardware account: confirm flow connects device, fetches sign request, signs, submits", async () => {
@@ -575,6 +607,8 @@ test("(s) hardware account: confirm flow connects device, fetches sign request, 
     expect(screen.getByText(/2 inputs/i)).toBeInTheDocument();
   });
 
+  // No stored hint → choose the device, then confirm on it.
+  fireEvent.click(screen.getByRole("radio", { name: /ledger/i }));
   fireEvent.click(screen.getByRole("button", { name: /confirm on.*ledger/i }));
 
   await waitFor(() => {
@@ -585,7 +619,7 @@ test("(s) hardware account: confirm flow connects device, fetches sign request, 
     expect(client.submitHardware).toHaveBeenCalledWith("pending-abc-123", "81825820aabb");
   });
 
-  // With no stored device-kind hint, a hardware wallet defaults to Ledger.
+  // The user chose Ledger above, so that is the device we connect.
   expect(vi.mocked(connectDevice).mock.calls[0][0]).toBe("ledger");
 
   // The device connect must begin directly from the confirm click, before
@@ -631,6 +665,7 @@ test("(t) hardware account: unsupported tx closes the connected device without s
     expect(screen.getByText(/2 inputs/i)).toBeInTheDocument();
   });
 
+  fireEvent.click(screen.getByRole("radio", { name: /ledger/i }));
   fireEvent.click(screen.getByRole("button", { name: /confirm on.*ledger/i }));
 
   await waitFor(() => {
@@ -640,4 +675,31 @@ test("(t) hardware account: unsupported tx closes the connected device without s
   expect(mockConnectDevice).toHaveBeenCalledOnce();
   expect(mockSignTx).not.toHaveBeenCalled();
   expect(mockClose).toHaveBeenCalledOnce();
+});
+
+test("(u) hardware account with a stored Trezor hint: no device prompt, gates on consent", async () => {
+  vi.spyOn(client, "buildSend").mockResolvedValue(MOCK_PREVIEW);
+  localStorage.clear();
+  localStorage.setItem("bursa.hw.deviceKind", JSON.stringify({ "hw-trez": "trezor" }));
+
+  render(<Send isHardware walletId="hw-trez" />);
+
+  const inputs = screen.getAllByRole("textbox");
+  fireEvent.change(inputs[0], { target: { value: "addr_test1recipient" } });
+  fireEvent.change(inputs[1], { target: { value: "5" } });
+  fireEvent.click(screen.getByRole("button", { name: /review/i }));
+
+  await waitFor(() => {
+    expect(screen.getByText(/2 inputs/i)).toBeInTheDocument();
+  });
+
+  // The stored hint means the device is known — no picker is shown, and the
+  // Trezor confirm is gated straight on the consent box.
+  expect(screen.queryByText(/which device backs this wallet/i)).not.toBeInTheDocument();
+  const confirm = screen.getByRole("button", { name: /confirm on.*trezor/i });
+  expect(confirm).toBeDisabled();
+  fireEvent.click(screen.getByRole("checkbox", { name: /connect\.trezor\.io/i }));
+  expect(confirm).not.toBeDisabled();
+
+  localStorage.clear();
 });

--- a/ui/web/src/screens/Send.test.tsx
+++ b/ui/web/src/screens/Send.test.tsx
@@ -7,7 +7,7 @@ import type { HardwareSigner } from "../hw";
 
 // Mock the hardware factory so tests don't try to open WebHID / a Trezor popup.
 vi.mock("../hw", () => ({
-  connectDevice: vi.fn(),
+  connectHardware: vi.fn(),
 }));
 
 // Send-parity capabilities shared by the mock signers below.
@@ -587,8 +587,8 @@ test("(s) hardware account: confirm flow connects device, fetches sign request, 
 
   const mockSignTx = vi.fn<HardwareSigner["signTx"]>().mockResolvedValue("81825820aabb");
   const mockClose = vi.fn().mockResolvedValue(undefined);
-  const { connectDevice } = await import("../hw");
-  vi.mocked(connectDevice).mockResolvedValue({
+  const { connectHardware } = await import("../hw");
+  vi.mocked(connectHardware).mockResolvedValue({
     kind: "ledger",
     capabilities: HW_CAPS,
     getAccountXpub: vi.fn(),
@@ -620,11 +620,11 @@ test("(s) hardware account: confirm flow connects device, fetches sign request, 
   });
 
   // The user chose Ledger above, so that is the device we connect.
-  expect(vi.mocked(connectDevice).mock.calls[0][0]).toBe("ledger");
+  expect(vi.mocked(connectHardware).mock.calls[0][0]).toBe("ledger");
 
   // The device connect must begin directly from the confirm click, before
   // yielding to the backend signing-request fetch (preserves user activation).
-  expect(vi.mocked(connectDevice).mock.invocationCallOrder[0]).toBeLessThan(
+  expect(vi.mocked(connectHardware).mock.invocationCallOrder[0]).toBeLessThan(
     vi.mocked(client.getHardwareSignRequest).mock.invocationCallOrder[0],
   );
 
@@ -641,8 +641,8 @@ test("(t) hardware account: unsupported tx closes the connected device without s
     unsupported: "certificates are not supported on hardware yet",
   });
 
-  const { connectDevice } = await import("../hw");
-  const mockConnectDevice = vi.mocked(connectDevice);
+  const { connectHardware } = await import("../hw");
+  const mockConnectDevice = vi.mocked(connectHardware);
   const mockSignTx = vi.fn();
   const mockClose = vi.fn().mockResolvedValue(undefined);
   mockConnectDevice.mockClear();
@@ -700,6 +700,100 @@ test("(u) hardware account with a stored Trezor hint: no device prompt, gates on
   expect(confirm).toBeDisabled();
   fireEvent.click(screen.getByRole("checkbox", { name: /connect\.trezor\.io/i }));
   expect(confirm).not.toBeDisabled();
+
+  localStorage.clear();
+});
+
+test("(v) a failed hardware attempt keeps the picker and does NOT persist the pick", async () => {
+  vi.spyOn(client, "buildSend").mockResolvedValue(MOCK_PREVIEW);
+  localStorage.clear();
+
+  const { connectHardware } = await import("../hw");
+  const mockConnect = vi.mocked(connectHardware);
+  mockConnect.mockReset();
+  // Simulate picking the wrong device: the connection attempt fails.
+  mockConnect.mockRejectedValue(new Error("no matching device found"));
+
+  render(<Send isHardware walletId="hw-recover" />);
+
+  const inputs = screen.getAllByRole("textbox");
+  fireEvent.change(inputs[0], { target: { value: "addr_test1recipient" } });
+  fireEvent.change(inputs[1], { target: { value: "5" } });
+  fireEvent.click(screen.getByRole("button", { name: /review/i }));
+
+  await waitFor(() => {
+    expect(screen.getByText(/2 inputs/i)).toBeInTheDocument();
+  });
+
+  // Pick the (wrong) device and try to confirm — the attempt fails.
+  fireEvent.click(screen.getByRole("radio", { name: /ledger/i }));
+  fireEvent.click(screen.getByRole("button", { name: /confirm on.*ledger/i }));
+
+  await waitFor(() => {
+    expect(screen.getByRole("alert")).toHaveTextContent(/no matching device/i);
+  });
+
+  // The picker is STILL reachable so the user can change the device.
+  expect(screen.getByText(/which device backs this wallet/i)).toBeInTheDocument();
+  expect(screen.getByRole("radio", { name: /trezor/i })).toBeInTheDocument();
+
+  // The mistaken pick was NOT persisted — only a successful send persists.
+  const { getStoredDeviceKind } = await import("../hw/deviceKind");
+  expect(getStoredDeviceKind("hw-recover")).toBeUndefined();
+
+  // Switching to the other device and retrying connects THAT device.
+  fireEvent.click(screen.getByRole("radio", { name: /trezor/i }));
+  fireEvent.click(screen.getByRole("checkbox", { name: /connect\.trezor\.io/i }));
+  fireEvent.click(screen.getByRole("button", { name: /confirm on.*trezor/i }));
+
+  await waitFor(() => {
+    const kinds = mockConnect.mock.calls.map((c) => c[0]);
+    expect(kinds[kinds.length - 1]).toBe("trezor");
+  });
+
+  localStorage.clear();
+});
+
+test("(w) a successful hardware send persists the chosen device kind", async () => {
+  vi.spyOn(client, "buildSend").mockResolvedValue(MOCK_PREVIEW);
+  vi.spyOn(client, "getHardwareSignRequest").mockResolvedValue(MOCK_HW_SIGN_RESP);
+  vi.spyOn(client, "submitHardware").mockResolvedValue(MOCK_TX_RESULT);
+  localStorage.clear();
+
+  const { connectHardware } = await import("../hw");
+  const mockConnect = vi.mocked(connectHardware);
+  mockConnect.mockReset();
+  mockConnect.mockResolvedValue({
+    kind: "ledger",
+    capabilities: HW_CAPS,
+    getAccountXpub: vi.fn(),
+    signTx: vi.fn<HardwareSigner["signTx"]>().mockResolvedValue("81825820aabb"),
+    close: vi.fn().mockResolvedValue(undefined),
+  });
+
+  render(<Send isHardware walletId="hw-persist" />);
+
+  const inputs = screen.getAllByRole("textbox");
+  fireEvent.change(inputs[0], { target: { value: "addr_test1recipient" } });
+  fireEvent.change(inputs[1], { target: { value: "5" } });
+  fireEvent.click(screen.getByRole("button", { name: /review/i }));
+
+  await waitFor(() => {
+    expect(screen.getByText(/2 inputs/i)).toBeInTheDocument();
+  });
+
+  const { getStoredDeviceKind } = await import("../hw/deviceKind");
+
+  // Merely SELECTING a device must not persist it.
+  fireEvent.click(screen.getByRole("radio", { name: /ledger/i }));
+  expect(getStoredDeviceKind("hw-persist")).toBeUndefined();
+
+  // A successful send persists the hint so the next send skips the picker.
+  fireEvent.click(screen.getByRole("button", { name: /confirm on.*ledger/i }));
+  await waitFor(() => {
+    expect(screen.getByText(new RegExp(MOCK_TX_RESULT.tx_hash))).toBeInTheDocument();
+  });
+  expect(getStoredDeviceKind("hw-persist")).toBe("ledger");
 
   localStorage.clear();
 });

--- a/ui/web/src/screens/Send.tsx
+++ b/ui/web/src/screens/Send.tsx
@@ -13,7 +13,7 @@ import {
 import { useContacts } from "../api/hooks";
 import { connectDevice } from "../hw";
 import type { HardwareKind, HardwareSigner } from "../hw";
-import { getDeviceKind } from "../hw/deviceKind";
+import { getStoredDeviceKind, setDeviceKind } from "../hw/deviceKind";
 import { Card } from "../components/Card";
 import { Input } from "../components/Input";
 import { Button } from "../components/Button";
@@ -323,9 +323,13 @@ function Compose({ to, setTo, adaAmount, setAdaAmount, assetRows, setAssetRows, 
 
 interface PreviewPhaseProps {
   preview: Preview;
-  // When set, this is a hardware wallet and the on-device confirm flow is used;
-  // the value is the specific device to reconnect for signing.
-  deviceKind?: HardwareKind;
+  // When true, this is a hardware wallet and the on-device confirm flow is used.
+  isHardware: boolean;
+  // The wallet id, used to remember the device kind once known/chosen.
+  walletId?: string;
+  // The device recorded for this wallet, or undefined when unknown (e.g. after
+  // a browser-data wipe) — in which case the user is prompted to choose it.
+  storedDeviceKind?: HardwareKind;
   onBack: () => void;
   onDone: (result: TxResult) => void;
 }
@@ -336,8 +340,20 @@ const OUTPUT_COLUMNS = [
   { key: "assets", label: "Assets" },
 ];
 
-function PreviewPhase({ preview, deviceKind, onBack, onDone }: PreviewPhaseProps) {
-  const isHardware = deviceKind !== undefined;
+function PreviewPhase({
+  preview,
+  isHardware,
+  walletId,
+  storedDeviceKind,
+  onBack,
+  onDone,
+}: PreviewPhaseProps) {
+  // The device to sign with: the stored hint when known, otherwise whatever the
+  // user picks below. When neither is set we must NOT assume a device — we
+  // prompt for one so we never reconnect the wrong signer.
+  const [chosenKind, setChosenKind] = useState<HardwareKind | undefined>(storedDeviceKind);
+  const deviceKind = chosenKind;
+  const needsDeviceChoice = isHardware && deviceKind === undefined;
   const deviceLabel = deviceKind ? DEVICE_LABELS[deviceKind] : "";
   // Trezor reaches connect.trezor.io, so its confirm is gated on an explicit
   // acknowledgement (consent law); local devices (Ledger) need no such gate.
@@ -350,6 +366,15 @@ function PreviewPhase({ preview, deviceKind, onBack, onDone }: PreviewPhaseProps
   const [loading, setLoading] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [exported, setExported] = useState<UnsignedTx | null>(null);
+
+  // Record the user's device choice so a later send reconnects it directly
+  // instead of prompting again (the local recovery path for a lost hint).
+  function chooseDevice(kind: HardwareKind) {
+    setError(null);
+    setExternalConsent(false);
+    setChosenKind(kind);
+    if (walletId) setDeviceKind(walletId, kind);
+  }
 
   const outputRows = preview.outputs.map((o) => ({
     address: o.address,
@@ -379,13 +404,20 @@ function PreviewPhase({ preview, deviceKind, onBack, onDone }: PreviewPhaseProps
   // request — so the connect happens first, directly from the handler.
   async function handleHardwareConfirm() {
     setError(null);
+    // Never assume a device: if the kind is unknown the user must pick one
+    // first (the confirm button is disabled until then, so this is defensive).
+    if (deviceKind === undefined) {
+      setError("Choose which hardware device backs this wallet to continue.");
+      return;
+    }
+    const kind = deviceKind;
     setLoading(true);
     let session: HardwareSigner | null = null;
     try {
       // 1. Connect directly from the click handler so a first-time user can
       // grant WebHID permission while browser user activation is still live.
-      // The device kind is the one recorded when this wallet was added.
-      const kind = deviceKind ?? "ledger";
+      // The device kind is the one recorded when this wallet was added (or the
+      // one the user just chose when no hint was stored).
       session = await connectDevice(kind, {
         // The confirm button is disabled until the Trezor consent box is
         // ticked, so this simply reports the already-given approval; the real
@@ -455,9 +487,36 @@ function PreviewPhase({ preview, deviceKind, onBack, onDone }: PreviewPhaseProps
 
         {isHardware ? (
           <>
-            <p className="helper-text">
-              Connect your {deviceLabel} and confirm the transaction on the device.
-            </p>
+            {needsDeviceChoice ? (
+              // The device kind for this wallet is unknown (e.g. a browser-data
+              // wipe cleared the local hint). Ask which device backs it rather
+              // than silently defaulting to Ledger and reconnecting the wrong
+              // signer.
+              <fieldset className="field-group" style={{ border: "none", padding: 0, margin: 0 }}>
+                <legend className="field-label">Which device backs this wallet?</legend>
+                <p className="helper-text">
+                  We could not tell whether this hardware wallet is a Ledger or a
+                  Trezor. Choose the device you used to add it.
+                </p>
+                {(["ledger", "trezor"] as const).map((k) => (
+                  <label className="checkbox-row" key={k}>
+                    <input
+                      type="radio"
+                      name="send-hw-device"
+                      value={k}
+                      checked={deviceKind === k}
+                      onChange={() => chooseDevice(k)}
+                      aria-label={DEVICE_LABELS[k]}
+                    />
+                    {DEVICE_LABELS[k]}
+                  </label>
+                ))}
+              </fieldset>
+            ) : (
+              <p className="helper-text">
+                Connect your {deviceLabel} and confirm the transaction on the device.
+              </p>
+            )}
             {needsExternalConsent && (
               <label className="checkbox-row">
                 <input
@@ -497,9 +556,14 @@ function PreviewPhase({ preview, deviceKind, onBack, onDone }: PreviewPhaseProps
           {isHardware ? (
             <Button
               onClick={handleHardwareConfirm}
-              disabled={loading || exporting || (needsExternalConsent && !externalConsent)}
+              disabled={
+                loading ||
+                exporting ||
+                needsDeviceChoice ||
+                (needsExternalConsent && !externalConsent)
+              }
             >
-              {loading ? "Signing…" : `Confirm on ${deviceLabel}`}
+              {loading ? "Signing…" : needsDeviceChoice ? "Choose a device" : `Confirm on ${deviceLabel}`}
             </Button>
           ) : (
             <Button onClick={handleConfirm} disabled={loading || exporting || !password}>
@@ -580,10 +644,12 @@ export function Send({
   walletId,
 }: { isHardware?: boolean; walletId?: string } = {}) {
   // For a hardware wallet, look up which device kind backs it so the confirm
-  // flow reconnects the right one. Defaults to "ledger" for wallets added
-  // before device-kind was recorded (see hw/deviceKind.ts).
-  const deviceKind: HardwareKind | undefined = isHardware
-    ? getDeviceKind(walletId ?? "")
+  // flow reconnects the right one. This can be `undefined` (unknown) after a
+  // browser-data wipe or on another browser; in that case the preview prompts
+  // the user to choose the device rather than silently assuming Ledger, which
+  // would try to reconnect the wrong signer (see hw/deviceKind.ts).
+  const storedDeviceKind: HardwareKind | undefined = isHardware
+    ? getStoredDeviceKind(walletId ?? "")
     : undefined;
 
   const [phase, setPhase] = useState<Phase>("compose");
@@ -624,7 +690,9 @@ export function Send({
     return (
       <PreviewPhase
         preview={preview}
-        deviceKind={deviceKind}
+        isHardware={isHardware ?? false}
+        walletId={walletId}
+        storedDeviceKind={storedDeviceKind}
         onBack={() => setPhase("compose")}
         onDone={handleDone}
       />

--- a/ui/web/src/screens/Send.tsx
+++ b/ui/web/src/screens/Send.tsx
@@ -11,7 +11,7 @@ import {
   ApiError,
 } from "../api/client";
 import { useContacts } from "../api/hooks";
-import { connectDevice } from "../hw";
+import { connectHardware } from "../hw";
 import type { HardwareKind, HardwareSigner } from "../hw";
 import { getStoredDeviceKind, setDeviceKind } from "../hw/deviceKind";
 import { Card } from "../components/Card";
@@ -353,6 +353,14 @@ function PreviewPhase({
   // prompt for one so we never reconnect the wrong signer.
   const [chosenKind, setChosenKind] = useState<HardwareKind | undefined>(storedDeviceKind);
   const deviceKind = chosenKind;
+  // The picker stays reachable whenever the device is not yet CONFIRMED by a
+  // stored hint (i.e. no persisted kind for this wallet). A user's pick is only
+  // tentative until a hardware send succeeds, so a wrong pick can be corrected —
+  // even after a failed attempt — by choosing a different device here.
+  const deviceKnownFromHint = storedDeviceKind !== undefined;
+  const showDevicePicker = isHardware && !deviceKnownFromHint;
+  // Confirm is gated until a device is chosen (defensive: the button is disabled
+  // until then), regardless of whether it came from a hint or the picker.
   const needsDeviceChoice = isHardware && deviceKind === undefined;
   const deviceLabel = deviceKind ? DEVICE_LABELS[deviceKind] : "";
   // Trezor reaches connect.trezor.io, so its confirm is gated on an explicit
@@ -367,13 +375,14 @@ function PreviewPhase({
   const [exporting, setExporting] = useState(false);
   const [exported, setExported] = useState<UnsignedTx | null>(null);
 
-  // Record the user's device choice so a later send reconnects it directly
-  // instead of prompting again (the local recovery path for a lost hint).
+  // Select a device to sign with. This is TENTATIVE: the hint is NOT persisted
+  // here, only after a successful hardware send (see handleHardwareConfirm), so
+  // a mistaken pick that never signs is not remembered and can be changed by
+  // picking again — including after a failed attempt.
   function chooseDevice(kind: HardwareKind) {
     setError(null);
     setExternalConsent(false);
     setChosenKind(kind);
-    if (walletId) setDeviceKind(walletId, kind);
   }
 
   const outputRows = preview.outputs.map((o) => ({
@@ -418,12 +427,11 @@ function PreviewPhase({
       // grant WebHID permission while browser user activation is still live.
       // The device kind is the one recorded when this wallet was added (or the
       // one the user just chose when no hint was stored).
-      session = await connectDevice(kind, {
-        // The confirm button is disabled until the Trezor consent box is
-        // ticked, so this simply reports the already-given approval; the real
-        // gate lives in connectTrezor and refuses to init() without it.
-        requestExternalConsent: async () => externalConsent,
-      });
+      // The confirm button is disabled until the Trezor consent box is ticked,
+      // so this simply reports the already-given approval; the real gate lives
+      // in connectTrezor and refuses to init() without it. For a local device
+      // (Ledger) the callback is ignored.
+      session = await connectHardware(kind, async () => externalConsent);
 
       // 2. Fetch the structured signing request once the device is connected.
       const signResp = await getHardwareSignRequest(preview.pending_id);
@@ -438,6 +446,10 @@ function PreviewPhase({
 
       // 4. Submit the signed transaction.
       const result = await submitHardware(preview.pending_id, witnessCbor);
+      // Persist the device-kind hint only NOW — after a successful hardware
+      // send — so a wrong pick that never signs is never remembered. A correct
+      // pick is remembered so a later send reconnects it without prompting.
+      if (walletId) setDeviceKind(walletId, kind);
       onDone(result);
     } catch (e) {
       setError(errorMessage(e));
@@ -487,16 +499,19 @@ function PreviewPhase({
 
         {isHardware ? (
           <>
-            {needsDeviceChoice ? (
-              // The device kind for this wallet is unknown (e.g. a browser-data
-              // wipe cleared the local hint). Ask which device backs it rather
-              // than silently defaulting to Ledger and reconnecting the wrong
-              // signer.
+            {showDevicePicker && (
+              // The device kind for this wallet is not confirmed by a stored
+              // hint (e.g. a browser-data wipe cleared it). Ask which device
+              // backs it rather than silently defaulting to Ledger and
+              // reconnecting the wrong signer. The picker STAYS visible after a
+              // pick so a mistaken choice can be changed — including after a
+              // failed attempt — until a send succeeds and persists the hint.
               <fieldset className="field-group" style={{ border: "none", padding: 0, margin: 0 }}>
                 <legend className="field-label">Which device backs this wallet?</legend>
                 <p className="helper-text">
                   We could not tell whether this hardware wallet is a Ledger or a
-                  Trezor. Choose the device you used to add it.
+                  Trezor. Choose the device you used to add it; you can change
+                  this if a connection attempt fails.
                 </p>
                 {(["ledger", "trezor"] as const).map((k) => (
                   <label className="checkbox-row" key={k}>
@@ -512,7 +527,8 @@ function PreviewPhase({
                   </label>
                 ))}
               </fieldset>
-            ) : (
+            )}
+            {deviceKind !== undefined && (
               <p className="helper-text">
                 Connect your {deviceLabel} and confirm the transaction on the device.
               </p>

--- a/ui/web/src/screens/Send.tsx
+++ b/ui/web/src/screens/Send.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
-import type { Preview, TxResult, SendAsset, UnsignedTx, HandleInfo, HardwareSignResponse } from "../api/types";
+import type { Preview, TxResult, SendAsset, UnsignedTx, HandleInfo } from "../api/types";
 import {
   buildSend,
   confirmSend,
@@ -11,16 +11,9 @@ import {
   ApiError,
 } from "../api/client";
 import { useContacts } from "../api/hooks";
-import { connectLedger } from "../hw/ledger";
-import type { LedgerSession } from "../hw/ledger";
-import type { SignTransactionRequest, TxInput, TxOutput } from "@cardano-foundation/ledgerjs-hw-app-cardano";
-import {
-  AddressType,
-  TransactionSigningMode,
-  TxOutputDestinationType,
-  TxOutputFormat,
-  TxRequiredSignerType,
-} from "@cardano-foundation/ledgerjs-hw-app-cardano";
+import { connectDevice } from "../hw";
+import type { HardwareKind, HardwareSigner } from "../hw";
+import { getDeviceKind } from "../hw/deviceKind";
 import { Card } from "../components/Card";
 import { Input } from "../components/Input";
 import { Button } from "../components/Button";
@@ -29,71 +22,12 @@ import { CopyButton } from "../components/CopyButton";
 import { DownloadButton } from "../components/DownloadButton";
 import { formatAda, parseAda } from "../format";
 
-// parseBip32Path converts a CIP-1852 path string to a numeric array.
-// "1852'/1815'/0'/0/3" → [0x80000000+1852, 0x80000000+1815, 0x80000000+0, 0, 3]
-function parseBip32Path(pathStr: string): number[] {
-  const HARDENED = 0x80000000;
-  return pathStr.split("/").map((seg) => {
-    const hardened = seg.endsWith("'");
-    const n = parseInt(hardened ? seg.slice(0, -1) : seg, 10);
-    return hardened ? n + HARDENED : n;
-  });
-}
-
-// mapToSignRequest converts a HardwareSignResponse (from the backend) to the
-// SignTransactionRequest format that ledgerjs expects.
-function mapToSignRequest(resp: HardwareSignResponse): SignTransactionRequest {
-  const inputs: TxInput[] = resp.inputs.map((inp) => ({
-    txHashHex: inp.tx_hash_hex,
-    outputIndex: inp.output_index,
-    path: inp.path ? parseBip32Path(inp.path) : null,
-  }));
-
-  const outputs: TxOutput[] = resp.outputs.map((out) => {
-    const destination = out.payment_path && out.stake_path
-      ? {
-          type: TxOutputDestinationType.DEVICE_OWNED as const,
-          params: {
-            type: AddressType.BASE_PAYMENT_KEY_STAKE_KEY as const,
-            params: {
-              spendingPath: parseBip32Path(out.payment_path),
-              stakingPath: parseBip32Path(out.stake_path),
-            },
-          },
-        }
-      : {
-          type: TxOutputDestinationType.THIRD_PARTY as const,
-          params: { addressHex: out.address_hex },
-        };
-
-    return {
-      format: TxOutputFormat.ARRAY_LEGACY,
-      destination,
-      amount: BigInt(out.lovelace),
-      // ledgerjs iterates this field even when the output contains ADA only.
-      tokenBundle: [],
-    };
-  });
-
-  return {
-    tx: {
-      network: {
-        protocolMagic: resp.protocol_magic,
-        networkId: resp.network_id,
-      },
-      inputs,
-      outputs,
-      fee: BigInt(resp.fee),
-      ttl: resp.ttl ? BigInt(resp.ttl) : null,
-      requiredSigners: resp.required_signers.map((hashHex) => ({
-        type: TxRequiredSignerType.HASH,
-        hashHex,
-      })),
-      includeNetworkId: resp.include_network_id || null,
-    },
-    signingMode: TransactionSigningMode.ORDINARY_TRANSACTION,
-  };
-}
+// Human-readable device names for the hardware confirm UI.
+const DEVICE_LABELS: Record<HardwareKind, string> = {
+  ledger: "Ledger",
+  trezor: "Trezor",
+  keystone: "Keystone",
+};
 
 type Phase = "compose" | "preview" | "done";
 
@@ -389,7 +323,9 @@ function Compose({ to, setTo, adaAmount, setAdaAmount, assetRows, setAssetRows, 
 
 interface PreviewPhaseProps {
   preview: Preview;
-  isHardware?: boolean;
+  // When set, this is a hardware wallet and the on-device confirm flow is used;
+  // the value is the specific device to reconnect for signing.
+  deviceKind?: HardwareKind;
   onBack: () => void;
   onDone: (result: TxResult) => void;
 }
@@ -400,9 +336,16 @@ const OUTPUT_COLUMNS = [
   { key: "assets", label: "Assets" },
 ];
 
-function PreviewPhase({ preview, isHardware, onBack, onDone }: PreviewPhaseProps) {
+function PreviewPhase({ preview, deviceKind, onBack, onDone }: PreviewPhaseProps) {
+  const isHardware = deviceKind !== undefined;
+  const deviceLabel = deviceKind ? DEVICE_LABELS[deviceKind] : "";
+  // Trezor reaches connect.trezor.io, so its confirm is gated on an explicit
+  // acknowledgement (consent law); local devices (Ledger) need no such gate.
+  const needsExternalConsent = deviceKind === "trezor";
+
   // password is only used in the software (!isHardware) confirm path; hooks cannot be conditional.
   const [password, setPassword] = useState("");
+  const [externalConsent, setExternalConsent] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [exporting, setExporting] = useState(false);
@@ -430,17 +373,25 @@ function PreviewPhase({ preview, isHardware, onBack, onDone }: PreviewPhaseProps
     }
   }
 
-  // Hardware confirm flow: connect Ledger → fetch signing request → signTx → submit.
-  // WebHID's device chooser must be requested while the confirm click still
-  // carries transient user activation, before yielding to a backend request.
+  // Hardware confirm flow: connect device → fetch signing request → signTx → submit.
+  // WebHID's device chooser (Ledger) must be requested while the confirm click
+  // still carries transient user activation, before yielding to a backend
+  // request — so the connect happens first, directly from the handler.
   async function handleHardwareConfirm() {
     setError(null);
     setLoading(true);
-    let session: LedgerSession | null = null;
+    let session: HardwareSigner | null = null;
     try {
       // 1. Connect directly from the click handler so a first-time user can
       // grant WebHID permission while browser user activation is still live.
-      session = await connectLedger();
+      // The device kind is the one recorded when this wallet was added.
+      const kind = deviceKind ?? "ledger";
+      session = await connectDevice(kind, {
+        // The confirm button is disabled until the Trezor consent box is
+        // ticked, so this simply reports the already-given approval; the real
+        // gate lives in connectTrezor and refuses to init() without it.
+        requestExternalConsent: async () => externalConsent,
+      });
 
       // 2. Fetch the structured signing request once the device is connected.
       const signResp = await getHardwareSignRequest(preview.pending_id);
@@ -448,10 +399,10 @@ function PreviewPhase({ preview, isHardware, onBack, onDone }: PreviewPhaseProps
         setError(`This transaction cannot be signed on hardware: ${signResp.unsupported}`);
         return;
       }
-      const request = mapToSignRequest(signResp);
 
-      // 3. Sign on the connected Ledger device.
-      const witnessCbor = await session.signTx(request);
+      // 3. Sign on the connected device (each signer maps the neutral request
+      // to its own SDK internally and returns witness-array CBOR).
+      const witnessCbor = await session.signTx(signResp);
 
       // 4. Submit the signed transaction.
       const result = await submitHardware(preview.pending_id, witnessCbor);
@@ -503,9 +454,23 @@ function PreviewPhase({ preview, isHardware, onBack, onDone }: PreviewPhaseProps
         </dl>
 
         {isHardware ? (
-          <p className="helper-text">
-            Connect your Ledger and confirm the transaction on the device.
-          </p>
+          <>
+            <p className="helper-text">
+              Connect your {deviceLabel} and confirm the transaction on the device.
+            </p>
+            {needsExternalConsent && (
+              <label className="checkbox-row">
+                <input
+                  type="checkbox"
+                  checked={externalConsent}
+                  onChange={(e) => setExternalConsent(e.target.checked)}
+                  aria-label={`Approve contacting connect.trezor.io to sign on ${deviceLabel}`}
+                />
+                I understand this connects to connect.trezor.io to reach my {deviceLabel},
+                which leaves my node.
+              </label>
+            )}
+          </>
         ) : (
           <>
             <label htmlFor="spend-password">Spending password</label>
@@ -530,8 +495,11 @@ function PreviewPhase({ preview, isHardware, onBack, onDone }: PreviewPhaseProps
             Back
           </Button>
           {isHardware ? (
-            <Button onClick={handleHardwareConfirm} disabled={loading || exporting}>
-              {loading ? "Signing…" : "Confirm on Ledger"}
+            <Button
+              onClick={handleHardwareConfirm}
+              disabled={loading || exporting || (needsExternalConsent && !externalConsent)}
+            >
+              {loading ? "Signing…" : `Confirm on ${deviceLabel}`}
             </Button>
           ) : (
             <Button onClick={handleConfirm} disabled={loading || exporting || !password}>
@@ -607,7 +575,17 @@ function DonePhase({ result, onReset }: DonePhaseProps) {
 
 // --- Top-level Send screen ---
 
-export function Send({ isHardware }: { isHardware?: boolean } = {}) {
+export function Send({
+  isHardware,
+  walletId,
+}: { isHardware?: boolean; walletId?: string } = {}) {
+  // For a hardware wallet, look up which device kind backs it so the confirm
+  // flow reconnects the right one. Defaults to "ledger" for wallets added
+  // before device-kind was recorded (see hw/deviceKind.ts).
+  const deviceKind: HardwareKind | undefined = isHardware
+    ? getDeviceKind(walletId ?? "")
+    : undefined;
+
   const [phase, setPhase] = useState<Phase>("compose");
   const [preview, setPreview] = useState<Preview | null>(null);
   const [txResult, setTxResult] = useState<TxResult | null>(null);
@@ -646,7 +624,7 @@ export function Send({ isHardware }: { isHardware?: boolean } = {}) {
     return (
       <PreviewPhase
         preview={preview}
-        isHardware={isHardware}
+        deviceKind={deviceKind}
         onBack={() => setPhase("compose")}
         onDone={handleDone}
       />


### PR DESCRIPTION
Adds a device-agnostic hardware-signing layer and Trezor support (send-parity), extending the existing Ledger integration.

## HardwareSigner abstraction
- `hw/types.ts`: `HardwareKind`, `HardwareCapabilities`, `HardwareSigner`, and a kind-discriminated `ConnectOptions` (Ledger local-only; Trezor requires the external-consent callback — enforced at compile time).
- `signTx` takes the neutral backend `HardwareSignResponse` rather than a device-specific type; each device maps it internally. `mapToSignRequest` moved out of `Send.tsx` into `hw/ledger.ts`.
- Shared encoders (`hw/xpub.ts`, `hw/witness.ts`, `hw/hex.ts`) so all devices produce byte-identical xpub + witness CBOR, with strict 32-byte/hex validation.
- `connectDevice(kind)` factory; `Send.tsx` is device-agnostic — it reconnects the wallet's recorded device, prompts to choose when unknown, and records the kind only after a successful hardware send.

## Trezor
- `hw/trezor.ts` via `@trezor/connect-web` (lazy-loaded, code-split out of the initial bundle). `cardanoGetPublicKey` → account xpub; `cardanoSignTransaction` (ORDINARY) → witness-array CBOR, including native-asset token bundles.
- Consent-gated: `TrezorConnect.init()` (which contacts `connect.trezor.io`) runs only after explicit user consent; the connect/confirm control is disabled until the "leaves my node" box is ticked. Transport disposal is reference-counted so one closed session doesn't drop a concurrent one.
- `AddWallet.tsx`: device picker (Ledger / Trezor; Keystone shown disabled) beside the node's read-only network.

## Verification
`npm run lint` 0 errors · `npm run test` 527 pass · `tsc --noEmit` clean · `vite build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Summary by cubic
Adds a device-agnostic hardware signing layer and Trezor support (send-only) with explicit user consent before any call to `connect.trezor.io`. The UI lets users pick Ledger or Trezor, remembers the device per wallet after a successful send, and produces identical xpub/witness bytes across devices.

- **New Features**
  - `HardwareSigner` abstraction with `connectDevice(kind)` and `connectHardware()`; kind-discriminated `ConnectOptionsByKind`; `signTx` takes a neutral request and returns witness-array CBOR via shared encoders.
  - Trezor via `@trezor/connect-web` (lazy-loaded): consent-gated `init`, send-parity only, shared `xpub`/`witness` encoders for identical bytes.
  - UI: hardware picker (Ledger/Trezor), Send reconnects the saved device or prompts when unknown, device kind saved per wallet after a successful hardware send, and the picker stays available after a failed attempt (Send now receives `walletId`).

- **Bug Fixes**
  - Multi-asset sends: map native assets into device token bundles for both Ledger and Trezor.
  - Safer inputs and connections: strict hex/xpub validation; connect options enforced per kind (Ledger local-only; Trezor requires external consent); consent check lives in the Trezor connector.
  - Trezor stability: reference-counted transport so one close doesn’t drop another session; concurrent `init` guarded; device-kind hint excludes `keystone`.

<sup>Written for commit e62499912b368c4aefdffa1fbbf9192e73b8069e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Screenshots

Real browser captures (Playwright, 1280×800) of the new AddWallet hardware flow.

**Hardware-device picker — Ledger / Trezor / Keystone (coming soon, disabled):**

![Hardware device picker](https://raw.githubusercontent.com/blinklabs-io/bursa/ci/screenshots/screenshots/pr-613/pr613-device-picker-ledger.png)

**Trezor selected — consent gate un-ticked, "Connect Trezor" disabled until acknowledged:**

![Trezor consent gate](https://raw.githubusercontent.com/blinklabs-io/bursa/ci/screenshots/screenshots/pr-613/pr613-trezor-consent-gated.png)

**Trezor consent acknowledged — "Connect Trezor" enabled:**

![Trezor consent approved](https://raw.githubusercontent.com/blinklabs-io/bursa/ci/screenshots/screenshots/pr-613/pr613-trezor-consent-approved.png)


