### PR TITLE
fix(api): same-origin / DNS-rebind guard on /vault and /wallet routes (#590)

### DIFF
--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -1223,7 +1223,67 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 	// everything else is served by the embedded frontend.
 	mux.Handle("/", spa)
 
-	return mux
+	// Wrap the whole mux in the same-origin / DNS-rebind guard. The /vault/* and
+	// /wallet/* routes register directly on the mux with no per-handler origin
+	// check, so this middleware is the single point that enforces it for them.
+	return sameOriginGuard(mux)
+}
+
+// sameOriginGuard wraps the API mux with a uniform same-origin / DNS-rebind
+// guard for the non-connector routes.
+//
+// Because the server listens only on loopback, a malicious web page can reach
+// these endpoints via DNS rebinding (it resolves its own hostname to 127.0.0.1,
+// so the browser sends the request to us with a public Host header). The
+// /vault/* and /wallet/* routes have no per-handler origin check, so this
+// middleware is where that class of request is rejected.
+//
+// The /connector/* routes are skipped: they already carry their own guards — a
+// bearer token for the extension-facing routes and in-handler
+// sameOrigin/strictSameOrigin for the SPA-facing ones — and an extension request
+// legitimately carries a chrome-extension:// Origin that would fail
+// strictSameOrigin here. Re-guarding them would break the connector.
+//
+// For every guarded request:
+//   - The Host must be a loopback address (isLoopbackHost). A non-loopback Host
+//     means a DNS-rebound cross-site page reached us; reject it. sameOrigin and
+//     strictSameOrigin already enforce this, but checking it up front rejects
+//     every method — including ones with no origin semantics — uniformly.
+//   - State-changing methods (POST/PUT/DELETE/PATCH) require strictSameOrigin:
+//     an Origin header that is present AND matches the server's own scheme+host.
+//   - Other methods (GET/HEAD, plus the SPA's navigations and asset loads) use
+//     sameOrigin, which additionally trusts the absent-Origin case that
+//     same-origin browser GETs produce — but only over a loopback Host.
+//
+// It reuses connector.go's sameOrigin/strictSameOrigin/isLoopbackHost verbatim
+// so the SPA's own calls decide identically to the connector's SPA routes: in
+// prod the SPA is served from 127.0.0.1:8090 (same origin as its fetches); in
+// dev the vite proxy forwards to the backend preserving the browser's
+// localhost:<port> Host and Origin (both loopback, and matching), so they pass.
+func sameOriginGuard(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Connector routes carry their own guards; do not double-guard.
+		if strings.HasPrefix(r.URL.Path, "/connector/") {
+			next.ServeHTTP(w, r)
+			return
+		}
+		// Loopback Host is required for every guarded request.
+		if !isLoopbackHost(r.Host) {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "cross-origin request refused"})
+			return
+		}
+		allowed := sameOrigin(r)
+		switch r.Method {
+		case http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch:
+			// State-changing methods must carry a matching Origin.
+			allowed = strictSameOrigin(r)
+		}
+		if !allowed {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "cross-origin request refused"})
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // walletList maps vault metadata to the client-facing wallet views, marking the

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -130,7 +130,7 @@ func TestNFTListReady(t *testing.T) {
 	h := nftHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}},
 		&fakeNFTs{list: []nft.NFT{{Unit: "policyAtoken", Name: "Token A", ImageCID: "bafyimage"}}})
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/nft", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/nft", nil))
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"name":"Token A"`) {
 		t.Fatalf("GET /wallet/nft = %d body=%q", rec.Code, rec.Body.String())
 	}
@@ -139,14 +139,14 @@ func TestNFTListReady(t *testing.T) {
 func TestNFTListGatedAndNoWallet(t *testing.T) {
 	h := nftHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}, &fakeNFTs{})
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/nft", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/nft", nil))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("GET /wallet/nft while starting = %d, want 503", rec.Code)
 	}
 
 	h = nftHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeNFTs{listErr: nft.ErrNoWallet})
 	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/nft", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/nft", nil))
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("GET /wallet/nft without wallet = %d, want 409", rec.Code)
 	}
@@ -156,13 +156,13 @@ func TestNFTImageConsentGate(t *testing.T) {
 	nf := &fakeNFTs{imageBytes: []byte("PNG")}
 	h := nftHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, nf)
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/nft/policyAtoken/image", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/nft/policyAtoken/image", nil))
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("disabled image = %d, want 403", rec.Code)
 	}
 	nf.enabled = true
 	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/nft/policyAtoken/image", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/nft/policyAtoken/image", nil))
 	if rec.Code != http.StatusOK || rec.Body.String() != "PNG" || nf.servedUnit != "policyAtoken" {
 		t.Fatalf("enabled image = %d body=%q unit=%q", rec.Code, rec.Body.String(), nf.servedUnit)
 	}
@@ -172,7 +172,7 @@ func TestNFTImageGatedWhileNodeStarts(t *testing.T) {
 	nf := &fakeNFTs{enabled: true, imageBytes: []byte("PNG")}
 	h := nftHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}, nf)
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/nft/policyAtoken/image", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/nft/policyAtoken/image", nil))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("image while starting = %d, want 503", rec.Code)
 	}
@@ -185,13 +185,13 @@ func TestNFTSettingsToggleAndValidation(t *testing.T) {
 	nf := &fakeNFTs{}
 	h := nftHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, nf)
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/nft-media", strings.NewReader(`{"enabled":true}`)))
+	h.ServeHTTP(rec, localReq(http.MethodPut, "/wallet/settings/nft-media", strings.NewReader(`{"enabled":true}`)))
 	if rec.Code != http.StatusOK || !nf.enabled {
 		t.Fatalf("enable = %d enabled=%v", rec.Code, nf.enabled)
 	}
 	nf.setCalled = false
 	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/nft-media", strings.NewReader(`{}`)))
+	h.ServeHTTP(rec, localReq(http.MethodPut, "/wallet/settings/nft-media", strings.NewReader(`{}`)))
 	if rec.Code != http.StatusBadRequest || nf.setCalled {
 		t.Fatalf("missing enabled = %d setCalled=%v", rec.Code, nf.setCalled)
 	}
@@ -200,12 +200,12 @@ func TestNFTSettingsToggleAndValidation(t *testing.T) {
 func TestNFTNilServiceDegradesGracefully(t *testing.T) {
 	h := nftHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, nil)
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/nft", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/nft", nil))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("nil service list = %d, want 503", rec.Code)
 	}
 	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/settings/nft-media", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/settings/nft-media", nil))
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"enabled":false`) {
 		t.Fatalf("nil service setting = %d body=%q", rec.Code, rec.Body.String())
 	}

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -19,12 +19,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/blinklabs-io/bursa/ui/internal/chain"
+	"github.com/blinklabs-io/bursa/ui/internal/connector"
 	"github.com/blinklabs-io/bursa/ui/internal/contacts"
 	"github.com/blinklabs-io/bursa/ui/internal/dex"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
@@ -37,6 +39,19 @@ import (
 	"github.com/blinklabs-io/bursa/ui/internal/vault"
 	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 )
+
+// localReq builds a test request that looks like the SPA's own same-origin call:
+// a loopback Host plus a matching Origin. The mux is wrapped in sameOriginGuard,
+// which rejects non-loopback Hosts and (for state-changing methods) a
+// missing/mismatched Origin, so route tests must present a legitimate origin to
+// reach the handler under test. Cross-origin / DNS-rebind rejection is covered
+// directly in TestSameOriginGuard.
+func localReq(method, target string, body io.Reader) *http.Request {
+	r := httptest.NewRequest(method, target, body)
+	r.Host = "127.0.0.1:8090"
+	r.Header.Set("Origin", "http://127.0.0.1:8090")
+	return r
+}
 
 type fakeStatuser struct{ s supervisor.Status }
 
