### PR TITLE
fix(ui): accurate useAsync fn-stability note + guard FakeEventSource.emit after close

### DIFF
--- a/ui/web/src/api/connector.test.ts
+++ b/ui/web/src/api/connector.test.ts
@@ -254,3 +254,14 @@ test("FakeEventSource exposes browser-compatible readyState constants", () => {
   expect(FakeEventSource.OPEN).toBe(1);
   expect(FakeEventSource.CLOSED).toBe(2);
 });
+
+test("FakeEventSource.emit after close() fires no onmessage", () => {
+  const es = new FakeEventSource("/connector/events");
+  let messages = 0;
+  es.onmessage = () => {
+    messages += 1;
+  };
+  es.close();
+  es.emit("{}");
+  expect(messages).toBe(0);
+});

--- a/ui/web/src/api/hooks.ts
+++ b/ui/web/src/api/hooks.ts
@@ -118,8 +118,11 @@ export function useAsync<T>(
   // closures/arrow functions are new identities each render. Callers MUST
   // therefore pass a STABLE `fn`: a module-level function (as the useStatus,
   // useBalance, etc. helpers below do) or one wrapped in useCallback. A caller
-  // that passes an unstable `fn` will silently only ever see the value from the
-  // first render's closure. `refresh` is the supported way to refetch.
+  // that passes an unstable `fn` keeps the previously-captured closure only
+  // until one of the effect deps (`refresh`/`tick`, `enabled`, or `pollMs`)
+  // changes and re-runs the effect, at which point the LATEST `fn` is captured;
+  // it is not permanently stuck on the first render's closure. `refresh` is the
+  // supported way to refetch.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tick, enabled, pollMs]);
 

--- a/ui/web/src/test-utils/FakeEventSource.ts
+++ b/ui/web/src/test-utils/FakeEventSource.ts
@@ -16,7 +16,10 @@ export class FakeEventSource {
     FakeEventSource.instances.push(this);
   }
 
+  // A closed stream is inert: a real EventSource delivers no message events
+  // after close(), so neither do we.
   emit(data: string) {
+    if (this.closed) return;
     this.onmessage?.({ data });
   }
 


### PR DESCRIPTION
Two small follow-up fixes from CodeRabbit review of #609.

- **`ui/web/src/api/hooks.ts`** — Reword the `useAsync` CONTRACT comment. The prior wording claimed an unstable `fn` is silently stuck on the first render's closure forever. In fact the effect deps are `[tick, enabled, pollMs]`, so when `refresh()` (bumps `tick`), `enabled`, or `pollMs` changes, the effect re-runs and captures the latest `fn`. The comment now states the closure is retained only until one of those deps changes.
- **`ui/web/src/test-utils/FakeEventSource.ts`** — Add `if (this.closed) return;` to `emit()`, matching the existing `emitError()`/`emitOpen()` guards and real `EventSource` behavior (no message events after `close()`). Added a test in `connector.test.ts` asserting `emit()` after `close()` fires no `onmessage`.

## Verification
`npm run lint` (no errors), `npm run test` (543 passed), `npm run type-check`, and `npm run build` all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the `useAsync` contract to note that an unstable `fn` is re-captured when `refresh`/`tick`, `enabled`, or `pollMs` change, and made `FakeEventSource.emit()` a no-op after `close()` to match real `EventSource`.

- **Bug Fixes**
  - Guarded `FakeEventSource.emit()` to no-op when closed; prevents post-close messages and matches `emitError()`/`emitOpen()`.
  - Added a test verifying `emit()` after `close()` triggers no `onmessage`.

<sup>Written for commit 24b4d67e36b3e7a7b2415eaacef1fb326444a816. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

