### PR TITLE
feat(ui): Keystone hardware wallet (air-gapped QR + USB)

### DIFF
--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -180,11 +180,42 @@ const feePaddingLovelace = 1000
 // pending holds a completed but unsigned tx while awaiting Confirm.
 type pending struct {
 	tx        *apollo.Apollo
-	utxoAddr  map[string]string // "txhash#index" → bech32 address (for signing)
+	utxoAddr  map[string]string       // "txhash#index" → bech32 address (for signing)
+	utxoValue map[string]hwInputValue // "txhash#index" → resolved input value (hardware display); nil for cert txs
 	created   time.Time
 	walletID  string
 	account   *wallet.Account
 	certKinds []CertKind // non-nil for delegation txs; drives stake/DRep witness addition at Confirm
+}
+
+// hwInputValue is a resolved input UTxO's value, retained at build time so the
+// hardware sign request can show each input's amount (+ native assets) on the
+// device. A Cardano input references only (txid, index) — its value is NOT in
+// the tx body — so an air-gapped signer (Keystone QR) cannot display the inputs
+// or compute the fee without it being supplied out of band.
+type hwInputValue struct {
+	lovelace uint64
+	assets   []HWAsset
+}
+
+// hwInputValueOf resolves a loaded UTxO into its lovelace + native-asset value.
+func hwInputValueOf(u lcommon.Utxo) hwInputValue {
+	v := hwInputValue{lovelace: u.Output.Amount().Uint64()}
+	if ma := u.Output.Assets(); ma != nil {
+		for _, pol := range ma.Policies() {
+			for _, name := range ma.Assets(pol) {
+				qty := ma.Asset(pol, name)
+				if qty != nil && qty.Sign() > 0 {
+					v.assets = append(v.assets, HWAsset{
+						PolicyIDHex:  hex.EncodeToString(pol.Bytes()),
+						AssetNameHex: hex.EncodeToString(name),
+						Amount:       qty.String(),
+					})
+				}
+			}
+		}
+	}
+	return v
 }
 
 // Service builds and holds pending send transactions.
@@ -315,6 +346,7 @@ func (s *Service) Build(ctx context.Context, req SendRequest) (Preview, error) {
 	// later signing. We pre-load them so Apollo's coin selection can see them
 	// without needing a live chain query inside Complete().
 	utxoAddr := make(map[string]string)
+	utxoValue := make(map[string]hwInputValue)
 	var loaded []lcommon.Utxo
 	for _, addrStr := range acct.ReceiveAddresses {
 		addr, err := lcommon.NewAddress(addrStr)
@@ -328,7 +360,9 @@ func (s *Service) Build(ctx context.Context, req SendRequest) (Preview, error) {
 		if len(utxos) > 0 {
 			loaded = append(loaded, utxos...)
 			for _, u := range utxos {
-				utxoAddr[makeUtxoRef(u)] = addrStr
+				ref := makeUtxoRef(u)
+				utxoAddr[ref] = addrStr
+				utxoValue[ref] = hwInputValueOf(u)
 			}
 		}
 	}
@@ -398,11 +432,12 @@ func (s *Service) Build(ctx context.Context, req SendRequest) (Preview, error) {
 	}
 	s.sweepExpiredLocked()
 	s.pending[id] = &pending{
-		tx:       a,
-		utxoAddr: utxoAddr,
-		created:  s.now(),
-		walletID: walletID,
-		account:  cloneAccount(acct),
+		tx:        a,
+		utxoAddr:  utxoAddr,
+		utxoValue: utxoValue,
+		created:   s.now(),
+		walletID:  walletID,
+		account:   cloneAccount(acct),
 	}
 	s.mu.Unlock()
 
@@ -2300,6 +2335,17 @@ type HWInput struct {
 	// Path is the CIP-1852 derivation path ("1852'/1815'/0'/0/3") for the
 	// payment key that must sign this input, or "" if the input is not ours.
 	Path string `json:"path,omitempty"`
+	// Lovelace is the input UTxO's ADA value (decimal string), resolved from the
+	// coin-selection inputs at build time. A Cardano input references only
+	// (txid, index), so an air-gapped signer (Keystone QR) needs this to display
+	// the inputs and compute the fee on-device. Empty when the value is unknown.
+	Lovelace string `json:"lovelace,omitempty"`
+	// AddressBech32 is the input UTxO's address, for on-device display.
+	AddressBech32 string `json:"address_bech32,omitempty"`
+	// Assets are the input UTxO's native assets (informational; the Keystone UTxO
+	// registry carries lovelace + address only, so these are display metadata for
+	// devices that can use them). Empty for ADA-only inputs.
+	Assets []HWAsset `json:"assets,omitempty"`
 }
 
 // HWOutput is one transaction output in the hardware sign request.
@@ -2479,9 +2525,16 @@ func (s *Service) HardwareSignRequest(pendingID string) (HardwareSignRequest, er
 		}
 		addrStr, found := p.utxoAddr[ref]
 		if found {
+			hwInp.AddressBech32 = addrStr
 			if idx, owned := idxOf[addrStr]; owned {
 				hwInp.Path = fmt.Sprintf("1852'/%d'/%d'/0/%d", 1815, accountNum, idx)
 			}
+		}
+		// Per-input amount + assets, resolved from coin-selection at build time.
+		// The air-gapped device shows these and derives the fee from them.
+		if val, ok := p.utxoValue[ref]; ok {
+			hwInp.Lovelace = strconv.FormatUint(val.lovelace, 10)
+			hwInp.Assets = val.assets
 		}
 		inputs = append(inputs, hwInp)
 	}

--- a/ui/internal/spend/spend_test.go
+++ b/ui/internal/spend/spend_test.go
@@ -1909,6 +1909,18 @@ func TestHardwareSignRequest(t *testing.T) {
 				t.Fatalf("unexpected path %q for index 0 payment key", inp.Path)
 			}
 		}
+		// Each owned input must carry its resolved value + address so an
+		// air-gapped signer can display the inputs and compute the fee. The
+		// single fake UTxO holds 10_000_000 lovelace at addr0.
+		if inp.Lovelace != "10000000" {
+			t.Fatalf("input Lovelace = %q, want 10000000 (resolved from coin selection)", inp.Lovelace)
+		}
+		if inp.AddressBech32 != addr0 {
+			t.Fatalf("input AddressBech32 = %q, want %q", inp.AddressBech32, addr0)
+		}
+		if len(inp.Assets) != 0 {
+			t.Fatalf("ADA-only input must carry no assets, got %+v", inp.Assets)
+		}
 	}
 	if !hasPath {
 		t.Fatal("at least one input should have a derivation path")

--- a/ui/web/package-lock.json
+++ b/ui/web/package-lock.json
@@ -7,8 +7,14 @@
       "name": "bursa-wallet-ui",
       "dependencies": {
         "@cardano-foundation/ledgerjs-hw-app-cardano": "^7.1.4",
+        "@keystonehq/bc-ur-registry-cardano": "^0.5.0",
+        "@keystonehq/hw-app-ada": "^0.1.1",
+        "@keystonehq/hw-transport-webusb": "^0.5.2",
         "@ledgerhq/hw-transport-webhid": "^6.35.4",
+        "@ngraveio/bc-ur": "^1.1.13",
         "@trezor/connect-web": "^9.7.3",
+        "@zxing/browser": "^0.1.5",
+        "@zxing/library": "^0.21.0",
         "bech32": "^1.1.4",
         "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
@@ -27,6 +33,8 @@
         "typescript": "^5.5.0",
         "typescript-eslint": "^8.0.0",
         "vite": "^6.0.0",
+        "vite-plugin-top-level-await": "^1.6.0",
+        "vite-plugin-wasm": "^3.6.0",
         "vitest": "^3.0.0"
       }
     },
@@ -1329,6 +1337,152 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keystonehq/alias-sampling": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@keystonehq/alias-sampling/-/alias-sampling-0.1.2.tgz",
+      "integrity": "sha512-5ukLB3bcgltgaFfQfYKYwHDUbwHicekYo53fSEa7xhVkAEqsA74kxdIwoBIURmGUtXe3EVIRm4SYlgcrt2Ri0w==",
+      "license": "MIT"
+    },
+    "node_modules/@keystonehq/bc-ur-registry": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.6.4.tgz",
+      "integrity": "sha512-j8Uy44DuAkvYkbf0jMxRY3UizJfn8wsEQr7GS3miRF44vcq7k0/yemVkftbn3jQ+0JYaUXf5wY7lVpLhAeW5nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ngraveio/bc-ur": "^1.1.5",
+        "bs58check": "^2.1.2",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry-cardano": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-cardano/-/bc-ur-registry-cardano-0.5.0.tgz",
+      "integrity": "sha512-/95c2HkIGPCOfVrawIVGRZDNePxLH94Po9iC91GjV2uo7xuXhicg42IO4CDj6yBh0je9HQ0UoOMErwxyU3jNFg==",
+      "license": "ISC",
+      "dependencies": {
+        "@keystonehq/bc-ur-registry": "^0.6.4",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@keystonehq/bc-ur-registry/node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/@keystonehq/hw-app-ada": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@keystonehq/hw-app-ada/-/hw-app-ada-0.1.1.tgz",
+      "integrity": "sha512-1Xey7HZhoRMGXQeAnR9dRpEq5Q5URzEiTeAOMmUmdqGbVMJNEgTUzNlSA9S6Qtw4rU/E24vokmrJW1Nv43+ZqQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@emurgo/cardano-serialization-lib-browser": "^13.2.0",
+        "@emurgo/cardano-serialization-lib-nodejs": "^13.1.0",
+        "@keystonehq/bc-ur-registry": "0.7.0",
+        "@keystonehq/bc-ur-registry-cardano": "^0.5.0",
+        "@keystonehq/hw-transport-error": "^0.0.2",
+        "@keystonehq/hw-transport-usb": "^0.1.1",
+        "@ngraveio/bc-ur": "^1.1.6",
+        "base-x": "^5.0.0",
+        "bech32": "^1.1.4",
+        "blakejs": "^1.2.1",
+        "cardano-hw-interop-lib": "^3.0.1",
+        "cbor": "^10.0.3",
+        "int64-buffer": "^1.0.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@keystonehq/hw-app-ada/node_modules/@keystonehq/bc-ur-registry": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.7.0.tgz",
+      "integrity": "sha512-E6NUd6Y+YYM+IcYGOEXfO9+MU1s63Qjm8brtHftvNhxbdXhGtTYIsa4FQmqZ6q34q91bMkMqUQFsQYPmIxcxfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ngraveio/bc-ur": "^1.1.5",
+        "bs58check": "^2.1.2",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@keystonehq/hw-app-ada/node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
+    "node_modules/@keystonehq/hw-app-ada/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@keystonehq/hw-app-ada/node_modules/bs58/node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@keystonehq/hw-app-ada/node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/@keystonehq/hw-transport-error": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@keystonehq/hw-transport-error/-/hw-transport-error-0.0.2.tgz",
+      "integrity": "sha512-j6rOJU277Cmq9oBiFjtVHJhUZ/gELGYGZMUXBlAom1WyK8pNrD3+I8kCVGp5Ss5oB+Zqo7Az5xCx/z+0i+Y40A==",
+      "license": "ISC"
+    },
+    "node_modules/@keystonehq/hw-transport-usb": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@keystonehq/hw-transport-usb/-/hw-transport-usb-0.1.3.tgz",
+      "integrity": "sha512-jB1WHb2b+OVxLqoQgtEeWblI/noTimBTXaLrm3/azCftK4Pk4dOhH8cY8zoyqMfkkApRTUhtCNiYZLU2fxCMPg==",
+      "license": "ISC",
+      "dependencies": {
+        "@keystonehq/hw-transport-error": "^0.0.2",
+        "@types/w3c-web-usb": "^1.0.10",
+        "buffer": "^6.0.3"
+      }
+    },
+    "node_modules/@keystonehq/hw-transport-webusb": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@keystonehq/hw-transport-webusb/-/hw-transport-webusb-0.5.2.tgz",
+      "integrity": "sha512-EM31TMFMtrbwJHJOJiIK0yTwhmh8KJERko/QlT8HYvmqyxpe4+cx7TNSLoa1wVGEoe530GpcF7ZKHCwvgvD82Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@keystonehq/hw-transport-error": "^0.0.2",
+        "@keystonehq/hw-transport-usb": "^0.1.3",
+        "buffer": "^6.0.3"
+      }
+    },
     "node_modules/@ledgerhq/devices": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.17.0.tgz",
@@ -1426,6 +1580,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.*"
+      }
+    },
+    "node_modules/@ngraveio/bc-ur": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@ngraveio/bc-ur/-/bc-ur-1.1.13.tgz",
+      "integrity": "sha512-j73akJMV4+vLR2yQ4AphPIT5HZmxVjn/LxpL7YHoINnXoH6ccc90Zzck6/n6a3bCXOVZwBxq+YHwbAKRV+P8Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@keystonehq/alias-sampling": "^0.1.1",
+        "assert": "^2.0.0",
+        "bignumber.js": "^9.0.1",
+        "cbor-sync": "^1.0.4",
+        "crc": "^3.8.0",
+        "jsbi": "^3.1.5",
+        "sha.js": "^2.4.11"
       }
     },
     "node_modules/@noble/curves": {
@@ -1547,6 +1716,24 @@
       "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@rollup/plugin-virtual": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-virtual/-/plugin-virtual-3.0.2.tgz",
+      "integrity": "sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
@@ -2736,6 +2923,275 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@swc/core": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.46.tgz",
+      "integrity": "sha512-Ri3em2mBpq3h2zSPliCYl63otDGqek8PPEfv2nWgRQEbZ/VBCNyypVTVQ6cEbTCXBhy+WE2T3fQb08moIyuYaw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.27"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.46",
+        "@swc/core-darwin-x64": "1.15.46",
+        "@swc/core-linux-arm-gnueabihf": "1.15.46",
+        "@swc/core-linux-arm64-gnu": "1.15.46",
+        "@swc/core-linux-arm64-musl": "1.15.46",
+        "@swc/core-linux-ppc64-gnu": "1.15.46",
+        "@swc/core-linux-s390x-gnu": "1.15.46",
+        "@swc/core-linux-x64-gnu": "1.15.46",
+        "@swc/core-linux-x64-musl": "1.15.46",
+        "@swc/core-win32-arm64-msvc": "1.15.46",
+        "@swc/core-win32-ia32-msvc": "1.15.46",
+        "@swc/core-win32-x64-msvc": "1.15.46"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.46.tgz",
+      "integrity": "sha512-IsISIT22EfktVJrlvIpnAxG2u/A9aob9l99HMlx80x72WlFmFPk1V3UhkEzx86eJP8hw049KTFv/RISho2cq2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.46.tgz",
+      "integrity": "sha512-4Tj4ppVIPCmUMpmGFiGtyEriwLyJ+yi/US4WfBrP/ok8COGddDZXLEzQETnKyK46mjvr1v0jevrS23zjoff7vA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.46.tgz",
+      "integrity": "sha512-i8tUGnNjyOgMmfmgFSg4aeJLQoFyfpIHK5FjpQAwpRyQIqEUB2w1e8zIDQzY1WhOxx8NoS1S5iUL813Un4Sf5A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.46.tgz",
+      "integrity": "sha512-c0OnhqzdhfOvv6qhNCcByepB+sNYOGZyhtr2Qa6ZCHvAWTYhSRw4j/u92Stue9PbZ/6q74b9nHzi76+kVzqQHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.46.tgz",
+      "integrity": "sha512-imyRpNEcUzFQFV2LE4jL68ErvmKEuZCbvZru77iQREunJ+bR4i658cupTgtG1mLYM3F1Tzy3Sb9xYb02KghWTg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.46.tgz",
+      "integrity": "sha512-ctEfcl/HcUeomK33cbySiHZm98GEDIxTm1EkpBsYCiHxElYBzvTXVeuQT2YwbUXn9XCrjiw4ipyUNk33k26qRg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.46.tgz",
+      "integrity": "sha512-DxlMdnt84TtRVTv7WL/thWyz9+QU8QZNNoAP9rrk0P68LziuhfePp8MjQ44zIprpTHTsEwyziIuGUUN5iSC1bQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.46.tgz",
+      "integrity": "sha512-SKxI7J6t90XPl8hRUqtJi9NfGdunN/E/vZMc7Bc0figeRdOPDBT+Tm8g7cx9xM0T0mewh2l+8dewa3Am27/P+A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.46.tgz",
+      "integrity": "sha512-qj9T6B7bosI0VEsrWOVXZN1OXxS8Tp63ywyrLxNdOycnUtLdkgYcoBsN5y8ImnDDsnwrEWZOy1e+J4xSe7mA3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.46.tgz",
+      "integrity": "sha512-8p7l4c3LU+eA5g9Et1JPhNeMC1oQwXTGU+uah8DPIBX7YXzqswvaBtyKVmXefVGi/DJU1x3YJsc3mbAp9aWzSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.46.tgz",
+      "integrity": "sha512-tUEnfr3Bn9u6FOjUb3PN9p+09qZC2j+wNDLKHzXXZn22rqGcUqR/ohCRSS+nG9B9+X+U+3FewNEHJkTmdIvMjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.46.tgz",
+      "integrity": "sha512-Vux7UDzBJYQggSuPfcl2w9iu+IJpgpRCxHzgCaVkELnAXAE4XZMOTX9HNcaNiwfeIDqdu2rkr69RuDm6wY8neA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
+      "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@swc/wasm": {
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.15.46.tgz",
+      "integrity": "sha512-XaHMuBVdMDZdi4h+V3471lo/R1aWefieDibevgiz7CFJPfAbmfqqQUPqpMYHx287+lrVWGeIbxS9swVEu8zruQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -3856,6 +4312,40 @@
         "ripple-keypairs": "^2.0.0"
       }
     },