@@ -498,7 +513,7 @@ func (f *fakeVault) AddHardwareWallet(name, accountXpubBech32, network, vaultPw 
 func TestHealthAlwaysOK(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/health", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("/health = %d, want 200", rec.Code)
 	}
@@ -508,7 +523,7 @@ func TestStatusReturnsSnapshot(t *testing.T) {
 	want := supervisor.Status{State: supervisor.StateSyncing, Tip: 42, CaughtUp: true}
 	h := NewHandler(fakeStatuser{s: want}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/status", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("/status = %d, want 200", rec.Code)
 	}
@@ -598,7 +613,7 @@ func TestVaultStatusReports(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: true, wallets: []vault.WalletMeta{{ID: "a"}, {ID: "b"}}}
 	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/status", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/vault/status", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /vault/status = %d, want 200", rec.Code)
 	}
@@ -619,7 +634,7 @@ func TestVaultStatusReportsLegacyKeystore(t *testing.T) {
 	legacy := &fakeLegacyKeystore{exists: true}
 	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler(), WithLegacyKeystore(legacy))
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/status", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/vault/status", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /vault/status = %d, want 200", rec.Code)
 	}
@@ -636,7 +651,7 @@ func TestVaultCreateRequiresPassword(t *testing.T) {
 	fv := &fakeVault{}
 	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"short"}`)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"short"}`)))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("POST /vault short password = %d, want 400", rec.Code)
 	}
@@ -649,7 +664,7 @@ func TestVaultCreateOK(t *testing.T) {
 	fv := &fakeVault{}
 	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /vault = %d, want 200", rec.Code)
 	}
@@ -662,7 +677,7 @@ func TestVaultCreateConflict(t *testing.T) {
 	fv := &fakeVault{createErr: vault.ErrVaultExists}
 	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/vault", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("POST /vault when exists = %d, want 409", rec.Code)
 	}
@@ -680,7 +695,7 @@ func TestVaultUnlockBindsSoleWalletAndReads(t *testing.T) {
 	h := NewHandler(st, fv, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /vault/unlock = %d, want 200", rec.Code)
 	}
@@ -696,7 +711,7 @@ func TestVaultUnlockBindsSoleWalletAndReads(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/balance", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/balance", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /wallet/balance after unlock = %d, want 200", rec.Code)
 	}
@@ -715,7 +730,7 @@ func TestVaultUnlockLegacyWalletDefaultsToFullType(t *testing.T) {
 	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /vault/unlock = %d, want 200", rec.Code)
 	}
@@ -735,7 +750,7 @@ func TestVaultUnlockWrongPassword(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: true, unlockErr: fmt.Errorf("%w: bad", vault.ErrWrongPassword)}
 	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"wrong-but-long-pw"}`)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"wrong-but-long-pw"}`)))
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("POST /vault/unlock wrong password = %d, want 401", rec.Code)
 	}
@@ -747,7 +762,7 @@ func TestVaultLock(t *testing.T) {
 	sp := &fakeSpender{set: true}
 	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/lock", nil))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/vault/lock", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /vault/lock = %d, want 200", rec.Code)
 	}
@@ -768,7 +783,7 @@ func TestMigrateLegacyKeystoreImportsAndBinds(t *testing.T) {
 
 	body := `{"name":"Imported","vault_password":"valid-vault-password","spend_password":"legacy-spend-password"}`
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/migrate-legacy", bytes.NewBufferString(body)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/vault/migrate-legacy", bytes.NewBufferString(body)))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /vault/migrate-legacy = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
@@ -807,7 +822,7 @@ func TestMigrateLegacyKeystoreWrongPassword(t *testing.T) {
 
 	body := `{"name":"Imported","vault_password":"valid-vault-password","spend_password":"wrong-password"}`
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/migrate-legacy", bytes.NewBufferString(body)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/vault/migrate-legacy", bytes.NewBufferString(body)))
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("wrong legacy password = %d, want 401", rec.Code)
 	}
@@ -823,7 +838,7 @@ func TestMigrateLegacyKeystoreRequiresSpendPasswordMinLength(t *testing.T) {
 
 	body := `{"name":"Imported","vault_password":"valid-vault-password","spend_password":"short"}`
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/migrate-legacy", bytes.NewBufferString(body)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/vault/migrate-legacy", bytes.NewBufferString(body)))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("short legacy spend password = %d, want 400", rec.Code)
 	}
@@ -846,7 +861,7 @@ func TestAddWalletEnablesReadsAndSpend(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /wallet = %d, want 200", rec.Code)
 	}
@@ -861,7 +876,7 @@ func TestAddWalletEnablesReadsAndSpend(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/balance", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/balance", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /wallet/balance after add = %d, want 200", rec.Code)
 	}
@@ -874,7 +889,7 @@ func TestAddWalletRequiresSpendPassword(t *testing.T) {
 	h := NewHandler(st, fv, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","vault_password":"valid-vault-password","spend_password":"short"}`
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("POST /wallet short spend password = %d, want 400", rec.Code)
 	}
@@ -889,7 +904,7 @@ func TestAddWalletRequiresVaultPassword(t *testing.T) {
 	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","spend_password":"valid-spend-password"}`
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("POST /wallet missing vault password = %d, want 400", rec.Code)
 	}
@@ -901,7 +916,7 @@ func TestAddWalletNetworkMismatch(t *testing.T) {
 	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"mainnet","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("POST /wallet network mismatch = %d, want 400", rec.Code)
 	}
@@ -913,7 +928,7 @@ func TestAddWalletDefaultNetworkIsNodeNetwork(t *testing.T) {
 	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preprod", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /wallet without network = %d, want 200", rec.Code)
 	}
@@ -928,7 +943,7 @@ func TestAddWalletDuplicateConflict(t *testing.T) {
 	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := `{"name":"main","mnemonic":"x x x","network":"preview","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("POST /wallet duplicate = %d, want 409", rec.Code)
 	}
@@ -940,7 +955,7 @@ func TestAddWalletDuplicateConflict(t *testing.T) {
 func TestGenerateMnemonic(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/mnemonic/generate", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/mnemonic/generate", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /wallet/mnemonic/generate = %d, want 200", rec.Code)
 	}
@@ -972,7 +987,7 @@ func TestActivateWalletBinds(t *testing.T) {
 	sp := &fakeSpender{}
 	h := NewHandler(st, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/w2/activate", nil))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/w2/activate", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /wallet/w2/activate = %d, want 200", rec.Code)
 	}
@@ -995,7 +1010,7 @@ func TestActivateUnknownWallet(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false}
 	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/nope/activate", nil))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/nope/activate", nil))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("activate unknown = %d, want 404", rec.Code)
 	}
@@ -1005,7 +1020,7 @@ func TestDeleteWalletRequiresVaultPassword(t *testing.T) {
 	fv := &fakeVault{exists: true, locked: false, wallets: []vault.WalletMeta{{ID: "w1"}}}
 	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/wallet/w1", bytes.NewBufferString(`{}`)))
+	h.ServeHTTP(rec, localReq(http.MethodDelete, "/wallet/w1", bytes.NewBufferString(`{}`)))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("DELETE /wallet/w1 without vault password = %d, want 400", rec.Code)
 	}
@@ -1020,7 +1035,7 @@ func TestDeleteWalletOK(t *testing.T) {
 	sp := &fakeSpender{set: true}
 	h := NewHandler(fakeStatuser{}, fv, fw, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/wallet/w1", bytes.NewBufferString(`{"vault_password":"valid-vault-password"}`)))
+	h.ServeHTTP(rec, localReq(http.MethodDelete, "/wallet/w1", bytes.NewBufferString(`{"vault_password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("DELETE /wallet/w1 = %d, want 200", rec.Code)
 	}
@@ -1038,7 +1053,7 @@ func TestWalletGatedWhileStarting(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/balance", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/balance", nil))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("GET /wallet/balance while starting = %d, want 503", rec.Code)
 	}
@@ -1049,7 +1064,7 @@ func TestWalletGatedWhileBootstrapping(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateBootstrapping}}
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/balance", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/balance", nil))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("GET /wallet/balance while bootstrapping = %d, want 503", rec.Code)
 	}
