### PR TITLE
feat(ui): import transaction (decode / cosign / submit a pasted tx, multisig-aware)

### DIFF
--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -260,6 +260,12 @@ type MultiSig interface {
 	Build(ctx context.Context, id string, req multisig.BuildRequest) (multisig.UnsignedTx, error)
 	Sign(unsignedTxCBOR, password string) (multisig.Witness, error)
 	Submit(ctx context.Context, id, unsignedTxCBOR string, witnessCBORs []string) (multisig.TxResult, error)
+	// InspectTx, CosignImported, and SubmitImported back the import-tx routes'
+	// classification/dispatch (decode-tx/cosign-tx/submit-tx): see
+	// importDecode, importCosign, and importSubmit below.
+	InspectTx(txCbor string) (multisig.TxInfo, error)
+	CosignImported(txCbor, password string) (multisig.CosignResult, error)
+	SubmitImported(ctx context.Context, txCbor string) (multisig.TxResult, error)
 }
 
 type decimalUint64 uint64
@@ -1446,20 +1452,56 @@ func registerMultiSigRoutes(mux *http.ServeMux, st Statuser, ms MultiSig, networ
 	}))
 }
 
-// importDecode, importCosign, and importSubmit back the decode-tx/cosign-tx/
-// submit-tx routes. They take the MultiSig service alongside the Spender so a
-// later task can classify a pasted tx and route native-multisig transactions
-// through ms without touching these call sites; for now (vkey path only) ms is
-// unused and every call delegates straight to sp.
-func importDecode(_ context.Context, sp Spender, _ MultiSig, txCbor string) (spend.TxSummary, error) {
-	return sp.DecodeTx(txCbor)
+// importDecodeResponse is decode-tx's response: the vkey-path TxSummary with
+// an optional multisig classification block merged in. When the pasted tx is
+// a native-script multi-sig spend, Kind is overridden to "native_multisig"
+// and MultiSig carries the policy/participant detail from ms.InspectTx.
+type importDecodeResponse struct {
+	spend.TxSummary
+	MultiSig *multisig.TxInfo `json:"multisig,omitempty"`
 }
 
-func importCosign(ctx context.Context, sp Spender, _ MultiSig, txCbor, password string, partial bool) (spend.CosignResult, error) {
+// importDecode, importCosign, and importSubmit back the decode-tx/cosign-tx/
+// submit-tx routes. Each classifies the pasted tx via ms.InspectTx first and
+// routes native-script multi-sig transactions through the MultiSig service;
+// everything else (vkey path) delegates to the Spender, unchanged from the
+// prior (vkey-only) behavior.
+func importDecode(_ context.Context, sp Spender, ms MultiSig, txCbor string) (importDecodeResponse, error) {
+	info, err := ms.InspectTx(txCbor)
+	if err != nil {
+		return importDecodeResponse{}, err
+	}
+	summary, err := sp.DecodeTx(txCbor)
+	if err != nil {
+		return importDecodeResponse{}, err
+	}
+	resp := importDecodeResponse{TxSummary: summary}
+	if info.IsMultiSig {
+		resp.Kind = "native_multisig"
+		resp.MultiSig = &info
+	}
+	return resp, nil
+}
+
+func importCosign(ctx context.Context, sp Spender, ms MultiSig, txCbor, password string, partial bool) (any, error) {
+	info, err := ms.InspectTx(txCbor)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsMultiSig {
+		return ms.CosignImported(txCbor, password)
+	}
 	return sp.CosignTx(ctx, txCbor, password, partial)
 }
 
-func importSubmit(ctx context.Context, sp Spender, _ MultiSig, txCbor string) (spend.TxResult, error) {
+func importSubmit(ctx context.Context, sp Spender, ms MultiSig, txCbor string) (any, error) {
+	info, err := ms.InspectTx(txCbor)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsMultiSig {
+		return ms.SubmitImported(ctx, txCbor)
+	}
 	return sp.SubmitTxCbor(ctx, txCbor)
 }
 

--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -82,7 +82,7 @@ type Spender interface {
 	// DecodeTx, CosignTx, and SubmitTxCbor back the "import transaction" flow:
 	// a user pastes a full tx CBOR built elsewhere (e.g. by a DApp or another
 	// wallet) to inspect it, add this wallet's witness(es), and broadcast it.
-	DecodeTx(txCbor string) (spend.TxSummary, error)
+	DecodeTx(ctx context.Context, txCbor string) (spend.TxSummary, error)
 	CosignTx(ctx context.Context, txCbor, password string, partialSign bool) (spend.CosignResult, error)
 	SubmitTxCbor(ctx context.Context, txCbor string) (spend.TxResult, error)
 }
@@ -1468,12 +1468,12 @@ type importDecodeResponse struct {
 // routes native-script multi-sig transactions through the MultiSig service;
 // everything else (vkey path) delegates to the Spender, unchanged from the
 // prior (vkey-only) behavior.
-func importDecode(_ context.Context, sp Spender, ms MultiSig, txCbor string) (importDecodeResponse, error) {
+func importDecode(ctx context.Context, sp Spender, ms MultiSig, txCbor string) (importDecodeResponse, error) {
 	info, err := ms.InspectTx(txCbor)
 	if err != nil {
 		return importDecodeResponse{}, err
 	}
-	summary, err := sp.DecodeTx(txCbor)
+	summary, err := sp.DecodeTx(ctx, txCbor)
 	if err != nil {
 		return importDecodeResponse{}, err
 	}

--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -79,6 +79,12 @@ type Spender interface {
 	SubmitSigned(ctx context.Context, unsignedTxCBOR, witnessCBOR string) (spend.TxResult, error)
 	BuildDelegation(ctx context.Context, req spend.DelegationRequest) (spend.DelegationPreview, error)
 	HardwareSignRequest(pendingID string) (spend.HardwareSignRequest, error)
+	// DecodeTx, CosignTx, and SubmitTxCbor back the "import transaction" flow:
+	// a user pastes a full tx CBOR built elsewhere (e.g. by a DApp or another
+	// wallet) to inspect it, add this wallet's witness(es), and broadcast it.
+	DecodeTx(txCbor string) (spend.TxSummary, error)
+	CosignTx(ctx context.Context, txCbor, password string, partialSign bool) (spend.CosignResult, error)
+	SubmitTxCbor(ctx context.Context, txCbor string) (spend.TxResult, error)
 }
 
 // NodeLookup is the node-backed verification/lookup surface the wallet uses to
@@ -970,6 +976,51 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 		serve(w, v, err)
 	}))
 
+	// Import transaction: paste a full tx CBOR built elsewhere to inspect it
+	// (decode-tx), add this wallet's witness(es) (cosign-tx), and broadcast the
+	// result (submit-tx). decode-tx and cosign-tx are ungated like sign-tx —
+	// pure crypto over the keystore/tx bytes, no node needed; submit-tx needs a
+	// synced node like submit-signed. The vkey path here delegates straight to
+	// the spender; multisig classification/routing is added in a later task.
+	mux.HandleFunc("POST /wallet/decode-tx", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			TxCBOR string `json:"tx_cbor"`
+		}
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		v, err := importDecode(r.Context(), sp, ms, req.TxCBOR)
+		serve(w, v, err)
+	})
+
+	mux.HandleFunc("POST /wallet/cosign-tx", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			TxCBOR      string `json:"tx_cbor"`
+			Password    string `json:"password"`
+			PartialSign *bool  `json:"partial_sign,omitempty"`
+		}
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		partial := true
+		if req.PartialSign != nil {
+			partial = *req.PartialSign
+		}
+		v, err := importCosign(r.Context(), sp, ms, req.TxCBOR, req.Password, partial)
+		serve(w, v, err)
+	})
+
+	mux.HandleFunc("POST /wallet/submit-tx", readyGate(st, func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			TxCBOR string `json:"tx_cbor"`
+		}
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		v, err := importSubmit(r.Context(), sp, ms, req.TxCBOR)
+		serve(w, v, err)
+	}))
+
 	// Staking & governance. Pool/DRep lookups verify a pasted ID through the node
 	// (gated like reads — they only need the node serving queries). Building a
 	// delegation tx and confirming it are gated like sends (a fully synced node),
@@ -1393,6 +1444,23 @@ func registerMultiSigRoutes(mux *http.ServeMux, st Statuser, ms MultiSig, networ
 		v, err := ms.Submit(r.Context(), r.PathValue("id"), req.UnsignedTxCBOR, req.Witnesses)
 		serve(w, v, err)
 	}))
+}
+
+// importDecode, importCosign, and importSubmit back the decode-tx/cosign-tx/
+// submit-tx routes. They take the MultiSig service alongside the Spender so a
+// later task can classify a pasted tx and route native-multisig transactions
+// through ms without touching these call sites; for now (vkey path only) ms is
+// unused and every call delegates straight to sp.
+func importDecode(_ context.Context, sp Spender, _ MultiSig, txCbor string) (spend.TxSummary, error) {
+	return sp.DecodeTx(txCbor)
+}
+
+func importCosign(ctx context.Context, sp Spender, _ MultiSig, txCbor, password string, partial bool) (spend.CosignResult, error) {
+	return sp.CosignTx(ctx, txCbor, password, partial)
+}
+
+func importSubmit(ctx context.Context, sp Spender, _ MultiSig, txCbor string) (spend.TxResult, error) {
+	return sp.SubmitTxCbor(ctx, txCbor)
 }
 
 // decodeBody decodes a JSON request body into v, writing a 400 and returning

--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -986,8 +986,10 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 	// (decode-tx), add this wallet's witness(es) (cosign-tx), and broadcast the
 	// result (submit-tx). decode-tx and cosign-tx are ungated like sign-tx —
 	// pure crypto over the keystore/tx bytes, no node needed; submit-tx needs a