+    "node_modules/@zxing/browser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@zxing/browser/-/browser-0.1.5.tgz",
+      "integrity": "sha512-4Lmrn/il4+UNb87Gk8h1iWnhj39TASEHpd91CwwSJtY5u+wa0iH9qS0wNLAWbNVYXR66WmT5uiMhZ7oVTrKfxw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@zxing/text-encoding": "^0.9.0"
+      },
+      "peerDependencies": {
+        "@zxing/library": "^0.21.0"
+      }
+    },
+    "node_modules/@zxing/library": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.21.3.tgz",
+      "integrity": "sha512-hZHqFe2JyH/ZxviJZosZjV+2s6EDSY0O24R+FQmlWZBZXP9IqMo7S3nb3+2LBWxodJQkSurdQGnqE7KXqrYgow==",
+      "license": "MIT",
+      "dependencies": {
+        "ts-custom-error": "^3.2.1"
+      },
+      "engines": {
+        "node": ">= 10.4.0"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "~0.9.0"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "license": "(Unlicense OR Apache-2.0)",
+      "optional": true
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -3965,6 +4455,19 @@
       "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
       "license": "MIT"
     },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4050,6 +4553,20 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/balanced-match": {
@@ -4168,6 +4685,26 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/blake2b": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.4.tgz",
+      "integrity": "sha512-AyBuuJNI64gIvwx13qiICz6H6hpmjvYS5DGkG6jbXMOT8Z3WUJ3V1X0FlhIoT1b/5JtHE3ki+xjtMvu1nn+t9A==",
+      "license": "ISC",
+      "dependencies": {
+        "blake2b-wasm": "^2.4.0",
+        "nanoassert": "^2.0.0"
+      }
+    },
+    "node_modules/blake2b-wasm": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-2.4.0.tgz",
+      "integrity": "sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.0.1",
+        "nanoassert": "^2.0.0"
       }
     },
     "node_modules/blakejs": {
@@ -4495,6 +5032,28 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cardano-hw-interop-lib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cardano-hw-interop-lib/-/cardano-hw-interop-lib-3.1.0.tgz",
+      "integrity": "sha512-xM7DH0gSc3pR0UIaWMywO2oKeUyw1vY/FSMSwS0W3tjmpGvO2rqderpFnZ0398HzPbXlTwG042+gwHbZ08gH+w==",
+      "license": "ISC",
+      "dependencies": {
+        "blake2b": "^2.1.4",
+        "cbor": "^9.0.1"
+      }
+    },
+    "node_modules/cardano-hw-interop-lib/node_modules/cbor": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-9.0.2.tgz",
+      "integrity": "sha512-JPypkxsB10s9QOWwa6zwPzqE1Md3vqpPc+cai4sAecuCsRyAtAl/pMyhPlMbT/xtPnm2dznJZYRLui57qiRhaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "nofilter": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/cashaddrjs": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cashaddrjs/-/cashaddrjs-0.4.4.tgz",
@@ -4515,6 +5074,12 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/cbor-sync": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cbor-sync/-/cbor-sync-1.0.4.tgz",
+      "integrity": "sha512-GWlXN4wiz0vdWWXBU71Dvc1q3aBo0HytqwAZnXF1wOwjqNnDWA1vZ1gDMFLlqohak31VQzmhiYfiCX5QSSfagA==",
+      "license": "MIT"
     },
     "node_modules/chai": {
       "version": "5.3.3",
@@ -4634,6 +5199,39 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.1.0"
+      }
+    },
+    "node_modules/crc/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
@@ -4823,6 +5421,23 @@
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
         "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5524,6 +6139,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -5945,6 +6569,22 @@
         "node": ">= 12"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -5977,6 +6617,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -5990,12 +6649,46 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-retry-allowed": {
       "version": "3.0.0",
@@ -6156,6 +6849,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbi": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.2.5.tgz",
+      "integrity": "sha512-aBE4n43IPvjaddScbvWRA2YlTzKEynHzu7MqOyTipdHucf/VxS63ViCjxYRg86M8Rxwbt/GfzHl1kKERkt45fQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/jsdom": {
       "version": "25.0.1",
@@ -6515,6 +7214,12 @@
       "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
       "license": "MIT"
     },