@@ -1062,7 +1077,7 @@ func TestWalletNoActiveWalletConflict(t *testing.T) {
 		t.Run(path, func(t *testing.T) {
 			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
-			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+			h.ServeHTTP(rec, localReq(http.MethodGet, path, nil))
 			if rec.Code != http.StatusConflict {
 				t.Fatalf("GET %s with no active wallet = %d, want 409", path, rec.Code)
 			}
@@ -1087,7 +1102,7 @@ func TestGetTransactionDetailOK(t *testing.T) {
 	}
 	h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/transactions/tx1", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/transactions/tx1", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /wallet/transactions/tx1 = %d, want 200", rec.Code)
 	}
@@ -1110,7 +1125,7 @@ func TestGetTransactionDetailNotFound(t *testing.T) {
 	fw := &fakeWallet{set: true, txDetailErr: chain.ErrNotFound}
 	h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/transactions/unknown", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/transactions/unknown", nil))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("GET /wallet/transactions/unknown = %d, want 404", rec.Code)
 	}
@@ -1540,14 +1555,14 @@ func TestMultiSigRoutesUngatedWhileNodeNotReady(t *testing.T) {
 	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, ms, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/multisig", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/multisig", nil))
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "Treasury") {
 		t.Fatalf("GET /wallet/multisig = %d body %s, want account", rec.Code, rec.Body.String())
 	}
 
 	rec = httptest.NewRecorder()
 	createBody := `{"label":"Treasury","policy":{"threshold":1,"participants":[{"key_hash_hex":"` + strings.Repeat("a", 56) + `"}]}}`
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/multisig", bytes.NewBufferString(createBody)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/multisig", bytes.NewBufferString(createBody)))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /wallet/multisig = %d body %s, want 200", rec.Code, rec.Body.String())
 	}
@@ -1556,7 +1571,7 @@ func TestMultiSigRoutesUngatedWhileNodeNotReady(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/multisig/my-key", bytes.NewBufferString(`{"password":"pw"}`)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/multisig/my-key", bytes.NewBufferString(`{"password":"pw"}`)))
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), strings.Repeat("b", 56)) {
 		t.Fatalf("POST /wallet/multisig/my-key = %d body %s, want key", rec.Code, rec.Body.String())
 	}
@@ -1565,7 +1580,7 @@ func TestMultiSigRoutesUngatedWhileNodeNotReady(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/multisig/sign", bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","password":"pw"}`)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/multisig/sign", bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","password":"pw"}`)))
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "81825820") {
 		t.Fatalf("POST /wallet/multisig/sign = %d body %s, want witness", rec.Code, rec.Body.String())
 	}
@@ -1583,7 +1598,7 @@ func TestMultiSigRoutesGated(t *testing.T) {
 	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, ms, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/multisig/acct1/balance", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/multisig/acct1/balance", nil))
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "1234567") {
 		t.Fatalf("GET balance = %d body %s, want balance", rec.Code, rec.Body.String())
 	}
@@ -1592,7 +1607,7 @@ func TestMultiSigRoutesGated(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/multisig/acct1/build", bytes.NewBufferString(`{"to":"addr_test1recipient","lovelace":"1000000"}`)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/multisig/acct1/build", bytes.NewBufferString(`{"to":"addr_test1recipient","lovelace":"1000000"}`)))
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "84a400") {
 		t.Fatalf("POST build = %d body %s, want unsigned tx", rec.Code, rec.Body.String())
 	}
@@ -1601,7 +1616,7 @@ func TestMultiSigRoutesGated(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/multisig/acct1/submit", bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witnesses":["81"]}`)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/multisig/acct1/submit", bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witnesses":["81"]}`)))
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "feedface") {
 		t.Fatalf("POST submit = %d body %s, want tx hash", rec.Code, rec.Body.String())
 	}
@@ -1622,7 +1637,7 @@ func TestMultiSigRoutesGated(t *testing.T) {
 	} {
 		t.Run("blocked "+tc.name, func(t *testing.T) {
 			rec := httptest.NewRecorder()
-			blocked.ServeHTTP(rec, httptest.NewRequest(tc.method, tc.path, bytes.NewBufferString(tc.body)))
+			blocked.ServeHTTP(rec, localReq(tc.method, tc.path, bytes.NewBufferString(tc.body)))
 			if rec.Code != http.StatusServiceUnavailable {
 				t.Fatalf("%s while node starting = %d, want 503", tc.name, rec.Code)
 			}
@@ -1676,7 +1691,7 @@ func TestMultiSigErrorStatusCodes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, tc.ms, "preview", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
-			h.ServeHTTP(rec, httptest.NewRequest(tc.method, tc.path, bytes.NewBufferString(tc.body)))
+			h.ServeHTTP(rec, localReq(tc.method, tc.path, bytes.NewBufferString(tc.body)))
 			if rec.Code != tc.wantCode {
 				t.Fatalf("%s status = %d, want %d; body %s", tc.name, rec.Code, tc.wantCode, rec.Body.String())
 			}
@@ -1690,7 +1705,7 @@ func TestSignDataReturnsSignature(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"address":"addr_test1xyz","message":"hello","password":"pw"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-data", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/sign-data", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /wallet/sign-data = %d, want 200", rec.Code)
 	}
@@ -1707,7 +1722,7 @@ func TestSignDataWrongPasswordReturns401(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"address":"a","message":"m","password":"bad"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-data", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/sign-data", body))
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("sign-data with wrong password = %d, want 401", rec.Code)
 	}
@@ -1719,7 +1734,7 @@ func TestVerifyDataReturnsResult(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"signature":"84a1","key":"a401","message":"hi","hashed":true,"expected_address":"addr_test1signed"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/verify-data", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/verify-data", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /wallet/verify-data = %d, want 200", rec.Code)
 	}
@@ -1741,7 +1756,7 @@ func TestVerifyDataInvalidArgsReturns400(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"signature":"zz","key":"a4","message":"hi"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/verify-data", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/verify-data", body))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("verify-data with bad input = %d, want 400", rec.Code)
 	}
@@ -1751,7 +1766,7 @@ func TestExportUnsignedRequiresReady(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateSyncing}}
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend1/export-unsigned", nil))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/send/pend1/export-unsigned", nil))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("export-unsigned while syncing = %d, want 503", rec.Code)
 	}
@@ -1765,7 +1780,7 @@ func TestExportUnsignedReturnsTx(t *testing.T) {
 	}}
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend1/export-unsigned", nil))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/send/pend1/export-unsigned", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("export-unsigned = %d, want 200", rec.Code)
 	}
@@ -1784,7 +1799,7 @@ func TestSignTxUngated(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","password":"pw","required_signers":["deadbeef"]}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-tx", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/sign-tx", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /wallet/sign-tx = %d, want 200", rec.Code)
 	}
@@ -1804,7 +1819,7 @@ func TestSignTxWrongPasswordReturns401(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","password":"bad","required_signers":["deadbeef"]}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-tx", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/sign-tx", body))
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("sign-tx wrong password = %d, want 401", rec.Code)
 	}
@@ -1815,7 +1830,7 @@ func TestSignTxInvalidTxReturns400(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"zz","password":"pw","required_signers":["deadbeef"]}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/sign-tx", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/sign-tx", body))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("sign-tx invalid tx = %d, want 400", rec.Code)
 	}
@@ -1826,7 +1841,7 @@ func TestSubmitSignedRequiresReady(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witness_cbor":"81"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-signed", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/submit-signed", body))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("submit-signed while syncing = %d, want 503", rec.Code)
 	}
@@ -1838,7 +1853,7 @@ func TestSubmitSignedReturnsTxHash(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witness_cbor":"81825820"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-signed", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/submit-signed", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("submit-signed = %d, want 200", rec.Code)
 	}
@@ -1856,7 +1871,7 @@ func TestSubmitSignedInvalidWitnessReturns400(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"unsigned_tx_cbor":"84a400","witness_cbor":"zz"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-signed", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/submit-signed", body))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("submit-signed bad witness = %d, want 400", rec.Code)
 	}
@@ -1868,7 +1883,7 @@ func TestSpendSendReadyReturnsPreview(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/send", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /wallet/send while ready = %d, want 200", rec.Code)
 	}
@@ -1887,7 +1902,7 @@ func TestSpendSendGatedWhileSyncing(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/send", body))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("POST /wallet/send while syncing = %d, want 503", rec.Code)
 	}