-	// synced node like submit-signed. The vkey path here delegates straight to
-	// the spender; multisig classification/routing is added in a later task.
+	// synced node like submit-signed. Each handler classifies the pasted tx via
+	// ms.InspectTx and routes native-script multisig txs to the multisig
+	// service, ordinary vkey txs straight to the spender (see importDecode/
+	// importCosign/importSubmit below).
 	mux.HandleFunc("POST /wallet/decode-tx", func(w http.ResponseWriter, r *http.Request) {
 		var req struct {
 			TxCBOR string `json:"tx_cbor"`

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -1037,6 +1037,20 @@ type fakeSpender struct {
 	hwSignReq    spend.HardwareSignRequest
 	hwSignReqErr error
 	gotHWSignID  string
+
+	// import-tx (decode-tx/cosign-tx/submit-tx vkey path); methods defined in
+	// importtx_test.go alongside the tests that exercise them.
+	decodeResult     spend.TxSummary
+	decodeErr        error
+	gotDecodeCBOR    string
+	cosignResult     spend.CosignResult
+	cosignErr        error
+	gotCosignCBOR    string
+	gotCosignPass    string
+	gotCosignPartial bool
+	submitTxResult   spend.TxResult
+	submitTxErr      error
+	gotSubmitTxCBOR  string
 }
 
 func (f *fakeSpender) SetAccount(id string, acct *wallet.Account) {

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -1324,6 +1324,19 @@ type fakeMultiSig struct {
 	gotSubmitID      string
 	gotSubmitTxCBOR  string
 	gotSubmitWitness []string
+
+	// import-tx (decode-tx/cosign-tx/submit-tx multisig path); methods defined
+	// in importtx_test.go alongside the tests that exercise them.
+	inspect             multisig.TxInfo
+	inspectErr          error
+	gotInspectCBOR      string
+	cosign              multisig.CosignResult
+	cosignImportedErr   error
+	gotCosignCBOR       string
+	gotCosignPassword   string
+	submitImported      multisig.TxResult
+	submitImportedErr   error
+	gotSubmitImportCBOR string
 }
 
 func (f *fakeMultiSig) List() ([]multisig.Account, error) {

--- a/ui/internal/api/importtx_test.go
+++ b/ui/internal/api/importtx_test.go
@@ -128,6 +128,9 @@ func TestDecodeTxHandler_MultiSigKind(t *testing.T) {
 	if !strings.Contains(rec.Body.String(), `"threshold":2`) {
 		t.Errorf("want multisig block with threshold, got %s", rec.Body.String())
 	}
+	if !strings.Contains(rec.Body.String(), `"fee":"2000000"`) {
+		t.Errorf("want spend-summary fee to survive the multisig merge, got %s", rec.Body.String())
+	}
 }
 
 func TestDecodeTxHandler_InvalidJSON(t *testing.T) {

--- a/ui/internal/api/importtx_test.go
+++ b/ui/internal/api/importtx_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package api
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/bursa/ui/internal/spend"
+	"github.com/blinklabs-io/bursa/ui/internal/supervisor"
+)
+
+// --- fakeSpender extensions for the vkey import-tx endpoints -----------------
+//
+// The fields these methods read/write are declared on fakeSpender itself (see
+// api_test.go) so the many existing call sites that construct a bare
+// &fakeSpender{} keep satisfying the extended Spender interface unchanged;
+// only the methods live here, next to the tests that exercise them.
+
+func (f *fakeSpender) DecodeTx(txCbor string) (spend.TxSummary, error) {
+	f.gotDecodeCBOR = txCbor
+	if f.decodeErr != nil {
+		return spend.TxSummary{}, f.decodeErr
+	}
+	return f.decodeResult, nil
+}
+
+func (f *fakeSpender) CosignTx(_ context.Context, txCbor, password string, partial bool) (spend.CosignResult, error) {
+	f.gotCosignCBOR = txCbor
+	f.gotCosignPass = password
+	f.gotCosignPartial = partial
+	if f.cosignErr != nil {
+		return spend.CosignResult{}, f.cosignErr
+	}
+	return f.cosignResult, nil
+}
+
+func (f *fakeSpender) SubmitTxCbor(_ context.Context, txCbor string) (spend.TxResult, error) {
+	f.gotSubmitTxCBOR = txCbor
+	if f.submitTxErr != nil {
+		return spend.TxResult{}, f.submitTxErr
+	}
+	return f.submitTxResult, nil
+}
+
+// --- POST /wallet/decode-tx ---------------------------------------------------
+
+func TestDecodeTxHandler_OK(t *testing.T) {
+	sp := &fakeSpender{decodeResult: spend.TxSummary{Kind: "vkey", Fee: "170000"}}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"tx_cbor":"84a4..."}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/decode-tx", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("decode-tx status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"kind":"vkey"`) {
+		t.Errorf("body missing kind: %s", rec.Body.String())
+	}
+	if sp.gotDecodeCBOR != "84a4..." {
+		t.Errorf("tx_cbor not passed through: %q", sp.gotDecodeCBOR)
+	}
+}
+
+func TestDecodeTxHandler_InvalidJSON(t *testing.T) {
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`not json`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/decode-tx", body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("decode-tx invalid json = %d, want 400", rec.Code)
+	}
+}
+
+// --- POST /wallet/cosign-tx ---------------------------------------------------
+
+func TestCosignTxHandler_InvalidTxIs400(t *testing.T) {
+	sp := &fakeSpender{cosignErr: fmt.Errorf("%w: bad", spend.ErrInvalidTx)}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"tx_cbor":"zz","password":"p"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/cosign-tx", body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("cosign-tx status = %d, want 400, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCosignTxHandler_OK_DefaultsPartialSignTrue(t *testing.T) {
+	sp := &fakeSpender{cosignResult: spend.CosignResult{TxCBOR: "84...merged"}}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"tx_cbor":"84a4...","password":"pw"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/cosign-tx", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("cosign-tx status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if sp.gotCosignCBOR != "84a4..." || sp.gotCosignPass != "pw" {
+		t.Errorf("args not passed through: cbor=%q pass=%q", sp.gotCosignCBOR, sp.gotCosignPass)
+	}
+	if !sp.gotCosignPartial {
+		t.Errorf("partial_sign should default to true when omitted")
+	}
+	if !strings.Contains(rec.Body.String(), "84...merged") {
+		t.Errorf("body missing merged tx_cbor: %s", rec.Body.String())
+	}
+}
+
+func TestCosignTxHandler_PartialSignFalseIsHonored(t *testing.T) {
+	sp := &fakeSpender{}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"tx_cbor":"84a4...","password":"pw","partial_sign":false}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/cosign-tx", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("cosign-tx status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if sp.gotCosignPartial {
+		t.Errorf("partial_sign=false should be honored, got true")
+	}
+}
+
+// --- POST /wallet/submit-tx ---------------------------------------------------
+
+func TestSubmitTxHandler_RequiresReady(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"tx_cbor":"84a4..."}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-tx", body))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("submit-tx while syncing = %d, want 503, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSubmitTxHandler_ReturnsTxHash(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	sp := &fakeSpender{submitTxResult: spend.TxResult{TxHash: "cafebabe"}}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"tx_cbor":"84a4..."}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-tx", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("submit-tx = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if sp.gotSubmitTxCBOR != "84a4..." {
+		t.Errorf("tx_cbor not passed through: %q", sp.gotSubmitTxCBOR)
+	}
+	if !strings.Contains(rec.Body.String(), "cafebabe") {
+		t.Errorf("tx hash missing: %s", rec.Body.String())
+	}
+}
+
+func TestSubmitTxHandler_InvalidTxIs400(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	sp := &fakeSpender{submitTxErr: fmt.Errorf("%w: bad hex", spend.ErrInvalidTx)}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"tx_cbor":"zz"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-tx", body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("submit-tx invalid tx = %d, want 400, body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/ui/internal/api/importtx_test.go
+++ b/ui/internal/api/importtx_test.go
@@ -34,7 +34,7 @@ import (
 // &fakeSpender{} keep satisfying the extended Spender interface unchanged;
 // only the methods live here, next to the tests that exercise them.
 
-func (f *fakeSpender) DecodeTx(txCbor string) (spend.TxSummary, error) {
+func (f *fakeSpender) DecodeTx(_ context.Context, txCbor string) (spend.TxSummary, error) {
 	f.gotDecodeCBOR = txCbor
 	if f.decodeErr != nil {
 		return spend.TxSummary{}, f.decodeErr

--- a/ui/internal/api/importtx_test.go
+++ b/ui/internal/api/importtx_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/blinklabs-io/bursa/ui/internal/multisig"
 	"github.com/blinklabs-io/bursa/ui/internal/spend"
 	"github.com/blinklabs-io/bursa/ui/internal/supervisor"
 )
@@ -59,6 +60,39 @@ func (f *fakeSpender) SubmitTxCbor(_ context.Context, txCbor string) (spend.TxRe
 	return f.submitTxResult, nil
 }
 
+// --- fakeMultiSig extensions for the import-tx endpoints ---------------------
+//
+// Like fakeSpender above, the fields these methods read/write are declared on
+// fakeMultiSig itself (see api_test.go) so existing call sites constructing a
+// bare &fakeMultiSig{} keep satisfying the extended MultiSig interface
+// unchanged; the default zero-value InspectTx returns IsMultiSig:false so the
+// vkey-path tests above still route straight to the spender.
+
+func (f *fakeMultiSig) InspectTx(txCbor string) (multisig.TxInfo, error) {
+	f.gotInspectCBOR = txCbor
+	if f.inspectErr != nil {
+		return multisig.TxInfo{}, f.inspectErr
+	}
+	return f.inspect, nil
+}
+
+func (f *fakeMultiSig) CosignImported(txCbor, password string) (multisig.CosignResult, error) {
+	f.gotCosignCBOR = txCbor
+	f.gotCosignPassword = password
+	if f.cosignImportedErr != nil {
+		return multisig.CosignResult{}, f.cosignImportedErr
+	}
+	return f.cosign, nil
+}
+
+func (f *fakeMultiSig) SubmitImported(_ context.Context, txCbor string) (multisig.TxResult, error) {
+	f.gotSubmitImportCBOR = txCbor
+	if f.submitImportedErr != nil {
+		return multisig.TxResult{}, f.submitImportedErr
+	}
+	return f.submitImported, nil
+}
+
 // --- POST /wallet/decode-tx ---------------------------------------------------
 
 func TestDecodeTxHandler_OK(t *testing.T) {
@@ -75,6 +109,24 @@ func TestDecodeTxHandler_OK(t *testing.T) {
 	}
 	if sp.gotDecodeCBOR != "84a4..." {
 		t.Errorf("tx_cbor not passed through: %q", sp.gotDecodeCBOR)
+	}
+}
+
+func TestDecodeTxHandler_MultiSigKind(t *testing.T) {
+	sp := &fakeSpender{decodeResult: spend.TxSummary{Kind: "vkey", Fee: "2000000"}}
+	ms := &fakeMultiSig{inspect: multisig.TxInfo{IsMultiSig: true, Threshold: 2, SignedCount: 1}}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, ms, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"tx_cbor":"84a4..."}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/decode-tx", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("decode-tx status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"kind":"native_multisig"`) {
+		t.Errorf("want native_multisig kind, got %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"threshold":2`) {
+		t.Errorf("want multisig block with threshold, got %s", rec.Body.String())
 	}
 }
 
@@ -132,6 +184,20 @@ func TestCosignTxHandler_PartialSignFalseIsHonored(t *testing.T) {
 	}
 	if sp.gotCosignPartial {
 		t.Errorf("partial_sign=false should be honored, got true")
+	}
+}
+
+func TestCosignTxHandler_RoutesMultiSig(t *testing.T) {
+	ms := &fakeMultiSig{
+		inspect: multisig.TxInfo{IsMultiSig: true, Threshold: 1},
+		cosign:  multisig.CosignResult{TxCBOR: "84beef", Added: true, SignedCount: 1, Threshold: 1},
+	}
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, ms, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"tx_cbor":"84a4...","password":"p"}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/cosign-tx", body))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "84beef") {
+		t.Fatalf("multisig cosign not routed: %d %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/ui/internal/multisig/importtx_test.go
+++ b/ui/internal/multisig/importtx_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"math/big"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	apollo "github.com/blinklabs-io/apollo/v2"
 	"github.com/blinklabs-io/bursa"
+	gcbor "github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 )
 
 func TestPolicyFromScript_RoundTrip(t *testing.T) {
@@ -149,6 +152,168 @@ func TestInspectTx_EmbeddedScript(t *testing.T) {
 			t.Errorf("participant %s reported signed on an unsigned tx", p.KeyHash)
 		}
 	}
+}
+
+// TestInspectTx_MintOnlyIsNotMultiSig covers the classification bug: an
+// ordinary vkey-signed payment that also mints a token/NFT under a
+// native-script policy carries that policy script in its witness set (the
+// ledger requires it there to authorize the mint) but has no script-locked
+// spend at all. InspectTx must NOT classify this as a multisig spend — doing
+// so would route it to the cosign/submit path, where it fails because the
+// wallet isn't a "participant" of the mint policy.
+func TestInspectTx_MintOnlyIsNotMultiSig(t *testing.T) {
+	fc := newFakeChain()
+	svc := NewService(fc, nil, filepath.Join(t.TempDir(), "multisig.json"))
+
+	// A bare pubkey native script used purely as a minting policy (not a
+	// multisig N-of-M threshold script, and not saved as an account here).
+	mintScript, err := bursa.NewScriptSig(bytesRepeat(9, 28))
+	if err != nil {
+		t.Fatalf("NewScriptSig: %v", err)
+	}
+	policyIDHex := hex.EncodeToString(mintScript.Hash().Bytes())
+
+	txHex := mintOnlyTxHex(t, fc, mintScript, policyIDHex)
+
+	info, err := svc.InspectTx(txHex)
+	if err != nil {
+		t.Fatalf("InspectTx: %v", err)
+	}
+	if info.IsMultiSig {
+		t.Errorf("mint-only native script must not be classified multisig: %+v", info)
+	}
+	if info.ScriptEmbedded {
+		t.Error("mint-only tx must not report ScriptEmbedded (routed to the vkey path)")
+	}
+}
+
+// TestInspectTx_MultiSigSpendPlusMint covers the mixed case: a real multisig
+// spend script alongside an unrelated mint policy script in the same witness
+// set. The spend script must still be selected (it doesn't match any mint
+// policy ID) and the tx must still classify as multisig.
+func TestInspectTx_MultiSigSpendPlusMint(t *testing.T) {
+	fc := newFakeChain()
+	svc := NewService(fc, nil, filepath.Join(t.TempDir(), "multisig.json"))
+	_, khA, _ := multiSigKeyHash(t, mnemonicA)
+	_, khB, _ := multiSigKeyHash(t, mnemonicB)
+
+	acct, err := svc.Create(CreateRequest{
+		Label:   "treasury",
+		Network: "preview",
+		Policy: Policy{
+			Threshold:    2,
+			Participants: []Participant{{KeyHashHex: khA}, {KeyHashHex: khB}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	fc.addUTxO(acct.ScriptAddress, strings.Repeat("77", 32), 0, 10_000_000)
+
+	built, err := svc.Build(context.Background(), acct.ID, BuildRequest{To: externalAddr(t), Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	// Attach an unrelated mint policy script (different hash) on top of the
+	// already-built multisig spend tx.
+	mintScript, err := bursa.NewScriptSig(bytesRepeat(8, 28))
+	if err != nil {
+		t.Fatalf("NewScriptSig: %v", err)
+	}
+	policyIDHex := hex.EncodeToString(mintScript.Hash().Bytes())
+	txHex := addMintToTx(t, built.UnsignedTxCBOR, mintScript, policyIDHex)
+
+	info, err := svc.InspectTx(txHex)
+	if err != nil {
+		t.Fatalf("InspectTx: %v", err)
+	}
+	if !info.IsMultiSig {
+		t.Fatalf("multisig spend script must still classify as multisig even with an unrelated mint policy attached: %+v", info)
+	}
+	if info.Threshold != 2 || len(info.Participants) != 2 {
+		t.Errorf("got %d-of-%d, want 2-of-2", info.Threshold, len(info.Participants))
+	}
+}
+
+// mintOnlyTxHex builds an ordinary vkey-signed payment tx (via
+// ordinaryUnsignedTxHex — no script-locked input at all) and then injects a
+// mint of one unit under mintScript's policy ID plus mintScript itself into
+// the witness set, directly at the decoded-struct level. This is the shape
+// the ledger requires to authorize a native-script mint, and exactly what
+// used to be misclassified as a multisig spend.
+//
+// Apollo's Mint/AttachScript builder methods only feed a fresh Complete()/
+// CompleteContext() build — they don't retroactively mutate a tx already
+// loaded via LoadTxCbor (GetTxCbor just re-serializes whatever is in the
+// loaded struct) — so post-hoc injection has to happen at the gouroboros
+// struct level, decoding then re-encoding the CBOR directly.
+func mintOnlyTxHex(t *testing.T, fc *fakeChain, mintScript *bursa.NativeScript, policyIDHex string) string {
+	t.Helper()
+	tx := decodeConwayTx(t, ordinaryUnsignedTxHex(t, fc))
+	injectMint(t, &tx, policyIDHex, []lcommon.NativeScript{*mintScript})
+	return encodeConwayTx(t, &tx)
+}
+
+// addMintToTx decodes an already-built unsigned tx CBOR and injects an
+// additional mint under mintScript's policy plus mintScript itself into the
+// witness set (ahead of whatever native scripts the tx already carries), so
+// the result carries both the original spend script and the new mint policy
+// script. See mintOnlyTxHex for why this happens at the struct level rather
+// than through Apollo's builder methods.
+func addMintToTx(t *testing.T, unsignedTxCBOR string, mintScript *bursa.NativeScript, policyIDHex string) string {
+	t.Helper()
+	tx := decodeConwayTx(t, unsignedTxCBOR)
+	scripts := append([]lcommon.NativeScript{*mintScript}, tx.WitnessSet.NativeScripts()...)
+	injectMint(t, &tx, policyIDHex, scripts)
+	return encodeConwayTx(t, &tx)
+}
+
+// decodeConwayTx hex-decodes and CBOR-decodes a Conway transaction.
+func decodeConwayTx(t *testing.T, txHex string) conway.ConwayTransaction {
+	t.Helper()
+	txBytes, err := hex.DecodeString(txHex)
+	if err != nil {
+		t.Fatalf("decode tx hex: %v", err)
+	}
+	var tx conway.ConwayTransaction
+	if _, err := gcbor.Decode(txBytes, &tx); err != nil {
+		t.Fatalf("decode tx: %v", err)
+	}
+	return tx
+}
+
+// injectMint sets tx.Body.TxMint to mint one unit under policyIDHex and
+// replaces the witness set's native scripts with scripts, clearing the CBOR
+// caches so re-encoding reflects the change.
+func injectMint(t *testing.T, tx *conway.ConwayTransaction, policyIDHex string, scripts []lcommon.NativeScript) {
+	t.Helper()
+	policyBytes, err := hex.DecodeString(policyIDHex)
+	if err != nil {
+		t.Fatalf("decode policy id: %v", err)
+	}
+	var policyID lcommon.Blake2b224
+	copy(policyID[:], policyBytes)
+	mintData := map[lcommon.Blake2b224]map[gcbor.ByteString]lcommon.MultiAssetTypeMint{
+		policyID: {gcbor.NewByteString([]byte("token")): big.NewInt(1)},
+	}
+	mint := lcommon.NewMultiAsset[lcommon.MultiAssetTypeMint](mintData)
+	tx.Body.TxMint = &mint
+	tx.WitnessSet.WsNativeScripts = gcbor.NewSetType(scripts, true)
+
+	tx.SetCbor(nil)
+	tx.Body.SetCbor(nil)
+	tx.WitnessSet.SetCbor(nil)
+}
+
+// encodeConwayTx CBOR-encodes a Conway transaction back to hex.
+func encodeConwayTx(t *testing.T, tx *conway.ConwayTransaction) string {
+	t.Helper()
+	out, err := gcbor.Encode(tx)
+	if err != nil {
+		t.Fatalf("re-encode tx: %v", err)
+	}
+	return hex.EncodeToString(out)
 }
 
 // TestInspectTx_NotMultiSig feeds InspectTx an ordinary (no native script)

--- a/ui/internal/multisig/importtx_test.go
+++ b/ui/internal/multisig/importtx_test.go
@@ -390,6 +390,85 @@ func TestCosignImported_PreservesOtherCosigner(t *testing.T) {
 	}
 }
 
+// --- SubmitImported ----------------------------------------------------------
+
+// TestSubmitImported_BelowThresholdRejected builds a 2-of-2 policy (this
+// wallet's own CIP-1854 key plus a foreign key-hash it does not own), funds
+// the script address, builds a spend, and cosigns with only this wallet's key
+// (1 of 2). SubmitImported must refuse to broadcast a below-threshold tx.
+func TestSubmitImported_BelowThresholdRejected(t *testing.T) {
+	fc := newFakeChain()
+	ks := newTestKeystore(t, mnemonicA)
+	svc := NewService(fc, ks, filepath.Join(t.TempDir(), "multisig.json"))
+
+	mk, err := svc.MyKey("test-password-123")
+	if err != nil {
+		t.Fatalf("MyKey: %v", err)
+	}
+	acct, err := svc.Create(CreateRequest{
+		Label:   "2of2",
+		Network: "preview",
+		Policy: Policy{Threshold: 2, Participants: []Participant{
+			{KeyHashHex: mk.KeyHashHex}, {KeyHashHex: strings.Repeat("cd", 28)},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	fc.addUTxO(acct.ScriptAddress, strings.Repeat("55", 32), 0, 10_000_000)
+
+	built, err := svc.Build(context.Background(), acct.ID, BuildRequest{To: externalAddr(t), Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	signed, err := svc.CosignImported(built.UnsignedTxCBOR, "test-password-123") // 1 of 2
+	if err != nil {
+		t.Fatalf("CosignImported: %v", err)
+	}
+	if _, err := svc.SubmitImported(context.Background(), signed.TxCBOR); !errors.Is(err, ErrInvalidWitness) {
+		t.Fatalf("SubmitImported error = %v, want ErrInvalidWitness (below threshold)", err)
+	}
+}
+
+// TestSubmitImported_ThresholdMetBroadcasts builds a 1-of-1 policy owned
+// entirely by this wallet, cosigns it (meeting the threshold), and asserts
+// SubmitImported broadcasts successfully and returns a non-empty tx hash.
+func TestSubmitImported_ThresholdMetBroadcasts(t *testing.T) {
+	fc := newFakeChain()
+	ks := newTestKeystore(t, mnemonicA)
+	svc := NewService(fc, ks, filepath.Join(t.TempDir(), "multisig.json"))
+
+	mk, err := svc.MyKey("test-password-123")
+	if err != nil {
+		t.Fatalf("MyKey: %v", err)
+	}
+	acct, err := svc.Create(CreateRequest{
+		Label:   "1of1",
+		Network: "preview",
+		Policy:  Policy{Threshold: 1, Participants: []Participant{{KeyHashHex: mk.KeyHashHex}}},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	fc.addUTxO(acct.ScriptAddress, strings.Repeat("66", 32), 0, 10_000_000)
+
+	built, err := svc.Build(context.Background(), acct.ID, BuildRequest{To: externalAddr(t), Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	signed, err := svc.CosignImported(built.UnsignedTxCBOR, "test-password-123")
+	if err != nil {
+		t.Fatalf("CosignImported: %v", err)
+	}
+	res, err := svc.SubmitImported(context.Background(), signed.TxCBOR)
+	if err != nil {
+		t.Fatalf("SubmitImported: %v", err)
+	}
+	if res.TxHash == "" {
+		t.Error("expected a tx hash")
+	}
+}
+
 // ordinaryUnsignedTxHex builds a plain (non-script) unsigned spend directly
 // through apollo — no AttachScript call — so the resulting Conway tx's
 // witness set carries zero native scripts. It exercises the same

--- a/ui/internal/multisig/importtx_test.go
+++ b/ui/internal/multisig/importtx_test.go
@@ -306,6 +306,90 @@ func TestCosignImported_NotAParticipant(t *testing.T) {
 	}
 }
 
+// TestCosignImported_PreservesOtherCosigner is the real multi-party regression
+// for CosignImported's headline guarantee ("preserves existing co-signer
+// witnesses"): unlike TestCosignImported_AddsAndMerges (a 1-of-1 policy where
+// there is no other co-signer to preserve), this builds a genuine 2-of-2
+// policy across two independent keystores/wallets (mirrors TestSpendFlow's
+// svcA/svcB setup) and cosigns in two hops through the pasted-CBOR flow:
+// svcA attaches its witness first, then svcB imports svcA's *result* CBOR and
+// attaches its own. The final tx must carry BOTH participants' witnesses —
+// proving svcB's merge didn't clobber svcA's — which InspectTx confirms via
+// SignedCount and each participant's Signed flag.
+func TestCosignImported_PreservesOtherCosigner(t *testing.T) {
+	fc := newFakeChain()
+	ksA := newTestKeystore(t, mnemonicA)
+	ksB := newTestKeystore(t, mnemonicB)
+
+	// Two independent wallets (separate keystores + separate on-disk stores),
+	// sharing only the fake chain.
+	svcA := NewService(fc, ksA, filepath.Join(t.TempDir(), "a.json"))
+	svcB := NewService(fc, ksB, filepath.Join(t.TempDir(), "b.json"))
+
+	mkA, err := svcA.MyKey("test-password-123")
+	if err != nil {
+		t.Fatalf("MyKey A: %v", err)
+	}
+	mkB, err := svcB.MyKey("test-password-123")
+	if err != nil {
+		t.Fatalf("MyKey B: %v", err)
+	}
+
+	// svcA creates the joint 2-of-2 account (its own store only — CosignImported
+	// recovers the policy from the tx's embedded script, so svcB never needs
+	// this account saved in its own store).
+	acct, err := svcA.Create(CreateRequest{
+		Label:   "joint",
+		Network: "preview",
+		Policy: Policy{
+			Threshold:    2,
+			Participants: []Participant{{KeyHashHex: mkA.KeyHashHex}, {KeyHashHex: mkB.KeyHashHex}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	fc.addUTxO(acct.ScriptAddress, strings.Repeat("44", 32), 0, 10_000_000)
+
+	built, err := svcA.Build(context.Background(), acct.ID, BuildRequest{To: externalAddr(t), Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	// Hop 1: svcA cosigns the freshly-built unsigned tx.
+	resA, err := svcA.CosignImported(built.UnsignedTxCBOR, "test-password-123")
+	if err != nil {
+		t.Fatalf("CosignImported A: %v", err)
+	}
+	if !resA.Added || resA.SignedCount != 1 {
+		t.Fatalf("CosignImported A = %+v, want Added=true SignedCount=1", resA)
+	}
+
+	// Hop 2: svcB pastes svcA's *result* CBOR (not the original unsigned tx)
+	// and cosigns it — the real "pass the CBOR along" workflow.
+	resB, err := svcB.CosignImported(resA.TxCBOR, "test-password-123")
+	if err != nil {
+		t.Fatalf("CosignImported B: %v", err)
+	}
+	if !resB.Added || resB.SignedCount != 2 {
+		t.Fatalf("CosignImported B = %+v, want Added=true SignedCount=2", resB)
+	}
+
+	// The final tx must carry BOTH witnesses: svcA's survived svcB's merge.
+	info, err := svcA.InspectTx(resB.TxCBOR)
+	if err != nil {
+		t.Fatalf("InspectTx: %v", err)
+	}
+	if info.SignedCount != 2 {
+		t.Fatalf("SignedCount = %d, want 2", info.SignedCount)
+	}
+	for _, p := range info.Participants {
+		if !p.Signed {
+			t.Errorf("participant %s not signed, want both participants signed", p.KeyHash)
+		}
+	}
+}
+
 // ordinaryUnsignedTxHex builds a plain (non-script) unsigned spend directly
 // through apollo — no AttachScript call — so the resulting Conway tx's
 // witness set carries zero native scripts. It exercises the same

--- a/ui/internal/multisig/importtx_test.go
+++ b/ui/internal/multisig/importtx_test.go
@@ -221,6 +221,91 @@ func TestFindByScriptHash_SkipsDecodeErrors(t *testing.T) {
 	}
 }
 
+// --- CosignImported ----------------------------------------------------------
+
+// TestCosignImported_AddsAndMerges builds a 1-of-1 account whose sole
+// participant is this wallet's own CIP-1854 key, funds it, builds a spend, and
+// cosigns the resulting pasted (unsigned) tx CBOR. The first cosign must
+// attach the wallet's witness (Added=true, SignedCount=1); re-cosigning the
+// returned CBOR must not attach a duplicate (Added=false, idempotent).
+func TestCosignImported_AddsAndMerges(t *testing.T) {
+	fc := newFakeChain()
+	ks := newTestKeystore(t, mnemonicA)
+	svc := NewService(fc, ks, filepath.Join(t.TempDir(), "multisig.json"))
+
+	mk, err := svc.MyKey("test-password-123")
+	if err != nil {
+		t.Fatalf("MyKey: %v", err)
+	}
+	acct, err := svc.Create(CreateRequest{
+		Label:   "solo",
+		Network: "preview",
+		Policy:  Policy{Threshold: 1, Participants: []Participant{{KeyHashHex: mk.KeyHashHex}}},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	fc.addUTxO(acct.ScriptAddress, strings.Repeat("22", 32), 0, 10_000_000)
+
+	built, err := svc.Build(context.Background(), acct.ID, BuildRequest{To: externalAddr(t), Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	res, err := svc.CosignImported(built.UnsignedTxCBOR, "test-password-123")
+	if err != nil {
+		t.Fatalf("CosignImported: %v", err)
+	}
+	if !res.Added || res.SignedCount != 1 || res.Threshold != 1 {
+		t.Fatalf("CosignImported = %+v, want Added=true SignedCount=1 Threshold=1", res)
+	}
+	if res.TxCBOR == "" {
+		t.Fatal("expected non-empty tx_cbor")
+	}
+
+	// Re-cosigning the returned (already-signed) CBOR is idempotent: no
+	// duplicate witness gets added.
+	res2, err := svc.CosignImported(res.TxCBOR, "test-password-123")
+	if err != nil {
+		t.Fatalf("CosignImported (2nd): %v", err)
+	}
+	if res2.Added {
+		t.Error("second cosign should not add a duplicate witness")
+	}
+	if res2.SignedCount != 1 {
+		t.Errorf("SignedCount after re-cosign = %d, want 1", res2.SignedCount)
+	}
+}
+
+// TestCosignImported_NotAParticipant builds an account whose sole participant
+// is a foreign key-hash the wallet does not own, and asserts CosignImported
+// refuses with ErrInvalidRequest rather than silently signing a script it
+// isn't party to.
+func TestCosignImported_NotAParticipant(t *testing.T) {
+	fc := newFakeChain()
+	ks := newTestKeystore(t, mnemonicA)
+	svc := NewService(fc, ks, filepath.Join(t.TempDir(), "multisig.json"))
+
+	acct, err := svc.Create(CreateRequest{
+		Label:   "foreign",
+		Network: "preview",
+		Policy:  Policy{Threshold: 1, Participants: []Participant{{KeyHashHex: strings.Repeat("ab", 28)}}},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	fc.addUTxO(acct.ScriptAddress, strings.Repeat("33", 32), 0, 10_000_000)
+
+	built, err := svc.Build(context.Background(), acct.ID, BuildRequest{To: externalAddr(t), Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if _, err := svc.CosignImported(built.UnsignedTxCBOR, "test-password-123"); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("CosignImported error = %v, want ErrInvalidRequest", err)
+	}
+}
+
 // ordinaryUnsignedTxHex builds a plain (non-script) unsigned spend directly
 // through apollo — no AttachScript call — so the resulting Conway tx's
 // witness set carries zero native scripts. It exercises the same

--- a/ui/internal/multisig/importtx_test.go
+++ b/ui/internal/multisig/importtx_test.go
@@ -293,6 +293,69 @@ func TestInspectTx_ScriptWithdrawalIsUnsupported(t *testing.T) {
 	}
 }
 
+// TestInspectTx_VotingProcedureScriptIsUnsupported covers the governance-vote
+// arm of the stake-purpose classifier: a DRep-script vote carries its native
+// script in the witness set to authorize the vote, NOT a payment spend.
+// InspectTx must NOT treat it as a payment-multisig spend (which would route it
+// to CosignImported and derive the wrong role-0 payment key); it must report a
+// recognizable-but-unsupported multisig (embedded script, threshold 0, no
+// participants).
+func TestInspectTx_VotingProcedureScriptIsUnsupported(t *testing.T) {
+	fc := newFakeChain()
+	svc := NewService(fc, nil, filepath.Join(t.TempDir(), "multisig.json"))
+
+	voteScript, err := composeScript(Policy{
+		Threshold:    1,
+		Participants: []Participant{{KeyHashHex: hex.EncodeToString(bytesRepeat(6, 28))}},
+	})
+	if err != nil {
+		t.Fatalf("composeScript: %v", err)
+	}
+	txHex := injectScriptVote(t, fc, voteScript)
+
+	info, err := svc.InspectTx(txHex)
+	if err != nil {
+		t.Fatalf("InspectTx: %v", err)
+	}
+	if !info.IsMultiSig || !info.ScriptEmbedded {
+		t.Fatalf("governance-vote script should classify as an embedded multisig: %+v", info)
+	}
+	if info.Threshold != 0 || len(info.Participants) != 0 {
+		t.Fatalf("governance-vote script must NOT be treated as a payment-multisig spend (want threshold 0, no participants): %+v", info)
+	}
+}
+
+// TestInspectTx_StakeScriptAlsoMintIsUnsupported covers the mint-vs-stake
+// precedence bug: a script that is both a stake/gov credential (here, a script-
+// credentialed withdrawal) AND reused as a mint policy must let the stake
+// purpose dominate. It must be classified as an unsupported stake/gov multisig
+// (threshold 0), NOT routed to the vkey path just because its hash also matches
+// a mint policy — the stake/gov witness would otherwise be left unsatisfied.
+func TestInspectTx_StakeScriptAlsoMintIsUnsupported(t *testing.T) {
+	fc := newFakeChain()
+	svc := NewService(fc, nil, filepath.Join(t.TempDir(), "multisig.json"))
+
+	script, err := composeScript(Policy{
+		Threshold:    1,
+		Participants: []Participant{{KeyHashHex: hex.EncodeToString(bytesRepeat(9, 28))}},
+	})
+	if err != nil {
+		t.Fatalf("composeScript: %v", err)
+	}
+	txHex := injectScriptWithdrawalAndMint(t, fc, script)
+
+	info, err := svc.InspectTx(txHex)
+	if err != nil {
+		t.Fatalf("InspectTx: %v", err)
+	}
+	if !info.IsMultiSig || !info.ScriptEmbedded {
+		t.Fatalf("stake script reused as a mint policy should classify as an embedded multisig: %+v", info)
+	}
+	if info.Threshold != 0 || len(info.Participants) != 0 {
+		t.Fatalf("stake-script-also-mint must NOT be routed to the vkey path (want threshold 0, no participants): %+v", info)
+	}
+}
+
 // TestStakeScriptCredentialHashes_Certificate exercises the certificate branch
 // of the stake-purpose detector directly: a stake-deregistration certificate
 // bearing a script credential must be collected (so InspectTx excludes that
@@ -322,6 +385,49 @@ func TestStakeScriptCredentialHashes_Certificate(t *testing.T) {
 	}
 }
 
+// TestStakeScriptCredentialHashes_VotingProcedure exercises the governance-vote
+// branch of the stake-purpose detector directly: DRep-script and committee-hot-
+// script voters authorize their vote via a native script and must be collected
+// (so InspectTx excludes those scripts from payment-spend candidates), while
+// key-hash voters (DRep-key, committee-hot-key, stake-pool) carry no script and
+// must not be collected.
+func TestStakeScriptCredentialHashes_VotingProcedure(t *testing.T) {
+	voterHash := func(fill byte) [28]byte {
+		var h [28]byte
+		copy(h[:], bytesRepeat(fill, 28))
+		return h
+	}
+	tx := &conway.ConwayTransaction{}
+	drepScript := voterHash(0xd1)
+	ccHotScript := voterHash(0xc2)
+	drepKey := voterHash(0xd3)
+	ccHotKey := voterHash(0xc4)
+	poolKey := voterHash(0x5e)
+	tx.Body.TxVotingProcedures = lcommon.VotingProcedures{
+		{Type: lcommon.VoterTypeDRepScriptHash, Hash: drepScript}:                       {},
+		{Type: lcommon.VoterTypeConstitutionalCommitteeHotScriptHash, Hash: ccHotScript}: {},
+		{Type: lcommon.VoterTypeDRepKeyHash, Hash: drepKey}:                              {},
+		{Type: lcommon.VoterTypeConstitutionalCommitteeHotKeyHash, Hash: ccHotKey}:       {},
+		{Type: lcommon.VoterTypeStakingPoolKeyHash, Hash: poolKey}:                       {},
+	}
+
+	got := stakeScriptCredentialHashes(tx)
+	if !got[hex.EncodeToString(drepScript[:])] {
+		t.Errorf("DRep-script voter hash not collected: %v", got)
+	}
+	if !got[hex.EncodeToString(ccHotScript[:])] {
+		t.Errorf("committee-hot-script voter hash not collected: %v", got)
+	}
+	for _, kh := range [][28]byte{drepKey, ccHotKey, poolKey} {
+		if got[hex.EncodeToString(kh[:])] {
+			t.Errorf("key-hash voter %x must not be collected as a stake script: %v", kh, got)
+		}
+	}
+	if len(got) != 2 {
+		t.Errorf("want exactly the 2 script voters, got %d: %v", len(got), got)
+	}
+}
+
 // injectScriptWithdrawal decodes an ordinary unsigned tx and rewrites it to
 // carry a reward-account withdrawal keyed by ns's script hash, plus ns in the
 // witness set — the shape a script-credentialed (stake-purpose) withdrawal
@@ -348,6 +454,41 @@ func injectScriptWithdrawal(t *testing.T, fc *fakeChain, ns *bursa.NativeScript)
 	tx.SetCbor(nil)
 	tx.Body.SetCbor(nil)
 	tx.WitnessSet.SetCbor(nil)
+	return encodeConwayTx(t, &tx)
+}
+
+// injectScriptVote decodes an ordinary unsigned tx and rewrites it to carry a
+// governance voting procedure cast by a DRep-script voter keyed by ns's script
+// hash, plus ns in the witness set — the shape a vote-by-native-script tx takes.
+// See mintOnlyTxHex for why this is done at the gouroboros struct level.
+func injectScriptVote(t *testing.T, fc *fakeChain, ns *bursa.NativeScript) string {
+	t.Helper()
+	tx := decodeConwayTx(t, ordinaryUnsignedTxHex(t, fc))
+
+	var voterHash [28]byte
+	copy(voterHash[:], ns.Hash().Bytes())
+	voter := &lcommon.Voter{Type: lcommon.VoterTypeDRepScriptHash, Hash: voterHash}
+	govAction := &lcommon.GovActionId{GovActionIdx: 0}
+	tx.Body.TxVotingProcedures = lcommon.VotingProcedures{
+		voter: {govAction: lcommon.VotingProcedure{Vote: 1}},
+	}
+	tx.WitnessSet.WsNativeScripts = gcbor.NewSetType([]lcommon.NativeScript{*ns}, true)
+
+	tx.SetCbor(nil)
+	tx.Body.SetCbor(nil)
+	tx.WitnessSet.SetCbor(nil)
+	return encodeConwayTx(t, &tx)
+}
+
+// injectScriptWithdrawalAndMint builds a script-credentialed withdrawal tx (as
+// injectScriptWithdrawal) and additionally mints one unit under the SAME script
+// hash as a mint policy — a stake/gov script reused as a mint policy. InspectTx
+// must let the stake purpose dominate the mint purpose and classify it as an
+// unsupported stake/gov multisig, not route it to the vkey path.
+func injectScriptWithdrawalAndMint(t *testing.T, fc *fakeChain, ns *bursa.NativeScript) string {
+	t.Helper()
+	tx := decodeConwayTx(t, injectScriptWithdrawal(t, fc, ns))
+	injectMint(t, &tx, hex.EncodeToString(ns.Hash().Bytes()), []lcommon.NativeScript{*ns})
 	return encodeConwayTx(t, &tx)
 }
 

--- a/ui/internal/multisig/importtx_test.go
+++ b/ui/internal/multisig/importtx_test.go
@@ -1,0 +1,84 @@
+package multisig
+
+import (
+	"encoding/hex"
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/bursa"
+)
+
+func TestPolicyFromScript_RoundTrip(t *testing.T) {
+	kh := func(b byte) string { return hex.EncodeToString(bytesRepeat(b, 28)) }
+	in := Policy{
+		Threshold: 2,
+		Participants: []Participant{
+			{KeyHashHex: kh(1)}, {KeyHashHex: kh(2)}, {KeyHashHex: kh(3)},
+		},
+	}
+	script, err := composeScript(in)
+	if err != nil {
+		t.Fatalf("composeScript: %v", err)
+	}
+	got, err := PolicyFromScript(script)
+	if err != nil {
+		t.Fatalf("PolicyFromScript: %v", err)
+	}
+	if got.Threshold != 2 || len(got.Participants) != 3 {
+		t.Fatalf("got %d-of-%d, want 2-of-3", got.Threshold, len(got.Participants))
+	}
+	for i, part := range got.Participants {
+		if part.KeyHashHex != in.Participants[i].KeyHashHex {
+			t.Errorf("participant %d key hash = %s, want %s", i, part.KeyHashHex, in.Participants[i].KeyHashHex)
+		}
+	}
+}
+
+func TestPolicyFromScript_TimeLocked(t *testing.T) {
+	before, after := uint64(100), uint64(200)
+	kh := func(b byte) string { return hex.EncodeToString(bytesRepeat(b, 28)) }
+	in := Policy{
+		Threshold: 1, Participants: []Participant{{KeyHashHex: kh(1)}},
+		InvalidBefore: &before, InvalidAfter: &after,
+	}
+	script, err := composeScript(in)
+	if err != nil {
+		t.Fatalf("composeScript: %v", err)
+	}
+	got, err := PolicyFromScript(script)
+	if err != nil {
+		t.Fatalf("PolicyFromScript: %v", err)
+	}
+	if got.InvalidBefore == nil || *got.InvalidBefore != before {
+		t.Errorf("invalid_before = %v, want %d", got.InvalidBefore, before)
+	}
+	if got.InvalidAfter == nil || *got.InvalidAfter != after {
+		t.Errorf("invalid_after = %v, want %d", got.InvalidAfter, after)
+	}
+	if got.Threshold != 1 || len(got.Participants) != 1 {
+		t.Fatalf("got %d-of-%d, want 1-of-1", got.Threshold, len(got.Participants))
+	}
+}
+
+// TestPolicyFromScript_UnsupportedShape covers a script shape composeScript
+// never emits (a bare pubkey script, with no threshold clause at all): it
+// must be rejected as ErrInvalidTx, not silently accepted or panicked on.
+func TestPolicyFromScript_UnsupportedShape(t *testing.T) {
+	kh := bytesRepeat(1, 28)
+	script, err := bursa.NewScriptSig(kh)
+	if err != nil {
+		t.Fatalf("NewScriptSig: %v", err)
+	}
+	_, err = PolicyFromScript(script)
+	if !errors.Is(err, ErrInvalidTx) {
+		t.Fatalf("PolicyFromScript() error = %v, want ErrInvalidTx", err)
+	}
+}
+
+func bytesRepeat(b byte, n int) []byte {
+	s := make([]byte, n)
+	for i := range s {
+		s[i] = b
+	}
+	return s
+}

--- a/ui/internal/multisig/importtx_test.go
+++ b/ui/internal/multisig/importtx_test.go
@@ -259,6 +259,98 @@ func TestInspectTx_MultiSigSpendPlusMint(t *testing.T) {
 	}
 }
 
+// TestInspectTx_ScriptWithdrawalIsUnsupported covers the classification bug for
+// stake-purpose native scripts: a reward-account withdrawal governed by a
+// native script carries that script in the witness set, but it is there to
+// authorize a stake action, NOT a payment spend. InspectTx must NOT treat it as
+// a payment-multisig spend — doing so routes it to CosignImported, which
+// derives the role-0 PAYMENT multisig key and so produces the wrong key for the
+// legitimate owner (whose participation is via the stake/DRep key). It must be
+// reported as a recognizable-but-unsupported multisig (embedded script,
+// threshold 0, no participants) so CosignImported/SubmitImported refuse it.
+func TestInspectTx_ScriptWithdrawalIsUnsupported(t *testing.T) {
+	fc := newFakeChain()
+	svc := NewService(fc, nil, filepath.Join(t.TempDir(), "multisig.json"))
+
+	stakeScript, err := composeScript(Policy{
+		Threshold:    1,
+		Participants: []Participant{{KeyHashHex: hex.EncodeToString(bytesRepeat(5, 28))}},
+	})
+	if err != nil {
+		t.Fatalf("composeScript: %v", err)
+	}
+	txHex := injectScriptWithdrawal(t, fc, stakeScript)
+
+	info, err := svc.InspectTx(txHex)
+	if err != nil {
+		t.Fatalf("InspectTx: %v", err)
+	}
+	if !info.IsMultiSig || !info.ScriptEmbedded {
+		t.Fatalf("stake-script withdrawal should classify as an embedded multisig: %+v", info)
+	}
+	if info.Threshold != 0 || len(info.Participants) != 0 {
+		t.Fatalf("stake-script withdrawal must NOT be treated as a payment-multisig spend (want threshold 0, no participants): %+v", info)
+	}
+}
+
+// TestStakeScriptCredentialHashes_Certificate exercises the certificate branch
+// of the stake-purpose detector directly: a stake-deregistration certificate
+// bearing a script credential must be collected (so InspectTx excludes that
+// script from payment-spend candidates), while the same certificate with an
+// addr-key-hash credential must not be.
+func TestStakeScriptCredentialHashes_Certificate(t *testing.T) {
+	scriptHashHex := hex.EncodeToString(bytesRepeat(7, 28))
+	var credHash lcommon.Blake2b224
+	copy(credHash[:], bytesRepeat(7, 28))
+
+	scriptCred := func(credType uint) *conway.ConwayTransaction {
+		tx := &conway.ConwayTransaction{}
+		tx.Body.TxCertificates = []lcommon.CertificateWrapper{{
+			Type: uint(lcommon.CertificateTypeStakeDeregistration),
+			Certificate: &lcommon.StakeDeregistrationCertificate{
+				StakeCredential: lcommon.Credential{CredType: credType, Credential: credHash},
+			},
+		}}
+		return tx
+	}
+
+	if got := stakeScriptCredentialHashes(scriptCred(lcommon.CredentialTypeScriptHash)); !got[scriptHashHex] {
+		t.Fatalf("stake-deregistration script credential %s not collected: %v", scriptHashHex, got)
+	}
+	if got := stakeScriptCredentialHashes(scriptCred(lcommon.CredentialTypeAddrKeyHash)); len(got) != 0 {
+		t.Fatalf("addr-key-hash credential must not be collected as a stake script: %v", got)
+	}
+}
+
+// injectScriptWithdrawal decodes an ordinary unsigned tx and rewrites it to
+// carry a reward-account withdrawal keyed by ns's script hash, plus ns in the
+// witness set — the shape a script-credentialed (stake-purpose) withdrawal
+// takes. See mintOnlyTxHex for why this is done at the gouroboros struct level.
+func injectScriptWithdrawal(t *testing.T, fc *fakeChain, ns *bursa.NativeScript) string {
+	t.Helper()
+	tx := decodeConwayTx(t, ordinaryUnsignedTxHex(t, fc))
+
+	// Reward account (stake address) with a script staking credential: a header
+	// byte of AddressTypeNoneScript on the testnet network, then the 28-byte
+	// script hash.
+	scriptHash := ns.Hash()
+	raw := append(
+		[]byte{byte(lcommon.AddressTypeNoneScript<<4 | lcommon.AddressNetworkTestnet)},
+		scriptHash.Bytes()...,
+	)
+	addr, err := lcommon.NewAddressFromBytes(raw)
+	if err != nil {
+		t.Fatalf("reward addr: %v", err)
+	}
+	tx.Body.TxWithdrawals = map[*lcommon.Address]uint64{&addr: 1_000_000}
+	tx.WitnessSet.WsNativeScripts = gcbor.NewSetType([]lcommon.NativeScript{*ns}, true)
+
+	tx.SetCbor(nil)
+	tx.Body.SetCbor(nil)
+	tx.WitnessSet.SetCbor(nil)
+	return encodeConwayTx(t, &tx)
+}
+
 // mintOnlyTxHex builds an ordinary vkey-signed payment tx (via
 // ordinaryUnsignedTxHex — no script-locked input at all) and then injects a
 // mint of one unit under mintScript's policy ID plus mintScript itself into

--- a/ui/internal/multisig/importtx_test.go
+++ b/ui/internal/multisig/importtx_test.go
@@ -83,6 +83,29 @@ func TestPolicyFromScript_UnsupportedShape(t *testing.T) {
 	}
 }
 
+// TestPolicyFromScript_RejectsMultipleThresholdClauses covers a non-canonical
+// `all` script the node validates in full but composeScript never emits: two
+// N-of-K threshold clauses. Silently keeping only the last would let cosigning
+// report readiness against one clause while the node still enforces both, so
+// PolicyFromScript must reject it.
+func TestPolicyFromScript_RejectsMultipleThresholdClauses(t *testing.T) {
+	first, err := bursa.NewMultiSigScript(1, bytesRepeat(1, 28))
+	if err != nil {
+		t.Fatalf("NewMultiSigScript(first): %v", err)
+	}
+	second, err := bursa.NewMultiSigScript(1, bytesRepeat(2, 28))
+	if err != nil {
+		t.Fatalf("NewMultiSigScript(second): %v", err)
+	}
+	all, err := bursa.NewScriptAll(first, second)
+	if err != nil {
+		t.Fatalf("NewScriptAll: %v", err)
+	}
+	if _, err := PolicyFromScript(all); !errors.Is(err, ErrInvalidTx) {
+		t.Fatalf("PolicyFromScript(two threshold clauses) error = %v, want ErrInvalidTx", err)
+	}
+}
+
 func bytesRepeat(b byte, n int) []byte {
 	s := make([]byte, n)
 	for i := range s {

--- a/ui/internal/multisig/importtx_test.go
+++ b/ui/internal/multisig/importtx_test.go
@@ -1,11 +1,16 @@
 package multisig
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	apollo "github.com/blinklabs-io/apollo/v2"
 	"github.com/blinklabs-io/bursa"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
 func TestPolicyFromScript_RoundTrip(t *testing.T) {
@@ -81,4 +86,190 @@ func bytesRepeat(b byte, n int) []byte {
 		s[i] = b
 	}
 	return s
+}
+
+// --- InspectTx / FindByScriptHash ------------------------------------------
+
+// TestInspectTx_EmbeddedScript builds a real 2-of-3 multisig account, funds
+// its script address, and Build()s an unsigned spend (which attaches the
+// native script to the witness set per Build's contract). InspectTx must
+// recover the embedded script's policy and report zero signatures collected
+// so far, plus pick up the saved account's label via FindByScriptHash.
+func TestInspectTx_EmbeddedScript(t *testing.T) {
+	fc := newFakeChain()
+	svc := NewService(fc, nil, filepath.Join(t.TempDir(), "multisig.json"))
+	_, khA, _ := multiSigKeyHash(t, mnemonicA)
+	_, khB, _ := multiSigKeyHash(t, mnemonicB)
+	khC := hex.EncodeToString(bytesRepeat(3, 28))
+
+	acct, err := svc.Create(CreateRequest{
+		Label:   "treasury",
+		Network: "preview",
+		Policy: Policy{
+			Threshold: 2,
+			Participants: []Participant{
+				{KeyHashHex: khA}, {KeyHashHex: khB}, {KeyHashHex: khC},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	fc.addUTxO(acct.ScriptAddress, strings.Repeat("11", 32), 0, 10_000_000)
+
+	built, err := svc.Build(context.Background(), acct.ID, BuildRequest{To: externalAddr(t), Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	info, err := svc.InspectTx(built.UnsignedTxCBOR)
+	if err != nil {
+		t.Fatalf("InspectTx: %v", err)
+	}
+	if !info.IsMultiSig {
+		t.Fatal("expected IsMultiSig")
+	}
+	if info.Threshold != 2 || len(info.Participants) != 3 {
+		t.Errorf("got %d-of-%d, want 2-of-3", info.Threshold, len(info.Participants))
+	}
+	if info.SignedCount != 0 {
+		t.Errorf("signed_count = %d, want 0", info.SignedCount)
+	}
+	if !info.ScriptEmbedded {
+		t.Error("Build attaches the script, so ScriptEmbedded should be true")
+	}
+	if info.Label != acct.Label {
+		t.Errorf("label = %q, want %q (recovered via FindByScriptHash)", info.Label, acct.Label)
+	}
+	if info.ScriptHash == "" {
+		t.Error("expected a non-empty script hash")
+	}
+	for _, p := range info.Participants {
+		if p.Signed {
+			t.Errorf("participant %s reported signed on an unsigned tx", p.KeyHash)
+		}
+	}
+}
+
+// TestInspectTx_NotMultiSig feeds InspectTx an ordinary (no native script)
+// unsigned tx CBOR and asserts it is not classified as multisig.
+func TestInspectTx_NotMultiSig(t *testing.T) {
+	fc := newFakeChain()
+	svc := NewService(fc, nil, filepath.Join(t.TempDir(), "multisig.json"))
+
+	info, err := svc.InspectTx(ordinaryUnsignedTxHex(t, fc))
+	if err != nil {
+		t.Fatalf("InspectTx: %v", err)
+	}
+	if info.IsMultiSig {
+		t.Error("ordinary tx must not be classified multisig")
+	}
+	if info.ScriptEmbedded {
+		t.Error("ordinary tx must not report an embedded script")
+	}
+}
+
+// TestInspectTx_MalformedHex covers the ErrInvalidTx wrapping requirement for
+// hex that doesn't even decode.
+func TestInspectTx_MalformedHex(t *testing.T) {
+	fc := newFakeChain()
+	svc := NewService(fc, nil, filepath.Join(t.TempDir(), "multisig.json"))
+	if _, err := svc.InspectTx("not-hex-at-all"); !errors.Is(err, ErrInvalidTx) {
+		t.Fatalf("InspectTx(bad hex) error = %v, want ErrInvalidTx", err)
+	}
+}
+
+// TestFindByScriptHash_SkipsDecodeErrors saves one account with a corrupt
+// ScriptCBOR (so decodeScript fails) and one valid account, and asserts the
+// search still finds the valid one rather than aborting on the bad record.
+func TestFindByScriptHash_SkipsDecodeErrors(t *testing.T) {
+	fc := newFakeChain()
+	svc := NewService(fc, nil, filepath.Join(t.TempDir(), "multisig.json"))
+	_, khA, _ := multiSigKeyHash(t, mnemonicA)
+
+	acct, err := svc.Create(CreateRequest{
+		Label:   "good",
+		Network: "preview",
+		Policy:  Policy{Threshold: 1, Participants: []Participant{{KeyHashHex: khA}}},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	script, err := decodeScript(acct.ScriptCBOR)
+	if err != nil {
+		t.Fatalf("decodeScript: %v", err)
+	}
+	wantHash := hex.EncodeToString(script.Hash().Bytes())
+
+	// Inject a second, corrupt account directly into the store (bypassing
+	// Create, which would validate the script).
+	corrupt := Account{ID: "corrupt", Label: "corrupt", Network: "preview", ScriptCBOR: "zz-not-hex"}
+	if err := svc.store.add(corrupt); err != nil {
+		t.Fatalf("add corrupt account: %v", err)
+	}
+
+	got, ok, err := svc.FindByScriptHash(wantHash)
+	if err != nil {
+		t.Fatalf("FindByScriptHash: %v", err)
+	}
+	if !ok || got.ID != acct.ID {
+		t.Fatalf("FindByScriptHash = %+v, %v, want %s, true", got, ok, acct.ID)
+	}
+
+	if _, ok, err := svc.FindByScriptHash(strings.Repeat("ab", 28)); err != nil || ok {
+		t.Fatalf("FindByScriptHash(unknown) = %v, %v, want false, nil", ok, err)
+	}
+}
+
+// ordinaryUnsignedTxHex builds a plain (non-script) unsigned spend directly
+// through apollo — no AttachScript call — so the resulting Conway tx's
+// witness set carries zero native scripts. It exercises the same
+// build/complete path as Service.Build minus the script attachment, giving a
+// realistic (not hand-crafted) "not multisig" fixture.
+func ordinaryUnsignedTxHex(t *testing.T, fc *fakeChain) string {
+	t.Helper()
+	root, err := bursa.GetRootKeyFromMnemonic(mnemonicA, "")
+	if err != nil {
+		t.Fatalf("root key: %v", err)
+	}
+	acctKey, err := bursa.GetAccountKey(root, 0)
+	if err != nil {
+		t.Fatalf("account key: %v", err)
+	}
+	pay, err := bursa.GetPaymentKey(acctKey, 0)
+	if err != nil {
+		t.Fatalf("payment key: %v", err)
+	}
+	stake, err := bursa.GetStakeKey(acctKey, 0)
+	if err != nil {
+		t.Fatalf("stake key: %v", err)
+	}
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyKey, lcommon.AddressNetworkTestnet,
+		pay.Public().PublicKey().Hash(), stake.Public().PublicKey().Hash(),
+	)
+	if err != nil {
+		t.Fatalf("plain addr: %v", err)
+	}
+	fc.addUTxO(addr.String(), strings.Repeat("cc", 32), 0, 10_000_000)
+
+	a := apollo.New(fc).
+		SetWallet(apollo.NewExternalWallet(addr)).
+		SetChangeAddress(addr)
+	utxos, err := fc.Utxos(context.Background(), addr)
+	if err != nil {
+		t.Fatalf("utxos: %v", err)
+	}
+	a = a.AddLoadedUTxOs(utxos...)
+	a = a.PayToAddress(addr, 1_000_000)
+
+	a, err = a.CompleteContext(context.Background())
+	if err != nil {
+		t.Fatalf("complete ordinary tx: %v", err)
+	}
+	cborBytes, err := a.GetTxCbor()
+	if err != nil {
+		t.Fatalf("encode ordinary tx: %v", err)
+	}
+	return hex.EncodeToString(cborBytes)
 }

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -2,6 +2,7 @@ package multisig
 
 import (
 	"context"
+	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -261,10 +262,21 @@ func composeScript(p Policy) (*bursa.NativeScript, error) {
 // panicked on.
 func PolicyFromScript(ns *bursa.NativeScript) (Policy, error) {
 	var p Policy
+	// composeScript emits exactly one threshold clause and at most one clause of
+	// each time-lock type. A non-canonical script (multiple N-of-K clauses, or
+	// repeated time-locks) is rejected rather than silently collapsed to the
+	// last one seen: the node validates ALL clauses of an `all`, so showing and
+	// threshold-checking only one would let cosigning report readiness while the
+	// node still rejects the tx.
+	var nofk, invalidBefore, invalidAfter int
 	var walk func(node *lcommon.NativeScript) error
 	walk = func(node *lcommon.NativeScript) error {
 		switch v := node.Item().(type) {
 		case *lcommon.NativeScriptNofK:
+			nofk++
+			if nofk > 1 {
+				return fmt.Errorf("%w: native script has more than one threshold clause", ErrInvalidTx)
+			}
 			parts := make([]Participant, 0, len(v.Scripts))
 			for i := range v.Scripts {
 				pk, ok := v.Scripts[i].Item().(*lcommon.NativeScriptPubkey)
@@ -276,9 +288,17 @@ func PolicyFromScript(ns *bursa.NativeScript) (Policy, error) {
 			p.Threshold = int(v.N)
 			p.Participants = parts
 		case *lcommon.NativeScriptInvalidBefore:
+			invalidBefore++
+			if invalidBefore > 1 {
+				return fmt.Errorf("%w: native script has more than one invalid-before clause", ErrInvalidTx)
+			}
 			slot := v.Slot
 			p.InvalidBefore = &slot
 		case *lcommon.NativeScriptInvalidHereafter:
+			invalidAfter++
+			if invalidAfter > 1 {
+				return fmt.Errorf("%w: native script has more than one invalid-hereafter clause", ErrInvalidTx)
+			}
 			slot := v.Slot
 			p.InvalidAfter = &slot
 		case *lcommon.NativeScriptAll:
@@ -674,20 +694,40 @@ func (s *Service) InspectTx(txCbor string) (TxInfo, error) {
 		}
 	}
 
-	var ns *lcommon.NativeScript
+	// An embedded native script is present for one of two reasons: it authorizes
+	// minting under its policy ID, or it satisfies a script-locked spend input.
+	// A script whose hash is a mint policy MAY be there only for minting, so its
+	// presence — even matching a saved account — is NOT proof of a spend
+	// (resolving the inputs would be required to know, and that needs a node).
+	// A script that is not a mint policy can only be there to satisfy a spend,
+	// so those are the candidate spend scripts.
+	var candidates []*lcommon.NativeScript
 	for i := range scripts {
 		hash := hex.EncodeToString(scripts[i].Hash().Bytes())
-		if _, ok, _ := s.FindByScriptHash(hash); ok || !mintPolicies[hash] {
-			ns = &scripts[i]
-			break
+		if !mintPolicies[hash] {
+			candidates = append(candidates, &scripts[i])
 		}
 	}
-	if ns == nil {
-		// Every embedded native script is a mint-only policy: there is no
-		// script-locked spend here, so this is an ordinary tx that happens to
-		// mint under a native-script policy — route to the vkey path.
+	switch len(candidates) {
+	case 0:
+		// Every embedded native script is a mint policy: without resolving the
+		// inputs there is no evidence of a script-locked spend, so this is an
+		// ordinary tx that mints under a native-script policy — route to the
+		// vkey path. (A mint policy that also happens to be saved as a multisig
+		// account in this wallet is NOT treated as a spend on that basis alone.)
 		return TxInfo{IsMultiSig: false}, nil
+	case 1:
+		// Exactly one candidate spend script — the supported case.
+	default:
+		// The spend is protected by more than one native script. Only a single
+		// policy can be inspected and threshold-checked here; classifying against
+		// just the first would let the UI report readiness while another script
+		// stays unsatisfied. Report multi-sig but leave the policy fields empty
+		// (Threshold stays 0), so CosignImported/SubmitImported refuse it rather
+		// than guess.
+		return TxInfo{IsMultiSig: true, ScriptEmbedded: true}, nil
 	}
+	ns := candidates[0]
 	scriptHash := hex.EncodeToString(ns.Hash().Bytes())
 
 	policy, err := PolicyFromScript(ns)
@@ -709,10 +749,25 @@ func (s *Service) InspectTx(txCbor string) (TxInfo, error) {
 		policy = mergeParticipantLabels(policy, acct.Policy)
 	}
 
-	// Signed participants = vkey witnesses already attached whose key-hash is
-	// a policy participant. Key-hashes are compared case-insensitively.
+	// Signed participants = vkey witnesses already attached whose key-hash is a
+	// policy participant AND whose signature verifies over the tx body bytes.
+	// Key-hashes are compared case-insensitively. Verifying the signature is
+	// essential: a pasted tx can carry a bogus witness for a participant's key,
+	// and counting it toward the threshold would let SubmitImported broadcast a
+	// tx the node then rejects.
+	bodyCbor := tx.Body.Cbor()
+	if bodyCbor == nil {
+		bodyCbor, err = cbor.Encode(&tx.Body)
+		if err != nil {
+			return TxInfo{}, fmt.Errorf("encode tx body: %w", err)
+		}
+	}
+	bodyHash := lcommon.Blake2b256Hash(bodyCbor)
 	signed := make(map[string]bool, len(tx.WitnessSet.VkeyWitnesses.Items()))
 	for _, w := range tx.WitnessSet.VkeyWitnesses.Items() {
+		if !vkeyWitnessValid(w, bodyHash.Bytes()) {
+			continue
+		}
 		kh := strings.ToLower(hex.EncodeToString(lcommon.Blake2b224Hash(w.Vkey).Bytes()))
 		signed[kh] = true
 	}
@@ -1034,10 +1089,24 @@ func (s *Service) CosignImported(txCbor, password string) (CosignResult, error) 
 		)
 	}
 
-	// Existing co-signer witnesses (dedupe key: lower-case key-hash).
+	// Rebuild the witness set from only the existing witnesses whose signature
+	// verifies over the body bytes, deduped by lower-case key-hash. Counting or
+	// deduping by key-hash alone is unsafe: a pasted tx can carry an invalid
+	// witness bearing this wallet's own key, which would make this cosign a
+	// no-op (added=false) and leave the bogus witness in place for the node to
+	// reject. Dropping non-verifying witnesses lets our valid one replace it.
 	signed := make(map[string]bool, len(tx.WitnessSet.VkeyWitnesses.Items()))
+	kept := make([]lcommon.VkeyWitness, 0, len(tx.WitnessSet.VkeyWitnesses.Items()))
 	for _, w := range tx.WitnessSet.VkeyWitnesses.Items() {
-		signed[strings.ToLower(hex.EncodeToString(lcommon.Blake2b224Hash(w.Vkey).Bytes()))] = true
+		if !vkeyWitnessValid(w, bodyHash.Bytes()) {
+			continue
+		}
+		kh := strings.ToLower(hex.EncodeToString(lcommon.Blake2b224Hash(w.Vkey).Bytes()))
+		if signed[kh] {
+			continue
+		}
+		signed[kh] = true
+		kept = append(kept, w)
 	}
 	added := false
 	if !signed[myKH] {
@@ -1045,12 +1114,11 @@ func (s *Service) CosignImported(txCbor, password string) (CosignResult, error) 
 		if err != nil {
 			return CosignResult{}, fmt.Errorf("sign with multisig key: %w", err)
 		}
-		if a, err = a.AddVerificationKeyWitness(w); err != nil {
-			return CosignResult{}, fmt.Errorf("attach witness: %w", err)
-		}
 		signed[myKH] = true
+		kept = append(kept, w)
 		added = true
 	}
+	tx.WitnessSet.VkeyWitnesses = cbor.NewSetType(kept, true)
 
 	// Clear the tx-level and witness-set caches so GetTxCbor re-serializes the
 	// merged witness set; the BODY cache stays intact so every witness (ours
@@ -1080,6 +1148,19 @@ func (s *Service) CosignImported(txCbor, password string) (CosignResult, error) 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+// vkeyWitnessValid reports whether w is a genuine Ed25519 signature by w.Vkey
+// over msg (the tx body hash bytes). Cardano's BIP32-Ed25519 witnesses verify
+// under standard Ed25519 against the 32-byte public key, so a pasted tx
+// carrying a malformed or foreign witness — even one bearing a participant's
+// key — is rejected here rather than counted toward the threshold on key-hash
+// alone.
+func vkeyWitnessValid(w lcommon.VkeyWitness, msg []byte) bool {
+	if len(w.Vkey) != ed25519.PublicKeySize || len(w.Signature) != ed25519.SignatureSize {
+		return false
+	}
+	return ed25519.Verify(ed25519.PublicKey(w.Vkey), msg, w.Signature)
+}
 
 // decodeScript reconstructs a native script from its hex CBOR.
 func decodeScript(scriptCBORHex string) (*bursa.NativeScript, error) {

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -854,6 +854,74 @@ type TxResult struct {
 	TxHash string `json:"tx_hash"`
 }
 
+// SubmitImported is the "paste a fully co-signed tx, broadcast it" flow: the
+// counterpart to CosignImported's off-band CBOR-passing workflow, where
+// instead of collecting separate witness blobs (Submit's contract) the
+// growing signed tx CBOR itself has been passed from co-signer to co-signer
+// and this is the final hop. It classifies the tx via InspectTx, attaches the
+// native script from a saved account when the tx doesn't already embed one,
+// verifies the collected witnesses meet the script's threshold, and
+// broadcasts — mirroring Submit's byte-safety (clear the tx-level and
+// witness-set CBOR caches, leave the body cache intact) and submit call.
+func (s *Service) SubmitImported(ctx context.Context, txCbor string) (TxResult, error) {
+	info, err := s.InspectTx(txCbor)
+	if err != nil {
+		return TxResult{}, err
+	}
+	if !info.IsMultiSig || info.Threshold == 0 {
+		return TxResult{}, fmt.Errorf("%w: not a recognizable multisig transaction", ErrInvalidTx)
+	}
+
+	a, err := apollo.New(s.chain).LoadTxCbor(strings.TrimSpace(txCbor))
+	if err != nil {
+		return TxResult{}, fmt.Errorf("%w: %w", ErrInvalidTx, err)
+	}
+	tx := a.GetTx()
+	if tx == nil {
+		return TxResult{}, fmt.Errorf("%w: no transaction body", ErrInvalidTx)
+	}
+
+	// Attach the native script if the tx doesn't already carry one but a saved
+	// account's script matches the hash InspectTx recovered from the policy.
+	if !info.ScriptEmbedded && info.ScriptHash != "" {
+		acct, ok, err := s.FindByScriptHash(info.ScriptHash)
+		if err != nil {
+			return TxResult{}, err
+		}
+		if !ok {
+			return TxResult{}, fmt.Errorf(
+				"%w: transaction lacks its native script and no saved account matches",
+				ErrInvalidTx,
+			)
+		}
+		script, err := decodeScript(acct.ScriptCBOR)
+		if err != nil {
+			return TxResult{}, err
+		}
+		a = a.AttachScript(*script)
+	}
+
+	if info.SignedCount < info.Threshold {
+		return TxResult{}, fmt.Errorf(
+			"%w: have %d of %d required signatures",
+			ErrInvalidWitness, info.SignedCount, info.Threshold,
+		)
+	}
+
+	// LoadTxCbor cached the decoded tx's raw CBOR; clear the tx-level and
+	// witness-set caches so SubmitContext re-serializes the (possibly
+	// newly-attached) script and witnesses. The BODY cache stays intact: the
+	// witnesses signed the original body bytes (mirrors Submit).
+	tx.SetCbor(nil)
+	tx.WitnessSet.SetCbor(nil)
+
+	txHash, err := a.SubmitContext(context.WithoutCancel(ctx))
+	if err != nil {
+		return TxResult{}, fmt.Errorf("%w: %w", ErrSubmitRejected, err)
+	}
+	return TxResult{TxHash: hex.EncodeToString(txHash.Bytes())}, nil
+}
+
 // CosignResult is returned from CosignImported: the merged tx CBOR plus
 // enough bookkeeping (whether this cosign actually added a new witness, how
 // many participant signatures the tx now carries, and the policy threshold)

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -854,6 +854,142 @@ type TxResult struct {
 	TxHash string `json:"tx_hash"`
 }
 
+// CosignResult is returned from CosignImported: the merged tx CBOR plus
+// enough bookkeeping (whether this cosign actually added a new witness, how
+// many participant signatures the tx now carries, and the policy threshold)
+// for the UI to show cosigning progress and decide whether the tx is ready to
+// submit.
+type CosignResult struct {
+	TxCBOR      string `json:"tx_cbor"`
+	Added       bool   `json:"added"`
+	SignedCount int    `json:"signed_count"`
+	Threshold   int    `json:"threshold"`
+}
+
+// CosignImported is the "paste a tx, cosign it, hand back the CBOR" flow: an
+// alternative to Sign+Submit's off-band witness collection where instead the
+// growing signed tx CBOR itself is passed from co-signer to co-signer. It
+// derives this wallet's CIP-1854 multi-sig key exactly as Sign does, verifies
+// (via InspectTx's recovered policy) that the wallet's key-hash is actually a
+// participant in the tx's script — refusing with ErrInvalidRequest otherwise,
+// since signing a script this wallet has no part in cannot help satisfy it —
+// then signs the tx's body hash and merges the resulting witness into the
+// tx's existing witness set, preserving whatever co-signer witnesses are
+// already attached. Merging is deduped by key-hash, so cosigning a tx that
+// already carries this wallet's witness is a no-op (Added=false).
+func (s *Service) CosignImported(txCbor, password string) (CosignResult, error) {
+	if s.keys == nil || !s.keys.Exists() {
+		return CosignResult{}, ErrNoKeystore
+	}
+	info, err := s.InspectTx(txCbor)
+	if err != nil {
+		return CosignResult{}, err
+	}
+	if !info.IsMultiSig || info.Threshold == 0 {
+		return CosignResult{}, fmt.Errorf("%w: not a recognizable multisig transaction", ErrInvalidTx)
+	}
+	participants := make(map[string]bool, len(info.Participants))
+	for _, p := range info.Participants {
+		participants[strings.ToLower(p.KeyHash)] = true
+	}
+
+	a, err := apollo.New(s.chain).LoadTxCbor(strings.TrimSpace(txCbor))
+	if err != nil {
+		return CosignResult{}, fmt.Errorf("%w: %w", ErrInvalidTx, err)
+	}
+	tx := a.GetTx()
+	if tx == nil {
+		return CosignResult{}, fmt.Errorf("%w: no transaction body", ErrInvalidTx)
+	}
+	// Witnesses sign the exact body bytes carried by the imported transaction.
+	// Re-encoding can drift while preserving semantics (mirrors Sign).
+	bodyCbor := tx.Body.Cbor()
+	if bodyCbor == nil {
+		bodyCbor, err = cbor.Encode(&tx.Body)
+		if err != nil {
+			return CosignResult{}, fmt.Errorf("encode tx body: %w", err)
+		}
+	}
+	bodyHash := lcommon.Blake2b256Hash(bodyCbor)
+
+	mnemonicBytes, err := s.keys.Unlock(password)
+	if err != nil {
+		if errors.Is(err, keystore.ErrDecryptFailed) {
+			return CosignResult{}, fmt.Errorf("%w: %w", ErrWrongPassword, err)
+		}
+		return CosignResult{}, fmt.Errorf("unlock keystore: %w", err)
+	}
+	var rootKey, acctKey, payKey bip32.XPrv
+	defer func() {
+		for _, k := range []bip32.XPrv{rootKey, acctKey, payKey} {
+			zero(k)
+		}
+		zeroBytes(mnemonicBytes)
+	}()
+
+	rootKey, err = bursa.GetRootKeyFromMnemonic(string(mnemonicBytes), "")
+	if err != nil {
+		return CosignResult{}, fmt.Errorf("root key: %w", err)
+	}
+	acctKey, err = bursa.GetMultiSigAccountKey(rootKey, 0)
+	if err != nil {
+		return CosignResult{}, fmt.Errorf("multisig account key: %w", err)
+	}
+	payKey, err = bursa.GetMultiSigPaymentKey(acctKey, 0)
+	if err != nil {
+		return CosignResult{}, fmt.Errorf("multisig payment key: %w", err)
+	}
+	myKH := strings.ToLower(hex.EncodeToString(lcommon.Blake2b224Hash(payKey.Public().PublicKey()).Bytes()))
+	if !participants[myKH] {
+		return CosignResult{}, fmt.Errorf(
+			"%w: this wallet is not a participant in the transaction's policy",
+			ErrInvalidRequest,
+		)
+	}
+
+	// Existing co-signer witnesses (dedupe key: lower-case key-hash).
+	signed := make(map[string]bool, len(tx.WitnessSet.VkeyWitnesses.Items()))
+	for _, w := range tx.WitnessSet.VkeyWitnesses.Items() {
+		signed[strings.ToLower(hex.EncodeToString(lcommon.Blake2b224Hash(w.Vkey).Bytes()))] = true
+	}
+	added := false
+	if !signed[myKH] {
+		w, err := apollo.NewVkeyWitnessFromSkey(bodyHash, []byte(payKey))
+		if err != nil {
+			return CosignResult{}, fmt.Errorf("sign with multisig key: %w", err)
+		}
+		if a, err = a.AddVerificationKeyWitness(w); err != nil {
+			return CosignResult{}, fmt.Errorf("attach witness: %w", err)
+		}
+		signed[myKH] = true
+		added = true
+	}
+
+	// Clear the tx-level and witness-set caches so GetTxCbor re-serializes the
+	// merged witness set; the BODY cache stays intact so every witness (ours
+	// and any prior co-signer's) still matches the re-emitted body bytes
+	// (mirrors Submit).
+	tx.SetCbor(nil)
+	tx.WitnessSet.SetCbor(nil)
+	mergedBytes, err := a.GetTxCbor()
+	if err != nil {
+		return CosignResult{}, fmt.Errorf("encode merged tx: %w", err)
+	}
+
+	signedCount := 0
+	for kh := range signed {
+		if participants[kh] {
+			signedCount++
+		}
+	}
+	return CosignResult{
+		TxCBOR:      hex.EncodeToString(mergedBytes),
+		Added:       added,
+		SignedCount: signedCount,
+		Threshold:   info.Threshold,
+	}, nil
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -18,6 +18,7 @@ import (
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 )
 
 // Sentinel errors. The API layer maps these to HTTP status codes via errors.Is.
@@ -97,6 +98,28 @@ type UnsignedTx struct {
 // common.VkeyWitness, normally length 1 — this co-signer's multi-sig key).
 type Witness struct {
 	WitnessCBOR string `json:"witness_cbor"`
+}
+
+// TxParticipant is one candidate signer of an inspected transaction's policy,
+// together with whether a vkey witness for it is already attached.
+type TxParticipant struct {
+	KeyHash string `json:"key_hash"`
+	Label   string `json:"label,omitempty"`
+	Signed  bool   `json:"signed"`
+}
+
+// TxInfo is the classification of a pasted transaction produced by InspectTx:
+// whether it is a native-script multi-sig spend, its recovered policy (if
+// any), and per-participant signed status so the UI can show co-signing
+// progress.
+type TxInfo struct {
+	IsMultiSig     bool            `json:"is_multisig"`
+	Label          string          `json:"label,omitempty"`
+	ScriptHash     string          `json:"script_hash,omitempty"`
+	Threshold      int             `json:"threshold,omitempty"`
+	Participants   []TxParticipant `json:"participants,omitempty"`
+	SignedCount    int             `json:"signed_count"`
+	ScriptEmbedded bool            `json:"script_embedded"`
 }
 
 // Keystore is the minimal interface the service needs of *keystore.Keystore.
@@ -323,6 +346,29 @@ func (s *Service) Get(id string) (Account, error) {
 // Delete removes a saved account by id.
 func (s *Service) Delete(id string) error {
 	return s.store.remove(id)
+}
+
+// FindByScriptHash searches the saved accounts for one whose native script
+// hashes to scriptHashHex (as produced by NativeScript.Hash). It returns
+// (Account{}, false, nil) when no account matches. A saved account whose
+// ScriptCBOR fails to decode is skipped rather than aborting the search —
+// one corrupt record must not hide every other account.
+func (s *Service) FindByScriptHash(scriptHashHex string) (Account, bool, error) {
+	accts, err := s.store.list()
+	if err != nil {
+		return Account{}, false, err
+	}
+	want := strings.ToLower(strings.TrimSpace(scriptHashHex))
+	for _, a := range accts {
+		script, err := decodeScript(a.ScriptCBOR)
+		if err != nil {
+			continue
+		}
+		if strings.ToLower(hex.EncodeToString(script.Hash().Bytes())) == want {
+			return a, true, nil
+		}
+	}
+	return Account{}, false, nil
 }
 
 // CreateRequest is the input to Create: a label, the network, and the policy.
@@ -584,6 +630,71 @@ func (s *Service) Build(ctx context.Context, id string, req BuildRequest) (Unsig
 	}, nil
 }
 
+// InspectTx classifies a pasted transaction CBOR: whether it is a native-
+// script multi-sig spend, its recovered policy, and per-participant signed
+// status. It prefers an embedded native script (Build attaches one to the
+// witness set); when found, it also tries to match a saved account by script
+// hash to recover a friendly label and any saved participant labels. A native
+// script that isn't a recognizable N-of-M policy is still reported as
+// multi-sig (with the script hash set) but leaves the policy fields empty so
+// the UI can warn, rather than erroring. A tx with no embedded native script
+// at all — without chain resolution of its inputs there is nothing to match
+// against — is reported as not multi-sig.
+func (s *Service) InspectTx(txCbor string) (TxInfo, error) {
+	txBytes, err := hex.DecodeString(strings.TrimSpace(txCbor))
+	if err != nil {
+		return TxInfo{}, fmt.Errorf("%w: tx hex: %w", ErrInvalidTx, err)
+	}
+	var tx conway.ConwayTransaction
+	if _, err := cbor.Decode(txBytes, &tx); err != nil {
+		return TxInfo{}, fmt.Errorf("%w: %w", ErrInvalidTx, err)
+	}
+
+	scripts := tx.WitnessSet.NativeScripts()
+	if len(scripts) == 0 {
+		return TxInfo{IsMultiSig: false}, nil
+	}
+	ns := &scripts[0]
+	scriptHash := hex.EncodeToString(ns.Hash().Bytes())
+
+	policy, err := PolicyFromScript(ns)
+	if err != nil {
+		// Not a recognizable N-of-M policy: report multi-sig + the script hash
+		// so the UI can warn, but leave the policy fields empty. Deliberately
+		// not an error — this is a classification result, not a failure.
+		return TxInfo{IsMultiSig: true, ScriptEmbedded: true, ScriptHash: scriptHash}, nil //nolint:nilerr // classification, not failure — see comment above
+	}
+
+	info := TxInfo{
+		IsMultiSig:     true,
+		ScriptEmbedded: true,
+		ScriptHash:     scriptHash,
+		Threshold:      policy.Threshold,
+	}
+	if acct, ok, _ := s.FindByScriptHash(scriptHash); ok {
+		info.Label = acct.Label
+		policy = mergeParticipantLabels(policy, acct.Policy)
+	}
+
+	// Signed participants = vkey witnesses already attached whose key-hash is
+	// a policy participant. Key-hashes are compared case-insensitively.
+	signed := make(map[string]bool, len(tx.WitnessSet.VkeyWitnesses.Items()))
+	for _, w := range tx.WitnessSet.VkeyWitnesses.Items() {
+		kh := strings.ToLower(hex.EncodeToString(lcommon.Blake2b224Hash(w.Vkey).Bytes()))
+		signed[kh] = true
+	}
+	info.Participants = make([]TxParticipant, 0, len(policy.Participants))
+	for _, part := range policy.Participants {
+		kh := strings.ToLower(part.KeyHashHex)
+		p := TxParticipant{KeyHash: kh, Label: part.Label, Signed: signed[kh]}
+		if p.Signed {
+			info.SignedCount++
+		}
+		info.Participants = append(info.Participants, p)
+	}
+	return info, nil
+}
+
 // Sign is a co-signer's step: it decrypts the seed, derives the wallet's CIP-1854
 // multi-sig key (NOT the CIP-1852 payment key used for ordinary sends), and emits
 // that key's vkey witness over the unsigned tx body. The witness is collected with
@@ -758,6 +869,30 @@ func decodeScript(scriptCBORHex string) (*bursa.NativeScript, error) {
 		return nil, fmt.Errorf("%w: decode script: %w", ErrInvalidRequest, err)
 	}
 	return &ns, nil
+}
+
+// mergeParticipantLabels copies each saved participant's Label onto the
+// matching (case-insensitive key-hash) participant recovered from the
+// script, leaving fromScript's ordering and threshold untouched. It is used
+// so InspectTx can show friendly names for participants of a saved account
+// even though the script itself only carries key-hashes.
+func mergeParticipantLabels(fromScript, saved Policy) Policy {
+	labels := make(map[string]string, len(saved.Participants))
+	for _, sp := range saved.Participants {
+		if sp.Label == "" {
+			continue
+		}
+		labels[strings.ToLower(sp.KeyHashHex)] = sp.Label
+	}
+	out := fromScript
+	out.Participants = make([]Participant, len(fromScript.Participants))
+	for i, p := range fromScript.Participants {
+		if label, ok := labels[strings.ToLower(p.KeyHashHex)]; ok {
+			p.Label = label
+		}
+		out.Participants[i] = p
+	}
+	return out
 }
 
 // scriptKeyHashes returns the participant key-hashes (as raw 28-byte slices) of a

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -858,11 +858,10 @@ type TxResult struct {
 // counterpart to CosignImported's off-band CBOR-passing workflow, where
 // instead of collecting separate witness blobs (Submit's contract) the
 // growing signed tx CBOR itself has been passed from co-signer to co-signer
-// and this is the final hop. It classifies the tx via InspectTx, attaches the
-// native script from a saved account when the tx doesn't already embed one,
-// verifies the collected witnesses meet the script's threshold, and
-// broadcasts — mirroring Submit's byte-safety (clear the tx-level and
-// witness-set CBOR caches, leave the body cache intact) and submit call.
+// and this is the final hop. It classifies the tx via InspectTx, verifies the
+// collected witnesses meet the script's threshold, and broadcasts —
+// mirroring Submit's byte-safety (clear the tx-level and witness-set CBOR
+// caches, leave the body cache intact) and submit call.
 func (s *Service) SubmitImported(ctx context.Context, txCbor string) (TxResult, error) {
 	info, err := s.InspectTx(txCbor)
 	if err != nil {
@@ -881,25 +880,12 @@ func (s *Service) SubmitImported(ctx context.Context, txCbor string) (TxResult, 
 		return TxResult{}, fmt.Errorf("%w: no transaction body", ErrInvalidTx)
 	}
 
-	// Attach the native script if the tx doesn't already carry one but a saved
-	// account's script matches the hash InspectTx recovered from the policy.
-	if !info.ScriptEmbedded && info.ScriptHash != "" {
-		acct, ok, err := s.FindByScriptHash(info.ScriptHash)
-		if err != nil {
-			return TxResult{}, err
-		}
-		if !ok {
-			return TxResult{}, fmt.Errorf(
-				"%w: transaction lacks its native script and no saved account matches",
-				ErrInvalidTx,
-			)
-		}
-		script, err := decodeScript(acct.ScriptCBOR)
-		if err != nil {
-			return TxResult{}, err
-		}
-		a = a.AttachScript(*script)
-	}
+	// A multisig tx always carries its native script: Build attaches it and
+	// co-signing preserves it, so a tx that reaches here is guaranteed to have
+	// an embedded script (the !IsMultiSig guard above rejects any tx without a
+	// recognizable embedded native-script policy). Recovering a stripped script
+	// from a saved account would require chain-based input resolution and is out
+	// of scope; see InspectTx.
 
 	if info.SignedCount < info.Threshold {
 		return TxResult{}, fmt.Errorf(

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -721,12 +721,15 @@ func (s *Service) InspectTx(txCbor string) (TxInfo, error) {
 	for i := range scripts {
 		hash := hex.EncodeToString(scripts[i].Hash().Bytes())
 		switch {
+		case stakeScriptHashes[hash]:
+			// Positively a stake/governance-purpose script (withdrawal,
+			// certificate, or governance-vote credential), not a payment spend.
+			// This is checked BEFORE the mint-policy case: a stake/gov script
+			// reused as a mint policy still needs its stake/gov witness, so it
+			// must not be routed to the vkey path — the stake purpose dominates.
+			stakePurpose = true
 		case mintPolicies[hash]:
 			// mint-only evidence — not a spend on this basis alone.
-		case stakeScriptHashes[hash]:
-			// Positively a stake/governance-purpose script (withdrawal or
-			// certificate credential), not a payment spend.
-			stakePurpose = true
 		default:
 			candidates = append(candidates, &scripts[i])
 		}
@@ -1186,9 +1189,10 @@ func (s *Service) CosignImported(txCbor, password string) (CosignResult, error) 
 
 // stakeScriptCredentialHashes returns the set (hex-encoded, lower-case) of
 // script-hash credentials the tx body uses for a non-payment purpose: the
-// script credentials of reward withdrawals and of certificates (stake and
-// DRep/committee). An embedded native script whose hash appears here is present
-// to authorize that stake/governance action, not a payment spend, so InspectTx
+// script credentials of reward withdrawals, of certificates (stake and
+// DRep/committee), and of governance voters (DRep-script / committee-hot-script
+// votes). An embedded native script whose hash appears here is present to
+// authorize that stake/governance action, not a payment spend, so InspectTx
 // must not classify it as payment multisig. This mirrors spend.neededKeyHashes'
 // certificate/withdrawal walk but collects script-hash (not addr-key-hash)
 // credentials.
@@ -1239,6 +1243,21 @@ func stakeScriptCredentialHashes(tx *conway.ConwayTransaction) map[string]bool {
 		}
 		if payload, ok := addr.StakingPayload().(lcommon.AddressPayloadScriptHash); ok {
 			out[hex.EncodeToString(payload.Hash.Bytes())] = true
+		}
+	}
+	// Governance votes: a DRep-script or committee-hot-script voter authorizes
+	// its vote via a native script, exactly like a script-credentialed
+	// certificate. (Stake-pool voters are key-only, so they never carry an
+	// embedded native script.) Collect those voter hashes so a vote-by-native-
+	// script tx is not mis-classified as a payment spend.
+	for voter := range tx.Body.TxVotingProcedures {
+		if voter == nil {
+			continue
+		}
+		switch voter.Type {
+		case lcommon.VoterTypeDRepScriptHash,
+			lcommon.VoterTypeConstitutionalCommitteeHotScriptHash:
+			out[hex.EncodeToString(voter.Hash[:])] = true
 		}
 	}
 	return out

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -2,7 +2,6 @@ package multisig
 
 import (
 	"context"
-	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -17,6 +16,7 @@ import (
 	"github.com/blinklabs-io/bursa/bip32"
 	"github.com/blinklabs-io/bursa/ui/internal/cardanonet"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
+	"github.com/blinklabs-io/bursa/ui/internal/txwitness"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
@@ -694,19 +694,54 @@ func (s *Service) InspectTx(txCbor string) (TxInfo, error) {
 		}
 	}
 
-	// An embedded native script is present for one of two reasons: it authorizes
-	// minting under its policy ID, or it satisfies a script-locked spend input.
+	// An embedded native script can be present for several reasons: it authorizes
+	// minting under its policy ID, satisfies a script-locked spend (payment)
+	// input, or authorizes a stake/governance action (a script-credentialed
+	// withdrawal or certificate). The mint and stake/gov purposes are resolvable
+	// from the tx body alone (mint policies, and the script-hash credentials of
+	// withdrawals/certificates); a payment spend is not (it would require
+	// resolving the referenced inputs against the chain, which needs a node).
+	//
 	// A script whose hash is a mint policy MAY be there only for minting, so its
-	// presence — even matching a saved account — is NOT proof of a spend
-	// (resolving the inputs would be required to know, and that needs a node).
-	// A script that is not a mint policy can only be there to satisfy a spend,
-	// so those are the candidate spend scripts.
+	// presence — even matching a saved account — is NOT proof of a spend. A
+	// script whose hash matches a withdrawal/certificate script credential is
+	// there for that stake/gov purpose: it must NOT be treated as a payment
+	// spend, because CosignImported derives the role-0 PAYMENT multisig key and
+	// would produce the wrong key for the legitimate owner (whose participation
+	// is via the stake/DRep key). Cosigning stake/gov native-script policies is
+	// not yet supported, so a tx carrying such a script is classified as an
+	// unsupported multi-sig (see below) rather than mis-signed as payment.
+	//
+	// After ruling out mint and stake/gov scripts, the remaining non-mint
+	// scripts can only be there to satisfy a spend, so those are the candidate
+	// payment-spend scripts.
+	stakeScriptHashes := stakeScriptCredentialHashes(&tx)
 	var candidates []*lcommon.NativeScript
+	stakePurpose := false
 	for i := range scripts {
 		hash := hex.EncodeToString(scripts[i].Hash().Bytes())
-		if !mintPolicies[hash] {
+		switch {
+		case mintPolicies[hash]:
+			// mint-only evidence — not a spend on this basis alone.
+		case stakeScriptHashes[hash]:
+			// Positively a stake/governance-purpose script (withdrawal or
+			// certificate credential), not a payment spend.
+			stakePurpose = true
+		default:
 			candidates = append(candidates, &scripts[i])
 		}
+	}
+	if stakePurpose {
+		// An embedded native script governs a withdrawal or certificate. The
+		// owner's participation is through the stake/DRep multi-sig key, which
+		// this import flow does not yet derive; classifying it as payment
+		// multisig would derive the wrong (role-0 payment) key. Report a
+		// recognizable-but-unsupported multi-sig (Threshold stays 0) so
+		// CosignImported/SubmitImported refuse it rather than derive the wrong
+		// key. This dominates even when a payment candidate is also present:
+		// satisfying only the payment script would still leave the stake/gov
+		// script unsigned, so the whole tx is unsupported here.
+		return TxInfo{IsMultiSig: true, ScriptEmbedded: true}, nil
 	}
 	switch len(candidates) {
 	case 0:
@@ -765,7 +800,7 @@ func (s *Service) InspectTx(txCbor string) (TxInfo, error) {
 	bodyHash := lcommon.Blake2b256Hash(bodyCbor)
 	signed := make(map[string]bool, len(tx.WitnessSet.VkeyWitnesses.Items()))
 	for _, w := range tx.WitnessSet.VkeyWitnesses.Items() {
-		if !vkeyWitnessValid(w, bodyHash.Bytes()) {
+		if !txwitness.Valid(w, bodyHash.Bytes()) {
 			continue
 		}
 		kh := strings.ToLower(hex.EncodeToString(lcommon.Blake2b224Hash(w.Vkey).Bytes()))
@@ -1098,7 +1133,7 @@ func (s *Service) CosignImported(txCbor, password string) (CosignResult, error) 
 	signed := make(map[string]bool, len(tx.WitnessSet.VkeyWitnesses.Items()))
 	kept := make([]lcommon.VkeyWitness, 0, len(tx.WitnessSet.VkeyWitnesses.Items()))
 	for _, w := range tx.WitnessSet.VkeyWitnesses.Items() {
-		if !vkeyWitnessValid(w, bodyHash.Bytes()) {
+		if !txwitness.Valid(w, bodyHash.Bytes()) {
 			continue
 		}
 		kh := strings.ToLower(hex.EncodeToString(lcommon.Blake2b224Hash(w.Vkey).Bytes()))
@@ -1149,17 +1184,64 @@ func (s *Service) CosignImported(txCbor, password string) (CosignResult, error) 
 // Helpers
 // ---------------------------------------------------------------------------
 
-// vkeyWitnessValid reports whether w is a genuine Ed25519 signature by w.Vkey
-// over msg (the tx body hash bytes). Cardano's BIP32-Ed25519 witnesses verify
-// under standard Ed25519 against the 32-byte public key, so a pasted tx
-// carrying a malformed or foreign witness — even one bearing a participant's
-// key — is rejected here rather than counted toward the threshold on key-hash
-// alone.
-func vkeyWitnessValid(w lcommon.VkeyWitness, msg []byte) bool {
-	if len(w.Vkey) != ed25519.PublicKeySize || len(w.Signature) != ed25519.SignatureSize {
-		return false
+// stakeScriptCredentialHashes returns the set (hex-encoded, lower-case) of
+// script-hash credentials the tx body uses for a non-payment purpose: the
+// script credentials of reward withdrawals and of certificates (stake and
+// DRep/committee). An embedded native script whose hash appears here is present
+// to authorize that stake/governance action, not a payment spend, so InspectTx
+// must not classify it as payment multisig. This mirrors spend.neededKeyHashes'
+// certificate/withdrawal walk but collects script-hash (not addr-key-hash)
+// credentials.
+func stakeScriptCredentialHashes(tx *conway.ConwayTransaction) map[string]bool {
+	out := make(map[string]bool)
+	addCred := func(cred *lcommon.Credential) {
+		if cred != nil && cred.CredType == lcommon.CredentialTypeScriptHash {
+			out[hex.EncodeToString(cred.Credential.Bytes())] = true
+		}
 	}
-	return ed25519.Verify(ed25519.PublicKey(w.Vkey), msg, w.Signature)
+	for _, cert := range tx.Body.Certificates() {
+		switch c := cert.(type) {
+		case *lcommon.StakeRegistrationCertificate:
+			addCred(&c.StakeCredential)
+		case *lcommon.StakeDeregistrationCertificate:
+			addCred(&c.StakeCredential)
+		case *lcommon.StakeDelegationCertificate:
+			addCred(c.StakeCredential)
+		case *lcommon.RegistrationCertificate:
+			addCred(&c.StakeCredential)
+		case *lcommon.DeregistrationCertificate:
+			addCred(&c.StakeCredential)
+		case *lcommon.VoteDelegationCertificate:
+			addCred(&c.StakeCredential)
+		case *lcommon.StakeVoteDelegationCertificate:
+			addCred(&c.StakeCredential)
+		case *lcommon.StakeRegistrationDelegationCertificate:
+			addCred(&c.StakeCredential)
+		case *lcommon.VoteRegistrationDelegationCertificate:
+			addCred(&c.StakeCredential)
+		case *lcommon.StakeVoteRegistrationDelegationCertificate:
+			addCred(&c.StakeCredential)
+		case *lcommon.RegistrationDrepCertificate:
+			addCred(&c.DrepCredential)
+		case *lcommon.DeregistrationDrepCertificate:
+			addCred(&c.DrepCredential)
+		case *lcommon.UpdateDrepCertificate:
+			addCred(&c.DrepCredential)
+		case *lcommon.AuthCommitteeHotCertificate:
+			addCred(&c.ColdCredential)
+		case *lcommon.ResignCommitteeColdCertificate:
+			addCred(&c.ColdCredential)
+		}
+	}
+	for addr := range tx.Body.TxWithdrawals {
+		if addr == nil {
+			continue
+		}
+		if payload, ok := addr.StakingPayload().(lcommon.AddressPayloadScriptHash); ok {
+			out[hex.EncodeToString(payload.Hash.Bytes())] = true
+		}
+	}
+	return out
 }
 
 // decodeScript reconstructs a native script from its hex CBOR.

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -640,6 +640,18 @@ func (s *Service) Build(ctx context.Context, id string, req BuildRequest) (Unsig
 // the UI can warn, rather than erroring. A tx with no embedded native script
 // at all — without chain resolution of its inputs there is nothing to match
 // against — is reported as not multi-sig.
+//
+// A native script rides in the witness set for exactly one of two reasons:
+// (a) it authorizes minting under its policy ID, or (b) it satisfies a
+// script-locked spend input. An ordinary vkey-signed payment that also mints
+// an NFT/token under a native-script policy (a common DApp-built tx) carries
+// a native script for reason (a) only and must NOT be classified as a
+// multisig spend. InspectTx tells the two apart: it collects the tx body's
+// mint policy IDs and, among the embedded scripts, selects the first one that
+// either matches a saved multisig account (definitely a spend) or whose hash
+// is not a mint policy (so it must be there for a spend). If every embedded
+// script is purely a mint policy, the tx is reported as not multi-sig so it
+// routes to the ordinary vkey path.
 func (s *Service) InspectTx(txCbor string) (TxInfo, error) {
 	txBytes, err := hex.DecodeString(strings.TrimSpace(txCbor))
 	if err != nil {
@@ -654,7 +666,28 @@ func (s *Service) InspectTx(txCbor string) (TxInfo, error) {
 	if len(scripts) == 0 {
 		return TxInfo{IsMultiSig: false}, nil
 	}
-	ns := &scripts[0]
+
+	mintPolicies := make(map[string]bool)
+	if mint := tx.Body.AssetMint(); mint != nil {
+		for _, pol := range mint.Policies() {
+			mintPolicies[hex.EncodeToString(pol.Bytes())] = true
+		}
+	}
+
+	var ns *lcommon.NativeScript
+	for i := range scripts {
+		hash := hex.EncodeToString(scripts[i].Hash().Bytes())
+		if _, ok, _ := s.FindByScriptHash(hash); ok || !mintPolicies[hash] {
+			ns = &scripts[i]
+			break
+		}
+	}
+	if ns == nil {
+		// Every embedded native script is a mint-only policy: there is no
+		// script-locked spend here, so this is an ordinary tx that happens to
+		// mint under a native-script policy — route to the vkey path.
+		return TxInfo{IsMultiSig: false}, nil
+	}
 	scriptHash := hex.EncodeToString(ns.Hash().Bytes())
 
 	policy, err := PolicyFromScript(ns)

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -225,6 +225,59 @@ func composeScript(p Policy) (*bursa.NativeScript, error) {
 	return all, nil
 }
 
+// PolicyFromScript recovers a Policy from a decoded native script — the inverse
+// of composeScript. It walks the script's node tree looking for exactly the
+// shapes composeScript produces: a bare NativeScriptNofK (threshold clause
+// only), or a NativeScriptAll wrapping optional time-lock clauses
+// (NativeScriptInvalidBefore / NativeScriptInvalidHereafter) plus the NofK.
+// Every sub-script under the NofK must be a NativeScriptPubkey — that's the
+// only leaf composeScript ever emits there.
+//
+// Any other shape (including NativeScriptAny, which composeScript never
+// produces) is rejected as ErrInvalidTx rather than silently accepted or
+// panicked on.
+func PolicyFromScript(ns *bursa.NativeScript) (Policy, error) {
+	var p Policy
+	var walk func(node *lcommon.NativeScript) error
+	walk = func(node *lcommon.NativeScript) error {
+		switch v := node.Item().(type) {
+		case *lcommon.NativeScriptNofK:
+			parts := make([]Participant, 0, len(v.Scripts))
+			for i := range v.Scripts {
+				pk, ok := v.Scripts[i].Item().(*lcommon.NativeScriptPubkey)
+				if !ok {
+					return fmt.Errorf("%w: threshold clause holds a non-pubkey sub-script", ErrInvalidTx)
+				}
+				parts = append(parts, Participant{KeyHashHex: hex.EncodeToString(pk.Hash)})
+			}
+			p.Threshold = int(v.N)
+			p.Participants = parts
+		case *lcommon.NativeScriptInvalidBefore:
+			slot := v.Slot
+			p.InvalidBefore = &slot
+		case *lcommon.NativeScriptInvalidHereafter:
+			slot := v.Slot
+			p.InvalidAfter = &slot
+		case *lcommon.NativeScriptAll:
+			for i := range v.Scripts {
+				if err := walk(&v.Scripts[i]); err != nil {
+					return err
+				}
+			}
+		default:
+			return fmt.Errorf("%w: unsupported native-script shape for a multisig policy", ErrInvalidTx)
+		}
+		return nil
+	}
+	if err := walk(ns); err != nil {
+		return Policy{}, err
+	}
+	if p.Threshold == 0 || len(p.Participants) == 0 {
+		return Policy{}, fmt.Errorf("%w: script has no threshold clause", ErrInvalidTx)
+	}
+	return p, nil
+}
+
 // scriptAddress derives the canonical Cardano script address for a native script.
 //
 // IMPORTANT: this does NOT use bursa.GetScriptAddress, which hashes only the bare

--- a/ui/internal/spend/importtx_test.go
+++ b/ui/internal/spend/importtx_test.go
@@ -1,0 +1,70 @@
+package spend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blinklabs-io/bursa/ui/internal/wallet"
+)
+
+// buildUnsignedSendFixture builds a real unsigned send transaction (via the
+// same Build -> ExportUnsigned path exercised in spend_test.go's air-gap
+// tests) and returns the Service it was built against, the active account,
+// and the resulting unsigned tx CBOR (hex).
+func buildUnsignedSendFixture(t *testing.T) (*Service, *wallet.Account, string) {
+	t.Helper()
+	acct := mustDeriveConfirmAccount(t)
+	addr0 := acct.ReceiveAddresses[0]
+	recvAddr := acct.ReceiveAddresses[2]
+
+	fc := newFakeChain(5_000_000, addr0)
+	s := NewService(fc, fakeKeystore{mnemonic: testMnemonic}, acct)
+
+	pv, err := s.Build(context.Background(), SendRequest{To: recvAddr, Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	unsigned, err := s.ExportUnsigned(pv.PendingID)
+	if err != nil {
+		t.Fatalf("ExportUnsigned: %v", err)
+	}
+	return s, acct, unsigned.UnsignedTxCBOR
+}
+
+// newBuildOnlyService returns a minimal Service with no wallet/keystore/chain
+// configured, suitable for exercising DecodeTx's input-validation paths that
+// never need an active account.
+func newBuildOnlyService(t *testing.T) *Service {
+	t.Helper()
+	return NewService(nil, nil, nil)
+}
+
+func TestDecodeTx_VkeySummary(t *testing.T) {
+	svc, _, unsignedCbor := buildUnsignedSendFixture(t)
+	got, err := svc.DecodeTx(unsignedCbor)
+	if err != nil {
+		t.Fatalf("DecodeTx: %v", err)
+	}
+	if got.Kind != "vkey" {
+		t.Errorf("kind = %q, want vkey", got.Kind)
+	}
+	if len(got.Outputs) == 0 {
+		t.Error("expected at least one output")
+	}
+	if got.Fee == "" || got.Fee == "0" {
+		t.Errorf("fee = %q, want a non-zero decimal string", got.Fee)
+	}
+	if got.IsComplete {
+		t.Error("unsigned tx must not be complete")
+	}
+	if len(got.ExistingSignatures) != 0 {
+		t.Errorf("unsigned tx has %d existing sigs, want 0", len(got.ExistingSignatures))
+	}
+}
+
+func TestDecodeTx_Malformed(t *testing.T) {
+	svc := newBuildOnlyService(t)
+	if _, err := svc.DecodeTx("zzzz"); err == nil {
+		t.Fatal("expected error for non-hex CBOR")
+	}
+}

--- a/ui/internal/spend/importtx_test.go
+++ b/ui/internal/spend/importtx_test.go
@@ -2,15 +2,65 @@ package spend
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/hex"
 	"errors"
 	"testing"
 
+	apollo "github.com/blinklabs-io/apollo/v2"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 )
+
+// foreignWitness builds a valid vkey witness over unsignedCbor's body bytes
+// from a fresh, unrelated Ed25519 key (i.e. a co-signer that is not this
+// wallet). Because CosignTx verifies and dedupes witnesses by signature, a
+// retained witness must be genuinely valid — a zero/garbage witness would be
+// (correctly) dropped, so it could not prove retention.
+func foreignWitness(t *testing.T, unsignedCbor string) (lcommon.VkeyWitness, string) {
+	t.Helper()
+	txBytes, err := hex.DecodeString(unsignedCbor)
+	if err != nil {
+		t.Fatalf("decode unsigned cbor: %v", err)
+	}
+	body, err := extractTxBodyCbor(txBytes)
+	if err != nil {
+		t.Fatalf("extract body: %v", err)
+	}
+	bodyHash := lcommon.Blake2b256Hash(body)
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	w := lcommon.VkeyWitness{Vkey: pub, Signature: ed25519.Sign(priv, bodyHash.Bytes())}
+	kh := hex.EncodeToString(lcommon.Blake2b224Hash(pub).Bytes())
+	return w, kh
+}
+
+// attachWitness re-serializes unsignedCbor with w merged into its witness set,
+// preserving the original body bytes (the SubmitSigned/CosignTx pattern), and
+// returns the new tx CBOR hex.
+func attachWitness(t *testing.T, s *Service, unsignedCbor string, w lcommon.VkeyWitness) string {
+	t.Helper()
+	a, err := apollo.New(s.chain).LoadTxCbor(unsignedCbor)
+	if err != nil {
+		t.Fatalf("LoadTxCbor: %v", err)
+	}
+	if a, err = a.AddVerificationKeyWitness(w); err != nil {
+		t.Fatalf("AddVerificationKeyWitness: %v", err)
+	}
+	lt := a.GetTx()
+	lt.SetCbor(nil)
+	lt.WitnessSet.SetCbor(nil)
+	b, err := a.GetTxCbor()
+	if err != nil {
+		t.Fatalf("GetTxCbor: %v", err)
+	}
+	return hex.EncodeToString(b)
+}
 
 // testPassword is the spending password used by the CosignTx fixtures below.
 // fakeKeystore.Unlock ignores the supplied password entirely (it always
@@ -53,7 +103,7 @@ func newBuildOnlyService(t *testing.T) *Service {
 
 func TestDecodeTx_VkeySummary(t *testing.T) {
 	svc, acct, unsignedCbor := buildUnsignedSendFixture(t)
-	got, err := svc.DecodeTx(unsignedCbor)
+	got, err := svc.DecodeTx(context.Background(), unsignedCbor)
 	if err != nil {
 		t.Fatalf("DecodeTx: %v", err)
 	}
@@ -105,22 +155,46 @@ func TestCosignTx_MergesPreservingExisting(t *testing.T) {
 	svc, acct, unsignedCbor := buildUnsignedSendFixture(t)
 	_ = acct
 
-	// First co-sign: wallet adds its payment witness.
-	res, err := svc.CosignTx(context.Background(), unsignedCbor, testPassword, true)
+	// Seed the fixture with a valid witness from an unrelated co-signer, so this
+	// test actually exercises retention: a regression that drops or replaces
+	// existing co-signer witnesses would now fail.
+	foreign, foreignKH := foreignWitness(t, unsignedCbor)
+	preSigned := attachWitness(t, svc, unsignedCbor, foreign)
+
+	// Sanity: the foreign witness is present before we cosign.
+	pre, err := svc.DecodeTx(context.Background(), preSigned)
+	if err != nil {
+		t.Fatalf("DecodeTx(preSigned): %v", err)
+	}
+	if !hasSigner(pre.ExistingSignatures, foreignKH) {
+		t.Fatalf("pre-signed fixture missing the foreign witness %s", foreignKH)
+	}
+
+	// First co-sign: wallet adds its own witness on top of the foreign one.
+	res, err := svc.CosignTx(context.Background(), preSigned, testPassword, true)
 	if err != nil {
 		t.Fatalf("CosignTx: %v", err)
 	}
 	if len(res.Added) == 0 {
 		t.Fatal("expected at least one added witness")
 	}
+	for _, a := range res.Added {
+		if a.KeyHash == foreignKH {
+			t.Fatalf("cosign re-added the foreign witness %s instead of preserving it", foreignKH)
+		}
+	}
 
-	// The updated tx must decode and now carry the witness(es).
-	summary, err := svc.DecodeTx(res.TxCBOR)
+	// The updated tx must decode, retain the foreign witness, and carry ours.
+	summary, err := svc.DecodeTx(context.Background(), res.TxCBOR)
 	if err != nil {
 		t.Fatalf("DecodeTx(updated): %v", err)
 	}
-	if len(summary.ExistingSignatures) < len(res.Added) {
-		t.Errorf("updated tx has %d sigs, want >= %d", len(summary.ExistingSignatures), len(res.Added))
+	if !hasSigner(summary.ExistingSignatures, foreignKH) {
+		t.Errorf("cosign dropped the pre-existing foreign witness %s", foreignKH)
+	}
+	if len(summary.ExistingSignatures) < len(res.Added)+1 {
+		t.Errorf("updated tx has %d sigs, want >= %d (foreign + added)",
+			len(summary.ExistingSignatures), len(res.Added)+1)
 	}
 
 	// Body-hash stability: re-cosigning must be idempotent (no duplicate witnesses).
@@ -131,6 +205,16 @@ func TestCosignTx_MergesPreservingExisting(t *testing.T) {
 	if len(res2.Added) != 0 {
 		t.Errorf("second cosign added %d witnesses, want 0 (already present)", len(res2.Added))
 	}
+}
+
+// hasSigner reports whether signers contains one with the given key hash.
+func hasSigner(signers []TxSummarySigner, keyHash string) bool {
+	for _, s := range signers {
+		if s.KeyHash == keyHash {
+			return true
+		}
+	}
+	return false
 }
 
 func TestCosignTx_WrongPassword(t *testing.T) {
@@ -158,7 +242,27 @@ func TestCosignTx_WrongPassword(t *testing.T) {
 
 func TestSubmitTxCbor_Broadcasts(t *testing.T) {
 	svc, _, unsignedCbor := buildUnsignedSendFixture(t) // fake chain records SubmitTx
-	res, err := svc.SubmitTxCbor(context.Background(), unsignedCbor)
+
+	// The import flow submits a fully assembled tx, not raw unsigned CBOR: cosign
+	// first, then broadcast the CosignResult's CBOR. Asserting the witness was
+	// added keeps this test honest — it would otherwise pass even if submission
+	// wrongly accepted an unsigned transaction.
+	cos, err := svc.CosignTx(context.Background(), unsignedCbor, testPassword, true)
+	if err != nil {
+		t.Fatalf("CosignTx: %v", err)
+	}
+	if len(cos.Added) == 0 {
+		t.Fatal("expected cosign to add at least one witness")
+	}
+	summary, err := svc.DecodeTx(context.Background(), cos.TxCBOR)
+	if err != nil {
+		t.Fatalf("DecodeTx(cosigned): %v", err)
+	}
+	if len(summary.ExistingSignatures) < len(cos.Added) {
+		t.Fatalf("cosigned tx has %d sigs, want >= %d", len(summary.ExistingSignatures), len(cos.Added))
+	}
+
+	res, err := svc.SubmitTxCbor(context.Background(), cos.TxCBOR)
 	if err != nil {
 		t.Fatalf("SubmitTxCbor: %v", err)
 	}
@@ -185,7 +289,7 @@ func TestDecodeTx_Malformed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := newBuildOnlyService(t)
-			_, err := svc.DecodeTx(tt.in)
+			_, err := svc.DecodeTx(context.Background(), tt.in)
 			if err == nil {
 				t.Fatalf("expected error for input %q", tt.in)
 			}

--- a/ui/internal/spend/importtx_test.go
+++ b/ui/internal/spend/importtx_test.go
@@ -2,7 +2,11 @@ package spend
 
 import (
 	"context"
+	"encoding/hex"
+	"errors"
 	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 
 	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 )
@@ -40,7 +44,7 @@ func newBuildOnlyService(t *testing.T) *Service {
 }
 
 func TestDecodeTx_VkeySummary(t *testing.T) {
-	svc, _, unsignedCbor := buildUnsignedSendFixture(t)
+	svc, acct, unsignedCbor := buildUnsignedSendFixture(t)
 	got, err := svc.DecodeTx(unsignedCbor)
 	if err != nil {
 		t.Fatalf("DecodeTx: %v", err)
@@ -60,11 +64,53 @@ func TestDecodeTx_VkeySummary(t *testing.T) {
 	if len(got.ExistingSignatures) != 0 {
 		t.Errorf("unsigned tx has %d existing sigs, want 0", len(got.ExistingSignatures))
 	}
+
+	// WalletCanAdd must name the actual payment key hash this wallet owns for
+	// the spent input (buildUnsignedSendFixture funds the tx from
+	// acct.ReceiveAddresses[0]), derived the same way walletPaymentKeyHashes
+	// does -- not hardcoded -- so a subtly-wrong key hash in DecodeTx would
+	// fail this test.
+	if len(got.WalletCanAdd) == 0 {
+		t.Fatal("expected at least one wallet_can_add entry for the unsigned send tx's input signer")
+	}
+	fundingAddr, err := lcommon.NewAddress(acct.ReceiveAddresses[0])
+	if err != nil {
+		t.Fatalf("parse funding address: %v", err)
+	}
+	wantKeyHash := hex.EncodeToString(fundingAddr.PaymentKeyHash().Bytes())
+
+	found := false
+	for _, signer := range got.WalletCanAdd {
+		if signer.KeyHash == wantKeyHash {
+			found = true
+			if signer.Role != "payment" {
+				t.Errorf("wallet_can_add entry for %s: role = %q, want payment", wantKeyHash, signer.Role)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("wallet_can_add %+v does not contain expected payment key hash %s", got.WalletCanAdd, wantKeyHash)
+	}
 }
 
 func TestDecodeTx_Malformed(t *testing.T) {
-	svc := newBuildOnlyService(t)
-	if _, err := svc.DecodeTx("zzzz"); err == nil {
-		t.Fatal("expected error for non-hex CBOR")
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{name: "non-hex", in: "zzzz"},
+		{name: "valid-hex-invalid-cbor", in: "00"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newBuildOnlyService(t)
+			_, err := svc.DecodeTx(tt.in)
+			if err == nil {
+				t.Fatalf("expected error for input %q", tt.in)
+			}
+			if !errors.Is(err, ErrInvalidTx) {
+				t.Errorf("err = %v, want it to wrap ErrInvalidTx", err)
+			}
+		})
 	}
 }

--- a/ui/internal/spend/importtx_test.go
+++ b/ui/internal/spend/importtx_test.go
@@ -8,8 +8,16 @@ import (
 
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 
+	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 )
+
+// testPassword is the spending password used by the CosignTx fixtures below.
+// fakeKeystore.Unlock ignores the supplied password entirely (it always
+// succeeds unless constructed with an err), so its value is arbitrary; a
+// dedicated fakeKeystore{err: keystore.ErrDecryptFailed} service is used to
+// exercise the wrong-password path instead (see TestCosignTx_WrongPassword).
+const testPassword = "cosign-test-password"
 
 // buildUnsignedSendFixture builds a real unsigned send transaction (via the
 // same Build -> ExportUnsigned path exercised in spend_test.go's air-gap
@@ -90,6 +98,61 @@ func TestDecodeTx_VkeySummary(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("wallet_can_add %+v does not contain expected payment key hash %s", got.WalletCanAdd, wantKeyHash)
+	}
+}
+
+func TestCosignTx_MergesPreservingExisting(t *testing.T) {
+	svc, acct, unsignedCbor := buildUnsignedSendFixture(t)
+	_ = acct
+
+	// First co-sign: wallet adds its payment witness.
+	res, err := svc.CosignTx(context.Background(), unsignedCbor, testPassword, true)
+	if err != nil {
+		t.Fatalf("CosignTx: %v", err)
+	}
+	if len(res.Added) == 0 {
+		t.Fatal("expected at least one added witness")
+	}
+
+	// The updated tx must decode and now carry the witness(es).
+	summary, err := svc.DecodeTx(res.TxCBOR)
+	if err != nil {
+		t.Fatalf("DecodeTx(updated): %v", err)
+	}
+	if len(summary.ExistingSignatures) < len(res.Added) {
+		t.Errorf("updated tx has %d sigs, want >= %d", len(summary.ExistingSignatures), len(res.Added))
+	}
+
+	// Body-hash stability: re-cosigning must be idempotent (no duplicate witnesses).
+	res2, err := svc.CosignTx(context.Background(), res.TxCBOR, testPassword, true)
+	if err != nil {
+		t.Fatalf("CosignTx (2nd): %v", err)
+	}
+	if len(res2.Added) != 0 {
+		t.Errorf("second cosign added %d witnesses, want 0 (already present)", len(res2.Added))
+	}
+}
+
+func TestCosignTx_WrongPassword(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	addr0 := acct.ReceiveAddresses[0]
+	fc := newFakeChain(5_000_000, addr0)
+	good := NewService(fc, fakeKeystore{mnemonic: testMnemonic}, acct)
+
+	pv, err := good.Build(context.Background(), SendRequest{To: acct.ReceiveAddresses[2], Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	unsigned, err := good.ExportUnsigned(pv.PendingID)
+	if err != nil {
+		t.Fatalf("ExportUnsigned: %v", err)
+	}
+
+	// A service bound to the same account whose keystore rejects the password.
+	bad := NewService(fc, fakeKeystore{err: keystore.ErrDecryptFailed}, acct)
+	_, err = bad.CosignTx(context.Background(), unsigned.UnsignedTxCBOR, "wrong", true)
+	if !errors.Is(err, ErrWrongPassword) {
+		t.Fatalf("err = %v, want ErrWrongPassword", err)
 	}
 }
 

--- a/ui/internal/spend/importtx_test.go
+++ b/ui/internal/spend/importtx_test.go
@@ -156,6 +156,24 @@ func TestCosignTx_WrongPassword(t *testing.T) {
 	}
 }
 
+func TestSubmitTxCbor_Broadcasts(t *testing.T) {
+	svc, _, unsignedCbor := buildUnsignedSendFixture(t) // fake chain records SubmitTx
+	res, err := svc.SubmitTxCbor(context.Background(), unsignedCbor)
+	if err != nil {
+		t.Fatalf("SubmitTxCbor: %v", err)
+	}
+	if res.TxHash == "" {
+		t.Error("expected a tx hash")
+	}
+}
+
+func TestSubmitTxCbor_BadHex(t *testing.T) {
+	svc := newBuildOnlyService(t)
+	if _, err := svc.SubmitTxCbor(context.Background(), "nothex"); !errors.Is(err, ErrInvalidTx) {
+		t.Fatalf("err = %v, want ErrInvalidTx", err)
+	}
+}
+
 func TestDecodeTx_Malformed(t *testing.T) {
 	tests := []struct {
 		name string

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -1467,6 +1467,167 @@ func (s *Service) DecodeTx(txCbor string) (TxSummary, error) {
 	return out, nil
 }
 
+// extractTxBodyCbor returns the raw CBOR bytes of the transaction body (element
+// [0] of the outer transaction array), preserving them exactly as supplied so the
+// signing hash (blake2b-256 of the body) matches what the node computes. It does
+// NOT re-encode the decoded struct. This mirrors connector.extractTxBodyCbor;
+// CosignTx uses this copy so the spend package does not depend on connector.
+func extractTxBodyCbor(txBytes []byte) ([]byte, error) {
+	var outer []cbor.RawMessage
+	if _, err := cbor.Decode(txBytes, &outer); err != nil {
+		return nil, fmt.Errorf("%w: decode tx as CBOR array: %w", ErrInvalidTx, err)
+	}
+	if len(outer) < 1 {
+		return nil, fmt.Errorf("%w: transaction CBOR array is empty (no body element)", ErrInvalidTx)
+	}
+	body := []byte(outer[0])
+	if len(body) == 0 {
+		return nil, fmt.Errorf("%w: transaction body element is empty", ErrInvalidTx)
+	}
+	return body, nil
+}
+
+// CosignResult is returned from CosignTx: the merged transaction CBOR (this
+// wallet's witnesses plus any co-signers' witnesses already present in the
+// pasted tx), the witnesses this call added, and a fresh no-password summary
+// of the updated transaction.
+type CosignResult struct {
+	TxCBOR  string            `json:"tx_cbor"`
+	Added   []TxSummarySigner `json:"added"`
+	Summary TxSummary         `json:"summary"`
+}
+
+// CosignTx derives this wallet's witnesses for a pasted transaction and MERGES
+// them into its existing witness set, preserving any co-signers' witnesses
+// already present (e.g. a native-multisig or shared-wallet transaction someone
+// else has partially signed). Unlike SubmitSigned/SignTx (the air-gap pair),
+// CosignTx keeps the wallet's own keystore local: it unlocks with password,
+// derives the account key, and calls deriveWitnesses exactly as WitnessTx does,
+// then attaches the resulting witnesses to the loaded tx via apollo and
+// re-serializes. It does not submit; the caller decides when to broadcast.
+//
+// Merging is idempotent and dedupes by vkey key-hash: re-cosigning an
+// already-signed tx adds zero duplicate witnesses.
+func (s *Service) CosignTx(
+	ctx context.Context,
+	txCbor, password string,
+	partialSign bool,
+) (CosignResult, error) {
+	if s.keys == nil {
+		return CosignResult{}, errors.New("no keystore configured")
+	}
+	walletID, acct, _ := s.currentBinding()
+	if acct == nil {
+		return CosignResult{}, ErrNoWallet
+	}
+	trimmed := strings.TrimSpace(txCbor)
+	txBytes, err := hex.DecodeString(trimmed)
+	if err != nil {
+		return CosignResult{}, fmt.Errorf("%w: tx hex: %w", ErrInvalidTx, err)
+	}
+	bodyCbor, err := extractTxBodyCbor(txBytes)
+	if err != nil {
+		return CosignResult{}, err
+	}
+	var tx conway.ConwayTransaction
+	if _, err := cbor.Decode(txBytes, &tx); err != nil {
+		return CosignResult{}, fmt.Errorf("%w: %w", ErrInvalidTx, err)
+	}
+
+	// Best-effort input-address resolution (needs a node; non-fatal without one
+	// -- required-signer and cert credentials still match without it).
+	var inputAddrs []string
+	for _, inp := range tx.Body.Inputs() {
+		u, err := s.chain.UtxoByRef(ctx, inp.Id(), inp.Index())
+		if err != nil || u == nil || u.Output == nil {
+			continue
+		}
+		inputAddrs = append(inputAddrs, u.Output.Address().String())
+	}
+
+	// Unlock + derive account key (zeroing on exit), same pattern as WitnessTx.
+	mnemonicBytes, err := s.unlockSeed(walletID, password)
+	if err != nil {
+		if errors.Is(err, keystore.ErrDecryptFailed) {
+			return CosignResult{}, fmt.Errorf("%w: %w", ErrWrongPassword, err)
+		}
+		return CosignResult{}, fmt.Errorf("unlock keystore: %w", err)
+	}
+	var rootKey, acctKey bip32.XPrv
+	defer func() {
+		for _, k := range []bip32.XPrv{rootKey, acctKey} {
+			for i := range k {
+				k[i] = 0
+			}
+		}
+		for i := range mnemonicBytes {
+			mnemonicBytes[i] = 0
+		}
+	}()
+	rootKey, err = bursa.GetRootKeyFromMnemonic(string(mnemonicBytes), "")
+	if err != nil {
+		return CosignResult{}, fmt.Errorf("root key: %w", err)
+	}
+	acctKey, err = bursa.GetAccountKey(rootKey, 0)
+	if err != nil {
+		return CosignResult{}, fmt.Errorf("account key: %w", err)
+	}
+
+	bodyHash := lcommon.Blake2b256Hash(bodyCbor)
+	witnesses, err := s.deriveWitnesses(
+		acctKey,
+		bodyHash,
+		tx.Body.RequiredSigners(),
+		&tx.Body,
+		inputAddrs,
+		acct,
+		partialSign,
+	)
+	if err != nil {
+		return CosignResult{}, err
+	}
+
+	// Merge into the pasted tx, preserving existing witnesses, deduped by key-hash.
+	present := map[string]bool{}
+	for _, w := range tx.WitnessSet.VkeyWitnesses.Items() {
+		present[hex.EncodeToString(lcommon.Blake2b224Hash(w.Vkey).Bytes())] = true
+	}
+	a, err := apollo.New(s.chain).LoadTxCbor(trimmed)
+	if err != nil {
+		return CosignResult{}, fmt.Errorf("%w: %w", ErrInvalidTx, err)
+	}
+	var added []TxSummarySigner
+	for _, w := range witnesses {
+		kh := hex.EncodeToString(lcommon.Blake2b224Hash(w.Vkey).Bytes())
+		if present[kh] {
+			continue
+		}
+		present[kh] = true
+		if a, err = a.AddVerificationKeyWitness(w); err != nil {
+			return CosignResult{}, fmt.Errorf("attach witness: %w", err)
+		}
+		added = append(added, TxSummarySigner{KeyHash: kh})
+	}
+
+	// Clear tx/witness-set caches (keep the body cache) so re-serialization
+	// includes the attached witnesses over the unchanged body bytes -- the
+	// SubmitSigned pattern (spend.go SubmitSigned, above).
+	if lt := a.GetTx(); lt != nil {
+		lt.SetCbor(nil)
+		lt.WitnessSet.SetCbor(nil)
+	}
+	mergedBytes, err := a.GetTxCbor()
+	if err != nil {
+		return CosignResult{}, fmt.Errorf("encode merged tx: %w", err)
+	}
+	mergedHex := hex.EncodeToString(mergedBytes)
+	summary, err := s.DecodeTx(mergedHex)
+	if err != nil {
+		return CosignResult{}, err
+	}
+	return CosignResult{TxCBOR: mergedHex, Added: added, Summary: summary}, nil
+}
+
 // assetsFromOutput enumerates a transaction output's native assets as decimal
 // quantities, mirroring the loop toPreview uses for Apollo-built outputs.
 func assetsFromOutput(o lcommon.TransactionOutput) []Asset {

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -99,6 +99,40 @@ type TxResult struct {
 	TxHash string `json:"tx_hash"`
 }
 
+// TxSummaryOutput is one output (or reward withdrawal) as presented in a
+// decoded transaction summary.
+type TxSummaryOutput struct {
+	Address  string  `json:"address"`
+	Lovelace string  `json:"lovelace"` // decimal lovelace string; see Asset.Quantity
+	Assets   []Asset `json:"assets,omitempty"`
+}
+
+// TxSummarySigner identifies a vkey witness (present or still needed) by its
+// Blake2b-224 key hash. Role is only populated in WalletCanAdd, where it tells
+// the caller which of the wallet's own keys (payment/stake/drep) would
+// produce that witness.
+type TxSummarySigner struct {
+	KeyHash string `json:"key_hash"`
+	Role    string `json:"role,omitempty"` // "payment"|"stake"|"drep" (only in wallet_can_add)
+}
+
+// TxSummary is a no-password, human-readable preview of a pasted transaction,
+// produced by DecodeTx. It classifies the transaction (vkey vs. native
+// multisig vs. already complete) and reports which of the wallet's own keys
+// could still add a required signature.
+type TxSummary struct {
+	Kind               string            `json:"kind"` // "vkey"|"native_multisig"|"complete"|"unknown"
+	Outputs            []TxSummaryOutput `json:"outputs"`
+	Fee                string            `json:"fee"`
+	TTL                uint64            `json:"ttl,omitempty"`
+	Certificates       []string          `json:"certificates,omitempty"`
+	Withdrawals        []TxSummaryOutput `json:"withdrawals,omitempty"` // Address=reward addr
+	NetworkID          *int              `json:"network_id,omitempty"`
+	ExistingSignatures []TxSummarySigner `json:"existing_signatures"`
+	WalletCanAdd       []TxSummarySigner `json:"wallet_can_add"`
+	IsComplete         bool              `json:"is_complete"`
+}
+
 // UnsignedTx is returned from ExportUnsigned: the completed-but-unsigned
 // transaction CBOR (hex) plus the key-hashes that must witness it. It is the
 // hand-off artifact carried (file or copy/paste) to an offline, keyed instance
@@ -1360,6 +1394,241 @@ func (s *Service) Submit(ctx context.Context, txBytes []byte) (string, error) {
 		return "", fmt.Errorf("%w: %w", ErrSubmitRejected, err)
 	}
 	return hex.EncodeToString(txHash.Bytes()), nil
+}
+
+// DecodeTx decodes a full tx CBOR into a no-password summary and classifies it as
+// an ordinary vkey tx. (The api layer upgrades kind to "native_multisig" when the
+// tx carries a native script.) wallet_can_add is derived from the active account's
+// public key hashes — no seed required, and nothing here signs or mutates the tx.
+func (s *Service) DecodeTx(txCbor string) (TxSummary, error) {
+	txBytes, err := hex.DecodeString(strings.TrimSpace(txCbor))
+	if err != nil {
+		return TxSummary{}, fmt.Errorf("%w: tx hex: %w", ErrInvalidTx, err)
+	}
+	var tx conway.ConwayTransaction
+	if _, err := cbor.Decode(txBytes, &tx); err != nil {
+		return TxSummary{}, fmt.Errorf("%w: %w", ErrInvalidTx, err)
+	}
+
+	out := TxSummary{
+		Kind:               "vkey",
+		Fee:                strconv.FormatUint(tx.Body.TxFee, 10),
+		ExistingSignatures: []TxSummarySigner{},
+		WalletCanAdd:       []TxSummarySigner{},
+	}
+	if ttl := tx.Body.TTL(); ttl != 0 {
+		out.TTL = ttl
+	}
+	for _, o := range tx.Body.Outputs() {
+		out.Outputs = append(out.Outputs, TxSummaryOutput{
+			Address:  o.Address().String(),
+			Lovelace: o.Amount().String(),
+			Assets:   assetsFromOutput(o),
+		})
+	}
+	for _, c := range tx.Body.Certificates() {
+		out.Certificates = append(out.Certificates, certLabel(c))
+	}
+	for addr, amount := range tx.Body.TxWithdrawals {
+		if addr == nil {
+			continue
+		}
+		out.Withdrawals = append(out.Withdrawals, TxSummaryOutput{
+			Address:  addr.String(),
+			Lovelace: strconv.FormatUint(amount, 10),
+		})
+	}
+
+	// Existing signatures already present in the witness set.
+	present := map[string]bool{}
+	for _, w := range tx.WitnessSet.VkeyWitnesses.Items() {
+		kh := hex.EncodeToString(lcommon.Blake2b224Hash(w.Vkey).Bytes())
+		present[kh] = true
+		out.ExistingSignatures = append(out.ExistingSignatures, TxSummarySigner{KeyHash: kh})
+	}
+
+	// wallet_can_add: match the active account's known payment key hashes (from its
+	// bech32 addresses) against required signers / cert / withdrawal credentials
+	// this wallet hasn't already witnessed.
+	_, acct, _ := s.currentBinding()
+	needed := neededKeyHashes(&tx) // key-14 + cert/withdrawal credentials, as a set
+	if acct != nil {
+		seen := map[string]bool{}
+		for _, kh := range walletPaymentKeyHashes(acct) {
+			khHex := hex.EncodeToString(kh.Bytes())
+			if needed[khHex] && !present[khHex] && !seen[khHex] {
+				seen[khHex] = true
+				out.WalletCanAdd = append(out.WalletCanAdd, TxSummarySigner{KeyHash: khHex, Role: "payment"})
+			}
+		}
+	}
+
+	out.IsComplete = len(out.WalletCanAdd) == 0 && coversAllNeeded(needed, present)
+	return out, nil
+}
+
+// assetsFromOutput enumerates a transaction output's native assets as decimal
+// quantities, mirroring the loop toPreview uses for Apollo-built outputs.
+func assetsFromOutput(o lcommon.TransactionOutput) []Asset {
+	ma := o.Assets()
+	if ma == nil {
+		return nil
+	}
+	var assets []Asset
+	for _, pol := range ma.Policies() {
+		for _, name := range ma.Assets(pol) {
+			qty := ma.Asset(pol, name)
+			if qty != nil && qty.Sign() > 0 {
+				assets = append(assets, Asset{
+					Unit:     hex.EncodeToString(pol.Bytes()) + hex.EncodeToString(name),
+					Quantity: qty.String(),
+				})
+			}
+		}
+	}
+	return assets
+}
+
+// certLabel returns a stable snake_case label for a certificate's kind, for
+// display in a decoded tx summary.
+func certLabel(c lcommon.Certificate) string {
+	switch c.(type) {
+	case *lcommon.StakeRegistrationCertificate:
+		return "stake_registration"
+	case *lcommon.StakeDeregistrationCertificate:
+		return "stake_deregistration"
+	case *lcommon.StakeDelegationCertificate:
+		return "stake_delegation"
+	case *lcommon.PoolRegistrationCertificate:
+		return "pool_registration"
+	case *lcommon.PoolRetirementCertificate:
+		return "pool_retirement"
+	case *lcommon.GenesisKeyDelegationCertificate:
+		return "genesis_key_delegation"
+	case *lcommon.MoveInstantaneousRewardsCertificate:
+		return "move_instantaneous_rewards"
+	case *lcommon.RegistrationCertificate:
+		return "registration"
+	case *lcommon.DeregistrationCertificate:
+		return "deregistration"
+	case *lcommon.VoteDelegationCertificate:
+		return "vote_delegation"
+	case *lcommon.StakeVoteDelegationCertificate:
+		return "stake_vote_delegation"
+	case *lcommon.StakeRegistrationDelegationCertificate:
+		return "stake_registration_delegation"
+	case *lcommon.VoteRegistrationDelegationCertificate:
+		return "vote_registration_delegation"
+	case *lcommon.StakeVoteRegistrationDelegationCertificate:
+		return "stake_vote_registration_delegation"
+	case *lcommon.AuthCommitteeHotCertificate:
+		return "auth_committee_hot"
+	case *lcommon.ResignCommitteeColdCertificate:
+		return "resign_committee_cold"
+	case *lcommon.RegistrationDrepCertificate:
+		return "registration_drep"
+	case *lcommon.DeregistrationDrepCertificate:
+		return "deregistration_drep"
+	case *lcommon.UpdateDrepCertificate:
+		return "update_drep"
+	default:
+		return "unknown"
+	}
+}
+
+// neededKeyHashes builds the set of addr-key-hash credentials (hex-encoded)
+// that must witness tx: key-14 required signers plus certificate and reward
+// withdrawal credentials. This mirrors the reqSet construction in
+// deriveWitnesses/WitnessTx so the two stay consistent — a hash this wallet
+// can witness for signing is also one DecodeTx should report as addable.
+func neededKeyHashes(tx *conway.ConwayTransaction) map[string]bool {
+	needed := make(map[string]bool)
+	addHash := func(kh lcommon.Blake2b224) {
+		needed[hex.EncodeToString(kh.Bytes())] = true
+	}
+	for _, kh := range tx.Body.RequiredSigners() {
+		addHash(kh)
+	}
+	addCredential := func(cred *lcommon.Credential) {
+		if cred != nil && cred.CredType == lcommon.CredentialTypeAddrKeyHash {
+			addHash(cred.Credential)
+		}
+	}
+	for _, cert := range tx.Body.Certificates() {
+		switch c := cert.(type) {
+		case *lcommon.StakeRegistrationCertificate:
+			addCredential(&c.StakeCredential)
+		case *lcommon.StakeDeregistrationCertificate:
+			addCredential(&c.StakeCredential)
+		case *lcommon.StakeDelegationCertificate:
+			addCredential(c.StakeCredential)
+		case *lcommon.RegistrationCertificate:
+			addCredential(&c.StakeCredential)
+		case *lcommon.DeregistrationCertificate:
+			addCredential(&c.StakeCredential)
+		case *lcommon.VoteDelegationCertificate:
+			addCredential(&c.StakeCredential)
+		case *lcommon.StakeVoteDelegationCertificate:
+			addCredential(&c.StakeCredential)
+		case *lcommon.StakeRegistrationDelegationCertificate:
+			addCredential(&c.StakeCredential)
+		case *lcommon.VoteRegistrationDelegationCertificate:
+			addCredential(&c.StakeCredential)
+		case *lcommon.StakeVoteRegistrationDelegationCertificate:
+			addCredential(&c.StakeCredential)
+		case *lcommon.RegistrationDrepCertificate:
+			addCredential(&c.DrepCredential)
+		case *lcommon.DeregistrationDrepCertificate:
+			addCredential(&c.DrepCredential)
+		case *lcommon.UpdateDrepCertificate:
+			addCredential(&c.DrepCredential)
+		case *lcommon.AuthCommitteeHotCertificate:
+			addCredential(&c.ColdCredential)
+		case *lcommon.ResignCommitteeColdCertificate:
+			addCredential(&c.ColdCredential)
+		}
+	}
+	for addr := range tx.Body.TxWithdrawals {
+		if addr == nil {
+			continue
+		}
+		if payload, ok := addr.StakingPayload().(lcommon.AddressPayloadKeyHash); ok {
+			addHash(payload.Hash)
+		}
+	}
+	return needed
+}
+
+// walletPaymentKeyHashes returns the payment key hashes for every address
+// (receive and change) the active account has derived.
+func walletPaymentKeyHashes(acct *wallet.Account) []lcommon.Blake2b224 {
+	hashes := make([]lcommon.Blake2b224, 0, len(acct.ReceiveAddresses)+len(acct.ChangeAddresses))
+	for _, addrStr := range acct.ReceiveAddresses {
+		addr, err := lcommon.NewAddress(addrStr)
+		if err != nil {
+			continue
+		}
+		hashes = append(hashes, addr.PaymentKeyHash())
+	}
+	for _, addrStr := range acct.ChangeAddresses {
+		addr, err := lcommon.NewAddress(addrStr)
+		if err != nil {
+			continue
+		}
+		hashes = append(hashes, addr.PaymentKeyHash())
+	}
+	return hashes
+}
+
+// coversAllNeeded reports whether every hex-encoded key hash in needed is
+// already present (already witnessed).
+func coversAllNeeded(needed, present map[string]bool) bool {
+	for kh := range needed {
+		if !present[kh] {
+			return false
+		}
+	}
+	return true
 }
 
 // WitnessTx derives the wallet's signing keys and builds a CBOR witness set

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -1446,6 +1446,48 @@ func (s *Service) WitnessTx(
 	// Hash the tx body to get the signing target.
 	txBodyHash := lcommon.Blake2b256Hash(txBodyCbor)
 
+	witnesses, err := s.deriveWitnesses(
+		acctKey,
+		txBodyHash,
+		requiredSignerHashes,
+		&txBody,
+		inputAddrs,
+		acct,
+		partialSign,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Encode witness set as CBOR using the ConwayTransactionWitnessSet type,
+	// which serialises as a map with integer keys (key 0 = vkey witnesses).
+	ws := conway.ConwayTransactionWitnessSet{}
+	if len(witnesses) > 0 {
+		ws.VkeyWitnesses = cbor.NewSetType(witnesses, true)
+	}
+	wsCbor, err := cbor.Encode(ws)
+	if err != nil {
+		return nil, fmt.Errorf("encode witness set: %w", err)
+	}
+	return wsCbor, nil
+}
+
+// deriveWitnesses derives the vkey witnesses this wallet can provide for a
+// transaction, given the already-derived account key. It matches required
+// signers (key-14 plus certificate/withdrawal credentials) and owned input
+// addresses to the wallet's payment/stake/DRep keys, deriving each candidate
+// key from acctKey and zeroing it locally once it has served its purpose.
+// Both WitnessTx and CosignTx call this so the derivation logic never drifts
+// between the two entry points.
+func (s *Service) deriveWitnesses(
+	acctKey bip32.XPrv,
+	txBodyHash lcommon.Blake2b256,
+	requiredSignerHashes []lcommon.Blake2b224,
+	txBody *conway.ConwayTransactionBody,
+	inputAddrs []string,
+	acct *wallet.Account,
+	partialSign bool,
+) ([]lcommon.VkeyWitness, error) {
 	// Build a map from every owned payment address to its CIP-1852 role/index.
 	// Receive addresses use role 0 and change addresses use role 1. An address
 	// absent from this map MUST NOT be signed — defaulting to role/index 0 would
@@ -1677,17 +1719,7 @@ func (s *Service) WitnessTx(
 		}()
 	}
 
-	// Encode witness set as CBOR using the ConwayTransactionWitnessSet type,
-	// which serialises as a map with integer keys (key 0 = vkey witnesses).
-	ws := conway.ConwayTransactionWitnessSet{}
-	if len(witnesses) > 0 {
-		ws.VkeyWitnesses = cbor.NewSetType(witnesses, true)
-	}
-	wsCbor, err := cbor.Encode(ws)
-	if err != nil {
-		return nil, fmt.Errorf("encode witness set: %w", err)
-	}
-	return wsCbor, nil
+	return witnesses, nil
 }
 
 // HardwareSignRequest is the structured signing request the SPA passes to the

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -6,6 +6,7 @@ package spend
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -1414,7 +1415,7 @@ func (s *Service) SubmitTxCbor(ctx context.Context, txCbor string) (TxResult, er
 // an ordinary vkey tx. (The api layer upgrades kind to "native_multisig" when the
 // tx carries a native script.) wallet_can_add is derived from the active account's
 // public key hashes — no seed required, and nothing here signs or mutates the tx.
-func (s *Service) DecodeTx(txCbor string) (TxSummary, error) {
+func (s *Service) DecodeTx(ctx context.Context, txCbor string) (TxSummary, error) {
 	txBytes, err := hex.DecodeString(strings.TrimSpace(txCbor))
 	if err != nil {
 		return TxSummary{}, fmt.Errorf("%w: tx hex: %w", ErrInvalidTx, err)
@@ -1423,6 +1424,15 @@ func (s *Service) DecodeTx(txCbor string) (TxSummary, error) {
 	if _, err := cbor.Decode(txBytes, &tx); err != nil {
 		return TxSummary{}, fmt.Errorf("%w: %w", ErrInvalidTx, err)
 	}
+	// The witnesses sign blake2b-256 of the raw body element, preserved exactly
+	// as supplied (see extractTxBodyCbor). We need it to verify existing
+	// witnesses below so a malformed signature is not counted as covering a
+	// required credential.
+	bodyCbor, err := extractTxBodyCbor(txBytes)
+	if err != nil {
+		return TxSummary{}, err
+	}
+	bodyHash := lcommon.Blake2b256Hash(bodyCbor)
 
 	out := TxSummary{
 		Kind:               "vkey",
@@ -1432,6 +1442,10 @@ func (s *Service) DecodeTx(txCbor string) (TxSummary, error) {
 	}
 	if ttl := tx.Body.TTL(); ttl != 0 {
 		out.TTL = ttl
+	}
+	if nid := tx.Body.NetworkId(); nid != nil {
+		v := int(*nid)
+		out.NetworkID = &v
 	}
 	for _, o := range tx.Body.Outputs() {
 		out.Outputs = append(out.Outputs, TxSummaryOutput{
@@ -1453,32 +1467,93 @@ func (s *Service) DecodeTx(txCbor string) (TxSummary, error) {
 		})
 	}
 
-	// Existing signatures already present in the witness set.
+	// Existing signatures already present in the witness set. A witness counts
+	// toward `present` (the "already covered" set used for wallet_can_add and
+	// completeness) only when its signature actually verifies over the body
+	// bytes — otherwise a pasted tx could carry a bogus witness for a required
+	// key and appear complete, or hide the fact that this wallet can still add
+	// the real one. Every attached witness is still listed for display.
 	present := map[string]bool{}
 	for _, w := range tx.WitnessSet.VkeyWitnesses.Items() {
 		kh := hex.EncodeToString(lcommon.Blake2b224Hash(w.Vkey).Bytes())
-		present[kh] = true
 		out.ExistingSignatures = append(out.ExistingSignatures, TxSummarySigner{KeyHash: kh})
-	}
-
-	// wallet_can_add: match the active account's known payment key hashes (from its
-	// bech32 addresses) against required signers / cert / withdrawal credentials
-	// this wallet hasn't already witnessed.
-	_, acct, _ := s.currentBinding()
-	needed := neededKeyHashes(&tx) // key-14 + cert/withdrawal credentials, as a set
-	if acct != nil {
-		seen := map[string]bool{}
-		for _, kh := range walletPaymentKeyHashes(acct) {
-			khHex := hex.EncodeToString(kh.Bytes())
-			if needed[khHex] && !present[khHex] && !seen[khHex] {
-				seen[khHex] = true
-				out.WalletCanAdd = append(out.WalletCanAdd, TxSummarySigner{KeyHash: khHex, Role: "payment"})
-			}
+		if vkeyWitnessValid(w, bodyHash.Bytes()) {
+			present[kh] = true
 		}
 	}
 
-	out.IsComplete = len(out.WalletCanAdd) == 0 && coversAllNeeded(needed, present)
+	// wallet_can_add: match the active account's known key hashes against the
+	// credentials this tx needs witnessed that it hasn't already. needed starts
+	// with key-14 required signers plus certificate/withdrawal credentials, then
+	// is augmented with each resolvable input's payment key hash — a pasted tx
+	// need not list its input signers as required signers, so without this an
+	// unsigned ordinary spend would look complete.
+	_, acct, _ := s.currentBinding()
+	needed := neededKeyHashes(&tx)
+	resolvedAllInputs := s.addInputKeyHashes(ctx, &tx, needed)
+	if acct != nil {
+		seen := map[string]bool{}
+		addCanAdd := func(khHex, role string) {
+			khHex = strings.ToLower(khHex)
+			if needed[khHex] && !present[khHex] && !seen[khHex] {
+				seen[khHex] = true
+				out.WalletCanAdd = append(out.WalletCanAdd, TxSummarySigner{KeyHash: khHex, Role: role})
+			}
+		}
+		for _, kh := range walletPaymentKeyHashes(acct) {
+			addCanAdd(hex.EncodeToString(kh.Bytes()), "payment")
+		}
+		// CosignTx can also derive this wallet's stake and DRep witnesses, so
+		// surface them when a delegation / DRep tx needs them — otherwise such an
+		// import would show no addable wallet signer at all.
+		if acct.StakeAddress != "" {
+			if sa, err := lcommon.NewAddress(acct.StakeAddress); err == nil {
+				addCanAdd(hex.EncodeToString(sa.StakeKeyHash().Bytes()), "stake")
+			}
+		}
+		if acct.DRepKeyHash != "" {
+			addCanAdd(acct.DRepKeyHash, "drep")
+		}
+	}
+
+	// A tx is only complete when there is nothing this wallet can add, every
+	// needed credential is already validly witnessed, AND we could resolve every
+	// input (so no unseen input credential is silently assumed satisfied). When
+	// inputs cannot be resolved — no node, or an already-spent input — treat
+	// completeness as unknown (false) rather than risk submitting an unsigned tx.
+	out.IsComplete = len(out.WalletCanAdd) == 0 &&
+		coversAllNeeded(needed, present) &&
+		resolvedAllInputs
 	return out, nil
+}
+
+// addInputKeyHashes resolves tx's inputs (best-effort, via the chain) and adds
+// each key-hash-locked input's payment credential to needed. It returns whether
+// every input was resolved: a script-locked input needs no vkey witness and
+// still counts as resolved, but an input the chain cannot return leaves the
+// tx's witness requirements only partially known. Without a chain, inputs are
+// unresolvable and completeness must stay unknown.
+func (s *Service) addInputKeyHashes(ctx context.Context, tx *conway.ConwayTransaction, needed map[string]bool) bool {
+	inputs := tx.Body.Inputs()
+	if len(inputs) == 0 {
+		return true
+	}
+	if s.chain == nil {
+		return false
+	}
+	resolvedAll := true
+	for _, inp := range inputs {
+		u, err := s.chain.UtxoByRef(ctx, inp.Id(), inp.Index())
+		if err != nil || u == nil || u.Output == nil {
+			resolvedAll = false
+			continue
+		}
+		addr := u.Output.Address()
+		if p, ok := addr.PayloadPayload().(lcommon.AddressPayloadKeyHash); ok {
+			needed[hex.EncodeToString(p.Hash.Bytes())] = true
+		}
+	}
+	return resolvedAll
 }
 
 // extractTxBodyCbor returns the raw CBOR bytes of the transaction body (element
@@ -1601,14 +1676,33 @@ func (s *Service) CosignTx(
 		return CosignResult{}, err
 	}
 
-	// Merge into the pasted tx, preserving existing witnesses, deduped by key-hash.
-	present := map[string]bool{}
-	for _, w := range tx.WitnessSet.VkeyWitnesses.Items() {
-		present[hex.EncodeToString(lcommon.Blake2b224Hash(w.Vkey).Bytes())] = true
-	}
 	a, err := apollo.New(s.chain).LoadTxCbor(trimmed)
 	if err != nil {
 		return CosignResult{}, fmt.Errorf("%w: %w", ErrInvalidTx, err)
+	}
+	lt := a.GetTx()
+	if lt == nil {
+		return CosignResult{}, fmt.Errorf("%w: no transaction body", ErrInvalidTx)
+	}
+	// Rebuild the witness set from only the existing witnesses whose signature
+	// verifies over the preserved body bytes, deduped by key-hash. A pasted tx
+	// can carry a malformed or foreign witness — including one bearing THIS
+	// wallet's own pubkey — and keying dedupe off key-hash alone would preserve
+	// that invalid witness and skip our valid replacement, getting the tx
+	// rejected at the node. Dropping non-verifying witnesses lets the valid one
+	// (ours below, or a later co-signer's) take its place.
+	present := map[string]bool{}
+	kept := make([]lcommon.VkeyWitness, 0, len(lt.WitnessSet.VkeyWitnesses.Items()))
+	for _, w := range lt.WitnessSet.VkeyWitnesses.Items() {
+		if !vkeyWitnessValid(w, bodyHash.Bytes()) {
+			continue
+		}
+		kh := hex.EncodeToString(lcommon.Blake2b224Hash(w.Vkey).Bytes())
+		if present[kh] {
+			continue
+		}
+		present[kh] = true
+		kept = append(kept, w)
 	}
 	var added []TxSummarySigner
 	for _, w := range witnesses {
@@ -1617,25 +1711,22 @@ func (s *Service) CosignTx(
 			continue
 		}
 		present[kh] = true
-		if a, err = a.AddVerificationKeyWitness(w); err != nil {
-			return CosignResult{}, fmt.Errorf("attach witness: %w", err)
-		}
+		kept = append(kept, w)
 		added = append(added, TxSummarySigner{KeyHash: kh})
 	}
+	lt.WitnessSet.VkeyWitnesses = cbor.NewSetType(kept, true)
 
 	// Clear tx/witness-set caches (keep the body cache) so re-serialization
-	// includes the attached witnesses over the unchanged body bytes -- the
+	// includes the rebuilt witness set over the unchanged body bytes -- the
 	// SubmitSigned pattern (spend.go SubmitSigned, above).
-	if lt := a.GetTx(); lt != nil {
-		lt.SetCbor(nil)
-		lt.WitnessSet.SetCbor(nil)
-	}
+	lt.SetCbor(nil)
+	lt.WitnessSet.SetCbor(nil)
 	mergedBytes, err := a.GetTxCbor()
 	if err != nil {
 		return CosignResult{}, fmt.Errorf("encode merged tx: %w", err)
 	}
 	mergedHex := hex.EncodeToString(mergedBytes)
-	summary, err := s.DecodeTx(mergedHex)
+	summary, err := s.DecodeTx(ctx, mergedHex)
 	if err != nil {
 		return CosignResult{}, err
 	}
@@ -1793,6 +1884,19 @@ func walletPaymentKeyHashes(acct *wallet.Account) []lcommon.Blake2b224 {
 		hashes = append(hashes, addr.PaymentKeyHash())
 	}
 	return hashes
+}
+
+// vkeyWitnessValid reports whether w is a genuine Ed25519 signature by w.Vkey
+// over msg — the transaction body hash bytes the witness is meant to sign.
+// Cardano's BIP32-Ed25519 witnesses verify under standard Ed25519 against the
+// 32-byte public key, so a pasted tx carrying a malformed or foreign witness
+// (even one bearing this wallet's own pubkey) is rejected here rather than
+// being trusted by key-hash alone.
+func vkeyWitnessValid(w lcommon.VkeyWitness, msg []byte) bool {
+	if len(w.Vkey) != ed25519.PublicKeySize || len(w.Signature) != ed25519.SignatureSize {
+		return false
+	}
+	return ed25519.Verify(ed25519.PublicKey(w.Vkey), msg, w.Signature)
 }
 
 // coversAllNeeded reports whether every hex-encoded key hash in needed is

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -6,7 +6,6 @@ package spend
 import (
 	"bytes"
 	"context"
-	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -22,6 +21,7 @@ import (
 	"github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/bursa/bip32"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
+	"github.com/blinklabs-io/bursa/ui/internal/txwitness"
 	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
@@ -1477,7 +1477,7 @@ func (s *Service) DecodeTx(ctx context.Context, txCbor string) (TxSummary, error
 	for _, w := range tx.WitnessSet.VkeyWitnesses.Items() {
 		kh := hex.EncodeToString(lcommon.Blake2b224Hash(w.Vkey).Bytes())
 		out.ExistingSignatures = append(out.ExistingSignatures, TxSummarySigner{KeyHash: kh})
-		if vkeyWitnessValid(w, bodyHash.Bytes()) {
+		if txwitness.Valid(w, bodyHash.Bytes()) {
 			present[kh] = true
 		}
 	}
@@ -1694,7 +1694,7 @@ func (s *Service) CosignTx(
 	present := map[string]bool{}
 	kept := make([]lcommon.VkeyWitness, 0, len(lt.WitnessSet.VkeyWitnesses.Items()))
 	for _, w := range lt.WitnessSet.VkeyWitnesses.Items() {
-		if !vkeyWitnessValid(w, bodyHash.Bytes()) {
+		if !txwitness.Valid(w, bodyHash.Bytes()) {
 			continue
 		}
 		kh := hex.EncodeToString(lcommon.Blake2b224Hash(w.Vkey).Bytes())
@@ -1884,19 +1884,6 @@ func walletPaymentKeyHashes(acct *wallet.Account) []lcommon.Blake2b224 {
 		hashes = append(hashes, addr.PaymentKeyHash())
 	}
 	return hashes
-}
-
-// vkeyWitnessValid reports whether w is a genuine Ed25519 signature by w.Vkey
-// over msg — the transaction body hash bytes the witness is meant to sign.
-// Cardano's BIP32-Ed25519 witnesses verify under standard Ed25519 against the
-// 32-byte public key, so a pasted tx carrying a malformed or foreign witness
-// (even one bearing this wallet's own pubkey) is rejected here rather than
-// being trusted by key-hash alone.
-func vkeyWitnessValid(w lcommon.VkeyWitness, msg []byte) bool {
-	if len(w.Vkey) != ed25519.PublicKeySize || len(w.Signature) != ed25519.SignatureSize {
-		return false
-	}
-	return ed25519.Verify(ed25519.PublicKey(w.Vkey), msg, w.Signature)
 }
 
 // coversAllNeeded reports whether every hex-encoded key hash in needed is

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -1396,6 +1396,20 @@ func (s *Service) Submit(ctx context.Context, txBytes []byte) (string, error) {
 	return hex.EncodeToString(txHash.Bytes()), nil
 }
 
+// SubmitTxCbor hex-decodes a full (already-signed) tx CBOR and broadcasts it
+// via Submit. It does not sign or hold key material.
+func (s *Service) SubmitTxCbor(ctx context.Context, txCbor string) (TxResult, error) {
+	txBytes, err := hex.DecodeString(strings.TrimSpace(txCbor))
+	if err != nil {
+		return TxResult{}, fmt.Errorf("%w: tx hex: %w", ErrInvalidTx, err)
+	}
+	hashHex, err := s.Submit(ctx, txBytes) // existing method; wraps ErrSubmitRejected
+	if err != nil {
+		return TxResult{}, err
+	}
+	return TxResult{TxHash: hashHex}, nil
+}
+
 // DecodeTx decodes a full tx CBOR into a no-password summary and classifies it as
 // an ordinary vkey tx. (The api layer upgrades kind to "native_multisig" when the
 // tx carries a native script.) wallet_can_add is derived from the active account's

--- a/ui/internal/txwitness/txwitness.go
+++ b/ui/internal/txwitness/txwitness.go
@@ -1,0 +1,25 @@
+// Package txwitness holds transaction-witness validation shared by the import
+// flow's two code paths (the ordinary vkey path in internal/spend and the
+// native-script path in internal/multisig). Keeping the Ed25519 check in one
+// place means a future validation fix cannot make the two paths diverge and
+// silently accept different witness sets.
+package txwitness
+
+import (
+	"crypto/ed25519"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// Valid reports whether w is a genuine Ed25519 signature by w.Vkey over msg —
+// the transaction body hash bytes the witness is meant to sign. Cardano's
+// BIP32-Ed25519 witnesses verify under standard Ed25519 against the 32-byte
+// public key, so a pasted tx carrying a malformed or foreign witness (even one
+// bearing this wallet's own pubkey) is rejected here rather than being trusted
+// by key-hash alone.
+func Valid(w lcommon.VkeyWitness, msg []byte) bool {
+	if len(w.Vkey) != ed25519.PublicKeySize || len(w.Signature) != ed25519.SignatureSize {
+		return false
+	}
+	return ed25519.Verify(ed25519.PublicKey(w.Vkey), msg, w.Signature)
+}

--- a/ui/internal/txwitness/txwitness_test.go
+++ b/ui/internal/txwitness/txwitness_test.go
@@ -1,0 +1,43 @@
+package txwitness
+
+import (
+	"crypto/ed25519"
+	"testing"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+func TestValid(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	msg := []byte("transaction body hash bytes")
+	sig := ed25519.Sign(priv, msg)
+
+	good := lcommon.VkeyWitness{Vkey: pub, Signature: sig}
+	if !Valid(good, msg) {
+		t.Error("a genuine signature over msg must be valid")
+	}
+
+	// Wrong message: the same key/signature over a different body must fail.
+	if Valid(good, []byte("a different body")) {
+		t.Error("signature over a different message must be rejected")
+	}
+
+	// Foreign/tampered signature bearing the same key must fail.
+	tampered := sig[:]
+	tampered = append([]byte(nil), tampered...)
+	tampered[0] ^= 0xff
+	if Valid(lcommon.VkeyWitness{Vkey: pub, Signature: tampered}, msg) {
+		t.Error("a tampered signature must be rejected")
+	}
+
+	// Malformed sizes are rejected without attempting verification.
+	if Valid(lcommon.VkeyWitness{Vkey: pub[:16], Signature: sig}, msg) {
+		t.Error("a short vkey must be rejected")
+	}
+	if Valid(lcommon.VkeyWitness{Vkey: pub, Signature: sig[:32]}, msg) {
+		t.Error("a short signature must be rejected")
+	}
+}

--- a/ui/web/src/api/client.test.ts
+++ b/ui/web/src/api/client.test.ts
@@ -1,4 +1,4 @@
-import { apiDelete, apiGet, ApiError } from "./client";
+import { apiDelete, apiGet, ApiError, decodeTx, cosignTx, submitTx } from "./client";
 
 function mockFetch(status: number, body: unknown) {
   globalThis.fetch = vi.fn().mockResolvedValue({
@@ -75,4 +75,38 @@ test("apiDelete is not retried after a network error", async () => {
 
   await expect(apiDelete("/wallet/test-wallet")).rejects.toBeInstanceOf(ApiError);
   expect(calls).toBe(1);
+});
+
+// --- Import-transaction (decode / cosign / submit) --------------------------
+
+test("decodeTx posts tx_cbor and returns the parsed TxSummary", async () => {
+  mockFetch(200, {
+    kind: "vkey",
+    outputs: [],
+    fee: "170000",
+    existing_signatures: [],
+    wallet_can_add: [],
+    is_complete: false,
+  });
+  await expect(decodeTx("84a4")).resolves.toEqual({
+    kind: "vkey",
+    outputs: [],
+    fee: "170000",
+    existing_signatures: [],
+    wallet_can_add: [],
+    is_complete: false,
+  });
+});
+
+test("cosignTx posts tx_cbor + password and returns a CosignResult", async () => {
+  mockFetch(200, { tx_cbor: "84beef", added: [{ key_hash: "abc" }] });
+  await expect(cosignTx({ tx_cbor: "84a4", password: "pw" })).resolves.toEqual({
+    tx_cbor: "84beef",
+    added: [{ key_hash: "abc" }],
+  });
+});
+
+test("submitTx posts tx_cbor and returns a TxResult", async () => {
+  mockFetch(200, { tx_hash: "abc123" });
+  await expect(submitTx("84beef")).resolves.toEqual({ tx_hash: "abc123" });
 });

--- a/ui/web/src/api/client.test.ts
+++ b/ui/web/src/api/client.test.ts
@@ -1,12 +1,28 @@
 import { apiDelete, apiGet, ApiError, decodeTx, cosignTx, submitTx } from "./client";
 
 function mockFetch(status: number, body: unknown) {
-  globalThis.fetch = vi.fn().mockResolvedValue({
+  const fn = vi.fn().mockResolvedValue({
     ok: status >= 200 && status < 300,
     status,
     json: async () => body,
     text: async () => JSON.stringify(body),
-  }) as unknown as typeof fetch;
+  });
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+// lastRequest returns the (url, init) the mocked fetch was called with, so a
+// test can assert the endpoint, HTTP method, and serialized body actually sent
+// — otherwise a wrong URL/method/payload would still pass, since the mock
+// accepts every request.
+function lastRequest(fn: ReturnType<typeof vi.fn>): { url: string; method: string; body: unknown } {
+  expect(fn).toHaveBeenCalledTimes(1);
+  const [url, init] = fn.mock.calls[0] as [string, RequestInit];
+  return {
+    url,
+    method: init.method ?? "GET",
+    body: init.body ? JSON.parse(init.body as string) : undefined,
+  };
 }
 
 test("apiGet returns the parsed body on 200", async () => {
@@ -79,8 +95,8 @@ test("apiDelete is not retried after a network error", async () => {
 
 // --- Import-transaction (decode / cosign / submit) --------------------------
 
-test("decodeTx posts tx_cbor and returns the parsed TxSummary", async () => {
-  mockFetch(200, {
+test("decodeTx POSTs tx_cbor to /wallet/decode-tx and returns the parsed TxSummary", async () => {
+  const fn = mockFetch(200, {
     kind: "vkey",
     outputs: [],
     fee: "170000",
@@ -96,17 +112,32 @@ test("decodeTx posts tx_cbor and returns the parsed TxSummary", async () => {
     wallet_can_add: [],
     is_complete: false,
   });
+  expect(lastRequest(fn)).toEqual({
+    url: "/wallet/decode-tx",
+    method: "POST",
+    body: { tx_cbor: "84a4" },
+  });
 });
 
-test("cosignTx posts tx_cbor + password and returns a CosignResult", async () => {
-  mockFetch(200, { tx_cbor: "84beef", added: [{ key_hash: "abc" }] });
+test("cosignTx POSTs tx_cbor + password to /wallet/cosign-tx and returns a CosignResult", async () => {
+  const fn = mockFetch(200, { tx_cbor: "84beef", added: [{ key_hash: "abc" }] });
   await expect(cosignTx({ tx_cbor: "84a4", password: "pw" })).resolves.toEqual({
     tx_cbor: "84beef",
     added: [{ key_hash: "abc" }],
   });
+  expect(lastRequest(fn)).toEqual({
+    url: "/wallet/cosign-tx",
+    method: "POST",
+    body: { tx_cbor: "84a4", password: "pw" },
+  });
 });
 
-test("submitTx posts tx_cbor and returns a TxResult", async () => {
-  mockFetch(200, { tx_hash: "abc123" });
+test("submitTx POSTs tx_cbor to /wallet/submit-tx and returns a TxResult", async () => {
+  const fn = mockFetch(200, { tx_hash: "abc123" });
   await expect(submitTx("84beef")).resolves.toEqual({ tx_hash: "abc123" });
+  expect(lastRequest(fn)).toEqual({
+    url: "/wallet/submit-tx",
+    method: "POST",
+    body: { tx_cbor: "84beef" },
+  });
 });

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -57,6 +57,8 @@ import type {
   MultiSigSignRequest,
   MultiSigSubmitRequest,
   HardwareSignResponse,
+  TxSummary,
+  CosignResult,
 } from "./types";
 
 export class ApiError extends Error {
@@ -312,3 +314,12 @@ export const multiSigSign = (req: MultiSigSignRequest) =>
   apiPost<WitnessResult>("/wallet/multisig/sign", req);
 export const multiSigSubmit = (id: string, req: MultiSigSubmitRequest) =>
   apiPost<TxResult>(`/wallet/multisig/${encodeURIComponent(id)}/submit`, req);
+
+// Import transaction: paste a full tx CBOR built elsewhere to inspect it
+// (decode-tx), add this wallet's witness(es) (cosign-tx), and broadcast the
+// result (submit-tx). The backend classifies vkey vs native-multisig
+// transactions and routes accordingly — see TxSummary/CosignResult in types.ts.
+export const decodeTx = (tx_cbor: string) => apiPost<TxSummary>("/wallet/decode-tx", { tx_cbor });
+export const cosignTx = (req: { tx_cbor: string; password: string; partial_sign?: boolean }) =>
+  apiPost<CosignResult>("/wallet/cosign-tx", req);
+export const submitTx = (tx_cbor: string) => apiPost<TxResult>("/wallet/submit-tx", { tx_cbor });

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -627,3 +627,67 @@ export interface AddHardwareWalletRequest {
   network: string;
   vault_password: string;
 }
+
+// --- Import transaction (decode / cosign / submit) --------------------------
+// Backend: spend.TxSummary, multisig.TxInfo, spend.CosignResult (vkey path) /
+// multisig.CosignResult (native-script path). All amounts are decimal STRINGS
+// (uint64 server-side), matching the rest of the API.
+
+export interface TxSummarySigner {
+  key_hash: string;
+  role?: string;
+}
+
+export interface TxSummaryOutput {
+  address: string;
+  lovelace: string;
+  assets?: { unit: string; quantity: string }[];
+}
+
+export interface TxSummaryMultiSigParticipant {
+  key_hash: string;
+  label?: string;
+  signed: boolean;
+}
+
+// multisig.TxInfo
+export interface TxSummaryMultiSig {
+  is_multisig: boolean;
+  label?: string;
+  script_hash?: string;
+  threshold?: number;
+  participants?: TxSummaryMultiSigParticipant[];
+  signed_count: number;
+  script_embedded: boolean;
+}
+
+// spend.TxSummary, with the api-layer's optional multisig.TxInfo attached.
+export interface TxSummary {
+  kind: "vkey" | "native_multisig" | "complete" | "unknown";
+  outputs: TxSummaryOutput[];
+  fee: string;
+  ttl?: number;
+  certificates?: string[];
+  withdrawals?: TxSummaryOutput[];
+  network_id?: number;
+  existing_signatures: TxSummarySigner[];
+  wallet_can_add: TxSummarySigner[];
+  is_complete: boolean;
+  multisig?: TxSummaryMultiSig;
+}
+
+// CosignResult accommodates both response shapes returned by POST
+// /wallet/cosign-tx: the vkey path (spend.CosignResult: added is the list of
+// signers just added, plus a fresh summary) and the native-multisig path
+// (multisig.CosignResult: added is a bool — whether this cosign added a new
+// witness — plus signed_count/threshold). `added`'s type differs between the
+// two Go structs, hence the union.
+export interface CosignResult {
+  tx_cbor: string;
+  // vkey path
+  added?: TxSummarySigner[] | boolean;
+  summary?: TxSummary;
+  // multisig path
+  signed_count?: number;
+  threshold?: number;
+}

--- a/ui/web/src/app.test.tsx
+++ b/ui/web/src/app.test.tsx
@@ -391,6 +391,22 @@ test("a hardware wallet can submit a multi-sig spend with external witnesses but
   );
 });
 
+test("deep-linking #/import with an active wallet renders the Import Transaction screen", async () => {
+  stubStatus("ready");
+  stubVault({ exists: true, locked: true, wallet_count: 1 });
+  quietPortfolio();
+  vi.spyOn(client, "unlockVault").mockResolvedValue([walletA]);
+  window.location.hash = "#/import";
+
+  render(<App />);
+  fireEvent.change(screen.getByLabelText(/vault password/i), { target: { value: "vault-password-xyz" } });
+  fireEvent.click(screen.getByRole("button", { name: /^unlock$/i }));
+
+  await waitFor(() =>
+    expect(screen.getByRole("heading", { name: /import transaction/i })).toBeInTheDocument(),
+  );
+});
+
 test("switching active wallets remounts routed content and refetches read state", async () => {
   stubStatus("ready");
   stubVault({ exists: true, locked: true, wallet_count: 2 });

--- a/ui/web/src/app.test.tsx
+++ b/ui/web/src/app.test.tsx
@@ -377,7 +377,7 @@ test("a hardware wallet can submit a multi-sig spend with external witnesses but
   fireEvent.change(screen.getByLabelText(/amount \(ada\)/i), { target: { value: "1" } });
   fireEvent.click(screen.getByRole("button", { name: /build transaction/i }));
 
-  expect(await screen.findByText(/0 of 1 collected/i)).toBeInTheDocument();
+  expect(await screen.findByText(/0 of 1 signed/i)).toBeInTheDocument();
   expect(screen.queryByRole("button", { name: /sign here/i })).not.toBeInTheDocument();
   fireEvent.change(screen.getByLabelText(/co-signer witness/i), { target: { value: "81a0external" } });
   fireEvent.click(screen.getByRole("button", { name: /add witness/i }));

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -26,6 +26,7 @@ import { VerifyMessage } from "./screens/VerifyMessage";
 import { Offline } from "./screens/Offline";
 import { Operate } from "./screens/Operate";
 import { MultiSig } from "./screens/MultiSig";
+import { ImportTransaction } from "./screens/ImportTransaction";
 import { Settings } from "./screens/Settings";
 import { ConnectorApproval } from "./screens/ConnectorApproval";
 
@@ -65,6 +66,7 @@ const NAV: { key: string; label: string }[] = [
   { key: "offline", label: "Offline" },
   { key: "operate", label: "Operate" },
   { key: "multisig", label: "Multi-sig" },
+  { key: "import", label: "Import Tx" },
   { key: "settings", label: "Settings" },
 ];
 
@@ -268,6 +270,7 @@ export function App() {
     else if (route === "offline" && canSign) activeRoute = "offline";
     else if (route === "operate" && canSign) activeRoute = "operate";
     else if (route === "multisig") activeRoute = "multisig";
+    else if (route === "import" && canSign) activeRoute = "import";
     else if (ROUTES.has(route) && route !== "send" && route !== "swap") activeRoute = route;
     else activeRoute = "portfolio";
   }
@@ -336,6 +339,11 @@ export function App() {
     // any active wallet. Building and submitting spends requires a synced node;
     // only local CIP-1854 key derivation/signing additionally requires a seed.
     content = <MultiSig canSpend={isReady} canSign={canSign} />;
+  } else if (route === "import") {
+    // Importing a transaction built elsewhere needs the active wallet's seed
+    // to add a signature (like Offline/Operate); submitting is separately
+    // gated inside the screen on the node being ready (canSubmit).
+    content = canSign ? <ImportTransaction canSubmit={isReady} /> : <Portfolio />;
   } else if (route === "receive") {
     // Explorer links on each address need the active wallet's real network
     // (preview/preprod/mainnet), which the generic ROUTES map (no props)
@@ -361,7 +369,8 @@ export function App() {
       (key === "staking" && !canStake) ||
       (key === "sign" && !canSign) ||
       (key === "offline" && !canSign) ||
-      (key === "operate" && !canSign);
+      (key === "operate" && !canSign) ||
+      (key === "import" && !canSign);
     return { key, label, disabled: gated, active: key === activeRoute };
   });
 

--- a/ui/web/src/components/MultiSigProgress.tsx
+++ b/ui/web/src/components/MultiSigProgress.tsx
@@ -18,10 +18,15 @@ interface MultiSigProgressProps {
 // pending.
 export function MultiSigProgress({ threshold, total, signedCount, participants }: MultiSigProgressProps) {
   const met = signedCount >= threshold;
+  // Report progress against the total signer count, not the threshold: a
+  // threshold-of-total policy can still have participants pending after the
+  // threshold is met, and "X of <threshold>" would misleadingly read as fully
+  // signed. Fall back to threshold only when the total is unknown (0).
+  const denominator = total > 0 ? total : threshold;
   return (
     <div className="ms-progress-block">
       <p className="ms-progress">
-        {signedCount} of {threshold} signed
+        {signedCount} of {denominator} signed
         {total > 0 && ` (policy ${threshold}-of-${total})`}
         {met ? " · threshold met" : ""}
       </p>

--- a/ui/web/src/components/MultiSigProgress.tsx
+++ b/ui/web/src/components/MultiSigProgress.tsx
@@ -1,0 +1,43 @@
+interface MultiSigParticipant {
+  key_hash: string;
+  label?: string;
+  signed: boolean;
+}
+
+interface MultiSigProgressProps {
+  threshold: number;
+  total: number;
+  signedCount: number;
+  participants?: MultiSigParticipant[];
+}
+
+// MultiSigProgress renders the shared N-of-M signing-progress display used by
+// multi-sig spend flows: a "K of N signed" line (with the M-of-N policy and a
+// threshold-met indicator once signedCount reaches threshold) and, when a
+// participants list is supplied, a signer-list marking each key as signed or
+// pending.
+export function MultiSigProgress({ threshold, total, signedCount, participants }: MultiSigProgressProps) {
+  const met = signedCount >= threshold;
+  return (
+    <div className="ms-progress-block">
+      <p className="ms-progress">
+        {signedCount} of {threshold} signed
+        {total > 0 && ` (policy ${threshold}-of-${total})`}
+        {met ? " · threshold met" : ""}
+      </p>
+      {participants && participants.length > 0 && (
+        <ul className="signer-list">
+          {participants.map((p) => (
+            <li key={p.key_hash} className="ms-participant">
+              <span aria-label={p.signed ? "signed" : "pending"}>{p.signed ? "✓" : "○"}</span>{" "}
+              <code className="tx-hash">
+                {p.label ? `${p.label}: ` : ""}
+                {p.key_hash}
+              </code>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/ui/web/src/components/components.test.tsx
+++ b/ui/web/src/components/components.test.tsx
@@ -6,6 +6,7 @@ import { CopyButton } from "./CopyButton";
 import { SyncBanner } from "./SyncBanner";
 import { MobileNav } from "./MobileNav";
 import { ExplorerLink } from "./ExplorerLink";
+import { MultiSigProgress } from "./MultiSigProgress";
 
 type MobileNavProps = Parameters<typeof MobileNav>[0];
 
@@ -282,4 +283,29 @@ test("ExplorerLink calls the webview bursaOpenExternal bridge instead of window.
   expect(preventDefault).toHaveBeenCalled();
   expect(bridge).toHaveBeenCalledWith("https://cardanoscan.io/pool/pool1abc");
   expect(openSpy).not.toHaveBeenCalled();
+});
+
+test("MultiSigProgress shows K of N signed and marks signed participants", () => {
+  render(
+    <MultiSigProgress
+      threshold={2}
+      total={3}
+      signedCount={1}
+      participants={[
+        { key_hash: "aa".repeat(28), label: "alice", signed: true },
+        { key_hash: "bb".repeat(28), signed: false },
+        { key_hash: "cc".repeat(28), signed: false },
+      ]}
+    />,
+  );
+
+  expect(screen.getByText(/1 of 2/)).toBeInTheDocument();
+  expect(screen.getByText(/alice/)).toBeInTheDocument();
+});
+
+test("MultiSigProgress shows threshold-met indicator once signedCount reaches threshold", () => {
+  render(<MultiSigProgress threshold={2} total={2} signedCount={2} />);
+
+  expect(screen.getByText(/2 of 2/)).toBeInTheDocument();
+  expect(screen.getByText(/threshold met/i)).toBeInTheDocument();
 });

--- a/ui/web/src/components/components.test.tsx
+++ b/ui/web/src/components/components.test.tsx
@@ -285,7 +285,7 @@ test("ExplorerLink calls the webview bursaOpenExternal bridge instead of window.
   expect(openSpy).not.toHaveBeenCalled();
 });
 
-test("MultiSigProgress shows K of N signed and marks signed participants", () => {
+test("MultiSigProgress shows signed-of-total and marks signed participants", () => {
   render(
     <MultiSigProgress
       threshold={2}
@@ -299,8 +299,18 @@ test("MultiSigProgress shows K of N signed and marks signed participants", () =>
     />,
   );
 
-  expect(screen.getByText(/1 of 2/)).toBeInTheDocument();
+  // Progress is signed-of-total (1 of 3), not signed-of-threshold: a pending
+  // third participant must not read as fully signed.
+  expect(screen.getByText(/1 of 3/)).toBeInTheDocument();
+  expect(screen.getByText(/policy 2-of-3/)).toBeInTheDocument();
+  // The threshold is not yet met at 1 signature.
+  expect(screen.queryByText(/threshold met/i)).not.toBeInTheDocument();
+
+  // Signed vs pending state must be conveyed accessibly, not merely by which
+  // names appear: alice is signed, the other two are pending.
   expect(screen.getByText(/alice/)).toBeInTheDocument();
+  expect(screen.getAllByLabelText("signed")).toHaveLength(1);
+  expect(screen.getAllByLabelText("pending")).toHaveLength(2);
 });
 
 test("MultiSigProgress shows threshold-met indicator once signedCount reaches threshold", () => {

--- a/ui/web/src/screens/ImportTransaction.test.tsx
+++ b/ui/web/src/screens/ImportTransaction.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ImportTransaction } from "./ImportTransaction";
+import * as client from "../api/client";
+import type { TxSummary } from "../api/types";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const vkeySummary: TxSummary = {
+  kind: "vkey",
+  outputs: [{ address: "addr_test1xyz", lovelace: "2000000" }],
+  fee: "170000",
+  existing_signatures: [],
+  wallet_can_add: [{ key_hash: "aa".repeat(28), role: "payment" }],
+  is_complete: false,
+};
+
+test("decodes a pasted tx and shows the preview", async () => {
+  vi.spyOn(client, "decodeTx").mockResolvedValue(vkeySummary);
+
+  render(<ImportTransaction canSubmit={true} />);
+
+  fireEvent.change(screen.getByLabelText(/transaction cbor/i), {
+    target: { value: "84a4" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /decode/i }));
+
+  await waitFor(() => expect(screen.getByText(/170000|0.17/)).toBeInTheDocument());
+  expect(screen.getByText(/add my signature/i)).toBeInTheDocument();
+});
+
+test("adds a signature and reveals export + submit", async () => {
+  vi.spyOn(client, "decodeTx").mockResolvedValue(vkeySummary);
+  vi.spyOn(client, "cosignTx").mockResolvedValue({
+    tx_cbor: "84beef",
+    added: [{ key_hash: "aa".repeat(28) }],
+    summary: {
+      ...vkeySummary,
+      existing_signatures: [{ key_hash: "aa".repeat(28) }],
+      wallet_can_add: [],
+      is_complete: true,
+    },
+  });
+
+  render(<ImportTransaction canSubmit={true} />);
+
+  fireEvent.change(screen.getByLabelText(/transaction cbor/i), {
+    target: { value: "84a4" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /decode/i }));
+  await screen.findByText(/add my signature/i);
+
+  fireEvent.change(screen.getByLabelText(/spending password/i), {
+    target: { value: "pw" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /add my signature/i }));
+
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: /submit to network/i })).toBeEnabled(),
+  );
+  expect(screen.getByText(/84beef/)).toBeInTheDocument();
+});
+
+test("disables submit when the node is not ready", async () => {
+  vi.spyOn(client, "decodeTx").mockResolvedValue({
+    ...vkeySummary,
+    is_complete: true,
+    wallet_can_add: [],
+  });
+
+  render(<ImportTransaction canSubmit={false} />);
+
+  fireEvent.change(screen.getByLabelText(/transaction cbor/i), {
+    target: { value: "84a4" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /decode/i }));
+
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: /submit to network/i })).toBeDisabled(),
+  );
+});
+
+test("renders multisig progress for a native_multisig tx", async () => {
+  vi.spyOn(client, "decodeTx").mockResolvedValue({
+    ...vkeySummary,
+    kind: "native_multisig",
+    multisig: {
+      is_multisig: true,
+      threshold: 2,
+      signed_count: 1,
+      script_embedded: true,
+      participants: [
+        { key_hash: "aa".repeat(28), signed: true },
+        { key_hash: "bb".repeat(28), signed: false },
+      ],
+    },
+  });
+
+  render(<ImportTransaction canSubmit={true} />);
+
+  fireEvent.change(screen.getByLabelText(/transaction cbor/i), {
+    target: { value: "84a4" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /decode/i }));
+
+  await waitFor(() => expect(screen.getByText(/1 of 2 signed/i)).toBeInTheDocument());
+});

--- a/ui/web/src/screens/ImportTransaction.test.tsx
+++ b/ui/web/src/screens/ImportTransaction.test.tsx
@@ -106,3 +106,75 @@ test("renders multisig progress for a native_multisig tx", async () => {
 
   await waitFor(() => expect(screen.getByText(/1 of 2 signed/i)).toBeInTheDocument());
 });
+
+// Real backend behavior for native_multisig: the multisig builder never
+// registers participant key-hashes as tx-level required signers, so
+// spend.DecodeTx (which derives wallet_can_add/is_complete from
+// required-signers/cert credentials) always reports wallet_can_add: [] and
+// is_complete: true — regardless of how many cosigners have actually signed.
+// The screen must fall back to summary.multisig for both the "add my
+// signature" affordance and the submit-readiness gate.
+const multisigBelowThreshold: TxSummary = {
+  ...vkeySummary,
+  kind: "native_multisig",
+  wallet_can_add: [],
+  is_complete: true,
+  multisig: {
+    is_multisig: true,
+    threshold: 2,
+    signed_count: 1,
+    script_embedded: true,
+    participants: [
+      { key_hash: "aa".repeat(28), signed: true },
+      { key_hash: "bb".repeat(28), signed: false },
+    ],
+  },
+};
+
+test("multisig: cosign affordance shows and submit stays gated on threshold, then unlocks once met", async () => {
+  const decodeSpy = vi.spyOn(client, "decodeTx").mockResolvedValue(multisigBelowThreshold);
+  const cosignSpy = vi.spyOn(client, "cosignTx").mockResolvedValue({
+    tx_cbor: "84beef",
+    added: true,
+    signed_count: 2,
+    threshold: 2,
+  });
+
+  render(<ImportTransaction canSubmit={true} />);
+
+  fireEvent.change(screen.getByLabelText(/transaction cbor/i), {
+    target: { value: "84a4" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /decode/i }));
+
+  // (a) Bug 1: despite wallet_can_add being empty, the multisig-aware
+  // fallback must still surface the password field + "Add my signature".
+  await screen.findByLabelText(/spending password/i);
+  expect(screen.getByRole("button", { name: /add my signature/i })).toBeInTheDocument();
+
+  // (b) Bug 2: despite is_complete: true, submit must stay disabled while
+  // signed_count (1) < threshold (2), with a label saying so.
+  const submitBtn = screen.getByRole("button", { name: /submit to network/i });
+  expect(submitBtn).toBeDisabled();
+  expect(submitBtn).toHaveTextContent(/need 1 more signature/i);
+
+  // Cosign, then the handleCosign multisig path re-decodes for a fresh
+  // summary — mock that follow-up call to report the threshold now met.
+  decodeSpy.mockResolvedValueOnce({
+    ...multisigBelowThreshold,
+    multisig: { ...multisigBelowThreshold.multisig!, signed_count: 2 },
+  });
+
+  fireEvent.change(screen.getByLabelText(/spending password/i), {
+    target: { value: "pw" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /add my signature/i }));
+
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: /submit to network/i })).toBeEnabled(),
+  );
+  expect(cosignSpy).toHaveBeenCalledWith({ tx_cbor: "84a4", password: "pw" });
+  expect(screen.getByRole("button", { name: /submit to network/i })).not.toHaveTextContent(
+    /need|incomplete|syncing/i,
+  );
+});

--- a/ui/web/src/screens/ImportTransaction.tsx
+++ b/ui/web/src/screens/ImportTransaction.tsx
@@ -107,12 +107,23 @@ export function ImportTransaction({ canSubmit }: { canSubmit: boolean }) {
   }
 
   const ms = summary?.multisig;
-  // wallet_can_add is authoritative for both vkey and native-multisig kinds:
-  // the backend only lists key-hashes this wallet actually holds and hasn't
-  // signed with yet.
-  const canAdd = summary ? summary.wallet_can_add.length > 0 : false;
+  // wallet_can_add is authoritative for the vkey kind, but the native-multisig
+  // builder deliberately never registers participant key-hashes as tx-level
+  // required signers, so spend.DecodeTx (which derives wallet_can_add from
+  // required-signers/cert credentials) always reports it empty for multisig —
+  // fall back to summary.multisig.is_multisig so the affordance still shows.
+  // If the wallet isn't actually a participant, cosignTx returns an error,
+  // which the screen already surfaces — that's the intended design.
+  const canAdd = summary
+    ? summary.wallet_can_add.length > 0 || (summary.multisig?.is_multisig ?? false)
+    : false;
   const remaining = ms && ms.threshold != null ? Math.max(ms.threshold - ms.signed_count, 0) : 0;
-  const readyToSubmit = summary?.is_complete ?? false;
+  // is_complete is meaningless for multisig (spend.DecodeTx reads it true
+  // immediately since it never sees multisig required-signers) — gate
+  // multisig readiness on the authoritative signed_count/threshold instead.
+  const readyToSubmit = ms?.is_multisig
+    ? ms.signed_count >= (ms.threshold ?? 0)
+    : (summary?.is_complete ?? false);
 
   return (
     <Card title="Import Transaction">

--- a/ui/web/src/screens/ImportTransaction.tsx
+++ b/ui/web/src/screens/ImportTransaction.tsx
@@ -101,7 +101,14 @@ export function ImportTransaction({ canSubmit }: { canSubmit: boolean }) {
           <code className="tx-hash">{result.tx_hash}</code>
           <CopyButton value={result.tx_hash} ariaLabel="Copy transaction hash" />
         </div>
-        <Button onClick={reset}>Import another</Button>
+        <Button
+          onClick={() => {
+            reset();
+            setCbor("");
+          }}
+        >
+          Import another
+        </Button>
       </Card>
     );
   }
@@ -177,6 +184,12 @@ export function ImportTransaction({ canSubmit }: { canSubmit: boolean }) {
                 <dd>{summary.certificates.join(", ")}</dd>
               </div>
             ) : null}
+            {summary.network_id != null ? (
+              <div className="dl-row">
+                <dt>Network</dt>
+                <dd>{summary.network_id === 1 ? "mainnet (1)" : `testnet (${summary.network_id})`}</dd>
+              </div>
+            ) : null}
           </dl>
 
           <p className="field-label">Outputs</p>
@@ -187,6 +200,22 @@ export function ImportTransaction({ canSubmit }: { canSubmit: boolean }) {
               </li>
             ))}
           </ul>
+
+          {summary.withdrawals?.length ? (
+            <>
+              {/* Reward withdrawals move funds out of this wallet's staking
+                  rewards just like outputs move funds out of its UTxOs, so they
+                  MUST be shown before the user cosigns or submits. */}
+              <p className="field-label">Reward withdrawals</p>
+              <ul className="signer-list">
+                {summary.withdrawals.map((wd, i) => (
+                  <li key={i}>
+                    <code className="tx-hash">{wd.address}</code> — {formatAda(wd.lovelace)} ADA
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : null}
 
           {ms?.is_multisig ? (
             <MultiSigProgress

--- a/ui/web/src/screens/ImportTransaction.tsx
+++ b/ui/web/src/screens/ImportTransaction.tsx
@@ -1,0 +1,242 @@
+import { useState } from "react";
+import { Card } from "../components/Card";
+import { Input } from "../components/Input";
+import { Button } from "../components/Button";
+import { CopyButton } from "../components/CopyButton";
+import { DownloadButton } from "../components/DownloadButton";
+import { MultiSigProgress } from "../components/MultiSigProgress";
+import { decodeTx, cosignTx, submitTx, ApiError } from "../api/client";
+import type { TxSummary, CosignResult, TxResult } from "../api/types";
+import { formatAda } from "../format";
+
+function errorMessage(err: unknown): string {
+  if (err instanceof ApiError) return err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+// ImportTransaction lets the user paste a full transaction CBOR built
+// elsewhere (unsigned, partially signed, or complete), decode it into a
+// type-aware preview (plain vkey spend vs native multi-sig), add this
+// wallet's own signature, and either export the updated CBOR (for the next
+// co-signer) or submit it to the network. Decoding never requires a
+// password; adding a signature does; submitting is additionally gated on the
+// node being ready (canSubmit).
+export function ImportTransaction({ canSubmit }: { canSubmit: boolean }) {
+  const [cbor, setCbor] = useState("");
+  const [summary, setSummary] = useState<TxSummary | null>(null);
+  const [current, setCurrent] = useState(""); // the working tx CBOR (updated after cosign)
+  const [password, setPassword] = useState("");
+  const [result, setResult] = useState<TxResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  function reset() {
+    setSummary(null);
+    setCurrent("");
+    setResult(null);
+    setError(null);
+    setPassword("");
+  }
+
+  async function handleDecode() {
+    setError(null);
+    setResult(null);
+    setBusy(true);
+    try {
+      const s = await decodeTx(cbor.trim());
+      setSummary(s);
+      setCurrent(cbor.trim());
+    } catch (e) {
+      setError(errorMessage(e));
+      setSummary(null);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleCosign() {
+    setError(null);
+    setBusy(true);
+    try {
+      const r: CosignResult = await cosignTx({ tx_cbor: current, password });
+      setCurrent(r.tx_cbor);
+      setPassword("");
+      // The vkey cosign response already carries a fresh summary — use it
+      // directly. The native-multisig response only carries signed_count/
+      // threshold (see CosignResult in api/types.ts), so re-decode the merged
+      // CBOR in that case to get a full, up-to-date preview.
+      if (r.summary) {
+        setSummary(r.summary);
+      } else {
+        const s = await decodeTx(r.tx_cbor);
+        setSummary(s);
+      }
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleSubmit() {
+    setError(null);
+    setBusy(true);
+    try {
+      const r = await submitTx(current);
+      setResult(r);
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (result) {
+    return (
+      <Card title="Transaction Submitted">
+        <p>Your transaction has been submitted.</p>
+        <p className="field-label">Transaction hash</p>
+        <div className="tx-hash-row">
+          <code className="tx-hash">{result.tx_hash}</code>
+          <CopyButton value={result.tx_hash} ariaLabel="Copy transaction hash" />
+        </div>
+        <Button onClick={reset}>Import another</Button>
+      </Card>
+    );
+  }
+
+  const ms = summary?.multisig;
+  // wallet_can_add is authoritative for both vkey and native-multisig kinds:
+  // the backend only lists key-hashes this wallet actually holds and hasn't
+  // signed with yet.
+  const canAdd = summary ? summary.wallet_can_add.length > 0 : false;
+  const remaining = ms && ms.threshold != null ? Math.max(ms.threshold - ms.signed_count, 0) : 0;
+  const readyToSubmit = summary?.is_complete ?? false;
+
+  return (
+    <Card title="Import Transaction">
+      <p className="helper-text">
+        Paste a transaction (CBOR hex) built elsewhere — unsigned, partially signed,
+        or complete. Review it, add your signature, then hand the updated CBOR to the
+        next co-signer or submit it.
+      </p>
+
+      <label htmlFor="import-cbor">Transaction CBOR</label>
+      <textarea
+        id="import-cbor"
+        className="field"
+        rows={4}
+        value={cbor}
+        onChange={(e) => {
+          setCbor(e.target.value);
+          reset();
+        }}
+        placeholder="hex…"
+        aria-label="Transaction CBOR"
+        disabled={busy}
+      />
+      <Button onClick={handleDecode} disabled={busy || !cbor.trim()}>
+        {busy && !summary ? "Decoding…" : "Decode"}
+      </Button>
+
+      {summary && (
+        <div className="import-preview">
+          {summary.kind === "unknown" && (
+            <p role="alert" className="warn-text">
+              Some parts of this transaction could not be decoded. Review carefully
+              before signing.
+            </p>
+          )}
+
+          <dl className="preview-summary">
+            <div className="dl-row">
+              <dt>Fee</dt>
+              <dd>{formatAda(summary.fee)} ADA</dd>
+            </div>
+            {summary.ttl ? (
+              <div className="dl-row">
+                <dt>TTL (slot)</dt>
+                <dd>{summary.ttl}</dd>
+              </div>
+            ) : null}
+            {summary.certificates?.length ? (
+              <div className="dl-row">
+                <dt>Certificates</dt>
+                <dd>{summary.certificates.join(", ")}</dd>
+              </div>
+            ) : null}
+          </dl>
+
+          <p className="field-label">Outputs</p>
+          <ul className="signer-list">
+            {summary.outputs.map((o, i) => (
+              <li key={i}>
+                <code className="tx-hash">{o.address}</code> — {formatAda(o.lovelace)} ADA
+              </li>
+            ))}
+          </ul>
+
+          {ms?.is_multisig ? (
+            <MultiSigProgress
+              threshold={ms.threshold ?? 0}
+              total={ms.participants?.length ?? 0}
+              signedCount={ms.signed_count}
+              participants={ms.participants}
+            />
+          ) : (
+            <p className="ms-progress">
+              {summary.existing_signatures.length} signature(s) present
+              {summary.is_complete ? " · complete" : ""}
+            </p>
+          )}
+
+          {canAdd && (
+            <>
+              <label htmlFor="import-pw">Spending password</label>
+              <Input
+                id="import-pw"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="Spending password"
+                aria-label="Spending password"
+                disabled={busy}
+              />
+              <Button onClick={handleCosign} disabled={busy || !password}>
+                {busy ? "Signing…" : "Add my signature"}
+              </Button>
+            </>
+          )}
+
+          <p className="field-label">Transaction CBOR (current)</p>
+          <div className="tx-hash-row">
+            <code className="tx-hash">{current}</code>
+            <CopyButton value={current} ariaLabel="Copy transaction CBOR" />
+            <DownloadButton value={current} filename="transaction.cbor" label="Download" />
+          </div>
+
+          <Button onClick={handleSubmit} disabled={busy || !canSubmit || !readyToSubmit}>
+            {/* The accessible name always starts with "Submit to network" — only
+                a parenthetical qualifier changes — so the button can be found by
+                that name whether it is enabled or disabled. */}
+            Submit to network
+            {!canSubmit
+              ? " (node syncing…)"
+              : !readyToSubmit
+                ? remaining > 0
+                  ? ` (need ${remaining} more signature(s))`
+                  : " (incomplete)"
+                : ""}
+          </Button>
+        </div>
+      )}
+
+      {error && (
+        <p role="alert" className="error-text">
+          {error}
+        </p>
+      )}
+    </Card>
+  );
+}

--- a/ui/web/src/screens/MultiSig.test.tsx
+++ b/ui/web/src/screens/MultiSig.test.tsx
@@ -140,18 +140,19 @@ test("spend flow: build then collect a threshold of witnesses and submit", async
   fireEvent.click(screen.getByRole("button", { name: /build transaction/i }));
 
   // Collect screen: progress starts at 0 of 2.
-  expect(await screen.findByText(/0 of 2 collected/i)).toBeInTheDocument();
+  expect(await screen.findByText(/0 of 2 signed/i)).toBeInTheDocument();
 
   // Sign here (1 of 2).
   fireEvent.change(screen.getByLabelText(/sign with this wallet/i), { target: { value: "pw" } });
   fireEvent.click(screen.getByRole("button", { name: /sign here/i }));
   await waitFor(() => expect(sign).toHaveBeenCalled());
-  expect(await screen.findByText(/1 of 2 collected/i)).toBeInTheDocument();
+  expect(await screen.findByText(/1 of 2 signed/i)).toBeInTheDocument();
 
   // Paste a second co-signer witness (2 of 2 → threshold met).
   fireEvent.change(screen.getByLabelText(/co-signer witness/i), { target: { value: "81a0sigB" } });
   fireEvent.click(screen.getByRole("button", { name: /add witness/i }));
-  expect(await screen.findByText(/2 of 2 collected/i)).toBeInTheDocument();
+  expect(await screen.findByText(/2 of 2 signed/i)).toBeInTheDocument();
+  expect(await screen.findByText(/threshold met/i)).toBeInTheDocument();
 
   // Submit.
   fireEvent.click(screen.getByRole("button", { name: /^submit$/i }));
@@ -187,7 +188,7 @@ test("seedless wallet can build, collect external witnesses, and submit without 
   fireEvent.click(screen.getByRole("button", { name: /build transaction/i }));
   await waitFor(() => expect(build).toHaveBeenCalled());
 
-  expect(await screen.findByText(/0 of 2 collected/i)).toBeInTheDocument();
+  expect(await screen.findByText(/0 of 2 signed/i)).toBeInTheDocument();
   expect(screen.queryByLabelText(/sign with this wallet/i)).not.toBeInTheDocument();
   expect(screen.queryByRole("button", { name: /sign here/i })).not.toBeInTheDocument();
 

--- a/ui/web/src/screens/MultiSig.tsx
+++ b/ui/web/src/screens/MultiSig.tsx
@@ -23,6 +23,7 @@ import { Input } from "../components/Input";
 import { Button } from "../components/Button";
 import { CopyButton } from "../components/CopyButton";
 import { DownloadButton } from "../components/DownloadButton";
+import { MultiSigProgress } from "../components/MultiSigProgress";
 import { formatAda, parseAda } from "../format";
 
 function errorMessage(err: unknown): string {
@@ -698,10 +699,7 @@ function CollectAndSubmit({
           />
         </div>
 
-        <p className="ms-progress">
-          {collected} of {built.threshold} collected
-          {collected > 0 && ` (${collected} witness${collected === 1 ? "" : "es"})`}
-        </p>
+        <MultiSigProgress threshold={built.threshold} total={built.required_signers.length} signedCount={collected} />
 
         {/* Sign locally only when the seed-derived CIP-1854 key is available. */}
         {canSign && (


### PR DESCRIPTION
Adds an **Import Transaction** flow: paste a transaction as CBOR to decode, co-sign, and submit it — for both single-sig (vkey) and native multi-sig (CIP-1854) wallets.

## What's included
**Backend**
- `spend`: `DecodeTx` (summary + classification), `CosignTx` (merge a witness into a pasted tx), `SubmitTxCbor` (broadcast a full tx).
- `multisig`: `PolicyFromScript`, `InspectTx`/`FindByScriptHash` classification, `CosignImported` (merge CIP-1854 witness), `SubmitImported` (threshold-checked broadcast).
- `api`: `decode-tx` / `cosign-tx` / `submit-tx` endpoints + an import classifier that dispatches to the vkey or multisig path.

**Frontend**
- Import Transaction screen (paste → decoded summary → cosign / submit), shared `MultiSigProgress` component, nav entry.

## Verification
Root (`CGO_ENABLED=0`), `ui/`, and `ui/web` all build/vet/test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

Real browser captures (Playwright, 1280×800) of the new Import Transaction screen.

**Empty import screen — paste a transaction CBOR, then Decode:**

![Import transaction empty](https://raw.githubusercontent.com/blinklabs-io/bursa/ci/screenshots/screenshots/pr-614/pr614-import-empty.png)

**Decoded-transaction summary — fee, TTL, outputs, signatures-present, cosign field, and node-gated submit:**

![Import transaction decoded](https://raw.githubusercontent.com/blinklabs-io/bursa/ci/screenshots/screenshots/pr-614/pr614-import-decoded.png)