+    "node_modules/nanoassert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA==",
+      "license": "ISC"
+    },
     "node_modules/nanoid": {
       "version": "3.3.16",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
@@ -6625,6 +7330,51 @@
       "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -7240,6 +7990,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -7817,6 +8584,15 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
@@ -7827,8 +8603,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -8037,11 +8812,34 @@
         "node": "^18 || ^20 || >= 21"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/varuint-bitcoin": {
       "version": "2.0.0",
@@ -8148,6 +8946,47 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-plugin-top-level-await": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-top-level-await/-/vite-plugin-top-level-await-1.6.0.tgz",
+      "integrity": "sha512-bNhUreLamTIkoulCR9aDXbTbhLk6n1YE8NJUTTxl5RYskNRtzOR0ASzSjBVRtNdjIfngDXo11qOsybGLNsrdww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/plugin-virtual": "^3.0.2",
+        "@swc/core": "^1.12.14",
+        "@swc/wasm": "^1.12.14",
+        "uuid": "10.0.0"
+      },
+      "peerDependencies": {
+        "vite": ">=2.8"
+      }
+    },
+    "node_modules/vite-plugin-top-level-await/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vite-plugin-wasm": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.6.0.tgz",
+      "integrity": "sha512-mL/QPziiIA4RAA6DkaZZzOstdwbW5jO4Vz7Zenj0wieKWBlNvIvX5L5ljum9lcUX0ShNfBgCNLKTjNkRVVqcsw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": "^2 || ^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/vitest": {

--- a/ui/web/package.json
+++ b/ui/web/package.json
@@ -13,8 +13,14 @@
   },
   "dependencies": {
     "@cardano-foundation/ledgerjs-hw-app-cardano": "^7.1.4",
+    "@keystonehq/bc-ur-registry-cardano": "^0.5.0",
+    "@keystonehq/hw-app-ada": "^0.1.1",
+    "@keystonehq/hw-transport-webusb": "^0.5.2",
     "@ledgerhq/hw-transport-webhid": "^6.35.4",
+    "@ngraveio/bc-ur": "^1.1.13",
     "@trezor/connect-web": "^9.7.3",
+    "@zxing/browser": "^0.1.5",
+    "@zxing/library": "^0.21.0",
     "bech32": "^1.1.4",
     "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
@@ -33,6 +39,8 @@
     "typescript": "^5.5.0",
     "typescript-eslint": "^8.0.0",
     "vite": "^6.0.0",
+    "vite-plugin-top-level-await": "^1.6.0",
+    "vite-plugin-wasm": "^3.6.0",
     "vitest": "^3.0.0"
   }
 }

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -429,6 +429,15 @@ export interface HWInput {
   tx_hash_hex: string;
   output_index: number;
   path?: string; // CIP-1852 path, e.g. "1852'/1815'/0'/0/0"
+  // lovelace + address_bech32 are the resolved value of the input UTxO. A
+  // Cardano input references only (tx_hash, output_index), so an air-gapped
+  // signer (Keystone QR) needs these to display the inputs and compute the fee
+  // on-device. Omitted when the backend could not resolve the input's value.
+  lovelace?: string; // decimal string
+  address_bech32?: string;
+  // Native assets on the input UTxO (informational). The Keystone UTxO registry
+  // carries lovelace + address only, so these are display metadata.
+  assets?: { policy_id_hex: string; asset_name_hex: string; amount: string }[];
 }
 
 export interface HWOutput {

--- a/ui/web/src/components/AnimatedQR.tsx
+++ b/ui/web/src/components/AnimatedQR.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
+
+// The QR chip uses a fixed high-contrast pair regardless of theme so it stays
+// scannable by a device camera on the dark panel (mirrors Receive.tsx).
+const QR_BG = "#ffffff";
+const QR_FG = "#0c0f15";
+const DEFAULT_SIZE = 240;
+
+// How long each frame is shown, in milliseconds. Slow enough that a Keystone
+// camera reliably captures each frame, fast enough that a multi-part animation
+// completes in a few seconds.
+const DEFAULT_INTERVAL_MS = 300;
+
+interface AnimatedQRProps {
+  /** UR fragment strings to cycle through as QR frames. */
+  fragments: string[];
+  size?: number;
+  intervalMs?: number;
+  title?: string;
+}
+
+/**
+ * Render an animated ("fountain") QR from a list of UR fragment strings, cycling
+ * one frame at a time. A single-fragment payload renders as a static QR. Purely
+ * client-side (bundled `qrcode.react`) — no network round-trip.
+ */
+export function AnimatedQR({
+  fragments,
+  size = DEFAULT_SIZE,
+  intervalMs = DEFAULT_INTERVAL_MS,
+  title = "Transaction request QR",
+}: AnimatedQRProps) {
+  const [frame, setFrame] = useState(0);
+
+  useEffect(() => {
+    setFrame(0);
+    if (fragments.length <= 1) return;
+    const timer = setInterval(() => {
+      setFrame((f) => (f + 1) % fragments.length);
+    }, intervalMs);
+    return () => clearInterval(timer);
+  }, [fragments, intervalMs]);
+
+  if (fragments.length === 0) return null;
+  const value = fragments[Math.min(frame, fragments.length - 1)];
+
+  return (
+    <div className="qr-animated">
+      <div className="receive-qr-frame">
+        <QRCodeSVG
+          value={value}
+          size={size}
+          bgColor={QR_BG}
+          fgColor={QR_FG}
+          level="M"
+          marginSize={2}
+          title={title}
+        />
+      </div>
+      {fragments.length > 1 && (
+        <p className="helper-text" aria-live="off">
+          Frame {frame + 1} of {fragments.length} — hold the animation steady in front of the device.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ui/web/src/components/KeystoneQRModal.tsx
+++ b/ui/web/src/components/KeystoneQRModal.tsx
@@ -1,0 +1,143 @@
+import { useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import type { KeystoneQRBridge, KeystoneScannedUR } from "../hw/types";
+import { Button } from "./Button";
+import { AnimatedQR } from "./AnimatedQR";
+import { QRScanner } from "./QRScanner";
+
+type Phase = "idle" | "display" | "display-armed" | "scan";
+
+interface KeystoneQRBridgeHandle {
+  /** The bridge to hand to connectKeystone/connectDevice("keystone", …). */
+  bridge: KeystoneQRBridge;
+  /** The modal to render in the screen; `null` when no flow is active. */
+  element: ReactNode;
+}
+
+/**
+ * Bridge the Keystone signer's imperative QR exchange to a React modal.
+ *
+ * The signer calls `displayRequest(fragments)` (animated request QR) and then
+ * awaits `scanResponse()` (webcam reply). This hook renders those two steps as a
+ * modal and resolves the promise when a complete UR is scanned. Everything is
+ * LOCAL — the animated QR is paper/screen and the scanner is the local camera;
+ * no network is contacted, so there is deliberately no consent gate here.
+ */
+export function useKeystoneQRBridge(): KeystoneQRBridgeHandle {
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [fragments, setFragments] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  // Bumped to force-remount <QRScanner> so a failed scan (camera denied, or a
+  // corrupt/incomplete UR that stopped the reader) can be retried in place
+  // without tearing down and restarting the whole signing flow.
+  const [scanAttempt, setScanAttempt] = useState(0);
+
+  const phaseRef = useRef<Phase>("idle");
+  const resolverRef = useRef<{
+    resolve: (ur: KeystoneScannedUR) => void;
+    reject: (err: Error) => void;
+  } | null>(null);
+
+  function goto(next: Phase) {
+    phaseRef.current = next;
+    setPhase(next);
+  }
+
+  const bridge = useMemo<KeystoneQRBridge>(
+    () => ({
+      displayRequest(frags: string[]) {
+        setError(null);
+        setFragments(frags);
+        goto("display");
+      },
+      scanResponse() {
+        return new Promise<KeystoneScannedUR>((resolve, reject) => {
+          resolverRef.current = { resolve, reject };
+          // If a request QR is already showing, keep it up and let the user
+          // advance to the camera when they've scanned it into the device;
+          // otherwise (account-sync) go straight to the camera.
+          goto(phaseRef.current === "display" ? "display-armed" : "scan");
+        });
+      },
+      close() {
+        resolverRef.current = null;
+        setFragments([]);
+        setError(null);
+        goto("idle");
+      },
+    }),
+    [],
+  );
+
+  function cancel() {
+    resolverRef.current?.reject(new Error("Keystone QR flow cancelled"));
+    bridge.close();
+  }
+
+  // Retry a failed scan: clear the error and remount <QRScanner> (via its key)
+  // so a fresh camera + decoder session starts. The pending scanResponse()
+  // promise is still unresolved, so the recovered scan resolves it as normal.
+  function retryScan() {
+    setError(null);
+    setScanAttempt((n) => n + 1);
+    goto("scan");
+  }
+
+  let body: ReactNode = null;
+  if (phase === "display" || phase === "display-armed") {
+    body = (
+      <>
+        <p className="helper-text">
+          Scan this animated code with your Keystone, review and approve the transaction on the
+          device, then continue to capture its signature.
+        </p>
+        <AnimatedQR fragments={fragments} />
+        {phase === "display-armed" && (
+          <Button onClick={() => goto("scan")}>Scan Keystone&apos;s signature</Button>
+        )}
+      </>
+    );
+  } else if (phase === "scan") {
+    body = (
+      <>
+        <QRScanner
+          key={scanAttempt}
+          onResult={(ur) => resolverRef.current?.resolve(ur)}
+          onError={(message) => setError(message)}
+        />
+      </>
+    );
+  }
+
+  // Offer Retry alongside Cancel whenever a scan has failed, so the user can
+  // rescan without abandoning (and rebuilding) the transaction.
+  const canRetry = phase === "scan" && error !== null;
+
+  const element =
+    phase === "idle" ? null : (
+      <div className="qr-modal-overlay" onClick={cancel}>
+        <div
+          className="qr-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Keystone QR"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {body}
+          {error && (
+            <p role="alert" className="error-text">
+              {error}
+            </p>
+          )}
+          <div className="qr-modal-actions">
+            {canRetry && <Button onClick={retryScan}>Retry scan</Button>}
+            <Button variant="ghost" onClick={cancel}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+
+  return { bridge, element };
+}

--- a/ui/web/src/components/QRScanner.tsx
+++ b/ui/web/src/components/QRScanner.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useRef, useState } from "react";
+import type { KeystoneScannedUR } from "../hw/types";
+
+interface QRScannerProps {
+  /** Called once a complete Uniform Resource has been decoded from the camera. */
+  onResult: (ur: KeystoneScannedUR) => void;
+  /** Called if the camera cannot be opened or a fatal decode error occurs. */
+  onError?: (message: string) => void;
+}
+
+// A ZXing control handle we can stop; typed loosely so we don't pull the SDK's
+// types into the initial bundle (the SDK itself is dynamically imported below).
+interface ScannerControls {
+  stop: () => void;
+}
+
+// Lazily install a global `Buffer`, which @ngraveio/bc-ur relies on but browsers
+// do not provide. Kept local so the `buffer` shim rides this code-split chunk.
+async function ensureBuffer(): Promise<void> {
+  const g = globalThis as unknown as { Buffer?: unknown };
+  if (typeof g.Buffer === "undefined") {
+    const mod = await import("buffer");
+    g.Buffer = mod.Buffer;
+  }
+}
+
+function toHex(bytes: Uint8Array): string {
+  let out = "";
+  for (const b of bytes) out += b.toString(16).padStart(2, "0");
+  return out;
+}
+
+/**
+ * Webcam QR scanner that assembles a (possibly animated / multi-part) Uniform
+ * Resource and resolves it as {type, cborHex}. Both the ZXing camera reader and
+ * the bc-ur decoder are dynamically imported so they stay OUT of the initial
+ * bundle — this component is only ever mounted inside a Keystone QR flow.
+ *
+ * Camera access is local (getUserMedia); nothing is sent over the network.
+ */
+export function QRScanner({ onResult, onError }: QRScannerProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [progress, setProgress] = useState<number>(0);
+
+  useEffect(() => {
+    let controls: ScannerControls | null = null;
+    let cancelled = false;
+    let done = false;
+
+    (async () => {
+      try {
+        await ensureBuffer();
+        const [{ BrowserQRCodeReader }, { URDecoder }] = await Promise.all([
+          import("@zxing/browser"),
+          import("@ngraveio/bc-ur"),
+        ]);
+        if (cancelled) return;
+
+        const decoder = new URDecoder();
+        const reader = new BrowserQRCodeReader();
+
+        controls = await reader.decodeFromVideoDevice(
+          undefined,
+          videoRef.current ?? undefined,
+          (result) => {
+            if (done || !result) return;
+            const text = result.getText().trim();
+            if (!text.toLowerCase().startsWith("ur:")) return;
+            try {
+              decoder.receivePart(text);
+            } catch {
+              // A stray/foreign QR that isn't a valid UR part — ignore and keep
+              // scanning rather than aborting the whole session.
+              return;
+            }
+            setProgress(Math.round(decoder.getProgress() * 100));
+            // A structurally valid but corrupt multipart stream (e.g. mismatched
+            // fragment checksums) puts the decoder into a permanent error state
+            // WITHOUT ever reaching isComplete(). Detect that and surface it, or
+            // the UI would sit on "Scanning…" forever with no way to recover.
+            if (decoder.isError()) {
+              done = true;
+              controls?.stop();
+              onError?.(
+                decoder.resultError() ||
+                  "The scanned QR could not be decoded. Restart the exchange on the device and rescan.",
+              );
+              return;
+            }
+            if (decoder.isComplete()) {
+              done = true;
+              controls?.stop();
+              if (!decoder.isSuccess()) {
+                onError?.(decoder.resultError() || "Failed to decode the scanned QR.");
+                return;
+              }
+              const ur = decoder.resultUR();
+              onResult({ type: ur.type, cborHex: toHex(new Uint8Array(ur.cbor)) });
+            }
+          },
+        );
+        if (cancelled) controls?.stop();
+      } catch (err) {
+        if (cancelled) return;
+        const message =
+          err instanceof Error
+            ? err.name === "NotAllowedError"
+              ? "Camera access was denied. Allow camera access to scan the Keystone reply."
+              : err.message
+            : "Could not open the camera.";
+        onError?.(message);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controls?.stop();
+    };
+    // onResult/onError are stable for the modal's lifetime; deliberately run once.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="qr-scanner">
+      {/* muted + playsInline so mobile browsers autoplay the preview inline. */}
+      <video ref={videoRef} className="qr-scanner-video" muted playsInline aria-label="Camera preview" />
+      <p className="helper-text" role="status" aria-live="polite">
+        Point the camera at the Keystone&apos;s QR. {progress > 0 ? `Reading… ${progress}%` : "Scanning…"}
+      </p>
+    </div>
+  );
+}

--- a/ui/web/src/hw/deviceKind.test.ts
+++ b/ui/web/src/hw/deviceKind.test.ts
@@ -1,5 +1,14 @@
 import { describe, test, expect, beforeEach } from "vitest";
-import { setDeviceKind, getDeviceKind, getStoredDeviceKind, STORAGE_KEY } from "./deviceKind";
+import {
+  setDeviceKind,
+  getDeviceKind,
+  getStoredDeviceKind,
+  STORAGE_KEY,
+  setKeystoneXfp,
+  getKeystoneXfp,
+  isValidKeystoneXfp,
+  KEYSTONE_XFP_KEY,
+} from "./deviceKind";
 
 beforeEach(() => {
   localStorage.clear();
@@ -17,11 +26,10 @@ describe("getStoredDeviceKind", () => {
     expect(getStoredDeviceKind("w2")).toBe("trezor");
   });
 
-  test("rejects a stale keystone hint (disabled this phase)", () => {
-    // A "keystone" hint must NOT select an unsupported signer — the allowlist
-    // omits it, so a stored keystone value reads back as unknown.
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ w1: "keystone" }));
-    expect(getStoredDeviceKind("w1")).toBeUndefined();
+  test("honors a stored keystone hint", () => {
+    // Keystone is an implemented signer now, so its hint is a recognised kind.
+    setDeviceKind("w1", "keystone");
+    expect(getStoredDeviceKind("w1")).toBe("keystone");
   });
 
   test("rejects an unrecognised value", () => {
@@ -33,12 +41,52 @@ describe("getStoredDeviceKind", () => {
 describe("getDeviceKind", () => {
   test("defaults to ledger when nothing recognised is stored", () => {
     expect(getDeviceKind("w1")).toBe("ledger");
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ w1: "keystone" }));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ w1: "bogus" }));
     expect(getDeviceKind("w1")).toBe("ledger");
   });
 
   test("returns the stored recognised kind", () => {
     setDeviceKind("w1", "trezor");
     expect(getDeviceKind("w1")).toBe("trezor");
+  });
+});
+
+describe("isValidKeystoneXfp", () => {
+  test("accepts an 8-hex-digit fingerprint (either case)", () => {
+    expect(isValidKeystoneXfp("52744703")).toBe(true);
+    expect(isValidKeystoneXfp("ABCDEF01")).toBe(true);
+  });
+
+  test("accepts boundary/edge fingerprints that are structurally valid hex", () => {
+    expect(isValidKeystoneXfp("00000000")).toBe(true); // all-zeros
+    expect(isValidKeystoneXfp("99999999")).toBe(true); // all-nines
+    expect(isValidKeystoneXfp("aBcDeF01")).toBe(true); // mixed-case hex
+  });
+
+  test("rejects malformed or non-string values", () => {
+    expect(isValidKeystoneXfp("5274470")).toBe(false); // too short
+    expect(isValidKeystoneXfp("527447033")).toBe(false); // too long
+    expect(isValidKeystoneXfp("5274470g")).toBe(false); // non-hex
+    expect(isValidKeystoneXfp(1234 as unknown)).toBe(false);
+    expect(isValidKeystoneXfp(undefined)).toBe(false);
+    expect(isValidKeystoneXfp({} as unknown)).toBe(false);
+  });
+});
+
+describe("getKeystoneXfp", () => {
+  test("returns undefined when nothing is stored", () => {
+    expect(getKeystoneXfp("w1")).toBeUndefined();
+  });
+
+  test("round-trips a valid fingerprint", () => {
+    setKeystoneXfp("w1", "52744703");
+    expect(getKeystoneXfp("w1")).toBe("52744703");
+  });
+
+  test("treats a malformed persisted value as unknown", () => {
+    // A corrupt/hand-edited entry must not be forwarded into a sign-request.
+    localStorage.setItem(KEYSTONE_XFP_KEY, JSON.stringify({ w1: "not-hex", w2: 42 }));
+    expect(getKeystoneXfp("w1")).toBeUndefined();
+    expect(getKeystoneXfp("w2")).toBeUndefined();
   });
 });

--- a/ui/web/src/hw/deviceKind.ts
+++ b/ui/web/src/hw/deviceKind.ts
@@ -26,10 +26,9 @@ import type { HardwareKind } from "./types";
 // read/write the SAME key as this module (one source of truth).
 export const STORAGE_KEY = "bursa.hw.deviceKind";
 
-// Kinds we accept from storage. Keystone is intentionally omitted: it is
-// disabled this phase, so a stale "keystone" hint must NOT select an
-// unsupported signer — it falls back to the documented "ledger" default.
-const KNOWN_KINDS: readonly HardwareKind[] = ["ledger", "trezor"];
+// Kinds we accept from storage. All implemented signers are listed; an
+// unrecognised value falls back to the documented "ledger" default.
+const KNOWN_KINDS: readonly HardwareKind[] = ["ledger", "trezor", "keystone"];
 
 type DeviceKindMap = Record<string, HardwareKind>;
 
@@ -92,4 +91,68 @@ export function getStoredDeviceKind(walletId: string): HardwareKind | undefined 
  */
 export function getDeviceKind(walletId: string): HardwareKind {
   return getStoredDeviceKind(walletId) ?? "ledger";
+}
+
+// ── Keystone master fingerprint (xfp) ────────────────────────────────────────
+//
+// A Keystone signing over QR must stamp its wallet master fingerprint on the
+// sign-request so the device recognises the witness paths as its own. That
+// fingerprint is learned only during account-sync (it rides the
+// crypto-multi-accounts QR), so it is remembered here — a purely local,
+// non-secret hint keyed by wallet id, exactly like the device-kind hint above.
+
+// localStorage key for the wallet-id → xfp map.
+export const KEYSTONE_XFP_KEY = "bursa.hw.keystoneXfp";
+
+function readXfpMap(): Record<string, string> {
+  if (typeof localStorage === "undefined") return {};
+  try {
+    const raw = localStorage.getItem(KEYSTONE_XFP_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object") return parsed as Record<string, string>;
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+/** Record the Keystone master fingerprint (hex) for a hardware wallet id. */
+export function setKeystoneXfp(walletId: string, xfp: string): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    const map = readXfpMap();
+    map[walletId] = xfp;
+    localStorage.setItem(KEYSTONE_XFP_KEY, JSON.stringify(map));
+  } catch {
+    // Best-effort: a full/blocked store just means the fingerprint is not
+    // remembered. The QR sign flow then treats the hint as absent and blocks
+    // signing (prompting an account-sync re-scan) rather than fabricating a zero.
+  }
+}
+
+/**
+ * A Cardano/BIP32 master fingerprint is exactly 4 bytes → 8 hex digits. Anything
+ * else in local storage is corrupt (e.g. a truncated write, a hand-edited value,
+ * or a non-string smuggled in by a malformed JSON blob) and MUST NOT be forwarded
+ * into a sign-request, where it would make the device fail to match its paths.
+ *
+ * "00000000" is deliberately VALID: a genuine all-zero fingerprint reported by a
+ * real device is a legitimate (1-in-2^32) value, and this guard blocks the
+ * ABSENCE of a fingerprint (undefined / corrupt storage), never a real one. The
+ * QR signer only refuses to FABRICATE a zero when the hint is missing (see the
+ * xfp note in keystone.ts) — it does not reject a device-reported zero.
+ */
+export function isValidKeystoneXfp(value: unknown): value is string {
+  return typeof value === "string" && /^[0-9a-f]{8}$/i.test(value);
+}
+
+/**
+ * Look up the stored Keystone master fingerprint, or `undefined` if unknown or
+ * malformed. Corrupt local state (a non-string, or a non-8-hex-digit value) is
+ * treated as unknown so it can never be forwarded into a QR signing request.
+ */
+export function getKeystoneXfp(walletId: string): string | undefined {
+  const xfp = readXfpMap()[walletId];
+  return isValidKeystoneXfp(xfp) ? xfp : undefined;
 }

--- a/ui/web/src/hw/index.test.ts
+++ b/ui/web/src/hw/index.test.ts
@@ -3,23 +3,27 @@ import type { HardwareSigner } from "./types";
 
 // Mock the concrete connectors so the factory can be exercised without opening
 // WebHID or loading connect.trezor.io.
-const { mockConnectLedger, mockConnectTrezor } = vi.hoisted(() => ({
+const { mockConnectLedger, mockConnectTrezor, mockConnectKeystone } = vi.hoisted(() => ({
   mockConnectLedger: vi.fn(),
   mockConnectTrezor: vi.fn(),
+  mockConnectKeystone: vi.fn(),
 }));
 
 vi.mock("./ledger", () => ({ connectLedger: mockConnectLedger }));
 vi.mock("./trezor", () => ({ connectTrezor: mockConnectTrezor }));
+vi.mock("./keystone", () => ({ connectKeystone: mockConnectKeystone }));
 
 import { connectDevice, connectHardware } from "./index";
 
 const fakeLedger = { kind: "ledger" } as unknown as HardwareSigner;
 const fakeTrezor = { kind: "trezor" } as unknown as HardwareSigner;
+const fakeKeystone = { kind: "keystone" } as unknown as HardwareSigner;
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockConnectLedger.mockResolvedValue(fakeLedger);
   mockConnectTrezor.mockResolvedValue(fakeTrezor);
+  mockConnectKeystone.mockResolvedValue(fakeKeystone);
 });
 
 describe("connectDevice factory", () => {
@@ -38,8 +42,17 @@ describe("connectDevice factory", () => {
     expect(session).toBe(fakeTrezor);
   });
 
-  test("keystone is not supported and throws", () => {
-    expect(() => connectDevice("keystone")).toThrow(/not yet supported/i);
+  test("keystone dispatches to connectKeystone, forwarding the transport options", async () => {
+    const bridge = {
+      displayRequest: () => {},
+      scanResponse: async () => ({ type: "", cborHex: "" }),
+      close: () => {},
+    };
+    const session = await connectDevice("keystone", { transport: "qr", bridge });
+    expect(mockConnectKeystone).toHaveBeenCalledWith({ transport: "qr", bridge });
+    expect(mockConnectLedger).not.toHaveBeenCalled();
+    expect(mockConnectTrezor).not.toHaveBeenCalled();
+    expect(session).toBe(fakeKeystone);
   });
 });
 
@@ -76,7 +89,11 @@ describe("connectHardware (dynamic kind)", () => {
     expect(mockConnectLedger).not.toHaveBeenCalled();
   });
 
-  test("keystone throws (unsupported this phase)", () => {
-    expect(() => connectHardware("keystone", async () => true)).toThrow(/not yet supported/i);
+  test("keystone is refused here (its only user-facing transport is QR, driven via connectDevice)", () => {
+    const consent = vi.fn().mockResolvedValue(true);
+    // connectHardware must NOT silently fall back to the ungated USB transport;
+    // the air-gapped QR flow is driven directly through connectDevice.
+    expect(() => connectHardware("keystone", consent)).toThrow(/air-gapped QR/i);
+    expect(mockConnectKeystone).not.toHaveBeenCalled();
   });
 });

--- a/ui/web/src/hw/index.ts
+++ b/ui/web/src/hw/index.ts
@@ -11,10 +11,12 @@ import type {
   ExternalConnectOptions,
   HardwareKind,
   HardwareSigner,
+  KeystoneConnectOptions,
   LocalConnectOptions,
 } from "./types";
 import { connectLedger } from "./ledger";
 import { connectTrezor } from "./trezor";
+import { connectKeystone } from "./keystone";
 
 export type {
   HardwareKind,
@@ -24,6 +26,11 @@ export type {
   ConnectOptionsByKind,
   LocalConnectOptions,
   ExternalConnectOptions,
+  KeystoneConnectOptions,
+  KeystoneQRConnectOptions,
+  KeystoneUSBConnectOptions,
+  KeystoneQRBridge,
+  KeystoneScannedUR,
 } from "./types";
 
 /**
@@ -39,7 +46,10 @@ export type {
  * {@link connectTrezor} — so this factory only narrows types and forwards; it
  * does not re-implement the consent gate.
  *
- * @throws Error for an unimplemented kind (Keystone is not supported yet).
+ * Keystone is LOCAL on both transports, so it takes a transport choice
+ * ({@link KeystoneConnectOptions}) rather than a consent callback.
+ *
+ * @throws Error for an unknown kind.
  */
 export function connectDevice(
   kind: "ledger",
@@ -51,11 +61,11 @@ export function connectDevice(
 ): Promise<HardwareSigner>;
 export function connectDevice(
   kind: "keystone",
-  opts?: ConnectOptionsByKind["keystone"],
+  opts: ConnectOptionsByKind["keystone"],
 ): Promise<HardwareSigner>;
 export function connectDevice(
   kind: HardwareKind,
-  opts?: LocalConnectOptions | ExternalConnectOptions,
+  opts?: LocalConnectOptions | ExternalConnectOptions | KeystoneConnectOptions,
 ): Promise<HardwareSigner> {
   switch (kind) {
     case "ledger":
@@ -66,7 +76,9 @@ export function connectDevice(
       // present and typed here.
       return connectTrezor(opts as ExternalConnectOptions);
     case "keystone":
-      throw new Error("Keystone hardware wallets are not yet supported");
+      // Both Keystone transports are local; connectKeystone dispatches on the
+      // transport in `opts` (QR needs a UI bridge, USB needs nothing).
+      return connectKeystone(opts as KeystoneConnectOptions);
     default: {
       // Exhaustiveness guard: a new HardwareKind must add a case above.
       const never: never = kind;
@@ -84,6 +96,12 @@ export function connectDevice(
  * cannot know the kind at compile time does not re-derive which kinds need
  * consent. `requestExternalConsent` is consulted ONLY for external-network
  * devices (Trezor); local devices (Ledger) ignore it.
+ *
+ * Keystone is NOT handled here: its only user-facing transport is air-gapped QR,
+ * which needs a UI bridge this signature cannot supply, so the screens drive it
+ * directly through {@link connectDevice}("keystone", { transport: "qr", … }).
+ * This dispatcher refuses Keystone rather than silently falling back to the
+ * ungated USB transport (see connectKeystoneUSB — not user-selectable).
  */
 export function connectHardware(
   kind: HardwareKind,
@@ -95,7 +113,9 @@ export function connectHardware(
     case "trezor":
       return connectDevice("trezor", { requestExternalConsent });
     case "keystone":
-      return connectDevice("keystone");
+      throw new Error(
+        "Keystone must be connected over its air-gapped QR transport via connectDevice(\"keystone\", { transport: \"qr\", … }); the USB transport is not user-selectable.",
+      );
     default: {
       const never: never = kind;
       throw new Error(`Unknown hardware device kind: ${String(never)}`);

--- a/ui/web/src/hw/keystone.test.ts
+++ b/ui/web/src/hw/keystone.test.ts
@@ -1,0 +1,490 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import {
+  CardanoSignature,
+  CryptoMultiAccounts,
+  CryptoHDKey,
+  CryptoKeypath,
+  PathComponent,
+  Buffer as URBuffer,
+} from "@keystonehq/bc-ur-registry-cardano";
+
+// The @keystonehq CBOR libraries decode against the GLOBAL Buffer, but construct
+// with the `buffer`-package Buffer. Under Node those two are different classes,
+// so Buffer.isBuffer() rejects the constructed input ("Unsupported input
+// format"). Align the global with the package Buffer — exactly what
+// keystone.ts's ensureBuffer() does in the browser, where no global exists.
+(globalThis as unknown as { Buffer: unknown }).Buffer = URBuffer;
+
+// ── USB transport + app mocks (no real WebUSB in CI) ──────────────────────────
+const { mockRequestPermission, mockConnect, mockClose, mockGetAppConfig, mockGetXpubs, mockSignTx } =
+  vi.hoisted(() => ({
+    mockRequestPermission: vi.fn().mockResolvedValue(undefined),
+    mockConnect: vi.fn(),
+    mockClose: vi.fn().mockResolvedValue(undefined),
+    mockGetAppConfig: vi.fn(),
+    mockGetXpubs: vi.fn(),
+    mockSignTx: vi.fn(),
+  }));
+
+vi.mock("@keystonehq/hw-transport-webusb", () => ({
+  TransportWebUSB: {
+    requestPermission: mockRequestPermission,
+    connect: mockConnect,
+  },
+}));
+
+vi.mock("@keystonehq/hw-app-ada", () => ({
+  // The neutral→SDK mapping references these enums; concrete values are
+  // irrelevant to the witness parity we assert, so stand-ins suffice.
+  default: vi.fn().mockImplementation(() => ({
+    getAppConfig: mockGetAppConfig,
+    getExtendedPublicKeys: mockGetXpubs,
+    signTransaction: mockSignTx,
+  })),
+  AddressType: { BASE_PAYMENT_KEY_STAKE_KEY: 0 },
+  TransactionSigningMode: { ORDINARY_TRANSACTION: "ordinary_transaction" },
+  TxOutputDestinationType: { DEVICE_OWNED: "device_owned", THIRD_PARTY: "third_party" },
+  TxOutputFormat: { ARRAY_LEGACY: 0 },
+  TxRequiredSignerType: { HASH: "required_signer_hash" },
+}));
+
+import {
+  connectKeystoneQR,
+  connectKeystoneUSB,
+  witnessSetToPairs,
+  parseAccountSyncUR,
+  parseAccountSyncXfp,
+  buildKeystoneUtxos,
+} from "./keystone";
+import { encodeXpub } from "./xpub";
+import { encodeWitnessArray } from "./witness";
+import type { KeystoneQRBridge } from "./types";
+import type { HardwareSignResponse } from "../api/types";
+
+// Shared parity vector — identical key material to the Ledger/Trezor canonical
+// vectors, so every device MUST produce the same bech32 xpub and, for the same
+// pubkey/sig, the same witness-array CBOR.
+const TEST_PUB_KEY_HEX = "beb7e770b3d0f1932b0a2f3a63285bf9ef7d3e461d55446d6a3911d8f0ee55c0";
+const TEST_CHAIN_CODE_HEX = "b0e2df16538508046649d0e6d5b32969555a23f2f1ebf2db2819359b0d88bd16";
+const TEST_XPUB_BECH32 =
+  "root_xvk1h6m7wu9n6rcex2c29uaxx2zml8hh60jxr425gmt28yga3u8w2hqtpcklzefc2zqyveyapek4kv5kj426y0e0r6ljmv5pjdvmpkyt69s8fpd2x";
+const TEST_SIG_HEX = "aabbccdd".repeat(16); // 64 bytes
+
+const HARDENED = 0x80000000;
+const ACCT0_PATH = [1852 + HARDENED, 1815 + HARDENED, 0 + HARDENED];
+
+const NEUTRAL_REQ: HardwareSignResponse = {
+  network: "mainnet",
+  network_id: 1,
+  include_network_id: true,
+  protocol_magic: 764824073,
+  inputs: [
+    {
+      tx_hash_hex: "deadbeef".repeat(8),
+      output_index: 0,
+      path: "1852'/1815'/0'/0/0",
+      lovelace: "5000000",
+      address_bech32: "addr1input",
+    },
+  ],
+  outputs: [
+    { address_hex: "60aabb", address_bech32: "addr1recipient", lovelace: "1000000" },
+    {
+      address_hex: "60ccdd",
+      address_bech32: "addr1change",
+      lovelace: "3800000",
+      payment_path: "1852'/1815'/0'/0/0",
+      stake_path: "1852'/1815'/0'/2/0",
+    },
+  ],
+  fee: "200000",
+  required_signers: [],
+  unsigned_tx_cbor: "84a4008182",
+};
+
+// ── Helpers to build the URs the device would show ────────────────────────────
+
+// The registry's Buffer (from the `buffer` package) differs from @types/node's
+// Buffer in TS though they are identical at runtime; bridge with a cast.
+const buf = (hex: string): Buffer => URBuffer.from(hex, "hex") as unknown as Buffer;
+
+// A crypto-multi-accounts UR (the account-sync QR) carrying account 0's key.
+function accountSyncCborHex(pubHex: string, ccHex: string, path: number[]): string {
+  const components = [];
+  const HARD = 0x80000000;
+  for (const n of path) {
+    const hardened = n >= HARD;
+    components.push(new PathComponent({ index: hardened ? n - HARD : n, hardened }));
+  }
+  const origin = new CryptoKeypath(components);
+  const hd = new CryptoHDKey({
+    isMaster: false,
+    key: buf(pubHex),
+    chainCode: buf(ccHex),
+    origin,
+  });
+  const ma = new CryptoMultiAccounts(buf("52744703"), [hd], "Keystone");
+  return Buffer.from(ma.toUR().cbor).toString("hex");
+}
+
+// A serialized TransactionWitnessSet: map {0: [[pubkey, sig]]}.
+function witnessSetHex(pubHex: string, sigHex: string): string {
+  return "a10081" + "82" + "5820" + pubHex + "5840" + sigHex;
+}
+
+// A cardano-signature UR wrapping the witness set.
+function signatureCborHex(pubHex: string, sigHex: string): string {
+  const sig = new CardanoSignature(buf(witnessSetHex(pubHex, sigHex)));
+  return Buffer.from(sig.toUR().cbor).toString("hex");
+}
+
+function makeBridge(): KeystoneQRBridge & {
+  displayRequest: ReturnType<typeof vi.fn>;
+  scanResponse: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+} {
+  return {
+    displayRequest: vi.fn(),
+    scanResponse: vi.fn(),
+    close: vi.fn(),
+  };
+}
+
+// ── QR transport ──────────────────────────────────────────────────────────────
+
+describe("connectKeystoneQR", () => {
+  test("reports kind 'keystone' and conservative QR capabilities (send only)", async () => {
+    // Staking is advertised as UNSUPPORTED over QR until stake signer paths are
+    // mapped into extraSigners — otherwise certificate txs would be witnessed
+    // incompletely (see KEYSTONE_QR_CAPABILITIES in keystone.ts).
+    const session = await connectKeystoneQR({ transport: "qr", bridge: makeBridge() });
+    expect(session.kind).toBe("keystone");
+    expect(session.capabilities).toEqual({
+      send: true,
+      staking: false,
+      governance: false,
+      multisig: false,
+      poolReg: false,
+    });
+  });
+
+  test("signTx refuses to build a request with a missing fingerprint (no zero fp)", async () => {
+    // Without a valid xfp the device cannot match the witness paths; the signer
+    // must block rather than silently send 00000000.
+    const bridge = makeBridge();
+    const session = await connectKeystoneQR({ transport: "qr", bridge });
+    await expect(session.signTx(NEUTRAL_REQ)).rejects.toThrow(/fingerprint is missing/i);
+    // It must NOT have shown a request QR or scanned anything.
+    expect(bridge.displayRequest).not.toHaveBeenCalled();
+    expect(bridge.scanResponse).not.toHaveBeenCalled();
+  });
+
+  test("signTx refuses a malformed (non-8-hex) fingerprint", async () => {
+    const bridge = makeBridge();
+    const session = await connectKeystoneQR({ transport: "qr", bridge, xfp: "xyz" });
+    await expect(session.signTx(NEUTRAL_REQ)).rejects.toThrow(/fingerprint is missing/i);
+    expect(bridge.displayRequest).not.toHaveBeenCalled();
+  });
+
+  test("getAccountXpub extracts the account key from the account-sync UR and matches the shared vector", async () => {
+    const bridge = makeBridge();
+    bridge.scanResponse.mockResolvedValue({
+      type: "crypto-multi-accounts",
+      cborHex: accountSyncCborHex(TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, ACCT0_PATH),
+    });
+    const session = await connectKeystoneQR({ transport: "qr", bridge });
+    const xpub = await session.getAccountXpub(0);
+    // Byte-for-byte identical to the Ledger/Trezor/Go xpub for the same key.
+    expect(xpub).toBe(TEST_XPUB_BECH32);
+    expect(bridge.close).toHaveBeenCalled();
+  });
+
+  test("getAccountXpub rejects a non-account-sync UR", async () => {
+    const bridge = makeBridge();
+    bridge.scanResponse.mockResolvedValue({
+      type: "cardano-signature",
+      cborHex: signatureCborHex(TEST_PUB_KEY_HEX, TEST_SIG_HEX),
+    });
+    const session = await connectKeystoneQR({ transport: "qr", bridge });
+    await expect(session.getAccountXpub(0)).rejects.toThrow(/account-sync/i);
+  });
+
+  test("signTx round-trips: shows the request QR, scans the signature, returns the witness-array CBOR", async () => {
+    const bridge = makeBridge();
+    bridge.scanResponse.mockResolvedValue({
+      type: "cardano-signature",
+      cborHex: signatureCborHex(TEST_PUB_KEY_HEX, TEST_SIG_HEX),
+    });
+    const session = await connectKeystoneQR({ transport: "qr", bridge, xfp: "52744703" });
+
+    const result = await session.signTx(NEUTRAL_REQ);
+
+    // The animated request QR was displayed with at least one UR fragment.
+    expect(bridge.displayRequest).toHaveBeenCalledOnce();
+    const fragments = bridge.displayRequest.mock.calls[0][0] as string[];
+    expect(fragments.length).toBeGreaterThan(0);
+    expect(fragments[0].toLowerCase()).toMatch(/^ur:cardano-sign-request\//);
+
+    // The assembled witness array is byte-identical to what the shared encoder
+    // produces for the same pubkey/sig — i.e. identical to Ledger/Trezor output.
+    expect(result).toBe(
+      encodeWitnessArray([{ pubKeyHex: TEST_PUB_KEY_HEX, sigHex: TEST_SIG_HEX }]),
+    );
+    expect(result.startsWith("8182")).toBe(true);
+    expect(result).toContain(TEST_PUB_KEY_HEX);
+    expect(result).toContain(TEST_SIG_HEX);
+    expect(bridge.close).toHaveBeenCalled();
+  });
+
+  test("signTx rejects a scanned UR that is not a signature", async () => {
+    const bridge = makeBridge();
+    bridge.scanResponse.mockResolvedValue({
+      type: "crypto-multi-accounts",
+      cborHex: accountSyncCborHex(TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, ACCT0_PATH),
+    });
+    const session = await connectKeystoneQR({ transport: "qr", bridge, xfp: "52744703" });
+    await expect(session.signTx(NEUTRAL_REQ)).rejects.toThrow(/cardano-signature/i);
+    expect(bridge.close).toHaveBeenCalled();
+  });
+
+  test("is fully local: no consent callback is part of the options or invoked", async () => {
+    // KeystoneConnectOptions carries NO consent field (unlike Trezor's). This
+    // test documents that the whole QR flow connects and signs with only a
+    // transport + bridge — there is nothing to gate on external consent.
+    const bridge = makeBridge();
+    bridge.scanResponse.mockResolvedValue({
+      type: "cardano-signature",
+      cborHex: signatureCborHex(TEST_PUB_KEY_HEX, TEST_SIG_HEX),
+    });
+    const opts = { transport: "qr" as const, bridge, xfp: "52744703" };
+    expect("requestExternalConsent" in opts).toBe(false);
+    const session = await connectKeystoneQR(opts);
+    await expect(session.signTx(NEUTRAL_REQ)).resolves.toBeTypeOf("string");
+  });
+});
+
+// ── witnessSetToPairs (shared decoder) ────────────────────────────────────────
+
+describe("witnessSetToPairs", () => {
+  test("extracts [pubkey, sig] pairs from a witness-set map (key 0)", () => {
+    const bytes = Uint8Array.from(Buffer.from(witnessSetHex(TEST_PUB_KEY_HEX, TEST_SIG_HEX), "hex"));
+    expect(witnessSetToPairs(bytes)).toEqual([
+      { pubKeyHex: TEST_PUB_KEY_HEX, sigHex: TEST_SIG_HEX },
+    ]);
+  });
+
+  test("trims an extended (pubkey||chaincode) vkey down to the 32-byte public key", () => {
+    // 64-byte vkey: pubkey (32) || chaincode (32). Only the pubkey belongs in a
+    // Cardano vkey witness, so parity with the other devices is preserved.
+    const extended = TEST_PUB_KEY_HEX + TEST_CHAIN_CODE_HEX;
+    const hex = "a10081" + "82" + "5840" + extended + "5840" + TEST_SIG_HEX;
+    const bytes = Uint8Array.from(Buffer.from(hex, "hex"));
+    expect(witnessSetToPairs(bytes)).toEqual([
+      { pubKeyHex: TEST_PUB_KEY_HEX, sigHex: TEST_SIG_HEX },
+    ]);
+  });
+
+  test("accepts the Conway set-tagged witness array (tag 258)", () => {
+    // map {0: 258([[pub,sig]])} — the tag wraps the array; the decoder unwraps it.
+    const hex = "a100" + "d90102" + "81" + "82" + "5820" + TEST_PUB_KEY_HEX + "5840" + TEST_SIG_HEX;
+    const bytes = Uint8Array.from(Buffer.from(hex, "hex"));
+    expect(witnessSetToPairs(bytes)).toEqual([
+      { pubKeyHex: TEST_PUB_KEY_HEX, sigHex: TEST_SIG_HEX },
+    ]);
+  });
+
+  test("throws on a truncated frame rather than yielding an empty witness", () => {
+    // A witness set map {0:[[pub,sig]]} truncated mid-signature: the declared
+    // 64-byte sig (5840…) is cut short, so the bounds guard must throw at the
+    // parse — NOT silently return a zero-length/plausible witness.
+    const full = "a10081" + "82" + "5820" + TEST_PUB_KEY_HEX + "5840" + TEST_SIG_HEX;
+    const truncated = full.slice(0, full.length - 20); // drop 10 bytes of the sig
+    const bytes = Uint8Array.from(Buffer.from(truncated, "hex"));
+    expect(() => witnessSetToPairs(bytes)).toThrow(/unexpected end of input/i);
+  });
+
+  test("throws when the public key is not 32 bytes", () => {
+    // Declare a 16-byte pubkey (5010…) — a wrong-length key must be rejected.
+    const badPub = "00".repeat(16);
+    const hex = "a10081" + "82" + "50" + badPub + "5840" + TEST_SIG_HEX;
+    const bytes = Uint8Array.from(Buffer.from(hex, "hex"));
+    expect(() => witnessSetToPairs(bytes)).toThrow(/public key is 16 bytes, expected 32/i);
+  });
+
+  test("throws when the signature is not 64 bytes", () => {
+    // Declare a 32-byte sig (5820…) — a wrong-length signature must be rejected.
+    const badSig = "11".repeat(32);
+    const hex = "a10081" + "82" + "5820" + TEST_PUB_KEY_HEX + "5820" + badSig;
+    const bytes = Uint8Array.from(Buffer.from(hex, "hex"));
+    expect(() => witnessSetToPairs(bytes)).toThrow(/signature is 32 bytes, expected 64/i);
+  });
+});
+
+// ── buildKeystoneUtxos (real per-input amount + address) ──────────────────────
+
+describe("buildKeystoneUtxos", () => {
+  test("maps each input's real lovelace amount + address onto the UTxO record", () => {
+    // The device must receive the true value/address so it can display inputs and
+    // compute the fee — NOT the old "0"/"" placeholders.
+    const utxos = buildKeystoneUtxos(NEUTRAL_REQ, "52744703");
+    expect(utxos).toHaveLength(1);
+    expect(utxos[0]).toEqual({
+      transactionHash: "deadbeef".repeat(8),
+      index: 0,
+      amount: "5000000",
+      xfp: "52744703",
+      hdPath: "1852'/1815'/0'/0/0",
+      address: "addr1input",
+    });
+  });
+
+  test("throws naming an input that has no derivation path (never silently dropped)", () => {
+    const req: HardwareSignResponse = {
+      ...NEUTRAL_REQ,
+      inputs: [{ tx_hash_hex: "ab".repeat(32), output_index: 3, lovelace: "1", address_bech32: "a" }],
+    };
+    expect(() => buildKeystoneUtxos(req, "52744703")).toThrow(
+      new RegExp(`${"ab".repeat(32)}#3.*no derivation path`, "i"),
+    );
+  });
+
+  test("throws when an input is missing its resolved amount/address", () => {
+    const req: HardwareSignResponse = {
+      ...NEUTRAL_REQ,
+      inputs: [{ tx_hash_hex: "cd".repeat(32), output_index: 1, path: "1852'/1815'/0'/0/0" }],
+    };
+    expect(() => buildKeystoneUtxos(req, "52744703")).toThrow(/missing its resolved amount\/address/i);
+  });
+
+  test("throws when there are no inputs to witness", () => {
+    const req: HardwareSignResponse = { ...NEUTRAL_REQ, inputs: [] };
+    expect(() => buildKeystoneUtxos(req, "52744703")).toThrow(/no inputs to witness/i);
+  });
+});
+
+describe("parseAccountSyncUR", () => {
+  test("returns the account xpub + master fingerprint for the requested account", async () => {
+    const sync = await parseAccountSyncUR(
+      {
+        type: "crypto-multi-accounts",
+        cborHex: accountSyncCborHex(TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, ACCT0_PATH),
+      },
+      0,
+    );
+    expect(sync.xpub).toBe(TEST_XPUB_BECH32);
+    expect(sync.xfp).toBe("52744703");
+    expect(sync.account).toBe(0);
+  });
+
+  test("rejects when the requested account is absent from the sync UR", async () => {
+    await expect(
+      parseAccountSyncUR(
+        {
+          type: "crypto-multi-accounts",
+          cborHex: accountSyncCborHex(TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, ACCT0_PATH),
+        },
+        5,
+      ),
+    ).rejects.toThrow(/does not contain account 5/i);
+  });
+});
+
+describe("parseAccountSyncXfp", () => {
+  test("returns just the master fingerprint (account-independent recovery)", async () => {
+    // Even for an account not present in the sync UR, the master fingerprint is
+    // recoverable — it is account-independent — so Send can re-learn a lost xfp.
+    const xfp = await parseAccountSyncXfp({
+      type: "crypto-multi-accounts",
+      cborHex: accountSyncCborHex(TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, ACCT0_PATH),
+    });
+    expect(xfp).toBe("52744703");
+  });
+
+  test("rejects a non-account-sync UR", async () => {
+    await expect(
+      parseAccountSyncXfp({
+        type: "cardano-signature",
+        cborHex: signatureCborHex(TEST_PUB_KEY_HEX, TEST_SIG_HEX),
+      }),
+    ).rejects.toThrow(/account-sync/i);
+  });
+});
+
+// ── USB transport ─────────────────────────────────────────────────────────────
+
+function setWebUSB(available: boolean) {
+  Object.defineProperty(globalThis.navigator ?? (globalThis.navigator = {} as Navigator), "usb", {
+    value: available ? {} : undefined,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe("connectKeystoneUSB", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setWebUSB(true);
+    const transport = { close: mockClose };
+    mockConnect.mockResolvedValue(transport);
+    mockGetAppConfig.mockResolvedValue({ version: "1.0.0", mfp: "52744703" });
+    mockGetXpubs.mockResolvedValue([
+      { publicKeyHex: TEST_PUB_KEY_HEX, chainCodeHex: TEST_CHAIN_CODE_HEX },
+    ]);
+    mockSignTx.mockResolvedValue({
+      txHashHex: "cafebabe",
+      witnesses: [{ path: ACCT0_PATH, witnessSignatureHex: TEST_SIG_HEX }],
+      auxiliaryDataSupplement: null,
+    });
+  });
+
+  test("throws a clear error when WebUSB is unavailable", async () => {
+    setWebUSB(false);
+    await expect(connectKeystoneUSB()).rejects.toThrow(/WebUSB not available/i);
+  });
+
+  test("reports kind 'keystone' and conservative USB capabilities (send only)", async () => {
+    const session = await connectKeystoneUSB();
+    expect(session.kind).toBe("keystone");
+    expect(session.capabilities).toEqual({
+      send: true,
+      staking: false,
+      governance: false,
+      multisig: false,
+      poolReg: false,
+    });
+    await session.close();
+    expect(mockClose).toHaveBeenCalledOnce();
+  });
+
+  test("requests permission before connecting (needs live user activation)", async () => {
+    await connectKeystoneUSB();
+    expect(mockRequestPermission).toHaveBeenCalledOnce();
+    expect(mockConnect).toHaveBeenCalledOnce();
+    expect(mockRequestPermission.mock.invocationCallOrder[0]).toBeLessThan(
+      mockConnect.mock.invocationCallOrder[0],
+    );
+  });
+
+  test("getAccountXpub reads the account key and matches the shared vector", async () => {
+    const session = await connectKeystoneUSB();
+    const xpub = await session.getAccountXpub(0);
+    expect(mockGetXpubs).toHaveBeenCalledWith({ paths: [ACCT0_PATH] });
+    expect(xpub).toBe(TEST_XPUB_BECH32);
+  });
+
+  test("signTx returns a witness array identical to the shared encoder output", async () => {
+    const session = await connectKeystoneUSB();
+    const result = await session.signTx(NEUTRAL_REQ);
+    expect(mockSignTx).toHaveBeenCalledOnce();
+    expect(result).toBe(
+      encodeWitnessArray([{ pubKeyHex: TEST_PUB_KEY_HEX, sigHex: TEST_SIG_HEX }]),
+    );
+    expect(result.startsWith("8182")).toBe(true);
+  });
+});
+
+// A sanity check that the shared encoder is the SAME one every device uses:
+// re-encoding the parity key here must equal the canonical Ledger/Trezor xpub.
+test("shared xpub encoder parity guard", () => {
+  expect(encodeXpub(TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX)).toBe(TEST_XPUB_BECH32);
+});

--- a/ui/web/src/hw/keystone.ts
+++ b/ui/web/src/hw/keystone.ts
@@ -1,0 +1,647 @@
+/**
+ * hw/keystone.ts — Keystone hardware-wallet signer (air-gapped QR + USB).
+ *
+ * Keystone is fully LOCAL on BOTH transports, so — unlike the Trezor path — no
+ * external-consent gate applies (see the consent-law note in hw/types.ts):
+ *   - QR  (primary): fully offline. An animated QR carries a `cardano-sign-request`
+ *          UR to the device; the device signs on-screen and shows a
+ *          `cardano-signature` UR the user scans back through the webcam. Only
+ *          the local camera (getUserMedia) is touched — no network egress.
+ *   - USB (secondary, best-effort): @keystonehq/hw-app-ada over WebUSB. The
+ *          vendor SDK is young (v0.1.1) and firmware coverage is unverified, so
+ *          failures are surfaced plainly and capabilities stay conservative.
+ *
+ * Every heavy dependency (@keystonehq/*, buffer) is loaded through a dynamic
+ * import inside the connect path so it is CODE-SPLIT out of the initial bundle.
+ *
+ * Xpub/witness encoding parity with Ledger/Trezor/Go is guaranteed by reusing
+ * the SHARED hw/xpub.ts and hw/witness.ts encoders: the account-sync xpub and
+ * the assembled witness array are byte-for-byte identical for identical key
+ * material (exercised in keystone.test.ts).
+ */
+
+import type { HardwareSignResponse } from "../api/types";
+import type {
+  HardwareCapabilities,
+  HardwareSigner,
+  KeystoneConnectOptions,
+  KeystoneQRConnectOptions,
+  KeystoneScannedUR,
+} from "./types";
+import { encodeXpub } from "./xpub";
+import { encodeWitnessArray } from "./witness";
+import { isValidKeystoneXfp } from "./deviceKind";
+
+// ── BIP32 path helpers ───────────────────────────────────────────────────────
+
+const HARDENED = 0x80000000;
+
+/** CIP-1852 account-level path string, e.g. account 0 → "1852'/1815'/0'". */
+function accountPathStr(account: number): string {
+  return `1852'/1815'/${account}'`;
+}
+
+/** CIP-1852 account-level path array, e.g. [1852', 1815', account']. */
+function accountPath(account: number): number[] {
+  return [1852 + HARDENED, 1815 + HARDENED, account + HARDENED];
+}
+
+// parseBip32Path converts a CIP-1852 path string to a numeric array.
+// "1852'/1815'/0'/0/3" → [0x80000000+1852, 0x80000000+1815, 0x80000000+0, 0, 3]
+function parseBip32Path(pathStr: string): number[] {
+  return pathStr.split("/").map((seg) => {
+    const hardened = seg.endsWith("'");
+    const n = parseInt(hardened ? seg.slice(0, -1) : seg, 10);
+    return hardened ? n + HARDENED : n;
+  });
+}
+
+/** Normalise a path to the "1852'/1815'/0'" form (drop any leading "m/"). */
+function normalizePath(path: string): string {
+  return path.replace(/^m\//, "").trim();
+}
+
+// ── Capabilities ───────────────────────────────────────────────────────────
+
+// QR is a "sign a raw tx body + witness these paths" model. Today only the
+// payment inputs are mapped into the request's `utxos`; stake-key signer paths
+// are NOT yet mapped into `extraSigners`, so a certificate tx would be witnessed
+// incompletely. Staking is therefore advertised as UNSUPPORTED until those
+// signer paths are wired in — don't flip this back to `true` without also
+// populating `extraSigners` with the stake path(s). Structured multisig /
+// pool-reg / governance are likewise not expressible here and stay gated off.
+const KEYSTONE_QR_CAPABILITIES: HardwareCapabilities = {
+  send: true,
+  staking: false,
+  governance: false,
+  multisig: false,
+  poolReg: false,
+};
+
+// USB rides a young, unverified vendor SDK. We do not claim more than the
+// send-parity baseline every implemented device already meets.
+const KEYSTONE_USB_CAPABILITIES: HardwareCapabilities = {
+  send: true,
+  staking: false,
+  governance: false,
+  multisig: false,
+  poolReg: false,
+};
+
+// UR animated-QR fragment size (bytes of CBOR per frame). Small enough that each
+// frame stays a low-density, reliably-scannable QR; larger txs simply animate
+// across more frames, which the receiver reassembles.
+const UR_MAX_FRAGMENT_LEN = 200;
+
+// ── buffer polyfill (lazy) ───────────────────────────────────────────────────
+
+/**
+ * The @keystonehq CBOR libraries read a global `Buffer`, which browsers do not
+ * provide. We install one lazily — only when a Keystone flow actually runs — so
+ * the `buffer` shim rides the code-split Keystone chunk and never bloats the
+ * initial bundle. Exported so the QR scanner component (which decodes URs with
+ * @ngraveio/bc-ur) can share the exact same guarantee.
+ */
+export async function ensureBuffer(): Promise<void> {
+  const g = globalThis as unknown as { Buffer?: unknown };
+  if (typeof g.Buffer === "undefined") {
+    const mod = await import("buffer");
+    g.Buffer = mod.Buffer;
+  }
+}
+
+// ── Minimal CBOR reader (witness-set extraction only) ────────────────────────
+//
+// Keystone's `cardano-signature` UR carries a serialized TransactionWitnessSet,
+// but the backend's submit endpoint wants the RAW vkey-witness array
+// ([[pubkey, sig], …]) that hw/witness.ts produces. We therefore decode just
+// enough CBOR to pull the vkey witnesses (map key 0) out of the witness set and
+// re-encode them through the shared encoder, so Keystone's witness output is
+// byte-identical to Ledger's and Trezor's.
+
+type CborValue = number | Uint8Array | string | CborValue[] | Map<number, CborValue>;
+
+// This decoder parses input that arrives off a camera (a scanned QR), so every
+// multi-byte read is bounds-checked against the buffer length: past the end,
+// `buf[i]` yields `undefined`, which would otherwise coerce to a plausible-looking
+// zero/NaN length and produce a silently-empty witness. Overrun MUST throw here so
+// a truncated/hostile frame fails at the parse rather than at submission.
+function need(buf: Uint8Array, pos: number, n: number): void {
+  if (pos + n > buf.length) {
+    throw new Error(`CBOR: unexpected end of input (need ${n} byte(s) at offset ${pos}, have ${buf.length})`);
+  }
+}
+
+/** Decode one CBOR data item at `offset`; returns the value and the next offset. */
+function decodeCbor(buf: Uint8Array, offset: number): { value: CborValue; next: number } {
+  need(buf, offset, 1);
+  const first = buf[offset];
+  const major = first >> 5;
+  const info = first & 0x1f;
+  let len = info;
+  let pos = offset + 1;
+  if (info === 24) {
+    need(buf, pos, 1);
+    len = buf[pos];
+    pos += 1;
+  } else if (info === 25) {
+    need(buf, pos, 2);
+    len = (buf[pos] << 8) | buf[pos + 1];
+    pos += 2;
+  } else if (info === 26) {
+    need(buf, pos, 4);
+    len = (buf[pos] * 0x1000000) + (buf[pos + 1] << 16) + (buf[pos + 2] << 8) + buf[pos + 3];
+    pos += 4;
+  } else if (info === 27) {
+    // 64-bit length: witness sets never approach 2^53, so a Number is safe here.
+    need(buf, pos, 8);
+    len = 0;
+    for (let i = 0; i < 8; i++) len = len * 256 + buf[pos + i];
+    pos += 8;
+  } else if (info > 27) {
+    throw new Error(`CBOR: unsupported additional-info ${info}`);
+  }
+
+  switch (major) {
+    case 0: // unsigned int
+      return { value: len, next: pos };
+    case 2: { // byte string
+      need(buf, pos, len);
+      const value = buf.slice(pos, pos + len);
+      return { value, next: pos + len };
+    }
+    case 3: { // text string
+      need(buf, pos, len);
+      const value = new TextDecoder().decode(buf.slice(pos, pos + len));
+      return { value, next: pos + len };
+    }
+    case 4: { // array
+      const arr: CborValue[] = [];
+      let p = pos;
+      for (let i = 0; i < len; i++) {
+        const r = decodeCbor(buf, p);
+        arr.push(r.value);
+        p = r.next;
+      }
+      return { value: arr, next: p };
+    }
+    case 5: { // map
+      const map = new Map<number, CborValue>();
+      let p = pos;
+      for (let i = 0; i < len; i++) {
+        const k = decodeCbor(buf, p);
+        const v = decodeCbor(buf, k.next);
+        map.set(k.value as number, v.value);
+        p = v.next;
+      }
+      return { value: map, next: p };
+    }
+    case 6: { // tag — unwrap (e.g. the Conway set tag 258 around the witness array)
+      const r = decodeCbor(buf, pos);
+      return { value: r.value, next: r.next };
+    }
+    default:
+      throw new Error(`CBOR: unsupported major type ${major}`);
+  }
+}
+
+function toHex(bytes: Uint8Array): string {
+  let out = "";
+  for (const b of bytes) out += b.toString(16).padStart(2, "0");
+  return out;
+}
+
+/**
+ * Extract {pubKeyHex, sigHex} pairs from a serialized TransactionWitnessSet.
+ *
+ * Accepts either the full witness set (a CBOR map whose key 0 is the vkey-witness
+ * array) or, defensively, a bare vkey-witness array. Each vkey witness is
+ * [pubkey_bytes, sig_bytes]. Some firmwares attach the 64-byte extended vkey
+ * (pubkey || chaincode); only the leading 32-byte Ed25519 public key belongs in
+ * a Cardano vkey witness, so we trim it to keep parity with the other devices.
+ */
+export function witnessSetToPairs(
+  witnessSetBytes: Uint8Array,
+): { pubKeyHex: string; sigHex: string }[] {
+  const { value } = decodeCbor(witnessSetBytes, 0);
+  let vkeyWitnesses: CborValue;
+  if (value instanceof Map) {
+    const w = value.get(0);
+    if (!w) throw new Error("Keystone witness set has no vkey witnesses (map key 0 absent)");
+    vkeyWitnesses = w;
+  } else if (Array.isArray(value)) {
+    vkeyWitnesses = value;
+  } else {
+    throw new Error("Keystone witness set is neither a map nor an array");
+  }
+  if (!Array.isArray(vkeyWitnesses)) {
+    throw new Error("Keystone vkey-witness field is not an array");
+  }
+  return vkeyWitnesses.map((w) => {
+    if (!Array.isArray(w) || w.length < 2) {
+      throw new Error("Keystone vkey witness is not a [pubkey, sig] pair");
+    }
+    const [pub, sig] = w;
+    if (!(pub instanceof Uint8Array) || !(sig instanceof Uint8Array)) {
+      throw new Error("Keystone vkey witness fields are not byte strings");
+    }
+    // Trim an extended (pubkey||chaincode) vkey down to the 32-byte public key.
+    const pubKey = pub.length > 32 ? pub.slice(0, 32) : pub;
+    // A truncated/malformed frame can decode to a wrong-length key or signature;
+    // reject it here rather than emit an invalid witness that fails at submission.
+    if (pubKey.length !== 32) {
+      throw new Error(`Keystone vkey witness public key is ${pubKey.length} bytes, expected 32`);
+    }
+    if (sig.length !== 64) {
+      throw new Error(`Keystone vkey witness signature is ${sig.length} bytes, expected 64`);
+    }
+    return { pubKeyHex: toHex(pubKey), sigHex: toHex(sig) };
+  });
+}
+
+// ── Account-sync (crypto-multi-accounts) parsing ─────────────────────────────
+
+export interface KeystoneAccountSync {
+  /** Bech32 "root_xvk" account xpub, byte-identical to Ledger/Trezor/Go. */
+  xpub: string;
+  /** Device master fingerprint (hex) — needed to sign later over QR. */
+  xfp: string;
+  /** The CIP-1852 account index the key was found at. */
+  account: number;
+}
+
+/**
+ * Parse a scanned `crypto-multi-accounts` UR into the CIP-1852 account xpub for
+ * the requested account. The device exports one or more account keys; we select
+ * the one whose derivation origin is m/1852'/1815'/<account>' and re-encode it
+ * through the shared hw/xpub.ts helper so it matches every other device.
+ */
+async function decodeAccountSync(scanned: KeystoneScannedUR) {
+  if (scanned.type !== "crypto-multi-accounts") {
+    throw new Error(
+      `Expected a Keystone account-sync QR (crypto-multi-accounts), got "${scanned.type}". ` +
+        "On the Keystone, open the Cardano account and choose Sync / Connect Software Wallet.",
+    );
+  }
+  await ensureBuffer();
+  const { CryptoMultiAccounts, Buffer: B } = await import("@keystonehq/bc-ur-registry-cardano");
+  // The registry's Buffer (from the `buffer` package) and @types/node's Buffer
+  // are structurally different in TS though identical at runtime; bridge with a
+  // cast at each library boundary.
+  const accounts = CryptoMultiAccounts.fromCBOR(B.from(scanned.cborHex, "hex") as unknown as Buffer);
+  const xfp = toHex(new Uint8Array(accounts.getMasterFingerprint()));
+  return { accounts, xfp };
+}
+
+/**
+ * Read ONLY the device master fingerprint (xfp) from a scanned account-sync UR.
+ *
+ * The fingerprint is account-independent, so — unlike {@link parseAccountSyncUR}
+ * — this needs no account index and does not require a specific account key to be
+ * present. Used by Send's recovery flow to re-learn the xfp of an
+ * already-added wallet whose local hint was lost, without re-deriving its xpub.
+ */
+export async function parseAccountSyncXfp(scanned: KeystoneScannedUR): Promise<string> {
+  const { xfp } = await decodeAccountSync(scanned);
+  return xfp;
+}
+
+export async function parseAccountSyncUR(
+  scanned: KeystoneScannedUR,
+  account: number,
+): Promise<KeystoneAccountSync> {
+  const { accounts, xfp } = await decodeAccountSync(scanned);
+  const wantHardened = accountPathStr(account); // "1852'/1815'/0'"
+  const wantPlain = wantHardened.replace(/'/g, "h"); // some encoders render as "1852h/1815h/0h"
+
+  for (const key of accounts.getKeys()) {
+    const origin = key.getOrigin?.();
+    const rawPath = origin ? normalizePath(origin.getPath()) : "";
+    const path = rawPath.toLowerCase();
+    if (path !== wantHardened && path !== wantPlain.toLowerCase()) continue;
+    const pubKey = toHex(new Uint8Array(key.getKey()));
+    const chainCode = toHex(new Uint8Array(key.getChainCode()));
+    return { xpub: encodeXpub(pubKey, chainCode), xfp, account };
+  }
+  throw new Error(
+    `This Keystone account-sync QR does not contain account ${account} ` +
+      `(m/${wantHardened}). Re-export the sync QR for that account on the device.`,
+  );
+}
+
+// ── QR sign-request assembly ─────────────────────────────────────────────────
+
+/** A Keystone CardanoUtxoData record (mirrors the registry's constructor input). */
+export interface KeystoneUtxo {
+  transactionHash: string;
+  index: number;
+  amount: string;
+  xfp: string;
+  hdPath: string;
+  address: string;
+}
+
+/**
+ * Map the neutral request's wallet inputs into Keystone UTxO records.
+ *
+ * Each record carries the input's REAL lovelace amount and address so the device
+ * can display the inputs and compute the fee (sum(inputs) − sum(outputs)) — the
+ * whole reason to tolerate the air-gapped QR dance is to confirm, on hardware the
+ * host cannot influence, exactly what is being approved.
+ *
+ * Every input in a send tx is wallet-owned and must therefore carry a derivation
+ * path AND a resolved value. A missing path or value is a wrong-shape request
+ * (an input the device could not witness, or could only partially describe), so
+ * we throw NAMING the offending input rather than silently drop it or pad it with
+ * a placeholder — either of which would let the device sign what it cannot show.
+ */
+export function buildKeystoneUtxos(req: HardwareSignResponse, xfp: string): KeystoneUtxo[] {
+  const utxos = req.inputs.map((inp) => {
+    const ref = `${inp.tx_hash_hex}#${inp.output_index}`;
+    if (!inp.path) {
+      throw new Error(
+        `Keystone cannot sign input ${ref}: it has no derivation path (not recognised as ` +
+          "wallet-owned), so the device could not witness it.",
+      );
+    }
+    if (!inp.lovelace || !inp.address_bech32) {
+      throw new Error(
+        `Keystone input ${ref} is missing its resolved amount/address, so the device could ` +
+          "not display it or compute the fee. This is a backend inconsistency; do not sign.",
+      );
+    }
+    return {
+      transactionHash: inp.tx_hash_hex,
+      index: inp.output_index,
+      // The Keystone UTxO registry carries lovelace + address only (no native
+      // assets), which is sufficient for ADA-only sends and for the fee display.
+      amount: inp.lovelace,
+      xfp,
+      hdPath: normalizePath(inp.path),
+      address: inp.address_bech32,
+    };
+  });
+  if (utxos.length === 0) {
+    throw new Error("Keystone sign request has no inputs to witness.");
+  }
+  return utxos;
+}
+
+// A random-enough request id; the device echoes it back on the signature so a
+// stale scan can be detected. crypto.randomUUID is available in every target
+// (secure-context browsers); fall back to a fixed nil UUID if it is missing.
+function newRequestId(): string {
+  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  return c?.randomUUID ? c.randomUUID() : "00000000-0000-0000-0000-000000000000";
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Connect a Keystone via the air-gapped QR transport. Fully offline: the only
+ * capability touched is the local webcam (through the UI bridge). No consent
+ * gate — nothing leaves the node.
+ */
+export async function connectKeystoneQR(
+  opts: KeystoneQRConnectOptions,
+): Promise<HardwareSigner> {
+  const { bridge } = opts;
+  if (!bridge) {
+    throw new Error("Keystone QR transport requires a UI bridge (animated-QR display + webcam scanner).");
+  }
+
+  return {
+    kind: "keystone",
+    capabilities: KEYSTONE_QR_CAPABILITIES,
+
+    async getAccountXpub(account: number): Promise<string> {
+      // The account xpub arrives on a SEPARATE account-sync QR, not the sign
+      // registry — the caller scans it and we extract the CIP-1852 key.
+      const scanned = await bridge.scanResponse();
+      try {
+        const sync = await parseAccountSyncUR(scanned, account);
+        return sync.xpub;
+      } finally {
+        bridge.close();
+      }
+    },
+
+    async signTx(req: HardwareSignResponse): Promise<string> {
+      await ensureBuffer();
+      const { CardanoSignRequest, CardanoSignature, Buffer: B } = await import(
+        "@keystonehq/bc-ur-registry-cardano"
+      );
+
+      // The device master fingerprint is mandatory: it is how the Keystone
+      // recognises the witness paths as its own. It is learned only at
+      // account-sync and remembered as a local hint, so it CAN go missing (e.g.
+      // a browser-data wipe). Never FABRICATE a zero fingerprint — a synthesized
+      // all-zero xfp would silently produce a request the device cannot match, so
+      // signing would appear to run but fail on-device. Block instead and steer
+      // the user to re-scan the account-sync QR (which yields the fingerprint
+      // again). Note: this blocks the ABSENCE of a fingerprint — a genuine
+      // all-zero xfp reported by a real device is a valid (1-in-2^32) value and
+      // is intentionally accepted (see isValidKeystoneXfp in deviceKind.ts).
+      const xfp = opts.xfp;
+      if (!isValidKeystoneXfp(xfp)) {
+        throw new Error(
+          "This Keystone wallet's device fingerprint is missing. Re-scan the account-sync QR " +
+            "(open the Cardano account on the device and choose Sync / Connect Software Wallet) to recover it, then try again.",
+        );
+      }
+      // Map the neutral request → a Keystone CardanoSignRequest:
+      //   signData    = the unsigned tx body the device signs;
+      //   utxos       = the wallet-owned inputs, each carrying its REAL lovelace
+      //                 amount + address so the device displays the inputs and
+      //                 computes the fee (sum(inputs) − sum(outputs)) on its own
+      //                 screen — the security control for an air-gapped signer;
+      //   extraSigners= none (send + simple witnessing only; structured
+      //                 multisig/cert signers are gated off by capabilities).
+      const signData = B.from(req.unsigned_tx_cbor, "hex") as unknown as Buffer;
+      const utxos = buildKeystoneUtxos(req, xfp);
+
+      const signRequest = CardanoSignRequest.constructCardanoSignRequest(
+        signData,
+        utxos,
+        [],
+        newRequestId(),
+        "bursa-wallet",
+      );
+
+      // Show the animated request QR, then wait for the user to scan the reply.
+      const fragments = signRequest.toUREncoder(UR_MAX_FRAGMENT_LEN).encodeWhole();
+      bridge.displayRequest(fragments);
+      try {
+        const scanned = await bridge.scanResponse();
+        if (scanned.type !== "cardano-signature") {
+          throw new Error(
+            `Expected a Keystone signature QR (cardano-signature), got "${scanned.type}".`,
+          );
+        }
+        const signature = CardanoSignature.fromCBOR(
+          B.from(scanned.cborHex, "hex") as unknown as Buffer,
+        );
+        const witnessSet = new Uint8Array(signature.getWitnessSet());
+        return encodeWitnessArray(witnessSetToPairs(witnessSet));
+      } finally {
+        bridge.close();
+      }
+    },
+
+    async close(): Promise<void> {
+      // No persistent transport for QR; make sure any open modal/camera is torn
+      // down (idempotent — bridge.close guards its own state).
+      bridge.close();
+    },
+  };
+}
+
+/**
+ * Connect a Keystone over USB (WebUSB).
+ *
+ * NOT USER-SELECTABLE: this rides a young vendor SDK (@keystonehq/hw-app-ada,
+ * pre-1.0) whose firmware coverage has never been exercised against real
+ * hardware. Until that validation lands, neither AddWallet nor Send offers a USB
+ * transport for Keystone — the device is air-gapped-QR-only. The code is kept
+ * (and unit-tested against SDK mocks) so wiring it back up is a one-line UI
+ * change once it can be validated on a device; it must not be re-exposed before.
+ *
+ * @throws Error — "WebUSB not available …" when the browser lacks WebUSB.
+ */
+export async function connectKeystoneUSB(): Promise<HardwareSigner> {
+  if (
+    typeof navigator === "undefined" ||
+    (navigator as Navigator & { usb?: unknown }).usb === undefined
+  ) {
+    throw new Error("WebUSB not available — open this in a Chromium browser to use Keystone over USB");
+  }
+
+  const { TransportWebUSB } = await import("@keystonehq/hw-transport-webusb");
+  const AdaModule = await import("@keystonehq/hw-app-ada");
+  const Ada = AdaModule.default;
+  const {
+    AddressType,
+    TransactionSigningMode,
+    TxOutputDestinationType,
+    TxOutputFormat,
+    TxRequiredSignerType,
+  } = AdaModule;
+
+  // requestPermission must run while the click's user-activation is still live.
+  await TransportWebUSB.requestPermission();
+  const transport = await TransportWebUSB.connect();
+  // The signing app needs the wallet master fingerprint; read it once, then
+  // build the app instance bound to it.
+  const bootstrap = new Ada(transport);
+  const { mfp } = await bootstrap.getAppConfig();
+  const cardano = new Ada(transport, mfp);
+
+  type LedgerLikeAssets = NonNullable<HardwareSignResponse["outputs"][number]["assets"]>;
+  function mapTokenBundle(assets: LedgerLikeAssets) {
+    const byPolicy = new Map<string, { assetNameHex: string; amount: bigint }[]>();
+    for (const a of assets) {
+      const tokens = byPolicy.get(a.policy_id_hex) ?? [];
+      tokens.push({ assetNameHex: a.asset_name_hex, amount: BigInt(a.amount) });
+      byPolicy.set(a.policy_id_hex, tokens);
+    }
+    return Array.from(byPolicy, ([policyIdHex, tokens]) => ({ policyIdHex, tokens }));
+  }
+
+  function mapToSignRequest(resp: HardwareSignResponse) {
+    const inputs = resp.inputs.map((inp) => ({
+      txHashHex: inp.tx_hash_hex,
+      outputIndex: inp.output_index,
+      path: inp.path ? parseBip32Path(inp.path) : null,
+    }));
+
+    const outputs = resp.outputs.map((out) => {
+      const destination =
+        out.payment_path && out.stake_path
+          ? {
+              type: TxOutputDestinationType.DEVICE_OWNED,
+              params: {
+                type: AddressType.BASE_PAYMENT_KEY_STAKE_KEY,
+                params: {
+                  spendingPath: parseBip32Path(out.payment_path),
+                  stakingPath: parseBip32Path(out.stake_path),
+                },
+              },
+            }
+          : {
+              type: TxOutputDestinationType.THIRD_PARTY,
+              params: { addressHex: out.address_hex },
+            };
+      return {
+        format: TxOutputFormat.ARRAY_LEGACY,
+        destination,
+        amount: BigInt(out.lovelace),
+        tokenBundle: out.assets && out.assets.length > 0 ? mapTokenBundle(out.assets) : [],
+      };
+    });
+
+    return {
+      tx: {
+        network: { protocolMagic: resp.protocol_magic, networkId: resp.network_id },
+        inputs,
+        outputs,
+        fee: BigInt(resp.fee),
+        ttl: resp.ttl ? BigInt(resp.ttl) : null,
+        requiredSigners: resp.required_signers.map((hashHex) => ({
+          type: TxRequiredSignerType.HASH,
+          hashHex,
+        })),
+        includeNetworkId: resp.include_network_id || null,
+      },
+      signingMode: TransactionSigningMode.ORDINARY_TRANSACTION,
+    };
+  }
+
+  return {
+    kind: "keystone",
+    capabilities: KEYSTONE_USB_CAPABILITIES,
+
+    async getAccountXpub(account: number): Promise<string> {
+      const [xpub] = await cardano.getExtendedPublicKeys({ paths: [accountPath(account)] });
+      return encodeXpub(xpub.publicKeyHex, xpub.chainCodeHex);
+    },
+
+    async signTx(req: HardwareSignResponse): Promise<string> {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const request = mapToSignRequest(req) as any;
+      const { witnesses } = await cardano.signTransaction(request);
+      const resolved = await Promise.all(
+        witnesses.map(async (w) => {
+          if (!w.path) {
+            throw new Error(
+              "Keystone returned a witness without a derivation path; cannot resolve its public key",
+            );
+          }
+          const [xpub] = await cardano.getExtendedPublicKeys({ paths: [w.path] });
+          return { pubKeyHex: xpub.publicKeyHex, sigHex: w.witnessSignatureHex };
+        }),
+      );
+      return encodeWitnessArray(resolved);
+    },
+
+    async close(): Promise<void> {
+      await transport.close();
+    },
+  };
+}
+
+/**
+ * Connect a Keystone with the given transport. Both transports are fully local,
+ * so no consent callback is involved.
+ */
+export function connectKeystone(opts: KeystoneConnectOptions): Promise<HardwareSigner> {
+  switch (opts.transport) {
+    case "qr":
+      return connectKeystoneQR(opts);
+    case "usb":
+      return connectKeystoneUSB();
+    default: {
+      const never: never = opts;
+      throw new Error(`Unknown Keystone transport: ${String((never as { transport?: string }).transport)}`);
+    }
+  }
+}

--- a/ui/web/src/hw/types.ts
+++ b/ui/web/src/hw/types.ts
@@ -83,16 +83,83 @@ export interface ExternalConnectOptions {
  */
 export type ConnectOptions = LocalConnectOptions | ExternalConnectOptions;
 
+// ── Keystone (air-gapped QR + USB) ───────────────────────────────────────────
+//
+// Keystone is fully LOCAL for both transports — QR is offline paper/camera and
+// USB is a direct cable — so NO external-consent gate applies (unlike Trezor).
+// The QR transport needs a UI bridge because signing is a two-way, user-driven
+// exchange (show an animated QR → user scans it with the device → user scans the
+// device's reply back through the webcam). The bridge below is that seam: the UI
+// owns pixels + camera; hw/keystone.ts owns all UR/CBOR. Everything stays local.
+
+/**
+ * A single Uniform Resource decoded from a scanned QR (or QR animation). `type`
+ * is the UR type (e.g. "cardano-signature", "crypto-multi-accounts") and
+ * `cborHex` is its raw CBOR payload as hex. hw/keystone.ts decodes it into the
+ * concrete Keystone registry item.
+ */
+export interface KeystoneScannedUR {
+  type: string;
+  cborHex: string;
+}
+
+/**
+ * UI bridge for the air-gapped QR transport. Implemented by the screen (a modal
+ * that renders the animated QR and the webcam scanner); consumed by the Keystone
+ * signer. Purely local — no method contacts the network.
+ */
+export interface KeystoneQRBridge {
+  /**
+   * Display the request to the user as an animated QR. `fragments` are the UR
+   * part strings the UI cycles through as QR frames. For account-sync (no
+   * request to show) this is never called.
+   */
+  displayRequest(fragments: string[]): void;
+  /**
+   * Prompt the user to scan the device's reply through the webcam and resolve
+   * with the decoded UR. Rejects if the user cancels or the camera is denied.
+   */
+  scanResponse(): Promise<KeystoneScannedUR>;
+  /** Tear down the modal + camera. Always invoked in a finally. */
+  close(): void;
+}
+
+/**
+ * Air-gapped QR transport options. `xfp` is the device master fingerprint
+ * captured during account-sync (needed so the device recognises the witness
+ * paths as its own); the screen sources it from its per-wallet local store.
+ */
+export interface KeystoneQRConnectOptions {
+  transport: "qr";
+  bridge: KeystoneQRBridge;
+  xfp?: string;
+}
+
+/** Direct-USB transport options (best-effort; young vendor SDK). */
+export interface KeystoneUSBConnectOptions {
+  transport: "usb";
+}
+
+/**
+ * Options for connecting a Keystone. A discriminated union on `transport`:
+ * "qr" (primary, air-gapped) or "usb" (secondary). Both are local, so — unlike
+ * {@link ExternalConnectOptions} — neither carries a consent callback.
+ */
+export type KeystoneConnectOptions =
+  | KeystoneQRConnectOptions
+  | KeystoneUSBConnectOptions;
+
 /**
  * Ties each {@link HardwareKind} to the connect-options it accepts, so the
  * factory can discriminate at compile time: a local device (Ledger) can NEVER
  * be handed a cloud-consent callback, and an external device (Trezor) can NEVER
  * be connected without one. Enforced via the kind-specific `connectDevice`
- * overloads in hw/index.ts. (Keystone is unsupported this phase; it accepts the
- * broad union and is rejected at runtime.)
+ * overloads in hw/index.ts. Keystone is local on both transports (QR and USB),
+ * so it takes {@link KeystoneConnectOptions} — a transport choice, never a
+ * cloud-consent callback.
  */
 export interface ConnectOptionsByKind {
   ledger: LocalConnectOptions;
   trezor: ExternalConnectOptions;
-  keystone: ConnectOptions;
+  keystone: KeystoneConnectOptions;
 }

--- a/ui/web/src/screens/AddWallet.test.tsx
+++ b/ui/web/src/screens/AddWallet.test.tsx
@@ -271,8 +271,8 @@ test("Connect hardware: Ledger is the default device; connects, adds wallet, sto
 
   // Ledger radio is selected by default.
   expect(screen.getByRole("radio", { name: /ledger/i })).toBeChecked();
-  // Keystone is listed but disabled (coming soon).
-  expect(screen.getByRole("radio", { name: /keystone/i })).toBeDisabled();
+  // Keystone is now a selectable device.
+  expect(screen.getByRole("radio", { name: /^keystone$/i })).toBeEnabled();
 
   // Fill in wallet name
   fireEvent.change(screen.getByLabelText(/wallet name/i), { target: { value: "Ledger Main" } });
@@ -384,4 +384,22 @@ test("Connect hardware: WebHID unavailable error message is shown", async () => 
     ).toBeInTheDocument(),
   );
   expect(onAdded).not.toHaveBeenCalled();
+});
+
+test("Connect hardware: Keystone is air-gapped QR only (no user-selectable USB transport)", async () => {
+  render(<AddWallet network="preview" knownVaultPassword="vault-pw" onAdded={vi.fn()} />);
+  goToHardware();
+
+  fireEvent.click(screen.getByRole("radio", { name: /^keystone$/i }));
+
+  // USB rides an unverified SDK, so it is NOT offered: there is no transport
+  // radio at all — Keystone connects air-gapped over QR only.
+  expect(screen.queryByRole("radio", { name: /^usb$/i })).not.toBeInTheDocument();
+  expect(screen.queryByRole("radio", { name: /air-gapped qr/i })).not.toBeInTheDocument();
+  expect(screen.getByText(/connects air-gapped over qr/i)).toBeInTheDocument();
+
+  // Keystone is local — no connect.trezor.io consent box appears.
+  expect(screen.queryByRole("checkbox", { name: /connect\.trezor\.io/i })).not.toBeInTheDocument();
+  // The QR flow scans an account QR rather than "connecting".
+  expect(screen.getByRole("button", { name: /scan account qr/i })).toBeInTheDocument();
 });

--- a/ui/web/src/screens/AddWallet.tsx
+++ b/ui/web/src/screens/AddWallet.tsx
@@ -7,7 +7,9 @@ import { CopyButton } from "../components/CopyButton";
 import { addWallet, addHardwareWallet, generateMnemonic, ApiError } from "../api/client";
 import { connectHardware } from "../hw";
 import type { HardwareKind, HardwareSigner } from "../hw";
-import { setDeviceKind } from "../hw/deviceKind";
+import { setDeviceKind, setKeystoneXfp } from "../hw/deviceKind";
+import { parseAccountSyncUR } from "../hw/keystone";
+import { useKeystoneQRBridge } from "../components/KeystoneQRModal";
 import type { WalletView } from "../api/types";
 import { MIN_PASSWORD_LEN, passwordLength } from "../password";
 import { CHALLENGE_WORD_COUNT, isChallengeAnswerCorrect, pickChallengeIndices, validateChallenge } from "../phraseChallenge";
@@ -51,12 +53,11 @@ interface AddWalletProps {
 // Mode within the Add Wallet flow.
 type Mode = "choose" | "create" | "create-confirm" | "restore" | "hardware";
 
-// Selectable hardware devices. Keystone is listed but disabled until its
-// signer lands, so users can see it is planned without being able to pick it.
+// Selectable hardware devices.
 const DEVICE_OPTIONS: { kind: HardwareKind; label: string; disabled?: boolean }[] = [
   { kind: "ledger", label: "Ledger" },
   { kind: "trezor", label: "Trezor" },
-  { kind: "keystone", label: "Keystone (coming soon)", disabled: true },
+  { kind: "keystone", label: "Keystone" },
 ];
 
 const DEVICE_LABELS: Record<HardwareKind, string> = {
@@ -96,6 +97,13 @@ export function AddWallet({
   const [deviceKind, setDeviceKindState] = useState<HardwareKind>("ledger");
   const [accountIndex, setAccountIndex] = useState("0");
   const [externalConsent, setExternalConsent] = useState(false);
+  // Keystone is offered as air-gapped QR ONLY. A USB transport exists in the
+  // signer code (hw/keystone.ts connectKeystoneUSB) but rides a young, unverified
+  // vendor SDK that has never been exercised against real hardware, so it is NOT
+  // user-selectable until that validation lands.
+  // The QR modal bridge is always mounted (hooks can't be conditional); it
+  // renders nothing until a Keystone QR flow drives it.
+  const { bridge: keystoneBridge, element: keystoneModal } = useKeystoneQRBridge();
 
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -214,14 +222,43 @@ export function AddWallet({
 
     setLoading(true);
     let session: HardwareSigner | null = null;
+    const defaultName = `${DEVICE_LABELS[deviceKind]} Wallet`;
     try {
-      // connectHardware dispatches to the right connector. For Trezor the
-      // consent box gates the connect button, so this reports the given
-      // approval; the real init() gate lives inside connectTrezor. For Ledger
-      // the callback is ignored.
+      if (deviceKind === "keystone") {
+        // Air-gapped account-sync: the account xpub arrives on its OWN QR
+        // (crypto-multi-accounts), scanned through the webcam modal — never a
+        // network round-trip and never the sign registry. parseAccountSyncUR
+        // re-encodes it through the shared xpub helper (byte-identical to every
+        // other device) and hands back the device master fingerprint we must
+        // remember so Send can sign over QR later.
+        let xfp: string;
+        let xpub: string;
+        try {
+          const scanned = await keystoneBridge.scanResponse();
+          const sync = await parseAccountSyncUR(scanned, account);
+          xpub = sync.xpub;
+          xfp = sync.xfp;
+        } finally {
+          keystoneBridge.close();
+        }
+        const wallet = await addHardwareWallet(name.trim() || defaultName, xpub, account, network, vaultPw);
+        setDeviceKind(wallet.id, "keystone");
+        // The xfp is a client-only hint (localStorage), not server-persisted
+        // wallet state. If it is ever missing or cleared, Send detects that
+        // (needsKeystoneResync) and prompts an account-sync re-scan to recover
+        // it before any QR signing — so a lost hint is non-fatal.
+        setKeystoneXfp(wallet.id, xfp);
+        onAdded(wallet);
+        return;
+      }
+
+      // Ledger and Trezor connect to a live device and read the account xpub
+      // from it (Keystone returned above via its QR account-sync). For Trezor the
+      // consent box gates the connect button, so this reports the given approval;
+      // the real init() gate lives inside connectTrezor. For local devices the
+      // callback is ignored.
       session = await connectHardware(deviceKind, async () => externalConsent);
       const xpub = await session.getAccountXpub(account);
-      const defaultName = `${DEVICE_LABELS[deviceKind]} Wallet`;
       const wallet = await addHardwareWallet(
         name.trim() || defaultName,
         xpub,
@@ -471,8 +508,14 @@ export function AddWallet({
   if (mode === "hardware") {
     const deviceLabel = DEVICE_LABELS[deviceKind];
     // Trezor reaches connect.trezor.io; its connect is gated on explicit
-    // acknowledgement (consent law). Ledger (WebHID) needs no such gate.
+    // acknowledgement (consent law). Ledger (WebHID) and Keystone (local QR/USB)
+    // need no such gate.
     const needsExternalConsent = deviceKind === "trezor";
+    const isKeystone = deviceKind === "keystone";
+    // Keystone is air-gapped QR only (USB is not user-selectable — see the note
+    // at the keystoneTransport removal above), so "is Keystone" implies QR.
+    const isKeystoneQR = isKeystone;
+    const connectVerb = isKeystoneQR ? "Scan account QR" : `Connect ${deviceLabel}`;
     return (
       <Card title="Connect hardware wallet">
         <form onSubmit={handleHardwareConnect}>
@@ -497,6 +540,12 @@ export function AddWallet({
               </label>
             ))}
           </fieldset>
+
+          {isKeystone && (
+            <p className="helper-text">
+              Keystone connects air-gapped over QR — no cable, nothing leaves your node.
+            </p>
+          )}
 
           <div className="field-group">
             <label htmlFor="hw-name">Wallet Name</label>
@@ -554,8 +603,9 @@ export function AddWallet({
           )}
 
           <p className="helper-text">
-            Connect your {deviceLabel} device, open the Cardano app, then click Connect.
-            No spending password is needed — the device signs every transaction.
+            {isKeystoneQR
+              ? "On your Keystone, open the Cardano account and choose Sync / Connect Software Wallet, then scan the account QR it shows. No spending password is needed — the device signs every transaction."
+              : `Connect your ${deviceLabel} device, open the Cardano app, then click Connect. No spending password is needed — the device signs every transaction.`}
           </p>
 
           {error && (
@@ -569,7 +619,7 @@ export function AddWallet({
               type="submit"
               disabled={loading || (needsExternalConsent && !externalConsent)}
             >
-              {loading ? "Connecting…" : `Connect ${deviceLabel}`}
+              {loading ? (isKeystoneQR ? "Scanning…" : "Connecting…") : connectVerb}
             </Button>
             <Button
               type="button"
@@ -586,6 +636,7 @@ export function AddWallet({
             )}
           </div>
         </form>
+        {keystoneModal}
       </Card>
     );
   }

--- a/ui/web/src/screens/Send.test.tsx
+++ b/ui/web/src/screens/Send.test.tsx
@@ -8,6 +8,7 @@ import type { HardwareSigner } from "../hw";
 // Mock the hardware factory so tests don't try to open WebHID / a Trezor popup.
 vi.mock("../hw", () => ({
   connectHardware: vi.fn(),
+  connectDevice: vi.fn(),
 }));
 
 // Send-parity capabilities shared by the mock signers below.
@@ -794,6 +795,66 @@ test("(w) a successful hardware send persists the chosen device kind", async () 
     expect(screen.getByText(new RegExp(MOCK_TX_RESULT.tx_hash))).toBeInTheDocument();
   });
   expect(getStoredDeviceKind("hw-persist")).toBe("ledger");
+
+  localStorage.clear();
+});
+
+test("(x) Keystone QR with a missing fingerprint blocks signing and prompts a re-scan", async () => {
+  vi.spyOn(client, "buildSend").mockResolvedValue(MOCK_PREVIEW);
+  localStorage.clear();
+  // Known to be a Keystone, but its fingerprint hint is absent (e.g. a
+  // browser-data wipe) — QR signing must not proceed with a zero fingerprint.
+  localStorage.setItem("bursa.hw.deviceKind", JSON.stringify({ "hw-ks": "keystone" }));
+
+  const { connectDevice } = await import("../hw");
+  const mockConnect = vi.mocked(connectDevice);
+  mockConnect.mockReset();
+
+  render(<Send isHardware walletId="hw-ks" />);
+
+  const inputs = screen.getAllByRole("textbox");
+  fireEvent.change(inputs[0], { target: { value: "addr_test1recipient" } });
+  fireEvent.change(inputs[1], { target: { value: "5" } });
+  fireEvent.click(screen.getByRole("button", { name: /review/i }));
+
+  await waitFor(() => {
+    expect(screen.getByText(/2 inputs/i)).toBeInTheDocument();
+  });
+
+  // The recovery prompt is shown and the confirm button is blocked (never a
+  // silent zero-fingerprint sign).
+  expect(screen.getByText(/reconnect this keystone/i)).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /scan account-sync qr/i })).toBeInTheDocument();
+  const confirm = screen.getByRole("button", { name: /reconnect keystone/i });
+  expect(confirm).toBeDisabled();
+
+  // Clicking the disabled confirm does nothing; no device connection is started.
+  fireEvent.click(confirm);
+  expect(mockConnect).not.toHaveBeenCalled();
+
+  localStorage.clear();
+});
+
+test("(y) Keystone QR with a stored fingerprint enables the confirm button", async () => {
+  vi.spyOn(client, "buildSend").mockResolvedValue(MOCK_PREVIEW);
+  localStorage.clear();
+  localStorage.setItem("bursa.hw.deviceKind", JSON.stringify({ "hw-ks2": "keystone" }));
+  localStorage.setItem("bursa.hw.keystoneXfp", JSON.stringify({ "hw-ks2": "52744703" }));
+
+  render(<Send isHardware walletId="hw-ks2" />);
+
+  const inputs = screen.getAllByRole("textbox");
+  fireEvent.change(inputs[0], { target: { value: "addr_test1recipient" } });
+  fireEvent.change(inputs[1], { target: { value: "5" } });
+  fireEvent.click(screen.getByRole("button", { name: /review/i }));
+
+  await waitFor(() => {
+    expect(screen.getByText(/2 inputs/i)).toBeInTheDocument();
+  });
+
+  // A valid fingerprint means no recovery prompt and a ready confirm button.
+  expect(screen.queryByText(/reconnect this keystone/i)).not.toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /confirm on.*keystone/i })).not.toBeDisabled();
 
   localStorage.clear();
 });

--- a/ui/web/src/screens/Send.tsx
+++ b/ui/web/src/screens/Send.tsx
@@ -11,9 +11,11 @@ import {
   ApiError,
 } from "../api/client";
 import { useContacts } from "../api/hooks";
-import { connectHardware } from "../hw";
+import { connectHardware, connectDevice } from "../hw";
 import type { HardwareKind, HardwareSigner } from "../hw";
-import { getStoredDeviceKind, setDeviceKind } from "../hw/deviceKind";
+import { getStoredDeviceKind, setDeviceKind, getKeystoneXfp, setKeystoneXfp } from "../hw/deviceKind";
+import { parseAccountSyncXfp } from "../hw/keystone";
+import { useKeystoneQRBridge } from "../components/KeystoneQRModal";
 import { Card } from "../components/Card";
 import { Input } from "../components/Input";
 import { Button } from "../components/Button";
@@ -359,16 +361,56 @@ function PreviewPhase({
   const needsDeviceChoice = isHardware && deviceKind === undefined;
   const deviceLabel = deviceKind ? DEVICE_LABELS[deviceKind] : "";
   // Trezor reaches connect.trezor.io, so its confirm is gated on an explicit
-  // acknowledgement (consent law); local devices (Ledger) need no such gate.
+  // acknowledgement (consent law); local devices (Ledger, Keystone) need none.
   const needsExternalConsent = deviceKind === "trezor";
+  const isKeystone = deviceKind === "keystone";
 
   // password is only used in the software (!isHardware) confirm path; hooks cannot be conditional.
   const [password, setPassword] = useState("");
   const [externalConsent, setExternalConsent] = useState(false);
+  // Keystone signs air-gapped over QR ONLY. A USB signer exists in the code
+  // (hw/keystone.ts connectKeystoneUSB) but rides a young, unverified vendor SDK
+  // never exercised against real hardware, so it is NOT user-selectable here.
+  // The Keystone device master fingerprint (xfp) for this wallet, sourced from
+  // the per-wallet local hint. QR signing REQUIRES it (the device matches its
+  // witness paths by it); when it is missing — e.g. after a browser-data wipe —
+  // we must NOT sign with a zero fingerprint. Instead the user re-scans the
+  // account-sync QR here to recover it (see handleKeystoneResync). Kept in state
+  // so a recovery updates the UI immediately.
+  const [keystoneXfp, setKeystoneXfpState] = useState<string | undefined>(() =>
+    walletId ? getKeystoneXfp(walletId) : undefined,
+  );
+  // The QR modal bridge is always mounted (hooks can't be conditional); it
+  // renders nothing until a Keystone QR flow drives it.
+  const { bridge: keystoneBridge, element: keystoneModal } = useKeystoneQRBridge();
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [exported, setExported] = useState<UnsignedTx | null>(null);
+
+  // QR signing needs the device fingerprint; when it is missing the user must
+  // re-scan the account-sync QR before they can sign (see handleKeystoneResync).
+  const needsKeystoneResync = isKeystone && keystoneXfp === undefined;
+
+  // Recover a lost Keystone fingerprint: re-scan the account-sync QR, read just
+  // the master fingerprint (account-independent), and persist it so QR signing
+  // can proceed. Mirrors the device-picker recovery pattern — no need to abandon
+  // and re-add the wallet.
+  async function handleKeystoneResync() {
+    setError(null);
+    setLoading(true);
+    try {
+      const scanned = await keystoneBridge.scanResponse();
+      const xfp = await parseAccountSyncXfp(scanned);
+      if (walletId) setKeystoneXfp(walletId, xfp);
+      setKeystoneXfpState(xfp);
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      keystoneBridge.close();
+      setLoading(false);
+    }
+  }
 
   // Select a device to sign with. This is TENTATIVE: the hint is NOT persisted
   // here, only after a successful hardware send (see handleHardwareConfirm), so
@@ -419,14 +461,35 @@ function PreviewPhase({
     let session: HardwareSigner | null = null;
     try {
       // 1. Connect directly from the click handler so a first-time user can
-      // grant WebHID permission while browser user activation is still live.
-      // The device kind is the one recorded when this wallet was added (or the
-      // one the user just chose when no hint was stored).
-      // The confirm button is disabled until the Trezor consent box is ticked,
-      // so this simply reports the already-given approval; the real gate lives
-      // in connectTrezor and refuses to init() without it. For a local device
-      // (Ledger) the callback is ignored.
-      session = await connectHardware(kind, async () => externalConsent);
+      // grant WebHID/WebUSB permission while browser user activation is still
+      // live. The device kind is the one recorded when this wallet was added
+      // (or the one the user just chose when no hint was stored).
+      if (kind === "keystone") {
+        // Keystone is air-gapped QR only — fully local, no consent gate. The
+        // animated-QR + webcam modal drives the exchange; the sign-request needs
+        // the device master fingerprint captured at account-sync (hw/keystone.ts).
+        // Never start a QR sign flow without a real fingerprint: a missing fp
+        // would build a request the device cannot match. The button is disabled
+        // while it is missing (needsKeystoneResync), so this is defensive —
+        // steer the user to the recovery re-scan.
+        if (keystoneXfp === undefined) {
+          setError(
+            "This Keystone wallet's device fingerprint is missing. Re-scan the account-sync QR to recover it before signing.",
+          );
+          return;
+        }
+        session = await connectDevice("keystone", {
+          transport: "qr",
+          bridge: keystoneBridge,
+          xfp: keystoneXfp,
+        });
+      } else {
+        // The confirm button is disabled until the Trezor consent box is
+        // ticked, so this simply reports the already-given approval; the real
+        // gate lives in connectTrezor and refuses to init() without it. For a
+        // local device (Ledger) the callback is ignored.
+        session = await connectHardware(kind, async () => externalConsent);
+      }
 
       // 2. Fetch the structured signing request once the device is connected.
       const signResp = await getHardwareSignRequest(preview.pending_id);
@@ -504,11 +567,11 @@ function PreviewPhase({
               <fieldset className="field-group" style={{ border: "none", padding: 0, margin: 0 }}>
                 <legend className="field-label">Which device backs this wallet?</legend>
                 <p className="helper-text">
-                  We could not tell whether this hardware wallet is a Ledger or a
-                  Trezor. Choose the device you used to add it; you can change
-                  this if a connection attempt fails.
+                  We could not tell which hardware wallet this is. Choose the
+                  device you used to add it; you can change this if a connection
+                  attempt fails.
                 </p>
-                {(["ledger", "trezor"] as const).map((k) => (
+                {(["ledger", "trezor", "keystone"] as const).map((k) => (
                   <label className="checkbox-row" key={k}>
                     <input
                       type="radio"
@@ -523,9 +586,28 @@ function PreviewPhase({
                 ))}
               </fieldset>
             )}
-            {deviceKind !== undefined && (
+            {needsKeystoneResync && (
+              // The device fingerprint hint was lost (e.g. browser-data wipe).
+              // QR signing cannot proceed without it, so recover it in place by
+              // re-scanning the account-sync QR rather than sending a request the
+              // device cannot match.
+              <fieldset className="field-group" style={{ border: "none", padding: 0, margin: 0 }}>
+                <legend className="field-label">Reconnect this Keystone</legend>
+                <p className="helper-text">
+                  We could not find this wallet&apos;s Keystone fingerprint on this browser
+                  (it may have been cleared). On the Keystone, open the Cardano account and
+                  choose Sync / Connect Software Wallet, then scan that QR to reconnect.
+                </p>
+                <Button onClick={handleKeystoneResync} disabled={loading}>
+                  {loading ? "Scanning…" : "Scan account-sync QR"}
+                </Button>
+              </fieldset>
+            )}
+            {deviceKind !== undefined && !needsKeystoneResync && (
               <p className="helper-text">
-                Connect your {deviceLabel} and confirm the transaction on the device.
+                {isKeystone
+                  ? "Confirm to show the transaction as a QR for your Keystone, then scan its signature back."
+                  : `Connect your ${deviceLabel} and confirm the transaction on the device.`}
               </p>
             )}
             {needsExternalConsent && (
@@ -571,10 +653,17 @@ function PreviewPhase({
                 loading ||
                 exporting ||
                 needsDeviceChoice ||
+                needsKeystoneResync ||
                 (needsExternalConsent && !externalConsent)
               }
             >
-              {loading ? "Signing…" : needsDeviceChoice ? "Choose a device" : `Confirm on ${deviceLabel}`}
+              {loading
+                ? "Signing…"
+                : needsDeviceChoice
+                  ? "Choose a device"
+                  : needsKeystoneResync
+                    ? "Reconnect Keystone"
+                    : `Confirm on ${deviceLabel}`}
             </Button>
           ) : (
             <Button onClick={handleConfirm} disabled={loading || exporting || !password}>
@@ -621,6 +710,7 @@ function PreviewPhase({
           </div>
         )}
       </div>
+      {keystoneModal}
     </Card>
   );
 }

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -2023,3 +2023,59 @@ a:hover {
   color: var(--accent);
   margin: var(--space-2) 0;
 }
+
+/* Keystone air-gapped QR modal: animated request QR + webcam scanner. */
+/* A dedicated overlay that OWNS centering (both axes), so the modal never relies
+   on a parent's incidental layout to be centered. */
+.qr-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, black 55%, transparent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4);
+  z-index: 50;
+}
+.qr-modal {
+  width: min(420px, 100%);
+  max-height: 100%;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  overflow-y: auto;
+}
+.qr-modal-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-2);
+  width: 100%;
+}
+.qr-animated {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+}
+.qr-scanner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+}
+.qr-scanner-video {
+  width: 100%;
+  max-width: 320px;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  background: #000;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+}

--- a/ui/web/vite.config.ts
+++ b/ui/web/vite.config.ts
@@ -1,8 +1,13 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+import wasm from "vite-plugin-wasm";
+import topLevelAwait from "vite-plugin-top-level-await";
 
 export default defineConfig({
-  plugins: [react()],
+  // wasm + topLevelAwait let the (dynamically imported, code-split) Keystone USB
+  // SDK load its WebAssembly serialization lib. They only affect that async
+  // chunk; the initial bundle is unaffected.
+  plugins: [react(), wasm(), topLevelAwait()],
   build: { outDir: "../internal/webui/dist", emptyOutDir: true },
   server: {
     proxy: {


### PR DESCRIPTION
Adds Keystone as a fully **air-gapped QR** hardware signer on the `HardwareSigner` abstraction — account xpub via a `crypto-multi-accounts` sync QR, and tx signing via an animated-UR exchange (display the unsigned request → scan the signed witness back). Byte-identical xpub/witness output to Ledger/Trezor via the shared `hw/xpub.ts` + `hw/witness.ts` encoders.

## On-device fee display
The neutral backend hardware-sign request now carries each input's real **lovelace amount + address** (resolved at tx-build time from coin-selection — no extra node query), so the Keystone displays the actual inputs and **computes the fee**. On an air-gapped signer the on-device display *is* the security control.

## Transports
**QR is the only user-selectable transport.** A USB path (`@keystonehq/hw-app-ada`) exists in code but is intentionally **not user-selectable**, pending validation on real hardware.

## Consent-law
QR is fully offline (camera is local) — no network egress, so no external-consent gate.

## Capabilities
`{ send: true, staking: false, governance: false, multisig: false, poolReg: false }` — conservative; the QR request maps payment inputs + change today.

## Safety
Bounds-checked CBOR reader (throws on truncated frames; asserts 32-byte pubkey / 64-byte sig); a missing account fingerprint blocks signing with an account-sync re-scan prompt (never fabricates a zero xfp); unmatched/valueless inputs throw rather than silently drop.

## Verification
`npm run lint` (0 errors) · `npm run test` (579 passing) · `tsc --noEmit` · `vite build`; Keystone libs code-split out of the initial bundle. Go root + ui: build/vet/test green.

## Summary by cubic
Adds Keystone hardware wallet support with a local, air‑gapped QR flow. The QR sign request now includes real input values and addresses so the device can show inputs and compute the fee; USB remains gated and not user‑selectable.

- **New Features**
  - Air‑gapped QR end‑to‑end: import xpub from `crypto-multi-accounts`, show animated `cardano-sign-request`, scan `cardano-signature`, and build witnesses. New UI: `AnimatedQR`, `QRScanner`, `KeystoneQRModal` (+ `useKeystoneQRBridge`). Capabilities: send‑only.
  - On‑device input/fee display: backend retains each input’s lovelace, address, and assets and includes them in `HWInput`; Keystone maps them into its UTxOs for accurate on‑device review.
  - UI/Performance: Keystone is selectable as QR‑only; Add Wallet includes the account‑sync scan; Send uses the QR modal bridge. Keystone/USB libs are dynamically imported and code‑split with `vite-plugin-wasm` and `vite-plugin-top-level-await`. Local‑only; no external‑consent gate.

- **Bug Fixes**
  - Safety/hardening: block QR signing without a valid master fingerprint; persist/validate Keystone XFP (8 hex). Bounds‑check QR witness parsing and assert key sizes; error on missing paths/values and on empty UTxO sets.
  - QR UX: add Retry to remount the scanner; detect and surface corrupt multipart URs; dedicated centered overlay. Dependencies: add `@zxing/library`.
  - Transport: USB path kept in code but hidden from pickers and refused by `connectHardware` pending real‑device validation.

<sup>Written for commit 91d44026a9fd7f51a5be74eda017296ca98b43b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Screenshots

Rendered browser captures (Playwright, 1280×800) of the Keystone UI states reachable without a physical device.

**Add Wallet — device picker (Keystone enabled)**

![Device picker with Keystone enabled](https://raw.githubusercontent.com/blinklabs-io/bursa/ci/screenshots/screenshots/pr-619/01-device-picker-keystone-enabled.png)



**Account-sync QR scan (xpub import)** — the webcam scanner modal; headless has no camera, so it shows the "Requested device not found" fallback.

![Account-sync QR scan prompt](https://raw.githubusercontent.com/blinklabs-io/bursa/ci/screenshots/screenshots/pr-619/03-account-sync-qr-scan.png)

**Send — animated sign-request QR modal**

![Send sign QR modal with animated UR](https://raw.githubusercontent.com/blinklabs-io/bursa/ci/screenshots/screenshots/pr-619/04-send-sign-qr-modal.png)