@@ -1899,7 +1914,7 @@ func TestSpendSendNoWalletConflict(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/send", body))
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("POST /wallet/send with no wallet = %d, want 409", rec.Code)
 	}
@@ -1911,7 +1926,7 @@ func TestSpendConfirmReadyReturnsTxHash(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-spend-password"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend123/confirm", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/send/pend123/confirm", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST confirm while ready = %d, want 200", rec.Code)
 	}
@@ -1932,7 +1947,7 @@ func TestSpendConfirmGatedWhileSyncing(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-spend-password"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pend123/confirm", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/send/pend123/confirm", body))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("POST confirm while syncing = %d, want 503", rec.Code)
 	}
@@ -1962,11 +1977,11 @@ func TestSpendErrorStatusCodes(t *testing.T) {
 			var req *http.Request
 			if tc.confirm {
 				sp.confirmErr = tc.err
-				req = httptest.NewRequest(http.MethodPost, "/wallet/send/pend123/confirm",
+				req = localReq(http.MethodPost, "/wallet/send/pend123/confirm",
 					bytes.NewBufferString(`{"password":"valid-spend-password"}`))
 			} else {
 				sp.buildErr = tc.err
-				req = httptest.NewRequest(http.MethodPost, "/wallet/send",
+				req = localReq(http.MethodPost, "/wallet/send",
 					bytes.NewBufferString(`{"to":"addr_test1recv","lovelace":"1000000"}`))
 			}
 			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
@@ -2013,7 +2028,7 @@ func TestGetHistoryExpiryReturnsState(t *testing.T) {
 	set := &fakeSettings{enabled: true, restartRequired: true}
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/settings/history-expiry", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/settings/history-expiry", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET history-expiry = %d, want 200", rec.Code)
 	}
@@ -2028,7 +2043,7 @@ func TestGetHistoryExpiryDefaultOff(t *testing.T) {
 	set := &fakeSettings{} // default off, no restart needed
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/settings/history-expiry", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/settings/history-expiry", nil))
 	got := decodeHistoryExpiry(t, rec.Body)
 	if got.Enabled || got.RestartRequired {
 		t.Fatalf("got %+v, want both false (default)", got)
@@ -2042,7 +2057,7 @@ func TestPutHistoryExpiryPersistsAndSignalsRestart(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"enabled":true}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
+	h.ServeHTTP(rec, localReq(http.MethodPut, "/wallet/settings/history-expiry", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("PUT history-expiry = %d, want 200", rec.Code)
 	}
@@ -2064,7 +2079,7 @@ func TestPutHistoryExpiryInvalidJSON(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{not json`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
+	h.ServeHTTP(rec, localReq(http.MethodPut, "/wallet/settings/history-expiry", body))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("PUT history-expiry with bad JSON = %d, want 400", rec.Code)
 	}
@@ -2081,7 +2096,7 @@ func TestPutHistoryExpiryRequiresExplicitEnabled(t *testing.T) {
 			h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
 			body := bytes.NewBufferString(bodyJSON)
-			h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
+			h.ServeHTTP(rec, localReq(http.MethodPut, "/wallet/settings/history-expiry", body))
 			if rec.Code != http.StatusBadRequest {
 				t.Fatalf("PUT history-expiry with %s = %d, want 400", bodyJSON, rec.Code)
 			}
@@ -2098,7 +2113,7 @@ func TestPutHistoryExpiryPersistError(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"enabled":true}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/history-expiry", body))
+	h.ServeHTTP(rec, localReq(http.MethodPut, "/wallet/settings/history-expiry", body))
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("PUT history-expiry with persist error = %d, want 500", rec.Code)
 	}
@@ -2123,7 +2138,7 @@ func TestGetAutoLockReturnsPersistedValue(t *testing.T) {
 	set := &fakeSettings{autoLockMinutes: 30}
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/settings/auto-lock", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/settings/auto-lock", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET auto-lock = %d, want 200", rec.Code)
 	}
@@ -2138,7 +2153,7 @@ func TestPutAutoLockPersists(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"minutes":5}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
+	h.ServeHTTP(rec, localReq(http.MethodPut, "/wallet/settings/auto-lock", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("PUT auto-lock = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
@@ -2156,7 +2171,7 @@ func TestPutAutoLockAcceptsOff(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"minutes":0}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
+	h.ServeHTTP(rec, localReq(http.MethodPut, "/wallet/settings/auto-lock", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("PUT auto-lock 0 (Off) = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
@@ -2171,7 +2186,7 @@ func TestPutAutoLockInvalidJSON(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{not json`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
+	h.ServeHTTP(rec, localReq(http.MethodPut, "/wallet/settings/auto-lock", body))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("PUT auto-lock with bad JSON = %d, want 400", rec.Code)
 	}
@@ -2186,7 +2201,7 @@ func TestPutAutoLockRequiresExplicitMinutes(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
+	h.ServeHTTP(rec, localReq(http.MethodPut, "/wallet/settings/auto-lock", body))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("PUT auto-lock with no minutes = %d, want 400", rec.Code)
 	}
@@ -2202,7 +2217,7 @@ func TestPutAutoLockRejectsOutOfSetValue(t *testing.T) {
 		h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
 		body := bytes.NewBufferString(fmt.Sprintf(`{"minutes":%d}`, bad))
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
+		h.ServeHTTP(rec, localReq(http.MethodPut, "/wallet/settings/auto-lock", body))
 		if rec.Code != http.StatusBadRequest {
 			t.Fatalf("PUT auto-lock with %d = %d, want 400", bad, rec.Code)
 		}
@@ -2218,7 +2233,7 @@ func TestPutAutoLockPersistError(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, set, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"minutes":5}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/wallet/settings/auto-lock", body))
+	h.ServeHTTP(rec, localReq(http.MethodPut, "/wallet/settings/auto-lock", body))
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("PUT auto-lock with persist error = %d, want 500", rec.Code)
 	}
@@ -2264,7 +2279,7 @@ func TestContactsListReturnsEntries(t *testing.T) {
 	}}
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/contacts", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/contacts", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /wallet/contacts = %d, want 200", rec.Code)
 	}
@@ -2284,7 +2299,7 @@ func TestContactsListUngated(t *testing.T) {
 	cb := &fakeContacts{}
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/contacts", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/contacts", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /wallet/contacts while stopped = %d, want 200", rec.Code)
 	}
@@ -2295,7 +2310,7 @@ func TestContactsCreateGeneratesEntry(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"name":"Alice","address":"addr_test1alice","note":"friend"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/contacts", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/contacts", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /wallet/contacts = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
 	}
@@ -2316,7 +2331,7 @@ func TestContactsUpdateExistingByID(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"id":"c1","name":"Alice Updated","address":"addr_test1alice2"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/contacts", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/contacts", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST update = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
 	}
@@ -2334,7 +2349,7 @@ func TestContactsUpsertUnknownIDReturns404(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"id":"missing","name":"Ghost","address":"addr_test1ghost"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/contacts", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/contacts", body))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("POST with unknown id = %d, want 404 (body=%s)", rec.Code, rec.Body.String())
 	}
@@ -2345,7 +2360,7 @@ func TestContactsCreateValidationErrorReturns400(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"name":"","address":"addr_test1alice"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/contacts", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/contacts", body))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("POST with blank name = %d, want 400 (body=%s)", rec.Code, rec.Body.String())
 	}
