### PR TITLE
test(ui): capability coverage for operate/* SPO flows, router, password, migrate, drawer

### DIFF
--- a/ui/web/src/app.test.tsx
+++ b/ui/web/src/app.test.tsx
@@ -421,19 +421,27 @@ test("switching active wallets remounts routed content and refetches read state"
   await waitFor(() => expect(getBalance).toHaveBeenCalledTimes(2));
 });
 
-test("a crafted hash (#/constructor) falls back to Portfolio instead of crashing", async () => {
-  stubStatus("ready");
-  stubVault({ exists: true, locked: true, wallet_count: 1 });
-  quietPortfolio();
-  vi.spyOn(client, "unlockVault").mockResolvedValue([walletA]);
-  window.location.hash = "#/constructor";
+// Prototype-pollution guard: a crafted hash whose name collides with an
+// inherited Object.prototype member must resolve through the production ROUTES
+// Map (app.tsx) to a real, absent key and fall back to Portfolio — never render
+// an inherited member as a "screen" nor crash. Exercised end-to-end here (not
+// against a hand-built Map) so the check is bound to the code that ships.
+test.each(["#/__proto__", "#/constructor"])(
+  "a crafted hash (%s) falls back to Portfolio instead of crashing",
+  async (hash) => {
+    stubStatus("ready");
+    stubVault({ exists: true, locked: true, wallet_count: 1 });
+    quietPortfolio();
+    vi.spyOn(client, "unlockVault").mockResolvedValue([walletA]);
+    window.location.hash = hash;
 
-  render(<App />);
-  fireEvent.change(screen.getByLabelText(/vault password/i), { target: { value: "vault-password-xyz" } });
-  fireEvent.click(screen.getByRole("button", { name: /^unlock$/i }));
+    render(<App />);
+    fireEvent.change(screen.getByLabelText(/vault password/i), { target: { value: "vault-password-xyz" } });
+    fireEvent.click(screen.getByRole("button", { name: /^unlock$/i }));
 
-  await waitFor(() => expect(screen.getByText("Balance")).toBeInTheDocument());
-});
+    await waitFor(() => expect(screen.getByText("Balance")).toBeInTheDocument());
+  },
+);
 
 test("Add wallet action opens the add-wallet form", async () => {
   stubStatus("ready");

--- a/ui/web/src/components/Drawer.test.tsx
+++ b/ui/web/src/components/Drawer.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Drawer } from "./Drawer";
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+// --- structure / rendering ---
+
+test("renders a modal dialog labelled by its title with its children", () => {
+  render(
+    <Drawer title="Transaction detail" onClose={vi.fn()}>
+      <p>Body content</p>
+    </Drawer>,
+  );
+
+  const dialog = screen.getByRole("dialog");
+  expect(dialog).toHaveAttribute("aria-modal", "true");
+  expect(dialog).toHaveAttribute("aria-label", "Transaction detail");
+  expect(screen.getByText("Body content")).toBeInTheDocument();
+  expect(screen.getByText("Transaction detail")).toBeInTheDocument();
+});
+
+// --- close affordances ---
+
+test("the close button calls onClose", () => {
+  const onClose = vi.fn();
+  render(<Drawer title="Detail" onClose={onClose} />);
+
+  fireEvent.click(screen.getByRole("button", { name: /close/i }));
+  expect(onClose).toHaveBeenCalledTimes(1);
+});
+
+test("clicking the backdrop calls onClose", () => {
+  const onClose = vi.fn();
+  const { container } = render(<Drawer title="Detail" onClose={onClose} />);
+
+  fireEvent.click(container.querySelector(".drawer-overlay")!);
+  expect(onClose).toHaveBeenCalledTimes(1);
+});
+
+test("clicking inside the drawer panel does NOT close it (click does not bubble to the backdrop)", () => {
+  const onClose = vi.fn();
+  render(
+    <Drawer title="Detail" onClose={onClose}>
+      <button>Inner</button>
+    </Drawer>,
+  );
+
+  fireEvent.click(screen.getByRole("dialog"));
+  expect(onClose).not.toHaveBeenCalled();
+});
+
+test("Escape closes the drawer", () => {
+  const onClose = vi.fn();
+  render(<Drawer title="Detail" onClose={onClose} />);
+
+  fireEvent.keyDown(document, { key: "Escape" });
+  expect(onClose).toHaveBeenCalledTimes(1);
+});
+
+test("a non-trap, non-Escape key does not close the drawer", () => {
+  const onClose = vi.fn();
+  render(
+    <Drawer title="Detail" onClose={onClose}>
+      <button>Inner</button>
+    </Drawer>,
+  );
+
+  fireEvent.keyDown(document, { key: "a" });
+  expect(onClose).not.toHaveBeenCalled();
+});
+
+// --- focus management ---
+
+test("moves focus into the drawer on open (the header Close is the first focusable)", () => {
+  render(
+    <Drawer title="Detail" onClose={vi.fn()}>
+      <a href="#x">First link</a>
+      <button>Second</button>
+    </Drawer>,
+  );
+
+  // The header Close button precedes the children in DOM order, so it is the
+  // first focusable element the trap lands on.
+  expect(screen.getByRole("button", { name: /close/i })).toHaveFocus();
+});
+
+test("focuses the header Close button even when the drawer has no children", () => {
+  render(<Drawer title="Detail" onClose={vi.fn()} />);
+  expect(screen.getByRole("button", { name: /close/i })).toHaveFocus();
+});
+
+test("restores focus to the previously focused element on unmount", () => {
+  const trigger = document.createElement("button");
+  trigger.textContent = "Open";
+  document.body.append(trigger);
+  trigger.focus();
+  expect(trigger).toHaveFocus();
+
+  const { unmount } = render(
+    <Drawer title="Detail" onClose={vi.fn()}>
+      <button>Inner</button>
+    </Drawer>,
+  );
+  // Focus moved off the trigger into the drawer (the header Close button).
+  expect(trigger).not.toHaveFocus();
+  expect(screen.getByRole("button", { name: /close/i })).toHaveFocus();
+
+  unmount();
+  expect(trigger).toHaveFocus();
+});
+
+// --- focus trap ---
+
+test("Tab from the last focusable element wraps to the first", () => {
+  render(
+    <Drawer title="Detail" onClose={vi.fn()}>
+      <button>Alpha</button>
+      <button>Omega</button>
+    </Drawer>,
+  );
+
+  // Focus order: Close (header), Alpha, Omega. Move to the last.
+  const omega = screen.getByRole("button", { name: /omega/i });
+  omega.focus();
+  fireEvent.keyDown(document, { key: "Tab" });
+
+  const close = screen.getByRole("button", { name: /close/i });
+  expect(close).toHaveFocus();
+});
+
+test("Shift+Tab from the first focusable element wraps to the last", () => {
+  render(
+    <Drawer title="Detail" onClose={vi.fn()}>
+      <button>Alpha</button>
+      <button>Omega</button>
+    </Drawer>,
+  );
+
+  const close = screen.getByRole("button", { name: /close/i });
+  close.focus();
+  fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+
+  expect(screen.getByRole("button", { name: /omega/i })).toHaveFocus();
+});
+
+test("Tab from the middle does not force-wrap (browser handles the move)", () => {
+  render(
+    <Drawer title="Detail" onClose={vi.fn()}>
+      <button>Alpha</button>
+      <button>Omega</button>
+    </Drawer>,
+  );
+
+  const alpha = screen.getByRole("button", { name: /alpha/i });
+  alpha.focus();
+  // Alpha is neither first (Close) nor last (Omega): the trap does not move focus.
+  fireEvent.keyDown(document, { key: "Tab" });
+  expect(alpha).toHaveFocus();
+});

--- a/ui/web/src/components/WalletSwitcher.test.tsx
+++ b/ui/web/src/components/WalletSwitcher.test.tsx
@@ -81,23 +81,27 @@ test("clicking the already-active wallet is a no-op", () => {
   expect(onActivated).not.toHaveBeenCalled();
 });
 
-test("a second selection is ignored while one switch is in flight", async () => {
+test("every wallet button is disabled while a switch is in flight, so no second request can start", async () => {
   let resolve!: (w: WalletView) => void;
   const activate = vi
     .spyOn(client, "activateWallet")
     .mockReturnValue(new Promise<WalletView>((r) => (resolve = r)));
   renderSwitcher();
 
-  // Kick off the switch to Savings; buttons disable while busy.
+  // Kick off the switch to Savings. The guard against a concurrent second
+  // request is enforced in the DOM: while one activation is pending, EVERY
+  // wallet button is disabled, so the user cannot dispatch another select().
   fireEvent.click(screen.getByRole("button", { name: /savings/i }));
   await waitFor(() => expect(screen.getByRole("button", { name: /savings/i })).toBeDisabled());
-
-  // A click during the in-flight switch must not start a second request.
-  fireEvent.click(screen.getByRole("button", { name: /savings/i }));
+  // The other wallet's button is disabled too — not just the one in flight —
+  // which is what actually prevents a second request from being started.
+  expect(screen.getByRole("button", { name: /main/i })).toBeDisabled();
   expect(activate).toHaveBeenCalledTimes(1);
 
+  // Buttons re-enable once the in-flight switch resolves.
   resolve({ ...walletB, active: true });
   await waitFor(() => expect(screen.getByRole("button", { name: /savings/i })).not.toBeDisabled());
+  expect(screen.getByRole("button", { name: /main/i })).not.toBeDisabled();
 });
 
 // --- error handling ---

--- a/ui/web/src/components/WalletSwitcher.test.tsx
+++ b/ui/web/src/components/WalletSwitcher.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { WalletSwitcher } from "./WalletSwitcher";
+import * as client from "../api/client";
+import type { WalletView } from "../api/types";
+
+const walletA: WalletView = {
+  id: "w1",
+  name: "Main",
+  network: "preview",
+  stake_address: "stake_test1abc",
+  addresses: ["addr_test1abc"],
+  active: true,
+  type: "full",
+};
+
+// network is "preprod" (not "mainnet") so the "main" substring in an accessible
+// name uniquely identifies wallet A's button.
+const walletB: WalletView = {
+  id: "w2",
+  name: "Savings",
+  network: "preprod",
+  stake_address: "stake1def",
+  addresses: ["addr1def"],
+  active: false,
+  type: "full",
+};
+
+function renderSwitcher(overrides: Partial<Parameters<typeof WalletSwitcher>[0]> = {}) {
+  const props = {
+    wallets: [walletA, walletB],
+    activeId: "w1",
+    onActivated: vi.fn(),
+    onAddWallet: vi.fn(),
+    onLock: vi.fn(),
+    ...overrides,
+  };
+  render(<WalletSwitcher {...props} />);
+  return props;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// --- rendering ---
+
+test("lists every wallet with its name and network, marking the active one", () => {
+  renderSwitcher();
+
+  expect(screen.getByText("Main")).toBeInTheDocument();
+  expect(screen.getByText("Savings")).toBeInTheDocument();
+  expect(screen.getByText("preview")).toBeInTheDocument();
+  expect(screen.getByText("preprod")).toBeInTheDocument();
+
+  const active = screen.getByRole("button", { name: /main/i });
+  expect(active).toHaveAttribute("aria-current", "true");
+  const inactive = screen.getByRole("button", { name: /savings/i });
+  expect(inactive).not.toHaveAttribute("aria-current");
+});
+
+// --- switching ---
+
+test("selecting an inactive wallet activates it server-side and reports the result", async () => {
+  const activated: WalletView = { ...walletB, active: true };
+  const activate = vi.spyOn(client, "activateWallet").mockResolvedValue(activated);
+  const { onActivated } = renderSwitcher();
+
+  fireEvent.click(screen.getByRole("button", { name: /savings/i }));
+
+  await waitFor(() => expect(activate).toHaveBeenCalledWith("w2"));
+  await waitFor(() => expect(onActivated).toHaveBeenCalledWith(activated));
+});
+
+test("clicking the already-active wallet is a no-op", () => {
+  const activate = vi.spyOn(client, "activateWallet");
+  const { onActivated } = renderSwitcher();
+
+  fireEvent.click(screen.getByRole("button", { name: /main/i }));
+
+  expect(activate).not.toHaveBeenCalled();
+  expect(onActivated).not.toHaveBeenCalled();
+});
+
+test("a second selection is ignored while one switch is in flight", async () => {
+  let resolve!: (w: WalletView) => void;
+  const activate = vi
+    .spyOn(client, "activateWallet")
+    .mockReturnValue(new Promise<WalletView>((r) => (resolve = r)));
+  renderSwitcher();
+
+  // Kick off the switch to Savings; buttons disable while busy.
+  fireEvent.click(screen.getByRole("button", { name: /savings/i }));
+  await waitFor(() => expect(screen.getByRole("button", { name: /savings/i })).toBeDisabled());
+
+  // A click during the in-flight switch must not start a second request.
+  fireEvent.click(screen.getByRole("button", { name: /savings/i }));
+  expect(activate).toHaveBeenCalledTimes(1);
+
+  resolve({ ...walletB, active: true });
+  await waitFor(() => expect(screen.getByRole("button", { name: /savings/i })).not.toBeDisabled());
+});
+
+// --- error handling ---
+
+test("surfaces an ApiError message when activation fails", async () => {
+  vi.spyOn(client, "activateWallet").mockRejectedValue(
+    new client.ApiError(423, "vault is locked"),
+  );
+  const { onActivated } = renderSwitcher();
+
+  fireEvent.click(screen.getByRole("button", { name: /savings/i }));
+
+  await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/vault is locked/i));
+  expect(onActivated).not.toHaveBeenCalled();
+  // Buttons re-enable after the failure.
+  expect(screen.getByRole("button", { name: /savings/i })).not.toBeDisabled();
+});
+
+test("shows a generic message for a non-ApiError failure", async () => {
+  vi.spyOn(client, "activateWallet").mockRejectedValue(new TypeError("boom"));
+  renderSwitcher();
+
+  fireEvent.click(screen.getByRole("button", { name: /savings/i }));
+
+  await waitFor(() =>
+    expect(screen.getByRole("alert")).toHaveTextContent(/could not switch wallet/i),
+  );
+});
+
+// --- footer actions ---
+
+test("the footer actions invoke their callbacks", () => {
+  const { onAddWallet, onLock } = renderSwitcher();
+
+  fireEvent.click(screen.getByRole("button", { name: /add wallet/i }));
+  expect(onAddWallet).toHaveBeenCalledTimes(1);
+
+  fireEvent.click(screen.getByRole("button", { name: /lock vault/i }));
+  expect(onLock).toHaveBeenCalledTimes(1);
+});

--- a/ui/web/src/password.test.ts
+++ b/ui/web/src/password.test.ts
@@ -1,0 +1,48 @@
+import { MIN_PASSWORD_LEN, passwordLength } from "./password";
+
+test("MIN_PASSWORD_LEN mirrors the node keystore minimum (12)", () => {
+  expect(MIN_PASSWORD_LEN).toBe(12);
+});
+
+// --- passwordLength counts code points, not bytes or UTF-16 units ---
+
+test("counts ASCII characters one-for-one", () => {
+  expect(passwordLength("")).toBe(0);
+  expect(passwordLength("abc")).toBe(3);
+  expect(passwordLength("a".repeat(12))).toBe(12);
+});
+
+test("counts a multi-byte character as a single code point (not its UTF-8 byte length)", () => {
+  // "é" is 2 UTF-8 bytes but one code point.
+  expect(passwordLength("é")).toBe(1);
+  // "€" is 3 UTF-8 bytes but one code point.
+  expect(passwordLength("€")).toBe(1);
+});
+
+test("counts an astral-plane emoji as one code point, not two UTF-16 units", () => {
+  // "😀" is a surrogate pair: length 2 via String.length, 1 code point.
+  expect("😀".length).toBe(2);
+  expect(passwordLength("😀")).toBe(1);
+});
+
+// --- boundary behavior at the MIN_PASSWORD_LEN gate ---
+// Every create/add-wallet flow rejects `passwordLength(pw) < MIN_PASSWORD_LEN`.
+
+test("a password one code point short of the minimum is below the gate", () => {
+  const eleven = "a".repeat(MIN_PASSWORD_LEN - 1);
+  expect(passwordLength(eleven)).toBe(MIN_PASSWORD_LEN - 1);
+  expect(passwordLength(eleven) < MIN_PASSWORD_LEN).toBe(true);
+});
+
+test("a password of exactly the minimum length passes the gate", () => {
+  const twelve = "a".repeat(MIN_PASSWORD_LEN);
+  expect(passwordLength(twelve)).toBe(MIN_PASSWORD_LEN);
+  expect(passwordLength(twelve) < MIN_PASSWORD_LEN).toBe(false);
+});
+
+test("12 emoji pass the gate on code points even though String.length is 24", () => {
+  const pw = "😀".repeat(MIN_PASSWORD_LEN);
+  expect(pw.length).toBe(MIN_PASSWORD_LEN * 2); // UTF-16 units
+  expect(passwordLength(pw)).toBe(MIN_PASSWORD_LEN); // code points
+  expect(passwordLength(pw) < MIN_PASSWORD_LEN).toBe(false);
+});

--- a/ui/web/src/router.test.ts
+++ b/ui/web/src/router.test.ts
@@ -2,9 +2,13 @@ import { act, renderHook } from "@testing-library/react";
 import { useHashRoute, navigate } from "./router";
 
 // The hash is global state shared across the jsdom window; reset it between
-// tests so a leftover route from one case can't leak into the next.
+// tests so a leftover route from one case can't leak into the next. Restoring
+// all mocks here guarantees any spy (e.g. the addEventListener/removeEventListener
+// spies below) is torn down even if an assertion throws before its own cleanup,
+// so a leaked spy can never bleed into another test.
 afterEach(() => {
   window.location.hash = "";
+  vi.restoreAllMocks();
 });
 
 // --- getRoute parsing (observed through useHashRoute's initial value) ---
@@ -72,9 +76,8 @@ test("registers a hashchange listener on mount and removes the same one on unmou
   // cleanup omits removeEventListener, unlike a behavioural-only assertion).
   unmount();
   expect(remove).toHaveBeenCalledWith("hashchange", handler);
-
-  add.mockRestore();
-  remove.mockRestore();
+  // Spies are restored in afterEach (vi.restoreAllMocks), so they cannot leak
+  // into other tests even if an assertion above throws first.
 });
 
 test("useHashRoute stops updating after unmount (no stale setState)", () => {

--- a/ui/web/src/router.test.ts
+++ b/ui/web/src/router.test.ts
@@ -1,0 +1,103 @@
+import { act, renderHook } from "@testing-library/react";
+import { useHashRoute, navigate } from "./router";
+
+// The hash is global state shared across the jsdom window; reset it between
+// tests so a leftover route from one case can't leak into the next.
+afterEach(() => {
+  window.location.hash = "";
+});
+
+// --- getRoute parsing (observed through useHashRoute's initial value) ---
+
+test("defaults to portfolio when there is no hash", () => {
+  window.location.hash = "";
+  const { result } = renderHook(() => useHashRoute());
+  expect(result.current).toBe("portfolio");
+});
+
+test("defaults to portfolio for a bare '#/' with no route name", () => {
+  window.location.hash = "#/";
+  const { result } = renderHook(() => useHashRoute());
+  expect(result.current).toBe("portfolio");
+});
+
+test("parses '#/route' into the bare route name", () => {
+  window.location.hash = "#/staking";
+  const { result } = renderHook(() => useHashRoute());
+  expect(result.current).toBe("staking");
+});
+
+// --- navigate ---
+
+test("navigate writes a canonical '#/route' hash", () => {
+  navigate("settings");
+  expect(window.location.hash).toBe("#/settings");
+});
+
+test("navigate then useHashRoute round-trips the route name", () => {
+  navigate("send");
+  const { result } = renderHook(() => useHashRoute());
+  expect(result.current).toBe("send");
+});
+
+// --- reactivity: hashchange updates the hook ---
+
+test("useHashRoute updates when the hash changes after mount", () => {
+  window.location.hash = "#/portfolio";
+  const { result } = renderHook(() => useHashRoute());
+  expect(result.current).toBe("portfolio");
+
+  act(() => {
+    navigate("swap");
+    window.dispatchEvent(new Event("hashchange"));
+  });
+
+  expect(result.current).toBe("swap");
+});
+
+test("useHashRoute stops updating after unmount (listener cleanup)", () => {
+  window.location.hash = "#/portfolio";
+  const { result, unmount } = renderHook(() => useHashRoute());
+  unmount();
+
+  act(() => {
+    navigate("contacts");
+    window.dispatchEvent(new Event("hashchange"));
+  });
+
+  // The unmounted hook keeps its last value; no throw from a stale setState.
+  expect(result.current).toBe("portfolio");
+});
+
+// --- prototype-pollution safety property ---
+//
+// The router itself only ever produces plain route strings — it never resolves
+// a route into a handler. The defense (see the long comment in app.tsx) is that
+// app.tsx stores routes in a Map, not a plain object, so a crafted hash like
+// "#/__proto__" or "#/constructor" resolves to a real, absent key rather than an
+// inherited Object.prototype member. These tests lock that property at the
+// lookup layer the router feeds.
+
+test("crafted '#/__proto__' and '#/constructor' hashes parse to their literal names", () => {
+  window.location.hash = "#/__proto__";
+  expect(renderHook(() => useHashRoute()).result.current).toBe("__proto__");
+
+  window.location.hash = "#/constructor";
+  expect(renderHook(() => useHashRoute()).result.current).toBe("constructor");
+});
+
+test("a Map lookup rejects inherited-member route names that a plain object would resolve", () => {
+  const routes = new Map<string, () => string>([["portfolio", () => "Portfolio"]]);
+
+  for (const crafted of ["__proto__", "constructor", "toString", "hasOwnProperty"]) {
+    // The Map has no such route: unknown → app falls back to Portfolio.
+    expect(routes.has(crafted)).toBe(false);
+    expect(routes.get(crafted)).toBeUndefined();
+  }
+
+  // Contrast: a plain object is the footgun the Map avoids — these inherited
+  // members are truthy and callable, which is exactly what would hijack routing.
+  const asObject: Record<string, unknown> = { portfolio: () => "Portfolio" };
+  expect(asObject["constructor"]).toBeDefined();
+  expect(typeof asObject["toString"]).toBe("function");
+});

--- a/ui/web/src/router.test.ts
+++ b/ui/web/src/router.test.ts
@@ -55,7 +55,29 @@ test("useHashRoute updates when the hash changes after mount", () => {
   expect(result.current).toBe("swap");
 });
 
-test("useHashRoute stops updating after unmount (listener cleanup)", () => {
+test("registers a hashchange listener on mount and removes the same one on unmount", () => {
+  const add = vi.spyOn(window, "addEventListener");
+  const remove = vi.spyOn(window, "removeEventListener");
+  window.location.hash = "#/portfolio";
+
+  const { unmount } = renderHook(() => useHashRoute());
+
+  // Mount must register a hashchange listener…
+  const registration = add.mock.calls.find(([type]) => type === "hashchange");
+  expect(registration).toBeDefined();
+  const handler = registration![1];
+  expect(remove).not.toHaveBeenCalledWith("hashchange", handler);
+
+  // …and unmount must remove that exact handler (fails if the effect's
+  // cleanup omits removeEventListener, unlike a behavioural-only assertion).
+  unmount();
+  expect(remove).toHaveBeenCalledWith("hashchange", handler);
+
+  add.mockRestore();
+  remove.mockRestore();
+});
+
+test("useHashRoute stops updating after unmount (no stale setState)", () => {
   window.location.hash = "#/portfolio";
   const { result, unmount } = renderHook(() => useHashRoute());
   unmount();
@@ -72,11 +94,15 @@ test("useHashRoute stops updating after unmount (listener cleanup)", () => {
 // --- prototype-pollution safety property ---
 //
 // The router itself only ever produces plain route strings — it never resolves
-// a route into a handler. The defense (see the long comment in app.tsx) is that
-// app.tsx stores routes in a Map, not a plain object, so a crafted hash like
-// "#/__proto__" or "#/constructor" resolves to a real, absent key rather than an
-// inherited Object.prototype member. These tests lock that property at the
-// lookup layer the router feeds.
+// a route into a handler, so all it can do here is faithfully echo a crafted
+// hash as its literal route name (asserted below). The actual defense lives in
+// app.tsx, which resolves routes through a Map (not a plain object) so a crafted
+// hash like "#/__proto__" or "#/constructor" hits a real, absent key rather than
+// an inherited Object.prototype member. That end-to-end property is exercised
+// against the production ROUTES lookup by rendering <App /> with those hashes in
+// app.test.tsx ("a crafted hash … falls back to Portfolio"); it is verified there
+// rather than against a hand-built Map here, so the check is bound to the code
+// that ships.
 
 test("crafted '#/__proto__' and '#/constructor' hashes parse to their literal names", () => {
   window.location.hash = "#/__proto__";
@@ -84,20 +110,4 @@ test("crafted '#/__proto__' and '#/constructor' hashes parse to their literal na
 
   window.location.hash = "#/constructor";
   expect(renderHook(() => useHashRoute()).result.current).toBe("constructor");
-});
-
-test("a Map lookup rejects inherited-member route names that a plain object would resolve", () => {
-  const routes = new Map<string, () => string>([["portfolio", () => "Portfolio"]]);
-
-  for (const crafted of ["__proto__", "constructor", "toString", "hasOwnProperty"]) {
-    // The Map has no such route: unknown → app falls back to Portfolio.
-    expect(routes.has(crafted)).toBe(false);
-    expect(routes.get(crafted)).toBeUndefined();
-  }
-
-  // Contrast: a plain object is the footgun the Map avoids — these inherited
-  // members are truthy and callable, which is exactly what would hijack routing.
-  const asObject: Record<string, unknown> = { portfolio: () => "Portfolio" };
-  expect(asObject["constructor"]).toBeDefined();
-  expect(typeof asObject["toString"]).toBe("function");
 });

--- a/ui/web/src/screens/MigrateLegacyKeystore.test.tsx
+++ b/ui/web/src/screens/MigrateLegacyKeystore.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MigrateLegacyKeystore } from "./MigrateLegacyKeystore";
+import * as client from "../api/client";
+import type { WalletView } from "../api/types";
+import { MIN_PASSWORD_LEN } from "../password";
+
+const wallet: WalletView = {
+  id: "w1",
+  name: "Imported",
+  network: "preview",
+  stake_address: "stake_test1abc",
+  addresses: ["addr_test1abc"],
+  active: true,
+  type: "full",
+};
+
+const VALID_VAULT_PW = "a".repeat(MIN_PASSWORD_LEN);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function fill(fields: { vault?: string; confirm?: string; spend?: string; name?: string }) {
+  if (fields.name !== undefined) {
+    fireEvent.change(screen.getByLabelText(/^wallet name$/i), { target: { value: fields.name } });
+  }
+  if (fields.vault !== undefined) {
+    fireEvent.change(screen.getByLabelText(/^new vault password$/i), {
+      target: { value: fields.vault },
+    });
+  }
+  if (fields.confirm !== undefined) {
+    fireEvent.change(screen.getByLabelText(/^confirm new vault password$/i), {
+      target: { value: fields.confirm },
+    });
+  }
+  if (fields.spend !== undefined) {
+    fireEvent.change(screen.getByLabelText(/^existing spending password$/i), {
+      target: { value: fields.spend },
+    });
+  }
+}
+
+// --- happy path ---
+
+test("imports the legacy keystore into a new vault and reports the wallet", async () => {
+  const migrate = vi.spyOn(client, "migrateLegacyKeystore").mockResolvedValue(wallet);
+  const onReady = vi.fn();
+
+  render(<MigrateLegacyKeystore onReady={onReady} onCreateNew={vi.fn()} />);
+
+  fill({ name: "  My Legacy  ", vault: VALID_VAULT_PW, confirm: VALID_VAULT_PW, spend: "oldpw" });
+  fireEvent.click(screen.getByRole("button", { name: /^import wallet$/i }));
+
+  await waitFor(() =>
+    expect(migrate).toHaveBeenCalledWith({
+      name: "My Legacy", // trimmed
+      vault_password: VALID_VAULT_PW,
+      spend_password: "oldpw",
+    }),
+  );
+  await waitFor(() => expect(onReady).toHaveBeenCalledWith(wallet));
+});
+
+test("a blank/whitespace name falls back to the default 'Wallet'", async () => {
+  const migrate = vi.spyOn(client, "migrateLegacyKeystore").mockResolvedValue(wallet);
+
+  render(<MigrateLegacyKeystore onReady={vi.fn()} onCreateNew={vi.fn()} />);
+
+  fill({ name: "   ", vault: VALID_VAULT_PW, confirm: VALID_VAULT_PW, spend: "oldpw" });
+  fireEvent.click(screen.getByRole("button", { name: /^import wallet$/i }));
+
+  await waitFor(() =>
+    expect(migrate).toHaveBeenCalledWith(expect.objectContaining({ name: "Wallet" })),
+  );
+});
+
+// --- client-side validation branches (API must not be called) ---
+
+test("rejects a too-short vault password before calling the API", () => {
+  const migrate = vi.spyOn(client, "migrateLegacyKeystore");
+
+  render(<MigrateLegacyKeystore onReady={vi.fn()} onCreateNew={vi.fn()} />);
+
+  fill({ vault: "short", confirm: "short", spend: "oldpw" });
+  fireEvent.click(screen.getByRole("button", { name: /^import wallet$/i }));
+
+  expect(screen.getByRole("alert")).toHaveTextContent(
+    new RegExp(`at least ${MIN_PASSWORD_LEN} characters`, "i"),
+  );
+  expect(migrate).not.toHaveBeenCalled();
+});
+
+test("rejects mismatched vault password confirmation", () => {
+  const migrate = vi.spyOn(client, "migrateLegacyKeystore");
+
+  render(<MigrateLegacyKeystore onReady={vi.fn()} onCreateNew={vi.fn()} />);
+
+  fill({ vault: VALID_VAULT_PW, confirm: VALID_VAULT_PW + "x", spend: "oldpw" });
+  fireEvent.click(screen.getByRole("button", { name: /^import wallet$/i }));
+
+  expect(screen.getByRole("alert")).toHaveTextContent(/passwords do not match/i);
+  expect(migrate).not.toHaveBeenCalled();
+});
+
+test("requires the existing spending password", () => {
+  const migrate = vi.spyOn(client, "migrateLegacyKeystore");
+
+  render(<MigrateLegacyKeystore onReady={vi.fn()} onCreateNew={vi.fn()} />);
+
+  fill({ vault: VALID_VAULT_PW, confirm: VALID_VAULT_PW, spend: "" });
+  fireEvent.click(screen.getByRole("button", { name: /^import wallet$/i }));
+
+  expect(screen.getByRole("alert")).toHaveTextContent(/existing spending password is required/i);
+  expect(migrate).not.toHaveBeenCalled();
+});
+
+// --- API error handling ---
+
+test("surfaces an ApiError message from a failed import", async () => {
+  vi.spyOn(client, "migrateLegacyKeystore").mockRejectedValue(
+    new client.ApiError(401, "incorrect spending password"),
+  );
+  const onReady = vi.fn();
+
+  render(<MigrateLegacyKeystore onReady={onReady} onCreateNew={vi.fn()} />);
+
+  fill({ vault: VALID_VAULT_PW, confirm: VALID_VAULT_PW, spend: "wrong" });
+  fireEvent.click(screen.getByRole("button", { name: /^import wallet$/i }));
+
+  await waitFor(() =>
+    expect(screen.getByRole("alert")).toHaveTextContent(/incorrect spending password/i),
+  );
+  expect(onReady).not.toHaveBeenCalled();
+  // Button is re-enabled after the failure so the user can retry.
+  expect(screen.getByRole("button", { name: /^import wallet$/i })).not.toBeDisabled();
+});
+
+test("shows a generic message for a non-ApiError thrown value", async () => {
+  vi.spyOn(client, "migrateLegacyKeystore").mockRejectedValue(new TypeError("network down"));
+
+  render(<MigrateLegacyKeystore onReady={vi.fn()} onCreateNew={vi.fn()} />);
+
+  fill({ vault: VALID_VAULT_PW, confirm: VALID_VAULT_PW, spend: "oldpw" });
+  fireEvent.click(screen.getByRole("button", { name: /^import wallet$/i }));
+
+  await waitFor(() =>
+    expect(screen.getByRole("alert")).toHaveTextContent(/an unexpected error occurred/i),
+  );
+});
+
+// --- create-new escape hatch ---
+
+test("'Create New Vault' calls onCreateNew without importing", () => {
+  const migrate = vi.spyOn(client, "migrateLegacyKeystore");
+  const onCreateNew = vi.fn();
+
+  render(<MigrateLegacyKeystore onReady={vi.fn()} onCreateNew={onCreateNew} />);
+
+  fireEvent.click(screen.getByRole("button", { name: /create new vault/i }));
+
+  expect(onCreateNew).toHaveBeenCalledTimes(1);
+  expect(migrate).not.toHaveBeenCalled();
+});

--- a/ui/web/src/screens/Operate.test.tsx
+++ b/ui/web/src/screens/Operate.test.tsx
@@ -282,60 +282,9 @@ test("Metadata tab builds the canonical JSON + hash", async () => {
   expect(await screen.findByText("feedface")).toBeInTheDocument();
 });
 
-test("Retirement tab builds an air-gap certificate from a cold vkey", async () => {
-  vi.spyOn(client, "poolBuildRetirementCert").mockResolvedValue({
-    pool_id: "pool1ret",
-    cbor_hex: "8304",
-  });
-  render(<Operate account={account} />);
-  fireEvent.click(screen.getByRole("tab", { name: /retirement/i }));
-  fireEvent.click(screen.getByRole("button", { name: /air-gap/i }));
-  fireEvent.change(screen.getByLabelText(/retirement epoch/i), { target: { value: "520" } });
-  fireEvent.change(screen.getByLabelText(/cold verification key/i), {
-    target: { value: "c0ld" },
-  });
-  fireEvent.click(screen.getByRole("button", { name: /build certificate/i }));
-
-  await waitFor(() =>
-    expect(client.poolBuildRetirementCert).toHaveBeenCalledWith({
-      cold_vkey_hex: "c0ld",
-      epoch: 520,
-    }),
-  );
-  expect(await screen.findByText("pool1ret")).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: /copy retirement pool id/i })).toBeInTheDocument();
-  expect(
-    screen.getByRole("button", { name: /copy retirement certificate cbor hex/i }),
-  ).toBeInTheDocument();
-});
-
-test("Retirement tab submits a retirement transaction", async () => {
-  vi.spyOn(client, "poolSubmitRetirement").mockResolvedValue({ tx_hash: "deadbeef" });
-  render(<Operate account={account} />);
-  fireEvent.click(screen.getByRole("tab", { name: /retirement/i }));
-  fireEvent.change(screen.getByLabelText(/retirement epoch/i), { target: { value: "520" } });
-  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
-  fireEvent.click(screen.getByRole("button", { name: /build & submit retirement/i }));
-
-  await waitFor(() =>
-    expect(client.poolSubmitRetirement).toHaveBeenCalledWith({ password: "pw", epoch: 520 }),
-  );
-  expect(await screen.findByText("deadbeef")).toBeInTheDocument();
-  expect(
-    screen.getByRole("button", { name: /copy retirement transaction hash/i }),
-  ).toBeInTheDocument();
-});
-
-test("Retirement rejects unsafe epoch integers before calling the API", () => {
-  vi.spyOn(client, "poolSubmitRetirement").mockResolvedValue({ tx_hash: "deadbeef" });
-  render(<Operate account={account} />);
-  fireEvent.click(screen.getByRole("tab", { name: /retirement/i }));
-  fireEvent.change(screen.getByLabelText(/retirement epoch/i), {
-    target: { value: "9007199254740993" },
-  });
-  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
-  fireEvent.click(screen.getByRole("button", { name: /build & submit retirement/i }));
-
-  expect(screen.getByRole("alert")).toHaveTextContent(/retirement epoch must be a non-negative integer/i);
-  expect(client.poolSubmitRetirement).not.toHaveBeenCalled();
-});
+// The Retirement tab's API contract (air-gap cert build, seed submission, and
+// epoch validation) is covered co-located in screens/operate/Retirement.test.tsx
+// against the same <Retirement /> component this tab mounts; the tab-mount itself
+// is exercised by "Operate tab aria-controls targets stay mounted" above. Those
+// contract cases are intentionally NOT duplicated here so the air-gap/submission
+// behaviour is maintained in a single suite.

--- a/ui/web/src/screens/operate/Credentials.test.tsx
+++ b/ui/web/src/screens/operate/Credentials.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Credentials } from "./Credentials";
+import * as client from "../../api/client";
+import type { PoolCredentials } from "../../api/types";
+
+const CREDS: PoolCredentials = {
+  network: "preview",
+  pool_id: "pool1deadbeef",
+  pool_id_hex: "abcd",
+  cold: { vkey_hex: "c0ldvkey", hash_hex: "c0ldhash" },
+  vrf: { vkey_hex: "vrfvkey", hash_hex: "vrfhash" },
+  kes: { vkey_hex: "kesvkey", hash_hex: "keshash" },
+  cold_index: 0,
+  vrf_index: 0,
+  kes_index: 0,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("derives credentials and renders the pool ID plus every key hash + vkey", async () => {
+  vi.spyOn(client, "poolCredentials").mockResolvedValue(CREDS);
+  render(<Credentials />);
+
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /generate credentials/i }));
+
+  await waitFor(() => expect(client.poolCredentials).toHaveBeenCalledWith("pw"));
+  expect(await screen.findByText("pool1deadbeef")).toBeInTheDocument();
+  for (const v of ["c0ldvkey", "c0ldhash", "vrfvkey", "vrfhash", "kesvkey", "keshash"]) {
+    expect(screen.getByText(v)).toBeInTheDocument();
+  }
+  // Per-key copy affordances are labelled distinctly.
+  expect(screen.getByRole("button", { name: /copy cold verification key/i })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /copy vrf key hash/i })).toBeInTheDocument();
+});
+
+test("clears the password field after a successful derivation", async () => {
+  vi.spyOn(client, "poolCredentials").mockResolvedValue(CREDS);
+  render(<Credentials />);
+
+  const pw = screen.getByLabelText(/spending password/i);
+  fireEvent.change(pw, { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /generate credentials/i }));
+
+  await waitFor(() => expect(pw).toHaveValue(""));
+});
+
+test("the generate button is disabled until a password is entered", () => {
+  render(<Credentials />);
+  const button = screen.getByRole("button", { name: /generate credentials/i });
+  expect(button).toBeDisabled();
+
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  expect(button).not.toBeDisabled();
+});
+
+test("submitting the form (Enter) derives without a button click", async () => {
+  vi.spyOn(client, "poolCredentials").mockResolvedValue(CREDS);
+  render(<Credentials />);
+
+  const pw = screen.getByLabelText(/spending password/i);
+  fireEvent.change(pw, { target: { value: "pw" } });
+  fireEvent.submit(pw.closest("form")!);
+
+  await waitFor(() => expect(client.poolCredentials).toHaveBeenCalledWith("pw"));
+});
+
+test("surfaces an ApiError from a wrong password", async () => {
+  vi.spyOn(client, "poolCredentials").mockRejectedValue(
+    new client.ApiError(401, "incorrect spending password"),
+  );
+  render(<Credentials />);
+
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "bad" } });
+  fireEvent.click(screen.getByRole("button", { name: /generate credentials/i }));
+
+  await waitFor(() =>
+    expect(screen.getByRole("alert")).toHaveTextContent(/incorrect spending password/i),
+  );
+});
+
+test("typing in the password field clears a prior error", async () => {
+  vi.spyOn(client, "poolCredentials").mockRejectedValue(new client.ApiError(401, "nope"));
+  render(<Credentials />);
+
+  const pw = screen.getByLabelText(/spending password/i);
+  fireEvent.change(pw, { target: { value: "bad" } });
+  fireEvent.click(screen.getByRole("button", { name: /generate credentials/i }));
+  await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+
+  fireEvent.change(pw, { target: { value: "retry" } });
+  expect(screen.queryByRole("alert")).toBeNull();
+});

--- a/ui/web/src/screens/operate/MetadataBuilder.test.tsx
+++ b/ui/web/src/screens/operate/MetadataBuilder.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MetadataBuilder } from "./MetadataBuilder";
+import * as client from "../../api/client";
+import type { PoolMetadataResult } from "../../api/types";
+
+const RESULT: PoolMetadataResult = {
+  json: '{"name":"My Pool","ticker":"POOL"}',
+  hash_hex: "feedface",
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("builds canonical JSON + hash, trimming each field before sending", async () => {
+  const build = vi.spyOn(client, "poolBuildMetadata").mockResolvedValue(RESULT);
+  render(<MetadataBuilder />);
+
+  fireEvent.change(screen.getByLabelText(/^name$/i), { target: { value: "  My Pool  " } });
+  fireEvent.change(screen.getByLabelText(/^ticker$/i), { target: { value: " POOL " } });
+  fireEvent.change(screen.getByLabelText(/^homepage$/i), {
+    target: { value: " https://pool.example " },
+  });
+  fireEvent.change(screen.getByLabelText(/^description$/i), { target: { value: " hi " } });
+  fireEvent.click(screen.getByRole("button", { name: /build metadata/i }));
+
+  await waitFor(() =>
+    expect(build).toHaveBeenCalledWith({
+      name: "My Pool",
+      ticker: "POOL",
+      homepage: "https://pool.example",
+      description: "hi",
+    }),
+  );
+  expect(await screen.findByText("feedface")).toBeInTheDocument();
+  expect(screen.getByText(RESULT.json)).toBeInTheDocument();
+});
+
+test("the build button requires both a name and a ticker", () => {
+  render(<MetadataBuilder />);
+  const button = screen.getByRole("button", { name: /build metadata/i });
+  expect(button).toBeDisabled();
+
+  fireEvent.change(screen.getByLabelText(/^name$/i), { target: { value: "My Pool" } });
+  expect(button).toBeDisabled(); // ticker still missing
+
+  fireEvent.change(screen.getByLabelText(/^ticker$/i), { target: { value: "POOL" } });
+  expect(button).not.toBeDisabled();
+});
+
+test("a whitespace-only ticker keeps the build button disabled", () => {
+  render(<MetadataBuilder />);
+  fireEvent.change(screen.getByLabelText(/^name$/i), { target: { value: "My Pool" } });
+  fireEvent.change(screen.getByLabelText(/^ticker$/i), { target: { value: "   " } });
+  expect(screen.getByRole("button", { name: /build metadata/i })).toBeDisabled();
+});
+
+test("surfaces an ApiError from the backend", async () => {
+  vi.spyOn(client, "poolBuildMetadata").mockRejectedValue(
+    new client.ApiError(400, "ticker too long"),
+  );
+  render(<MetadataBuilder />);
+
+  fireEvent.change(screen.getByLabelText(/^name$/i), { target: { value: "My Pool" } });
+  fireEvent.change(screen.getByLabelText(/^ticker$/i), { target: { value: "TOOLONG" } });
+  fireEvent.click(screen.getByRole("button", { name: /build metadata/i }));
+
+  await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/ticker too long/i));
+});

--- a/ui/web/src/screens/operate/OperationalCert.test.tsx
+++ b/ui/web/src/screens/operate/OperationalCert.test.tsx
@@ -1,0 +1,245 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { OperationalCert } from "./OperationalCert";
+import * as client from "../../api/client";
+import type { OpCert, OpCertPayload, KESPeriodInfo } from "../../api/types";
+
+const KES_INFO: KESPeriodInfo = {
+  current_period: 42,
+  tip_slot: 5_443_200,
+  slots_per_kes_period: 129_600,
+  max_kes_evolutions: 62,
+};
+
+const OPCERT: OpCert = {
+  kes_vkey_hex: "ke5vkey",
+  issue_number: 3,
+  kes_period: 7,
+  cold_signature_hex: "c0ldsig",
+  kes_index: 0,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function switchToAirGap() {
+  fireEvent.click(screen.getByRole("button", { name: /^air-gap$/i }));
+}
+
+// --- KES period readout ---
+
+test("reads and displays the current KES period", async () => {
+  vi.spyOn(client, "poolKESPeriod").mockResolvedValue(KES_INFO);
+  render(<OperationalCert />);
+
+  fireEvent.click(screen.getByRole("button", { name: /read current kes period/i }));
+
+  await waitFor(() => expect(screen.getByText("42")).toBeInTheDocument());
+  expect(screen.getByText("5443200")).toBeInTheDocument();
+  expect(screen.getByText("129600")).toBeInTheDocument();
+});
+
+test("surfaces an error when reading the KES period fails", async () => {
+  vi.spyOn(client, "poolKESPeriod").mockRejectedValue(new client.ApiError(503, "tip unavailable"));
+  render(<OperationalCert />);
+
+  fireEvent.click(screen.getByRole("button", { name: /read current kes period/i }));
+  await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/tip unavailable/i));
+});
+
+test("reading the KES period auto-fills the empty KES period input", async () => {
+  vi.spyOn(client, "poolKESPeriod").mockResolvedValue(KES_INFO);
+  render(<OperationalCert />);
+
+  // Before reading: the seed form's KES period is empty with a prompt placeholder.
+  const periodField = screen.getByLabelText(/^kes period$/i);
+  expect(periodField).toHaveValue(null);
+
+  fireEvent.click(screen.getByRole("button", { name: /read current kes period/i }));
+  await waitFor(() => expect(periodField).toHaveValue(42));
+});
+
+// --- seed mode: issue ---
+
+test("seed mode issues an operational certificate and clears the password", async () => {
+  const issue = vi.spyOn(client, "poolIssueOpCert").mockResolvedValue(OPCERT);
+  render(<OperationalCert />);
+
+  fireEvent.change(screen.getByLabelText(/kes key index/i), { target: { value: "1" } });
+  fireEvent.change(screen.getByLabelText(/issue number/i), { target: { value: "2" } });
+  fireEvent.change(screen.getByLabelText(/^kes period$/i), { target: { value: "7" } });
+  const pw = screen.getByLabelText(/spending password/i);
+  fireEvent.change(pw, { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /issue certificate/i }));
+
+  await waitFor(() =>
+    expect(issue).toHaveBeenCalledWith({
+      password: "pw",
+      kes_index: 1,
+      issue_number: 2,
+      kes_period: 7,
+    }),
+  );
+  await waitFor(() => expect(pw).toHaveValue(""));
+  expect(await screen.findByText("ke5vkey")).toBeInTheDocument();
+  expect(screen.getByText("c0ldsig")).toBeInTheDocument();
+});
+
+// --- seed mode: rotate ---
+
+test("checking KES rotation relabels the fields and calls poolRotateKES", async () => {
+  const rotate = vi.spyOn(client, "poolRotateKES").mockResolvedValue(OPCERT);
+  render(<OperationalCert />);
+
+  fireEvent.click(screen.getByLabelText(/kes rotation/i));
+
+  // Labels switch to the rotation wording.
+  expect(screen.getByLabelText(/new kes key index/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/previous issue number/i)).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /rotate kes/i })).toBeInTheDocument();
+
+  fireEvent.change(screen.getByLabelText(/new kes key index/i), { target: { value: "2" } });
+  fireEvent.change(screen.getByLabelText(/previous issue number/i), { target: { value: "4" } });
+  fireEvent.change(screen.getByLabelText(/^kes period$/i), { target: { value: "9" } });
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /rotate kes/i }));
+
+  await waitFor(() =>
+    expect(rotate).toHaveBeenCalledWith({
+      password: "pw",
+      new_kes_index: 2,
+      prev_issue_number: 4,
+      kes_period: 9,
+    }),
+  );
+});
+
+test("seed mode rejects a KES period that is not a whole number", async () => {
+  const issue = vi.spyOn(client, "poolIssueOpCert");
+  render(<OperationalCert />);
+
+  // Clear the KES period so it fails parseNonNegativeInteger.
+  fireEvent.change(screen.getByLabelText(/^kes period$/i), { target: { value: "" } });
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /issue certificate/i }));
+
+  await waitFor(() =>
+    expect(screen.getByRole("alert")).toHaveTextContent(/kes period must be a whole number/i),
+  );
+  expect(issue).not.toHaveBeenCalled();
+});
+
+test("the seed issue button is disabled until a password is entered", () => {
+  render(<OperationalCert />);
+  const button = screen.getByRole("button", { name: /issue certificate/i });
+  expect(button).toBeDisabled();
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  expect(button).not.toBeDisabled();
+});
+
+// --- air-gap mode: two-step payload then assemble ---
+
+test("air-gap mode builds the to-be-signed payload", async () => {
+  const payload: OpCertPayload = {
+    payload_hex: "5ec0ffee",
+    kes_vkey_hex: "ke5vkey",
+    issue_number: 0,
+    kes_period: 5,
+  };
+  const build = vi.spyOn(client, "poolOpCertPayload").mockResolvedValue(payload);
+  render(<OperationalCert />);
+  switchToAirGap();
+
+  fireEvent.change(screen.getByLabelText(/kes verification key/i), { target: { value: " ke5 " } });
+  fireEvent.change(screen.getByLabelText(/^kes period$/i), { target: { value: "5" } });
+  fireEvent.click(screen.getByRole("button", { name: /build to-be-signed payload/i }));
+
+  await waitFor(() =>
+    expect(build).toHaveBeenCalledWith({ kes_vkey_hex: "ke5", issue_number: 0, kes_period: 5 }),
+  );
+  expect(await screen.findByText("5ec0ffee")).toBeInTheDocument();
+});
+
+test("air-gap payload button is gated on the KES vkey", () => {
+  render(<OperationalCert />);
+  switchToAirGap();
+  const button = screen.getByRole("button", { name: /build to-be-signed payload/i });
+  expect(button).toBeDisabled();
+  fireEvent.change(screen.getByLabelText(/kes verification key/i), { target: { value: "ke5" } });
+  expect(button).not.toBeDisabled();
+});
+
+test("editing the KES vkey after building clears the stale payload", async () => {
+  vi.spyOn(client, "poolOpCertPayload").mockResolvedValue({
+    payload_hex: "5ec0ffee",
+    kes_vkey_hex: "ke5",
+    issue_number: 0,
+    kes_period: 5,
+  });
+  render(<OperationalCert />);
+  switchToAirGap();
+
+  const vkey = screen.getByLabelText(/kes verification key/i);
+  fireEvent.change(vkey, { target: { value: "ke5" } });
+  fireEvent.change(screen.getByLabelText(/^kes period$/i), { target: { value: "5" } });
+  fireEvent.click(screen.getByRole("button", { name: /build to-be-signed payload/i }));
+  expect(await screen.findByText("5ec0ffee")).toBeInTheDocument();
+
+  fireEvent.change(vkey, { target: { value: "ke5changed" } });
+  expect(screen.queryByText("5ec0ffee")).toBeNull();
+});
+
+test("air-gap mode assembles a certificate from an offline signature", async () => {
+  const assemble = vi.spyOn(client, "poolAssembleOpCert").mockResolvedValue(OPCERT);
+  render(<OperationalCert />);
+  switchToAirGap();
+
+  fireEvent.change(screen.getByLabelText(/kes verification key/i), { target: { value: " ke5 " } });
+  fireEvent.change(screen.getByLabelText(/^kes period$/i), { target: { value: "7" } });
+  fireEvent.change(screen.getByLabelText(/cold verification key/i), { target: { value: " c0ld " } });
+  fireEvent.change(screen.getByLabelText(/cold signature/i), { target: { value: " 5ig " } });
+  fireEvent.click(screen.getByRole("button", { name: /assemble certificate/i }));
+
+  await waitFor(() =>
+    expect(assemble).toHaveBeenCalledWith({
+      cold_vkey_hex: "c0ld",
+      kes_vkey_hex: "ke5",
+      signature_hex: "5ig",
+      issue_number: 0,
+      kes_period: 7,
+    }),
+  );
+  expect(await screen.findByText("ke5vkey")).toBeInTheDocument();
+});
+
+test("assemble button is gated on cold vkey, signature, and KES vkey", () => {
+  render(<OperationalCert />);
+  switchToAirGap();
+  const assemble = screen.getByRole("button", { name: /assemble certificate/i });
+  expect(assemble).toBeDisabled();
+
+  fireEvent.change(screen.getByLabelText(/kes verification key/i), { target: { value: "ke5" } });
+  fireEvent.change(screen.getByLabelText(/cold verification key/i), { target: { value: "c0ld" } });
+  expect(assemble).toBeDisabled(); // signature still missing
+
+  fireEvent.change(screen.getByLabelText(/cold signature/i), { target: { value: "5ig" } });
+  expect(assemble).not.toBeDisabled();
+});
+
+test("air-gap assemble surfaces an ApiError", async () => {
+  vi.spyOn(client, "poolAssembleOpCert").mockRejectedValue(
+    new client.ApiError(400, "signature does not verify"),
+  );
+  render(<OperationalCert />);
+  switchToAirGap();
+
+  fireEvent.change(screen.getByLabelText(/kes verification key/i), { target: { value: "ke5" } });
+  fireEvent.change(screen.getByLabelText(/^kes period$/i), { target: { value: "7" } });
+  fireEvent.change(screen.getByLabelText(/cold verification key/i), { target: { value: "c0ld" } });
+  fireEvent.change(screen.getByLabelText(/cold signature/i), { target: { value: "bad" } });
+  fireEvent.click(screen.getByRole("button", { name: /assemble certificate/i }));
+
+  await waitFor(() =>
+    expect(screen.getByRole("alert")).toHaveTextContent(/signature does not verify/i),
+  );
+});

--- a/ui/web/src/screens/operate/Registration.test.tsx
+++ b/ui/web/src/screens/operate/Registration.test.tsx
@@ -25,12 +25,16 @@ function fillSeedMinimum(pledge = "100000000", password = "pw") {
 
 // --- air-gap mode (the branch Operate.test.tsx does not exercise) ---
 
-test("air-gap mode builds from a cold vkey + VRF key hash, not a password", async () => {
+test("air-gap mode builds from a cold vkey + VRF key hash, and never sends the spending password", async () => {
   const build = vi
     .spyOn(client, "poolBuildRegistrationAirGap")
     .mockResolvedValue({ pool_id: "pool1air", cbor_hex: "8a03air" });
   renderReg();
 
+  // Enter a spending password in seed mode FIRST, then switch to air-gap. The
+  // password state persists across the toggle, so this guards the security
+  // invariant: even a leftover password must never reach the air-gap request.
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "supersecret" } });
   fireEvent.click(screen.getByRole("button", { name: /air-gap/i }));
   expect(screen.queryByLabelText(/spending password/i)).toBeNull();
 
@@ -44,6 +48,10 @@ test("air-gap mode builds from a cold vkey + VRF key hash, not a password", asyn
   expect(arg.cold_vkey_hex).toBe("c0ld");
   expect(arg.vrf_key_hash_hex).toBe("vrf");
   expect(arg.pledge).toBe("100000000");
+  // The captured air-gap request body must carry no password field and no
+  // trace of the value the user typed in seed mode.
+  expect(arg).not.toHaveProperty("password");
+  expect(JSON.stringify(arg)).not.toContain("supersecret");
   expect(await screen.findByText("pool1air")).toBeInTheDocument();
   expect(screen.getByText("8a03air")).toBeInTheDocument();
 });

--- a/ui/web/src/screens/operate/Registration.test.tsx
+++ b/ui/web/src/screens/operate/Registration.test.tsx
@@ -1,0 +1,216 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Registration } from "./Registration";
+import * as client from "../../api/client";
+import type { Account } from "../../api/types";
+
+const account: Account = {
+  network: "preview",
+  stake_address: "stake_test1reward",
+  receive_addresses: ["addr_test1aaa"],
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderReg() {
+  render(<Registration account={account} />);
+}
+
+// Fill the minimum a build needs in seed mode: pledge + password.
+function fillSeedMinimum(pledge = "100000000", password = "pw") {
+  fireEvent.change(screen.getByLabelText(/^pledge/i), { target: { value: pledge } });
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: password } });
+}
+
+// --- air-gap mode (the branch Operate.test.tsx does not exercise) ---
+
+test("air-gap mode builds from a cold vkey + VRF key hash, not a password", async () => {
+  const build = vi
+    .spyOn(client, "poolBuildRegistrationAirGap")
+    .mockResolvedValue({ pool_id: "pool1air", cbor_hex: "8a03air" });
+  renderReg();
+
+  fireEvent.click(screen.getByRole("button", { name: /air-gap/i }));
+  expect(screen.queryByLabelText(/spending password/i)).toBeNull();
+
+  fireEvent.change(screen.getByLabelText(/^pledge/i), { target: { value: "100000000" } });
+  fireEvent.change(screen.getByLabelText(/cold verification key/i), { target: { value: " c0ld " } });
+  fireEvent.change(screen.getByLabelText(/vrf key hash/i), { target: { value: " vrf " } });
+  fireEvent.click(screen.getByRole("button", { name: /build certificate/i }));
+
+  await waitFor(() => expect(build).toHaveBeenCalled());
+  const arg = vi.mocked(build).mock.calls[0][0];
+  expect(arg.cold_vkey_hex).toBe("c0ld");
+  expect(arg.vrf_key_hash_hex).toBe("vrf");
+  expect(arg.pledge).toBe("100000000");
+  expect(await screen.findByText("pool1air")).toBeInTheDocument();
+  expect(screen.getByText("8a03air")).toBeInTheDocument();
+});
+
+test("air-gap build button is gated on both cold vkey and VRF hash", () => {
+  renderReg();
+  fireEvent.click(screen.getByRole("button", { name: /air-gap/i }));
+  const build = screen.getByRole("button", { name: /build certificate/i });
+  expect(build).toBeDisabled();
+
+  fireEvent.change(screen.getByLabelText(/cold verification key/i), { target: { value: "c0ld" } });
+  expect(build).toBeDisabled(); // VRF hash still missing
+
+  fireEvent.change(screen.getByLabelText(/vrf key hash/i), { target: { value: "vrf" } });
+  expect(build).not.toBeDisabled();
+});
+
+// --- optional field passthrough ---
+
+test("owners are split on commas/whitespace and reward + metadata fields pass through", async () => {
+  const build = vi
+    .spyOn(client, "poolBuildRegistration")
+    .mockResolvedValue({ pool_id: "pool1reg", cbor_hex: "8a03" });
+  renderReg();
+
+  fillSeedMinimum();
+  fireEvent.change(screen.getByLabelText(/reward account/i), { target: { value: " stake_test1xyz " } });
+  fireEvent.change(screen.getByLabelText(/^owners/i), {
+    target: { value: "stake1a, stake1b   stake1c" },
+  });
+  fireEvent.change(screen.getByLabelText(/metadata url/i), {
+    target: { value: " https://p.example/m.json " },
+  });
+  fireEvent.change(screen.getByLabelText(/metadata hash/i), { target: { value: " abcdef " } });
+  fireEvent.click(screen.getByRole("button", { name: /build certificate/i }));
+
+  await waitFor(() => expect(build).toHaveBeenCalled());
+  const arg = vi.mocked(build).mock.calls[0][0];
+  expect(arg.owners).toEqual(["stake1a", "stake1b", "stake1c"]);
+  expect(arg.reward_address).toBe("stake_test1xyz");
+  expect(arg.metadata_url).toBe("https://p.example/m.json");
+  expect(arg.metadata_hash).toBe("abcdef");
+});
+
+test("an IPv6-looking relay host maps to ipv6, not ipv4", async () => {
+  const build = vi
+    .spyOn(client, "poolBuildRegistration")
+    .mockResolvedValue({ pool_id: "pool1reg", cbor_hex: "8a03" });
+  renderReg();
+
+  fillSeedMinimum();
+  fireEvent.click(screen.getByRole("button", { name: /add relay/i }));
+  fireEvent.change(screen.getByLabelText(/relay host/i), { target: { value: "2001:db8::1" } });
+  fireEvent.change(screen.getByLabelText(/relay port/i), { target: { value: "3001" } });
+  fireEvent.click(screen.getByRole("button", { name: /build certificate/i }));
+
+  await waitFor(() => expect(build).toHaveBeenCalled());
+  const arg = vi.mocked(build).mock.calls[0][0];
+  expect(arg.relays).toEqual([
+    { type: "single_host_address", ipv6: "2001:db8::1", port: 3001 },
+  ]);
+});
+
+test("removing a relay row drops it from the request", async () => {
+  const build = vi
+    .spyOn(client, "poolBuildRegistration")
+    .mockResolvedValue({ pool_id: "pool1reg", cbor_hex: "8a03" });
+  renderReg();
+
+  fillSeedMinimum();
+  fireEvent.click(screen.getByRole("button", { name: /add relay/i }));
+  fireEvent.change(screen.getByLabelText(/relay host/i), { target: { value: "1.2.3.4" } });
+  fireEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+  fireEvent.click(screen.getByRole("button", { name: /build certificate/i }));
+
+  await waitFor(() => expect(build).toHaveBeenCalled());
+  expect(vi.mocked(build).mock.calls[0][0].relays).toBeUndefined();
+});
+
+// --- validation branches (API must not be called) ---
+
+test("missing pledge blocks the build", () => {
+  const build = vi.spyOn(client, "poolBuildRegistration");
+  renderReg();
+
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /build certificate/i }));
+
+  expect(screen.getByRole("alert")).toHaveTextContent(/pledge and cost are required/i);
+  expect(build).not.toHaveBeenCalled();
+});
+
+test("a relay with a port but no host reports 'Relay host is required'", () => {
+  const build = vi.spyOn(client, "poolBuildRegistration");
+  renderReg();
+
+  fillSeedMinimum();
+  fireEvent.click(screen.getByRole("button", { name: /add relay/i }));
+  fireEvent.change(screen.getByLabelText(/relay port/i), { target: { value: "3001" } });
+  fireEvent.click(screen.getByRole("button", { name: /build certificate/i }));
+
+  expect(screen.getByRole("alert")).toHaveTextContent(/relay host is required/i);
+  expect(build).not.toHaveBeenCalled();
+});
+
+test("a relay port outside 0-65535 is rejected client-side", () => {
+  const build = vi.spyOn(client, "poolBuildRegistration");
+  renderReg();
+
+  fillSeedMinimum();
+  fireEvent.click(screen.getByRole("button", { name: /add relay/i }));
+  fireEvent.change(screen.getByLabelText(/relay host/i), { target: { value: "1.2.3.4" } });
+  fireEvent.change(screen.getByLabelText(/relay port/i), { target: { value: "99999" } });
+  fireEvent.click(screen.getByRole("button", { name: /build certificate/i }));
+
+  expect(screen.getByRole("alert")).toHaveTextContent(/must be an integer between 0 and 65535/i);
+  expect(build).not.toHaveBeenCalled();
+});
+
+test("a non-positive margin denominator is rejected", () => {
+  const build = vi.spyOn(client, "poolBuildRegistration");
+  renderReg();
+
+  fillSeedMinimum();
+  fireEvent.change(screen.getByLabelText(/margin denominator/i), { target: { value: "0" } });
+  fireEvent.click(screen.getByRole("button", { name: /build certificate/i }));
+
+  expect(screen.getByRole("alert")).toHaveTextContent(
+    /margin denominator must be greater than 0/i,
+  );
+  expect(build).not.toHaveBeenCalled();
+});
+
+test("a negative margin numerator is rejected", () => {
+  const build = vi.spyOn(client, "poolBuildRegistration");
+  renderReg();
+
+  fillSeedMinimum();
+  fireEvent.change(screen.getByLabelText(/margin numerator/i), { target: { value: "-1" } });
+  fireEvent.click(screen.getByRole("button", { name: /build certificate/i }));
+
+  expect(screen.getByRole("alert")).toHaveTextContent(
+    /margin numerator must be greater than or equal to 0/i,
+  );
+  expect(build).not.toHaveBeenCalled();
+});
+
+// --- hand-off / error handling ---
+
+test("documents that in-app submission is not yet wired (cert build + hand-off only)", () => {
+  renderReg();
+  expect(screen.getByText(/submitting a registration transaction in-app is not yet wired/i))
+    .toBeInTheDocument();
+  // There is no submit-transaction control on this screen — only a build.
+  expect(screen.queryByRole("button", { name: /submit/i })).toBeNull();
+});
+
+test("surfaces an ApiError from a failed build", async () => {
+  vi.spyOn(client, "poolBuildRegistration").mockRejectedValue(
+    new client.ApiError(422, "reward account is not registered"),
+  );
+  renderReg();
+
+  fillSeedMinimum();
+  fireEvent.click(screen.getByRole("button", { name: /build certificate/i }));
+
+  await waitFor(() =>
+    expect(screen.getByRole("alert")).toHaveTextContent(/reward account is not registered/i),
+  );
+});

--- a/ui/web/src/screens/operate/Retirement.test.tsx
+++ b/ui/web/src/screens/operate/Retirement.test.tsx
@@ -44,6 +44,9 @@ test("seed mode submits a retirement transaction and shows the tx hash", async (
   await waitFor(() => expect(submit).toHaveBeenCalledWith({ password: "pw", epoch: 520 }));
   expect(await screen.findByText("deadbeef")).toBeInTheDocument();
   expect(screen.getByText(/retirement transaction submitted/i)).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: /copy retirement transaction hash/i }),
+  ).toBeInTheDocument();
 });
 
 // --- air-gap mode: cold-vkey cert, no submit button ---
@@ -67,6 +70,12 @@ test("air-gap mode builds a certificate from a cold vkey and has no submit butto
     expect(build).toHaveBeenCalledWith({ cold_vkey_hex: "c0ld", epoch: 300 }),
   );
   expect(await screen.findByText("pool1air")).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: /copy retirement pool id/i }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: /copy retirement certificate cbor hex/i }),
+  ).toBeInTheDocument();
 });
 
 // --- validation ---

--- a/ui/web/src/screens/operate/Retirement.test.tsx
+++ b/ui/web/src/screens/operate/Retirement.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Retirement } from "./Retirement";
+import * as client from "../../api/client";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function switchToAirGap() {
+  fireEvent.click(screen.getByRole("button", { name: /air-gap/i }));
+}
+
+// --- seed mode: build certificate ---
+
+test("seed mode builds a retirement certificate from the spending password", async () => {
+  const build = vi
+    .spyOn(client, "poolBuildRetirementCert")
+    .mockResolvedValue({ pool_id: "pool1ret", cbor_hex: "8304cafe" });
+  render(<Retirement />);
+
+  fireEvent.change(screen.getByLabelText(/retirement epoch/i), { target: { value: "520" } });
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /^build certificate$/i }));
+
+  await waitFor(() =>
+    expect(build).toHaveBeenCalledWith({ password: "pw", epoch: 520 }),
+  );
+  expect(await screen.findByText("pool1ret")).toBeInTheDocument();
+  expect(screen.getByText("8304cafe")).toBeInTheDocument();
+});
+
+// --- seed mode: submit transaction ---
+
+test("seed mode submits a retirement transaction and shows the tx hash", async () => {
+  const submit = vi
+    .spyOn(client, "poolSubmitRetirement")
+    .mockResolvedValue({ tx_hash: "deadbeef" });
+  render(<Retirement />);
+
+  fireEvent.change(screen.getByLabelText(/retirement epoch/i), { target: { value: "520" } });
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /build & submit retirement/i }));
+
+  await waitFor(() => expect(submit).toHaveBeenCalledWith({ password: "pw", epoch: 520 }));
+  expect(await screen.findByText("deadbeef")).toBeInTheDocument();
+  expect(screen.getByText(/retirement transaction submitted/i)).toBeInTheDocument();
+});
+
+// --- air-gap mode: cold-vkey cert, no submit button ---
+
+test("air-gap mode builds a certificate from a cold vkey and has no submit button", async () => {
+  const build = vi
+    .spyOn(client, "poolBuildRetirementCert")
+    .mockResolvedValue({ pool_id: "pool1air", cbor_hex: "8304" });
+  render(<Retirement />);
+  switchToAirGap();
+
+  // The seed-only submit action is not offered in air-gap mode.
+  expect(screen.queryByRole("button", { name: /build & submit retirement/i })).toBeNull();
+  expect(screen.queryByLabelText(/spending password/i)).toBeNull();
+
+  fireEvent.change(screen.getByLabelText(/retirement epoch/i), { target: { value: "300" } });
+  fireEvent.change(screen.getByLabelText(/cold verification key/i), { target: { value: "  c0ld  " } });
+  fireEvent.click(screen.getByRole("button", { name: /^build certificate$/i }));
+
+  await waitFor(() =>
+    expect(build).toHaveBeenCalledWith({ cold_vkey_hex: "c0ld", epoch: 300 }),
+  );
+  expect(await screen.findByText("pool1air")).toBeInTheDocument();
+});
+
+// --- validation ---
+
+test("build requires an epoch value", () => {
+  const build = vi.spyOn(client, "poolBuildRetirementCert");
+  render(<Retirement />);
+
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /^build certificate$/i }));
+
+  expect(screen.getByRole("alert")).toHaveTextContent(/retirement epoch is required/i);
+  expect(build).not.toHaveBeenCalled();
+});
+
+test("build rejects an epoch above the safe-integer range before calling the API", () => {
+  const build = vi.spyOn(client, "poolBuildRetirementCert");
+  render(<Retirement />);
+
+  fireEvent.change(screen.getByLabelText(/retirement epoch/i), {
+    target: { value: "9007199254740993" },
+  });
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /^build certificate$/i }));
+
+  expect(screen.getByRole("alert")).toHaveTextContent(
+    /retirement epoch must be a non-negative integer/i,
+  );
+  expect(build).not.toHaveBeenCalled();
+});
+
+test("submit rejects a non-integer epoch before calling the API", () => {
+  const submit = vi.spyOn(client, "poolSubmitRetirement");
+  render(<Retirement />);
+
+  // Epoch input is type=number; feed a value that fails the /^\d+$/ parse.
+  fireEvent.change(screen.getByLabelText(/retirement epoch/i), { target: { value: "1.5" } });
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /build & submit retirement/i }));
+
+  expect(screen.getByRole("alert")).toHaveTextContent(
+    /retirement epoch must be a non-negative integer/i,
+  );
+  expect(submit).not.toHaveBeenCalled();
+});
+
+// --- disabled-state gating ---
+
+test("seed build/submit buttons are gated on password and epoch", () => {
+  render(<Retirement />);
+  const buildBtn = screen.getByRole("button", { name: /^build certificate$/i });
+  const submitBtn = screen.getByRole("button", { name: /build & submit retirement/i });
+
+  expect(buildBtn).toBeDisabled();
+  expect(submitBtn).toBeDisabled();
+
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  // Build only needs a password; submit also needs an epoch.
+  expect(buildBtn).not.toBeDisabled();
+  expect(submitBtn).toBeDisabled();
+
+  fireEvent.change(screen.getByLabelText(/retirement epoch/i), { target: { value: "10" } });
+  expect(submitBtn).not.toBeDisabled();
+});
+
+// --- error handling ---
+
+test("surfaces an ApiError from a failed submission", async () => {
+  vi.spyOn(client, "poolSubmitRetirement").mockRejectedValue(
+    new client.ApiError(409, "pool is already retired"),
+  );
+  render(<Retirement />);
+
+  fireEvent.change(screen.getByLabelText(/retirement epoch/i), { target: { value: "520" } });
+  fireEvent.change(screen.getByLabelText(/spending password/i), { target: { value: "pw" } });
+  fireEvent.click(screen.getByRole("button", { name: /build & submit retirement/i }));
+
+  await waitFor(() =>
+    expect(screen.getByRole("alert")).toHaveTextContent(/pool is already retired/i),
+  );
+});


### PR DESCRIPTION
Adds co-located frontend tests for UI modules that a coverage audit flagged as untested. **New test files only — no production code changed.**

## Now covered
- **`src/router.ts`** — `#/route` parsing, `navigate` round-trip, `useHashRoute` hashchange reactivity + listener cleanup on unmount, and the prototype-pollution safety property (crafted `#/__proto__`, `#/constructor` names resolve to absent Map keys; the Map-vs-plain-object distinction from the `app.tsx` comment is locked in). The app-level fallback for a crafted hash is already covered by `app.test.tsx`.
- **`src/password.ts`** — `MIN_PASSWORD_LEN` gate boundaries (11/12) and code-point (not byte / UTF-16) counting for multi-byte and astral-plane emoji input.
- **`src/screens/MigrateLegacyKeystore.tsx`** — happy-path import (name trim + default), all three client-side validation branches, `ApiError` vs generic error handling, and the "Create New Vault" escape hatch.
- **`src/components/Drawer.tsx`** — dialog structure/labelling, close affordances (button / backdrop / Escape, plus inner-click no-close), focus move-in and restore-on-unmount, and Tab / Shift+Tab focus-trap wrap.
- **`src/components/WalletSwitcher.tsx`** — listing + active marking, activate-and-report, in-flight double-click guard, no-op on the active wallet, `ApiError`/generic error handling, footer actions.
- **The 5 `src/screens/operate/*` SPO cold-key screens** (`Credentials`, `MetadataBuilder`, `Retirement`, `Registration`, `OperationalCert`), tested directly per screen — form validation, request construction, the **air-gap** paths (payload → assemble, cold-vkey cert), KES rotation + KES-period auto-fill, IPv6/relay handling, and CBOR/cert rendering + error paths. `Registration` asserts the cert-**build** + hand-off path only; in-app submission is documented as not-yet-wired and is deliberately not asserted.

## Coverage delta (v8)
| Metric | Before | After |
|---|---|---|
| Statements | 91.2% | **94.33%** |
| Branch | 84.92% | **87.79%** |
| Functions | 76.4% | **80.34%** |
| Lines | 91.2% | **94.33%** |

Notable per-module: `OperationalCert.tsx` 59% → 99%, `MigrateLegacyKeystore.tsx` 88% → 100%, `Drawer.tsx` 65% → 100%, `WalletSwitcher.tsx` 93% → 100%, `Registration.tsx` 86% → 98%, `Retirement.tsx` 94% → 99%.

## Verification
`npm run lint` (0 errors; 1 pre-existing warning in `connectorNotify.ts`, untouched), `npm run type-check`, `npm run test` (**485 pass**, was 399), and `npm run build` all green. The build's rewrite of `ui/internal/webui/dist/*` was reverted — not part of this test-only change.

## Notes
- **No screenshots:** test-only PR (adds test files, no production or UI changes) — nothing rendered to capture.
- The `@vitest/coverage-v8` dev-dependency was installed only to measure the delta and reverted; coverage is not wired into CI (`test` script is `vitest run`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add co-located UI tests for the router, password utils, `Drawer`, `WalletSwitcher`, legacy keystore migration, and SPO operate screens to close coverage gaps. Test-only change; no production code modified; statements/lines now 94.33% (was 91.2%).

- **New Features**
  - Router: `#/route` parsing, `navigate` round-trip, hashchange reactivity, listener cleanup, and prototype-pollution safety exercised end-to-end by rendering `App` with `#/__proto__`/`#/constructor` (falls back to Portfolio).
  - Password: `MIN_PASSWORD_LEN` boundaries and code-point counting (multi-byte and emoji).
  - Components: `Drawer` (modal semantics, close via button/backdrop/Escape, focus trap/restore), `WalletSwitcher` (list + active marking, activation with in-flight disable, no-op on active, errors, footer actions).
  - Migrate: `MigrateLegacyKeystore` happy path, client-side validation, `ApiError` vs generic errors, "Create New Vault" path.
  - SPO screens: `Credentials`, `MetadataBuilder`, `OperationalCert`, `Registration`, `Retirement` — form validation, air-gap flows (payload/assemble; cold vkey), KES rotation + auto-fill, IPv6/relay handling, CBOR/cert rendering; `Registration` asserts build + hand-off only.

- **Bug Fixes**
  - Capability tests now assert their named behavior: `WalletSwitcher` verifies all wallet buttons disable during a pending switch; router test spies on add/removeEventListener to ensure the exact hashchange handler is removed and guarantees spy restoration via `afterEach` to prevent leaks.
  - Prototype-pollution check targets the production ROUTES `Map` via `App` E2E; removed the hand-built `Map` test.
  - De-duplicated `Retirement` API-contract cases from `Operate.test.tsx` (now covered in `operate/Retirement.test.tsx` with copy-button assertions); `Registration` air-gap test ensures no password is ever sent or leaked.

<sup>Written for commit bcaa601fb31b12939064a83b28987b8964b4130c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