@@ -2359,7 +2374,7 @@ func TestContactsCreateInvalidJSONReturns400(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{not json`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/contacts", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/contacts", body))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("POST with bad JSON = %d, want 400", rec.Code)
 	}
@@ -2369,7 +2384,7 @@ func TestContactsDeleteOK(t *testing.T) {
 	cb := &fakeContacts{entries: []contacts.Entry{{ID: "c1", Name: "Alice", Address: "addr_test1alice"}}}
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/wallet/contacts/c1", nil))
+	h.ServeHTTP(rec, localReq(http.MethodDelete, "/wallet/contacts/c1", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("DELETE /wallet/contacts/c1 = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
 	}
@@ -2382,7 +2397,7 @@ func TestContactsDeleteUnknownReturns404(t *testing.T) {
 	cb := &fakeContacts{}
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, cb, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodDelete, "/wallet/contacts/nope", nil))
+	h.ServeHTTP(rec, localReq(http.MethodDelete, "/wallet/contacts/nope", nil))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("DELETE unknown id = %d, want 404", rec.Code)
 	}
@@ -2407,7 +2422,7 @@ func TestAssetLookupOK(t *testing.T) {
 	}}
 	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lookup, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/assets/policy123746f6b656e", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/assets/policy123746f6b656e", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /wallet/assets/{unit} = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
@@ -2431,7 +2446,7 @@ func TestAssetLookupNotFound(t *testing.T) {
 	lookup := &fakeLookup{assetErr: chain.ErrNotFound}
 	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lookup, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/assets/policymissing", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/assets/policymissing", nil))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("GET /wallet/assets/{unit} (not found) = %d, want 404", rec.Code)
 	}
@@ -2440,7 +2455,7 @@ func TestAssetLookupNotFound(t *testing.T) {
 func TestAssetLookupUnavailableWhenNoLookup(t *testing.T) {
 	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/assets/policy123746f6b656e", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/assets/policy123746f6b656e", nil))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("GET /wallet/assets/{unit} with nil lookup = %d, want 503", rec.Code)
 	}
@@ -2451,7 +2466,7 @@ func TestAssetLookupGatedWhileStarting(t *testing.T) {
 	lookup := &fakeLookup{}
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lookup, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/assets/policy123746f6b656e", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/assets/policy123746f6b656e", nil))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("GET /wallet/assets/{unit} while starting = %d, want 503", rec.Code)
 	}
@@ -2462,7 +2477,7 @@ func TestPoolCredentialsReturnsCreds(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"spend-password"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/credentials", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/credentials", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /wallet/pool/credentials = %d, want 200", rec.Code)
 	}
@@ -2479,7 +2494,7 @@ func TestPoolCredentialsRejectsTrailingJSON(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"spend-password"} {"password":"ignored"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/credentials", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/credentials", body))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("credentials with trailing JSON = %d, want 400", rec.Code)
 	}
@@ -2493,7 +2508,7 @@ func TestPoolCredentialsNoWalletConflict(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"x"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/credentials", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/credentials", body))
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("credentials with no wallet = %d, want 409", rec.Code)
 	}
@@ -2504,7 +2519,7 @@ func TestPoolCredentialsWrongPassword401(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"bad"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/credentials", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/credentials", body))
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("credentials wrong password = %d, want 401", rec.Code)
 	}
@@ -2514,7 +2529,7 @@ func TestPoolKESPeriodGatedWhileStarting(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/pool/kes-period", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/pool/kes-period", nil))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("kes-period while starting = %d, want 503", rec.Code)
 	}
@@ -2524,7 +2539,7 @@ func TestPoolKESPeriodReady(t *testing.T) {
 	po := &fakePoolOps{kes: poolops.KESPeriodInfo{CurrentPeriod: 7, SlotsPerKESPeriod: 129600}}
 	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/pool/kes-period", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/pool/kes-period", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("kes-period ready = %d, want 200", rec.Code)
 	}
@@ -2542,7 +2557,7 @@ func TestPoolOpCertIssue(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","kes_index":0,"issue_number":3,"kes_period":7}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/opcert", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/opcert", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("opcert issue = %d, want 200", rec.Code)
 	}
@@ -2559,7 +2574,7 @@ func TestPoolOpCertRotate(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","new_kes_index":1,"prev_issue_number":3,"kes_period":7}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/opcert/rotate", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/opcert/rotate", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("opcert rotate = %d, want 200", rec.Code)
 	}
@@ -2584,7 +2599,7 @@ func TestPoolOpCertPayloadAndAssembleAirGap(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"kes_vkey_hex":"ab","issue_number":1,"kes_period":2}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/opcert/payload", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/opcert/payload", body))
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "8203") {
 		t.Fatalf("opcert payload = %d body %s", rec.Code, rec.Body.String())
 	}
@@ -2594,7 +2609,7 @@ func TestPoolOpCertPayloadAndAssembleAirGap(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	body = bytes.NewBufferString(`{"cold_vkey_hex":"aa","kes_vkey_hex":"bb","signature_hex":"cc","issue_number":1,"kes_period":2}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/opcert/assemble", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/opcert/assemble", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("opcert assemble = %d, want 200", rec.Code)
 	}
@@ -2608,7 +2623,7 @@ func TestPoolAssembleOpCertBadSignature400(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"cold_vkey_hex":"aa","kes_vkey_hex":"bb","signature_hex":"00","issue_number":1,"kes_period":2}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/opcert/assemble", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/opcert/assemble", body))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("assemble bad sig = %d, want 400", rec.Code)
 	}
@@ -2619,7 +2634,7 @@ func TestPoolMetadataBuilder(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"name":"P","ticker":"POOL","homepage":"https://x","description":"d"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/metadata", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/metadata", body))
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "deadbeef") {
 		t.Fatalf("metadata = %d body %s", rec.Code, rec.Body.String())
 	}
@@ -2634,7 +2649,7 @@ func TestPoolIDFromColdVKey(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"cold_vkey_hex":"` + strings.Repeat("ab", 32) + `"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/id", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/id", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("pool id status = %d, want 200; body: %s", rec.Code, rec.Body.String())
 	}
@@ -2656,7 +2671,7 @@ func TestPoolRegistrationSeedAndAirGap(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","pledge":1,"cost":1,"margin_num":1,"margin_denom":50}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/registration", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/registration", body))
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "pool1reg") {
 		t.Fatalf("registration seed = %d body %s", rec.Code, rec.Body.String())
 	}
@@ -2666,7 +2681,7 @@ func TestPoolRegistrationSeedAndAirGap(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	body = bytes.NewBufferString(`{"cold_vkey_hex":"ab","vrf_key_hash_hex":"cd","pledge":1,"cost":1,"margin_num":0,"margin_denom":1}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/registration/airgap", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/registration/airgap", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("registration airgap = %d, want 200", rec.Code)
 	}
@@ -2681,7 +2696,7 @@ func TestPoolRegistrationAcceptsStringAmounts(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","pledge":"9007199254740993","cost":"18446744073709551615","margin_num":1,"margin_denom":50}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/registration", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/registration", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("registration string amounts = %d body %s", rec.Code, rec.Body.String())
 	}
@@ -2695,7 +2710,7 @@ func TestPoolRetirementCert(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","epoch":500}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/retirement/cert", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/retirement/cert", body))
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "pool1ret") {
 		t.Fatalf("retirement cert = %d body %s", rec.Code, rec.Body.String())
 	}
@@ -2705,7 +2720,7 @@ func TestPoolRetirementCert(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	body = bytes.NewBufferString(`{"cold_vkey_hex":"ab","epoch":501}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/retirement/cert", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/retirement/cert", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("retirement airgap cert = %d, want 200", rec.Code)
 	}
@@ -2719,7 +2734,7 @@ func TestPoolRetirementSubmitGatedWhileSyncing(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","epoch":500}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/retirement/submit", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/retirement/submit", body))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("retirement submit while syncing = %d, want 503", rec.Code)
 	}
@@ -2730,7 +2745,7 @@ func TestPoolRetirementSubmitReady(t *testing.T) {
 	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","epoch":500}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/retirement/submit", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/retirement/submit", body))
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "feedface") {
 		t.Fatalf("retirement submit ready = %d body %s", rec.Code, rec.Body.String())
 	}
@@ -2744,7 +2759,7 @@ func TestPoolRetirementSubmitRejected422(t *testing.T) {
 	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"pw","epoch":500}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/pool/retirement/submit", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/pool/retirement/submit", body))
 	if rec.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("retirement submit rejected = %d, want 422", rec.Code)
 	}
@@ -2762,7 +2777,7 @@ func TestVaultUnlockAttachesPoolWallet(t *testing.T) {
 	}
 	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, po, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/vault/unlock", bytes.NewBufferString(`{"password":"valid-vault-password"}`)))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /vault/unlock = %d, want 200", rec.Code)
 	}
@@ -2782,7 +2797,7 @@ func TestTPMStatusReturnsProbeResult(t *testing.T) {
 	}}
 	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/tpm/status", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/vault/tpm/status", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /vault/tpm/status = %d, want 200", rec.Code)
 	}
@@ -2804,7 +2819,7 @@ func TestTPMStatusReturnsUnavailableWithReason(t *testing.T) {
 	}}
 	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/tpm/status", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/vault/tpm/status", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /vault/tpm/status = %d, want 200", rec.Code)
 	}
@@ -2825,7 +2840,7 @@ func TestTPMStatusReturnsEnabledAndPCRBound(t *testing.T) {
 	}}
 	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/vault/tpm/status", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/vault/tpm/status", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /vault/tpm/status = %d, want 200", rec.Code)
 	}
@@ -2843,7 +2858,7 @@ func TestEnableTPMCallsVaultMethodWithPassword(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-vault-password","pcrBound":true}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/enable", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/vault/tpm/enable", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /vault/tpm/enable = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
@@ -2863,7 +2878,7 @@ func TestEnableTPMWithoutPCRBound(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-vault-password"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/enable", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/vault/tpm/enable", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /vault/tpm/enable no pcrBound = %d, want 200", rec.Code)
 	}
@@ -2880,7 +2895,7 @@ func TestEnableTPMWrongPasswordReturns401(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"wrong-but-long-password"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/enable", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/vault/tpm/enable", body))
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("POST /vault/tpm/enable wrong password = %d, want 401", rec.Code)
 	}
@@ -2894,7 +2909,7 @@ func TestEnableTPMUnavailableReturns409(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-vault-password"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/enable", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/vault/tpm/enable", body))
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("POST /vault/tpm/enable unavailable = %d, want 409", rec.Code)
 	}
@@ -2907,7 +2922,7 @@ func TestEnableTPMRequiresPassword(t *testing.T) {
 		fv := &fakeVault{tpmStatus: vault.TPMStatusInfo{Available: true}}
 		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/enable", bytes.NewBufferString(body)))
+		h.ServeHTTP(rec, localReq(http.MethodPost, "/vault/tpm/enable", bytes.NewBufferString(body)))
 		if rec.Code != http.StatusBadRequest {
 			t.Fatalf("POST /vault/tpm/enable body %s = %d, want 400", body, rec.Code)
 		}
@@ -2922,7 +2937,7 @@ func TestDisableTPMCallsVaultMethodWithPassword(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"valid-vault-password"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/disable", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/vault/tpm/disable", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /vault/tpm/disable = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
@@ -2939,7 +2954,7 @@ func TestDisableTPMWrongPasswordReturns401(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"password":"wrong-but-long-password"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/disable", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/vault/tpm/disable", body))
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("POST /vault/tpm/disable wrong password = %d, want 401", rec.Code)
 	}
@@ -2952,7 +2967,7 @@ func TestDisableTPMRequiresPassword(t *testing.T) {
 		fv := &fakeVault{}
 		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/vault/tpm/disable", bytes.NewBufferString(body)))
+		h.ServeHTTP(rec, localReq(http.MethodPost, "/vault/tpm/disable", bytes.NewBufferString(body)))
 		if rec.Code != http.StatusBadRequest {
 			t.Fatalf("POST /vault/tpm/disable body %s = %d, want 400", body, rec.Code)
 		}
@@ -2971,7 +2986,7 @@ func TestTPMRoutesRejectTrailingJSON(t *testing.T) {
 		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
 		body := bytes.NewBufferString(`{"password":"valid-vault-password"}{"junk":true}`)
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, route, body))
+		h.ServeHTTP(rec, localReq(http.MethodPost, route, body))
 		if rec.Code != http.StatusBadRequest {
 			t.Fatalf("POST %s with trailing JSON = %d, want 400", route, rec.Code)
 		}
@@ -3014,7 +3029,7 @@ func (f *fakeNodeLookup) Asset(_ context.Context, _ string) (chain.AssetInfo, er
 func TestHandleLookupUnavailableWithoutLookup(t *testing.T) {
 	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/chris", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/handle/chris", nil))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("GET /wallet/handle/chris with no lookup = %d, want 503", rec.Code)
 	}
@@ -3024,7 +3039,7 @@ func TestHandleLookupResolvesOnMainnet(t *testing.T) {
 	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr1abc", Quantity: "1"}}}
 	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /wallet/handle/$chris = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
@@ -3045,7 +3060,7 @@ func TestHandleLookupResolvesOnPreview(t *testing.T) {
 	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr_test1abc", Quantity: "1"}}}
 	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /wallet/handle/$chris on preview = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
@@ -3066,7 +3081,7 @@ func TestHandleLookupWithoutDollarSign(t *testing.T) {
 	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr1abc"}}}
 	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/chris", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/handle/chris", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /wallet/handle/chris = %d, want 200", rec.Code)
 	}
@@ -3076,7 +3091,7 @@ func TestHandleLookupNotFoundOnInvalidNetwork(t *testing.T) {
 	lk := &fakeNodeLookup{assetAddrs: []chain.AssetAddress{{Address: "addr1abc"}}}
 	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, &fakeMultiSig{}, "mainnte", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("GET /wallet/handle/$chris on invalid network = %d, want 404: %s", rec.Code, rec.Body.String())
 	}
@@ -3089,7 +3104,7 @@ func TestHandleLookupNotFoundWhenNodeHasNotSeenAsset(t *testing.T) {
 	lk := &fakeNodeLookup{assetErr: chain.ErrNotFound}
 	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("GET /wallet/handle/$chris unseen asset = %d, want 404", rec.Code)
 	}
@@ -3099,7 +3114,7 @@ func TestHandleLookupBadGatewayOnHardError(t *testing.T) {
 	lk := &fakeNodeLookup{assetErr: errors.New("node exploded")}
 	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("GET /wallet/handle/$chris hard error = %d, want 502", rec.Code)
 	}
@@ -3110,7 +3125,7 @@ func TestHandleLookupGatedWhileStarting(t *testing.T) {
 	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateStarting}}
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lk, &fakePoolOps{}, nil, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/handle/$chris", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/handle/$chris", nil))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("GET /wallet/handle/$chris while starting = %d, want 503", rec.Code)
 	}
@@ -3123,14 +3138,14 @@ func TestDexRoutesAbsentWhenQuoterNil(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/dex/pools", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/dex/pools", nil))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("GET /wallet/dex/pools with nil quoter = %d, want 404", rec.Code)
 	}
 
 	rec = httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"asset_in":"lovelace","asset_out":"dead","amount_in":"1000000"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/dex/quote", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/dex/quote", body))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("POST /wallet/dex/quote with nil quoter = %d, want 404", rec.Code)
 	}
@@ -3143,7 +3158,7 @@ func TestDexPoolsReturnsOK(t *testing.T) {
 	h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/dex/pools", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/dex/pools", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /wallet/dex/pools = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
@@ -3166,7 +3181,7 @@ func TestDexPoolsRequiresReadyNode(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/dex/pools", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/dex/pools", nil))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("GET /wallet/dex/pools while starting = %d, want 503", rec.Code)
 	}
@@ -3181,7 +3196,7 @@ func TestDexQuoteReturnsOK(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"asset_in":"lovelace","asset_out":"deadbeef","amount_in":"1000000"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/dex/quote", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/dex/quote", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /wallet/dex/quote = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
@@ -3204,7 +3219,7 @@ func TestDexQuoteInvalidAmountReturns400(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"asset_in":"lovelace","asset_out":"deadbeef","amount_in":"not-a-number"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/dex/quote", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/dex/quote", body))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("POST /wallet/dex/quote with bad amount_in = %d, want 400", rec.Code)
 	}
@@ -3219,7 +3234,7 @@ func TestDexQuoteRejectsTrailingJSON(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"asset_in":"lovelace","asset_out":"deadbeef","amount_in":"1000000"}{"junk":true}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/dex/quote", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/dex/quote", body))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("POST /wallet/dex/quote with trailing JSON = %d, want 400", rec.Code)
 	}
@@ -3247,7 +3262,7 @@ func TestDexQuoteErrorMapping(t *testing.T) {
 			h := NewHandler(fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, dx, &fakeMultiSig{}, "mainnet", http.NotFoundHandler())
 			rec := httptest.NewRecorder()
 			body := bytes.NewBufferString(`{"asset_in":"lovelace","asset_out":"deadbeef","amount_in":"1000000"}`)
-			h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/dex/quote", body))
+			h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/dex/quote", body))
 			if rec.Code != tc.want {
 				t.Fatalf("POST /wallet/dex/quote with %s = %d, want %d: %s", tc.name, rec.Code, tc.want, rec.Body.String())
 			}
@@ -3267,7 +3282,7 @@ func TestHardwareWalletRoute(t *testing.T) {
 
 		body := `{"name":"Ledger","account_xpub":"acct_xvk1test","account_index":7,"network":"preview","vault_password":"valid-vault-password"}`
 		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
+		h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
 		if rec.Code != http.StatusOK {
 			t.Fatalf("POST /wallet/hardware = %d, want 200: %s", rec.Code, rec.Body.String())
 		}
@@ -3300,7 +3315,7 @@ func TestHardwareWalletRoute(t *testing.T) {
 		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
 		body := `{"name":"Ledger","account_xpub":"acct_xvk1test","account_index":2147483648,"network":"preview","vault_password":"valid-vault-password"}`
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
+		h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
 		if rec.Code != http.StatusBadRequest {
 			t.Fatalf("hardened account index = %d, want 400", rec.Code)
 		}
@@ -3313,7 +3328,7 @@ func TestHardwareWalletRoute(t *testing.T) {
 		fv := &fakeVault{exists: true, locked: false}
 		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(`{bad json`)))
+		h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(`{bad json`)))
 		if rec.Code != http.StatusBadRequest {
 			t.Fatalf("malformed JSON = %d, want 400", rec.Code)
 		}
@@ -3327,7 +3342,7 @@ func TestHardwareWalletRoute(t *testing.T) {
 		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
 		body := `{"name":"Ledger","account_xpub":"","network":"preview","vault_password":"valid-vault-password"}`
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
+		h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
 		if rec.Code != http.StatusBadRequest {
 			t.Fatalf("empty xpub = %d, want 400", rec.Code)
 		}
@@ -3338,7 +3353,7 @@ func TestHardwareWalletRoute(t *testing.T) {
 		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
 		body := `{"name":"","account_xpub":"acct_xvk1test","network":"preview","vault_password":"valid-vault-password"}`
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
+		h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
 		if rec.Code != http.StatusBadRequest {
 			t.Fatalf("empty name = %d, want 400", rec.Code)
 		}
@@ -3349,7 +3364,7 @@ func TestHardwareWalletRoute(t *testing.T) {
 		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
 		body := `{"name":"Ledger","account_xpub":"acct_xvk1test","network":"preview"}`
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
+		h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
 		if rec.Code != http.StatusBadRequest {
 			t.Fatalf("missing vault_password = %d, want 400", rec.Code)
 		}
@@ -3360,7 +3375,7 @@ func TestHardwareWalletRoute(t *testing.T) {
 		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
 		body := `{"name":"Ledger","account_xpub":"acct_xvk1test","network":"preview","vault_password":"valid-vault-password"}`
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
+		h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
 		if rec.Code != http.StatusConflict {
 			t.Fatalf("duplicate hardware wallet = %d, want 409", rec.Code)
 		}
@@ -3371,7 +3386,7 @@ func TestHardwareWalletRoute(t *testing.T) {
 		h := NewHandler(fakeStatuser{}, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 		rec := httptest.NewRecorder()
 		body := `{"name":"Ledger","account_xpub":"acct_xvk1test","network":"mainnet","vault_password":"valid-vault-password"}`
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
+		h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/hardware", bytes.NewBufferString(body)))
 		if rec.Code != http.StatusBadRequest {
 			t.Fatalf("network mismatch = %d, want 400", rec.Code)
 		}
@@ -3397,7 +3412,7 @@ func TestHardwareSignRequestRoute(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/wallet/send/pending-123/hardware-sign-request", nil))
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/send/pending-123/hardware-sign-request", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /hardware-sign-request = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
@@ -3429,7 +3444,7 @@ func TestSubmitHardwareRoute(t *testing.T) {
 
 	body := `{"witness_cbor":"81825820"}`
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/send/pending-123/submit-hardware",
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/send/pending-123/submit-hardware",
 		strings.NewReader(body)))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST /submit-hardware = %d, want 200: %s", rec.Code, rec.Body.String())
@@ -3443,5 +3458,87 @@ func TestSubmitHardwareRoute(t *testing.T) {
 	}
 	if sp.gotSubmitTx != "84a400deadbeef" || sp.gotSubmitWit != "81825820" {
 		t.Fatalf("SubmitSigned called with wrong args: tx=%q wit=%q", sp.gotSubmitTx, sp.gotSubmitWit)
+	}
+}
+
+// TestSameOriginGuard exercises the mux-level same-origin / DNS-rebind guard
+// (sameOriginGuard) that wraps the handler returned by NewHandler. It covers the
+// non-connector /vault and /wallet routes: same-origin reads are allowed,
+// cross-origin and DNS-rebound Hosts are rejected, and state-changing methods
+// additionally require a present, matching Origin.
+func TestSameOriginGuard(t *testing.T) {
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+
+	const noOrigin = "\x00" // sentinel: do not set an Origin header at all
+
+	cases := []struct {
+		name     string
+		method   string
+		target   string
+		host     string
+		origin   string
+		wantCode int
+	}{
+		// --- Same-origin GET (reads) ---
+		{"same-origin GET", http.MethodGet, "/vault/status", "127.0.0.1:8090", "http://127.0.0.1:8090", http.StatusOK},
+		{"same-origin GET no Origin header", http.MethodGet, "/vault/status", "127.0.0.1:8090", noOrigin, http.StatusOK},
+		{"dev-proxy GET (localhost)", http.MethodGet, "/vault/status", "localhost:5173", "http://localhost:5173", http.StatusOK},
+		{"cross-origin GET rejected", http.MethodGet, "/vault/status", "127.0.0.1:8090", "http://evil.com", http.StatusForbidden},
+		{"DNS-rebind GET rejected", http.MethodGet, "/vault/status", "evil.com:8090", "http://evil.com:8090", http.StatusForbidden},
+		{"DNS-rebind GET no Origin rejected", http.MethodGet, "/vault/status", "evil.com", noOrigin, http.StatusForbidden},
+
+		// --- State-changing methods require a present, matching Origin ---
+		{"same-origin POST", http.MethodPost, "/vault/lock", "127.0.0.1:8090", "http://127.0.0.1:8090", http.StatusOK},
+		{"dev-proxy POST (localhost)", http.MethodPost, "/vault/lock", "localhost:5173", "http://localhost:5173", http.StatusOK},
+		{"POST without Origin rejected", http.MethodPost, "/vault/lock", "127.0.0.1:8090", noOrigin, http.StatusForbidden},
+		{"cross-origin POST rejected", http.MethodPost, "/vault/lock", "127.0.0.1:8090", "http://evil.com", http.StatusForbidden},
+		{"DNS-rebind POST rejected", http.MethodPost, "/vault/lock", "evil.com:8090", "http://evil.com:8090", http.StatusForbidden},
+
+		// DELETE is state-changing too. Allowed → reaches the handler, which
+		// reports 404 for the unknown contact (proving it passed the guard);
+		// rejected → 403 from the guard before the handler runs.
+		{"same-origin DELETE reaches handler", http.MethodDelete, "/wallet/contacts/nope", "127.0.0.1:8090", "http://127.0.0.1:8090", http.StatusNotFound},
+		{"DELETE without Origin rejected", http.MethodDelete, "/wallet/contacts/nope", "127.0.0.1:8090", noOrigin, http.StatusForbidden},
+		{"DNS-rebind DELETE rejected", http.MethodDelete, "/wallet/contacts/nope", "evil.com:8090", "http://evil.com:8090", http.StatusForbidden},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.target, nil)
+			req.Host = tc.host
+			if tc.origin != noOrigin {
+				req.Header.Set("Origin", tc.origin)
+			}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != tc.wantCode {
+				t.Fatalf("%s %s host=%q origin=%q: status = %d, want %d (body: %s)",
+					tc.method, tc.target, tc.host, tc.origin, rec.Code, tc.wantCode, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestSameOriginGuardSkipsConnector verifies the mux-level guard does NOT
+// re-guard the /connector/* routes: they carry their own auth (bearer token /
+// in-handler same-origin) and an extension request legitimately presents a
+// chrome-extension:// Origin that would fail strictSameOrigin. A POST to the
+// token-exempt /connector/pair route with such an Origin must reach the
+// connector handler (202 pending) rather than being rejected 403 by the guard.
+func TestSameOriginGuardSkipsConnector(t *testing.T) {
+	svc := connector.NewService(t.TempDir(), &fakeConnectorBackend{}, nil)
+	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler(), WithConnector(svc))
+
+	req := httptest.NewRequest(http.MethodPost, "/connector/pair", strings.NewReader(`{"extension_id":"chrome-extension://guardtest"}`))
+	req.Host = "127.0.0.1:8090"
+	req.Header.Set("Origin", "chrome-extension://guardtest")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("guard rejected a /connector/ route it must skip: %d (%s)", rec.Code, rec.Body.String())
+	}
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("POST /connector/pair (initiate) = %d, want 202 (%s)", rec.Code, rec.Body.String())
 	}
 }

--- a/ui/internal/api/importtx_test.go
+++ b/ui/internal/api/importtx_test.go
@@ -100,7 +100,7 @@ func TestDecodeTxHandler_OK(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"tx_cbor":"84a4..."}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/decode-tx", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/decode-tx", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("decode-tx status = %d, body=%s", rec.Code, rec.Body.String())
 	}
@@ -118,7 +118,7 @@ func TestDecodeTxHandler_MultiSigKind(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, ms, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"tx_cbor":"84a4..."}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/decode-tx", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/decode-tx", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("decode-tx status = %d, body=%s", rec.Code, rec.Body.String())
 	}
@@ -137,7 +137,7 @@ func TestDecodeTxHandler_InvalidJSON(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`not json`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/decode-tx", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/decode-tx", body))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("decode-tx invalid json = %d, want 400", rec.Code)
 	}
@@ -150,7 +150,7 @@ func TestCosignTxHandler_InvalidTxIs400(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"tx_cbor":"zz","password":"p"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/cosign-tx", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/cosign-tx", body))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("cosign-tx status = %d, want 400, body=%s", rec.Code, rec.Body.String())
 	}
@@ -161,7 +161,7 @@ func TestCosignTxHandler_OK_DefaultsPartialSignTrue(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"tx_cbor":"84a4...","password":"pw"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/cosign-tx", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/cosign-tx", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("cosign-tx status = %d, body=%s", rec.Code, rec.Body.String())
 	}
@@ -181,7 +181,7 @@ func TestCosignTxHandler_PartialSignFalseIsHonored(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"tx_cbor":"84a4...","password":"pw","partial_sign":false}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/cosign-tx", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/cosign-tx", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("cosign-tx status = %d, body=%s", rec.Code, rec.Body.String())
 	}
@@ -198,7 +198,7 @@ func TestCosignTxHandler_RoutesMultiSig(t *testing.T) {
 	h := NewHandler(fakeStatuser{}, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, ms, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"tx_cbor":"84a4...","password":"p"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/cosign-tx", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/cosign-tx", body))
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "84beef") {
 		t.Fatalf("multisig cosign not routed: %d %s", rec.Code, rec.Body.String())
 	}
@@ -211,7 +211,7 @@ func TestSubmitTxHandler_RequiresReady(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"tx_cbor":"84a4..."}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-tx", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/submit-tx", body))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("submit-tx while syncing = %d, want 503, body=%s", rec.Code, rec.Body.String())
 	}
@@ -223,7 +223,7 @@ func TestSubmitTxHandler_ReturnsTxHash(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"tx_cbor":"84a4..."}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-tx", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/submit-tx", body))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("submit-tx = %d, body=%s", rec.Code, rec.Body.String())
 	}
@@ -241,7 +241,7 @@ func TestSubmitTxHandler_InvalidTxIs400(t *testing.T) {
 	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, sp, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"tx_cbor":"zz"}`)
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/wallet/submit-tx", body))
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet/submit-tx", body))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("submit-tx invalid tx = %d, want 400, body=%s", rec.Code, rec.Body.String())
 	}


### PR DESCRIPTION
## What

The `/vault/*` and `/wallet/*` routes register directly on the mux in `ui/internal/api/api.go` with no origin check. Because the control surface listens on loopback, a malicious web page can reach them via DNS rebinding (resolving its own hostname to `127.0.0.1`, so the browser sends the request with a public `Host` header). Only the connector routes were previously hardened. `GET /vault/status` leaks state and the `POST`/`DELETE` routes (lock/unlock/add/delete wallet, send) are worse.

This wraps the mux returned by `NewHandler` in a `sameOriginGuard` middleware that reuses the existing connector helpers (`isLoopbackHost` / `sameOrigin` / `strictSameOrigin`) verbatim:

- Every guarded request must arrive over a loopback `Host`.
- State-changing methods (`POST`/`PUT`/`DELETE`/`PATCH`) require `strictSameOrigin` — an `Origin` header present and matching the server's own scheme+host.
- `GET`/`HEAD` use `sameOrigin`, which also accepts the absent-`Origin` case that same-origin browser GETs produce, but only over a loopback `Host`.

The `/connector/*` routes are skipped so their own guards (bearer token for extension-facing routes; in-handler same-origin for SPA-facing routes) keep working — an extension request legitimately carries a `chrome-extension://` Origin that would otherwise fail `strictSameOrigin`.

The SPA's own calls still pass in both prod (served from `127.0.0.1:8090`, same origin as its fetches) and dev (the vite proxy forwards to the backend preserving the browser's loopback `Host`/`Origin`).

## Tests

- `TestSameOriginGuard`: table-driven — same-origin GET allowed; no-Origin GET allowed over loopback; dev-proxy `localhost` allowed; cross-origin and DNS-rebound `Host` GETs rejected; state-changing POST/DELETE require a present, matching Origin (rejected without it, allowed with it).
- `TestSameOriginGuardSkipsConnector`: a `chrome-extension://` POST to `/connector/pair` reaches the connector handler (202) instead of being rejected by the mux guard.
- Existing api route tests now route through a loopback `localReq` helper, so the whole suite also exercises the guard's allow-path.

## Verify

`cd ui && go build ./cmd/... ./internal/... && go vet ./cmd/... ./internal/... && go test ./cmd/... ./internal/...` — all green (20 packages, exit 0).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a same-origin/DNS-rebind guard to the `/vault/*` and `/wallet/*` API routes by wrapping the mux from `NewHandler`. Blocks cross-origin access and requires a loopback `Host`, while keeping SPA and extension flows working.

- **Bug Fixes**
  - Wrap API mux in `sameOriginGuard`; skip `/connector/*` so bearer tokens and `chrome-extension://` Origins continue to work.
  - Require loopback `Host`. Use `strictSameOrigin` for mutating methods; `sameOrigin` for `GET`/`HEAD`.
  - Add table-driven guard tests + `localReq` helper.
  - Route import-tx and NFT handler tests through `localReq` (loopback `Host` + matching `Origin`).
  - SPA calls still pass in prod (`127.0.0.1:8090`) and dev (vite proxy).

<sup>Written for commit c9e42825dd7fbd48859dc9ecf62e00df300a942e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added same-origin protections for API requests.
  * Restricted non-connector requests to loopback hosts.
  * Added stricter origin validation for state-changing actions.
  * Preserved dedicated protections for connector endpoints.

* **Tests**
  * Added coverage for same-origin, cross-origin, DNS-rebinding, and connector scenarios.
  * Updated API request tests to use valid local origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->