### PR TITLE
fix: []byte mnemonic derivation to avoid un-zeroable string in signing paths

### DIFF
--- a/bursa.go
+++ b/bursa.go
@@ -619,20 +619,19 @@ func ExtractKeyFiles(wallet *Wallet) (map[string]string, error) {
 	return result, nil
 }
 
+// GetRootKeyFromMnemonic derives the CIP-1852 root key from a mnemonic string.
+// It delegates to GetRootKeyFromMnemonicBytes; callers that hold the decrypted
+// mnemonic in a zeroable byte slice (e.g. signing paths) should call that
+// function directly to avoid materializing an un-zeroable mnemonic string.
+//
+// Behavior change: every invalid mnemonic now returns ErrInvalidMnemonic
+// uniformly. Previously the underlying bip39.EntropyFromMnemonic error could be
+// surfaced; callers matching on that specific error should match on
+// ErrInvalidMnemonic instead.
 func GetRootKeyFromMnemonic(mnemonic, password string) (bip32.XPrv, error) {
-	if !bip39.IsMnemonicValid(mnemonic) {
-		return nil, ErrInvalidMnemonic
-	}
-	entropy, err := bip39.EntropyFromMnemonic(mnemonic)
-	if err != nil {
-		return nil, err
-	}
-	pwBytes := []byte{}
-	if password != "" {
-		pwBytes = []byte(password)
-	}
-	rootKey := GetRootKey(entropy, pwBytes)
-	return rootKey, nil
+	b := []byte(mnemonic)
+	defer zeroBytes(b)
+	return GetRootKeyFromMnemonicBytes(b, password)
 }
 
 func GetRootKey(entropy []byte, password []byte) bip32.XPrv {

--- a/bursa_test.go
+++ b/bursa_test.go
@@ -584,6 +584,79 @@ func TestGetRootKeyFromMnemonic(t *testing.T) {
 	}
 }
 
+func TestGetRootKeyFromMnemonicBytes(t *testing.T) {
+	// Independent oracle. The byte decoder is validated against
+	// go-bip39's EntropyFromMnemonic (the upstream decoder, not the code
+	// under test) rather than against GetRootKeyFromMnemonic — which now
+	// delegates to GetRootKeyFromMnemonicBytes and so would only compare the
+	// decoder with itself. For each of the five legal BIP39 word counts a valid
+	// mnemonic is sourced from fixed entropy via go-bip39's encoder, decoded
+	// back through the upstream decoder, and both entropyFromMnemonicBytes and
+	// GetRootKeyFromMnemonicBytes are asserted to agree. This exercises every
+	// checksumShift value (12/15/18/21/24 words -> shift 4/3/2/1/0).
+	t.Run("matches upstream decoder", func(t *testing.T) {
+		for _, words := range []int{12, 15, 18, 21, 24} {
+			// entropyLen bytes: 4 per 3 words (128..256 bits).
+			entropy := make([]byte, words/3*4)
+			for i := range entropy {
+				entropy[i] = byte(i*7 + 3) // deterministic, non-uniform
+			}
+
+			// Source a valid mnemonic from fixed entropy via the upstream
+			// encoder, so the vector is a real BIP39 mnemonic of this length.
+			mnemonic, err := bip39.NewMnemonic(entropy)
+			require.NoError(t, err, "%d words: NewMnemonic", words)
+			require.Len(t, strings.Fields(mnemonic), words)
+
+			// Oracle: decode with the upstream decoder, independent of the
+			// code under test.
+			wantEntropy, err := bip39.EntropyFromMnemonic(mnemonic)
+			require.NoError(t, err, "%d words: EntropyFromMnemonic", words)
+			assert.Equal(t, entropy, wantEntropy,
+				"%d words: upstream round-trip", words)
+
+			gotEntropy, err := entropyFromMnemonicBytes([]byte(mnemonic))
+			require.NoError(t, err, "%d words: entropyFromMnemonicBytes", words)
+			assert.Equal(t, wantEntropy, gotEntropy,
+				"%d words: byte decoder disagrees with upstream", words)
+
+			for _, password := range []string{"", "testpassword"} {
+				var pwBytes []byte
+				if password != "" {
+					pwBytes = []byte(password)
+				}
+				want := GetRootKey(wantEntropy, pwBytes)
+				got, err := GetRootKeyFromMnemonicBytes([]byte(mnemonic), password)
+				require.NoError(t, err,
+					"%d words: GetRootKeyFromMnemonicBytes(%q)", words, password)
+				assert.Equal(t, []byte(want), []byte(got),
+					"%d words: root key mismatch for password %q", words, password)
+			}
+		}
+	})
+
+	t.Run("rejects invalid mnemonic", func(t *testing.T) {
+		// A 12-word mnemonic whose last token is not in the BIP39 word list:
+		// legal length, so it reaches word lookup and fails there.
+		unknownWord := "abandon abandon abandon abandon abandon abandon " +
+			"abandon abandon abandon abandon abandon zzzzzz"
+		// All-"abandon": every token is a valid word and the length is legal,
+		// so it reaches checksum verification and fails there (the valid
+		// all-zero-entropy mnemonic ends in "about", not "abandon"). Confirmed
+		// checksum-invalid via bip39.EntropyFromMnemonic (returns an error).
+		_, err := bip39.EntropyFromMnemonic(
+			"abandon abandon abandon abandon abandon abandon " +
+				"abandon abandon abandon abandon abandon abandon")
+		require.Error(t, err, "sanity: all-abandon must be checksum-invalid")
+		invalidChecksum := "abandon abandon abandon abandon abandon abandon " +
+			"abandon abandon abandon abandon abandon abandon"
+		for _, m := range []string{"", "invalid mnemonic", unknownWord, invalidChecksum} {
+			_, err := GetRootKeyFromMnemonicBytes([]byte(m), "")
+			assert.ErrorIs(t, err, ErrInvalidMnemonic)
+		}
+	})
+}
+
 func TestCIP0003KeyGeneration(t *testing.T) {
 	// Test CIP-0003 compliance for wallet key generation
 	// These test vectors validate the complete key generation pipeline:

--- a/mnemonic_bytes.go
+++ b/mnemonic_bytes.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,46 +12,56 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package wallet
+package bursa
 
 import (
 	"bytes"
 	"crypto/sha256"
 
-	"github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/bursa/bip32"
 	bip39 "github.com/blinklabs-io/go-bip39"
 )
 
-// RootKeyFromMnemonicBytes derives a CIP-1852 root key from a zeroable mnemonic
-// byte slice. It mirrors bursa.GetRootKeyFromMnemonic without materializing the
-// full mnemonic as an immutable Go string, so signing paths that hold the
-// decrypted mnemonic in a zeroable buffer can derive without leaving an
-// un-zeroable copy on the heap. The caller keeps ownership of, and must zero,
-// the mnemonic slice it passes in.
+// GetRootKeyFromMnemonicBytes derives the CIP-1852 root key from a mnemonic held
+// in a zeroable byte slice, without ever materializing it as an immutable Go
+// string. This is the entry point signing paths should use so the decrypted
+// mnemonic never lingers on the heap in a string that cannot be zeroed; callers
+// remain responsible for zeroing the byte slice they pass in.
 //
-// The ui module pins the bursa root module to a published commit (there is no
-// local replace directive), so this lives here rather than calling a root-module
-// helper: it lets the wallet's own packages derive from bytes without depending
-// on an unreleased bursa version.
-func RootKeyFromMnemonicBytes(mnemonic []byte) (bip32.XPrv, error) {
+// go-bip39 (v0.2.0) exposes no byte-oriented decode: every public entry point
+// (IsMnemonicValid, EntropyFromMnemonic) takes a string and would force an
+// immutable copy of the mnemonic. To avoid that, the BIP39 mnemonic->entropy
+// decode (word lookup + checksum verification) is reimplemented here over the
+// byte slice, using only go-bip39's word list. It produces entropy identical to
+// bip39.EntropyFromMnemonic for a valid mnemonic.
+func GetRootKeyFromMnemonicBytes(
+	mnemonic []byte,
+	password string,
+) (bip32.XPrv, error) {
 	entropy, err := entropyFromMnemonicBytes(mnemonic)
 	if err != nil {
 		return nil, err
 	}
 	defer zeroBytes(entropy)
-	return bursa.GetRootKey(entropy, nil), nil
+	var pwBytes []byte
+	if password != "" {
+		pwBytes = []byte(password)
+	}
+	defer zeroBytes(pwBytes)
+	return GetRootKey(entropy, pwBytes), nil
 }
 
+// entropyFromMnemonicBytes decodes BIP39 entropy from a mnemonic byte slice,
+// verifying the checksum, without allocating an immutable mnemonic string.
 func entropyFromMnemonicBytes(mnemonic []byte) ([]byte, error) {
 	words := bytes.Fields(mnemonic)
 	if len(words)%3 != 0 || len(words) < 12 || len(words) > 24 {
-		return nil, bursa.ErrInvalidMnemonic
+		return nil, ErrInvalidMnemonic
 	}
 
 	wordList := bip39.GetWordList()
 	if len(wordList) != 2048 {
-		return nil, bursa.ErrInvalidMnemonic
+		return nil, ErrInvalidMnemonic
 	}
 
 	entropyLen := len(words) / 3 * 4
@@ -61,7 +71,7 @@ func entropyFromMnemonicBytes(mnemonic []byte) ([]byte, error) {
 	for i, word := range words {
 		index, ok := mnemonicWordIndex(word, wordList)
 		if !ok {
-			return nil, bursa.ErrInvalidMnemonic
+			return nil, ErrInvalidMnemonic
 		}
 		writeMnemonicIndexBits(data, i, index)
 	}
@@ -71,13 +81,15 @@ func entropyFromMnemonicBytes(mnemonic []byte) ([]byte, error) {
 	gotChecksum := data[entropyLen] >> checksumShift
 	wantChecksum := hash[0] >> checksumShift
 	if gotChecksum != wantChecksum {
-		return nil, bursa.ErrInvalidMnemonic
+		return nil, ErrInvalidMnemonic
 	}
 	entropy := make([]byte, entropyLen)
 	copy(entropy, data[:entropyLen])
 	return entropy, nil
 }
 
+// writeMnemonicIndexBits writes the 11-bit word index for the word at wordOffset
+// into the packed bit buffer out (big-endian, matching BIP39 encoding).
 func writeMnemonicIndexBits(out []byte, wordOffset, index int) {
 	for bit := 0; bit < 11; bit++ {
 		if index&(1<<uint(10-bit)) == 0 {
@@ -88,6 +100,8 @@ func writeMnemonicIndexBits(out []byte, wordOffset, index int) {
 	}
 }
 
+// mnemonicWordIndex returns the BIP39 word list index for word, comparing over
+// bytes so the mnemonic is never converted to a string.
 func mnemonicWordIndex(word []byte, wordList []string) (int, bool) {
 	for i, candidate := range wordList {
 		if len(word) != len(candidate) {
@@ -107,6 +121,7 @@ func mnemonicWordIndex(word []byte, wordList []string) (int, bool) {
 	return 0, false
 }
 
+// zeroBytes overwrites b with zeros.
 func zeroBytes(b []byte) {
 	for i := range b {
 		b[i] = 0

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -17,6 +17,7 @@ import (
 	"github.com/blinklabs-io/bursa/ui/internal/cardanonet"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/txwitness"
+	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
@@ -458,7 +459,7 @@ func (s *Service) MyKey(password string) (MyKey, error) {
 		zeroBytes(mnemonicBytes)
 	}()
 
-	rootKey, err = bursa.GetRootKeyFromMnemonic(string(mnemonicBytes), "")
+	rootKey, err = wallet.RootKeyFromMnemonicBytes(mnemonicBytes)
 	if err != nil {
 		return MyKey{}, fmt.Errorf("root key: %w", err)
 	}
@@ -864,7 +865,7 @@ func (s *Service) Sign(unsignedTxCBOR, password string) (Witness, error) {
 		zeroBytes(mnemonicBytes)
 	}()
 
-	rootKey, err = bursa.GetRootKeyFromMnemonic(string(mnemonicBytes), "")
+	rootKey, err = wallet.RootKeyFromMnemonicBytes(mnemonicBytes)
 	if err != nil {
 		return Witness{}, fmt.Errorf("root key: %w", err)
 	}
@@ -1107,7 +1108,7 @@ func (s *Service) CosignImported(txCbor, password string) (CosignResult, error) 
 		zeroBytes(mnemonicBytes)
 	}()
 
-	rootKey, err = bursa.GetRootKeyFromMnemonic(string(mnemonicBytes), "")
+	rootKey, err = wallet.RootKeyFromMnemonicBytes(mnemonicBytes)
 	if err != nil {
 		return CosignResult{}, fmt.Errorf("root key: %w", err)
 	}

--- a/ui/internal/poolops/service.go
+++ b/ui/internal/poolops/service.go
@@ -150,7 +150,7 @@ func (s *Service) unlockRoot(walletID, password string) (bip32.XPrv, func(), err
 		}
 		return nil, func() {}, fmt.Errorf("unlock keystore: %w", err)
 	}
-	root, err := bursa.GetRootKeyFromMnemonic(string(mnemonic), "")
+	root, err := wallet.RootKeyFromMnemonicBytes(mnemonic)
 	if err != nil {
 		keystore.Zero(mnemonic)
 		return nil, func() {}, fmt.Errorf("root key: %w", err)

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -473,7 +473,7 @@ func (s *Service) SignData(addrStr string, message []byte, password string) (sig
 		}
 	}()
 
-	rootKey, err = bursa.GetRootKeyFromMnemonic(string(mnemonicBytes), "")
+	rootKey, err = wallet.RootKeyFromMnemonicBytes(mnemonicBytes)
 	if err != nil {
 		return "", "", fmt.Errorf("root key: %w", err)
 	}
@@ -531,7 +531,7 @@ func (s *Service) PubDRepKey(password string) ([]byte, error) {
 		}
 	}()
 
-	rootKey, err = bursa.GetRootKeyFromMnemonic(string(mnemonicBytes), "")
+	rootKey, err = wallet.RootKeyFromMnemonicBytes(mnemonicBytes)
 	if err != nil {
 		return nil, fmt.Errorf("root key: %w", err)
 	}
@@ -587,7 +587,7 @@ func (s *Service) PubStakeKey(password string) ([]byte, error) {
 		}
 	}()
 
-	rootKey, err = bursa.GetRootKeyFromMnemonic(string(mnemonicBytes), "")
+	rootKey, err = wallet.RootKeyFromMnemonicBytes(mnemonicBytes)
 	if err != nil {
 		return nil, fmt.Errorf("root key: %w", err)
 	}
@@ -900,7 +900,7 @@ func (s *Service) Confirm(ctx context.Context, pendingID, password string) (TxRe
 	}()
 
 	// --- step 3: derive account key ---
-	rootKey, err = bursa.GetRootKeyFromMnemonic(string(mnemonicBytes), "")
+	rootKey, err = wallet.RootKeyFromMnemonicBytes(mnemonicBytes)
 	if err != nil {
 		return TxResult{}, fmt.Errorf("root key: %w", err)
 	}
@@ -1207,7 +1207,7 @@ func (s *Service) SignTx(unsignedTxCBOR, password string, requiredSigners []stri
 		}
 	}()
 
-	rootKey, err = bursa.GetRootKeyFromMnemonic(string(mnemonicBytes), "")
+	rootKey, err = wallet.RootKeyFromMnemonicBytes(mnemonicBytes)
 	if err != nil {
 		return Witness{}, fmt.Errorf("root key: %w", err)
 	}
@@ -1653,7 +1653,7 @@ func (s *Service) CosignTx(
 			mnemonicBytes[i] = 0
 		}
 	}()
-	rootKey, err = bursa.GetRootKeyFromMnemonic(string(mnemonicBytes), "")
+	rootKey, err = wallet.RootKeyFromMnemonicBytes(mnemonicBytes)
 	if err != nil {
 		return CosignResult{}, fmt.Errorf("root key: %w", err)
 	}
@@ -1969,7 +1969,7 @@ func (s *Service) WitnessTx(
 		}
 	}()
 
-	rootKey, err = bursa.GetRootKeyFromMnemonic(string(mnemonicBytes), "")
+	rootKey, err = wallet.RootKeyFromMnemonicBytes(mnemonicBytes)
 	if err != nil {
 		return nil, fmt.Errorf("root key: %w", err)
 	}

--- a/ui/internal/wallet/account.go
+++ b/ui/internal/wallet/account.go
@@ -50,7 +50,7 @@ func AccountXpub(mnemonic string) (string, error) {
 
 // AccountXpubFromMnemonicBytes is the zeroable-byte variant of AccountXpub.
 func AccountXpubFromMnemonicBytes(mnemonic []byte) (string, error) {
-	root, err := rootKeyFromMnemonicBytes(mnemonic)
+	root, err := RootKeyFromMnemonicBytes(mnemonic)
 	if err != nil {
 		return "", fmt.Errorf("root key from mnemonic: %w", err)
 	}
@@ -89,7 +89,7 @@ func DeriveFromMnemonicBytes(mnemonic []byte, network string, windowN int) (*Acc
 	if err != nil {
 		return nil, err
 	}
-	root, err := rootKeyFromMnemonicBytes(mnemonic)
+	root, err := RootKeyFromMnemonicBytes(mnemonic)
 	if err != nil {
 		return nil, fmt.Errorf("root key from mnemonic: %w", err)
 	}

--- a/ui/internal/wallet/mnemonic_bytes_test.go
+++ b/ui/internal/wallet/mnemonic_bytes_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wallet
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/bursa"
+	bip39 "github.com/blinklabs-io/go-bip39"
+)
+
+// TestRootKeyFromMnemonicBytesMatchesUpstream validates the local byte decoder
+// against go-bip39's EntropyFromMnemonic (the upstream decoder) rather than
+// against bursa.GetRootKeyFromMnemonic. That string path is a genuine
+// cross-check only while ui pins a pre-zeroization bursa; once ui bumps past
+// the PR that makes GetRootKeyFromMnemonic delegate to the byte decoder, it
+// would become circular. Asserting against the upstream decoder keeps this a
+// real guard after a bump. All five BIP39 word counts are covered so every
+// checksumShift value (12/15/18/21/24 words -> shift 4/3/2/1/0) is exercised.
+func TestRootKeyFromMnemonicBytesMatchesUpstream(t *testing.T) {
+	for _, words := range []int{12, 15, 18, 21, 24} {
+		entropy := make([]byte, words/3*4)
+		for i := range entropy {
+			entropy[i] = byte(i*7 + 3) // deterministic, non-uniform
+		}
+
+		mnemonic, err := bip39.NewMnemonic(entropy)
+		if err != nil {
+			t.Fatalf("%d words: NewMnemonic: %v", words, err)
+		}
+		if got := len(strings.Fields(mnemonic)); got != words {
+			t.Fatalf("%d words: got %d words", words, got)
+		}
+
+		wantEntropy, err := bip39.EntropyFromMnemonic(mnemonic)
+		if err != nil {
+			t.Fatalf("%d words: EntropyFromMnemonic: %v", words, err)
+		}
+		gotEntropy, err := entropyFromMnemonicBytes([]byte(mnemonic))
+		if err != nil {
+			t.Fatalf("%d words: entropyFromMnemonicBytes: %v", words, err)
+		}
+		if !bytes.Equal(wantEntropy, gotEntropy) {
+			t.Fatalf("%d words: byte decoder disagrees with upstream", words)
+		}
+
+		want := bursa.GetRootKey(wantEntropy, nil)
+		got, err := RootKeyFromMnemonicBytes([]byte(mnemonic))
+		if err != nil {
+			t.Fatalf("%d words: RootKeyFromMnemonicBytes: %v", words, err)
+		}
+		if !bytes.Equal([]byte(want), []byte(got)) {
+			t.Fatalf("%d words: root key mismatch vs upstream-derived key", words)
+		}
+	}
+}
+
+func TestRootKeyFromMnemonicBytesRejectsInvalid(t *testing.T) {
+	// A 12-word mnemonic whose last token is not in the BIP39 word list:
+	// legal length, so it reaches word lookup and fails there.
+	unknownWord := "abandon abandon abandon abandon abandon abandon " +
+		"abandon abandon abandon abandon abandon zzzzzz"
+	// All-"abandon": every token is a valid word and the length is legal, so
+	// it reaches checksum verification and fails there (the valid all-zero-
+	// entropy mnemonic ends in "about", not "abandon"). Confirmed checksum-
+	// invalid via bip39.EntropyFromMnemonic (returns an error).
+	invalidChecksum := "abandon abandon abandon abandon abandon abandon " +
+		"abandon abandon abandon abandon abandon abandon"
+	if _, err := bip39.EntropyFromMnemonic(invalidChecksum); err == nil {
+		t.Fatal("sanity: all-abandon must be checksum-invalid")
+	}
+	for _, m := range []string{"", "invalid mnemonic", unknownWord, invalidChecksum} {
+		if _, err := RootKeyFromMnemonicBytes([]byte(m)); !errors.Is(err, bursa.ErrInvalidMnemonic) {
+			t.Errorf("mnemonic %q: got err %v, want ErrInvalidMnemonic", m, err)
+		}
+	}
+}


### PR DESCRIPTION
Closes #591.

Every signing path derived the root key with `GetRootKeyFromMnemonic(string(mnemonicBytes), "")`. The `string()` conversion allocates an immutable copy of the decrypted mnemonic that cannot be zeroed and lingers on the heap, defeating the surrounding zeroing of `mnemonicBytes`.

## Root module
- Add `GetRootKeyFromMnemonicBytes(mnemonic []byte, password string) (bip32.XPrv, error)`, deriving the root key from a zeroable byte slice with no intermediate mnemonic string.
- go-bip39 v0.2.0 has no byte-oriented decode — `IsMnemonicValid`/`EntropyFromMnemonic` both take a `string` — so the BIP39 mnemonic→entropy decode (word lookup + checksum) is reimplemented over bytes using only its word list.
- `GetRootKeyFromMnemonic` now delegates to the byte version.

## ui module
- The signing paths (`spend`, `multisig`, `poolops`) now derive via the `wallet` package's byte-based `RootKeyFromMnemonicBytes` (the existing `AccountXpub` byte decoder, now exported), so the decrypted mnemonic is never converted to a string. Existing `mnemonicBytes` zeroing is preserved.
- The ui module pins bursa to a published commit (no local replace directive), so it routes through its own byte decoder rather than the newly added root helper.

## Tests
- Root: `GetRootKeyFromMnemonicBytes` derives the same root key as the string version for the canonical `abandon … about` mnemonic, and rejects invalid input.
- ui: `wallet.RootKeyFromMnemonicBytes` matches the string derivation and rejects invalid input.

## Verification
- Root: `CGO_ENABLED=0 go build ./...`, `CGO_ENABLED=0 go test ./...`, `golangci-lint run ./...` — all pass.
- ui: `go build/vet/test ./cmd/... ./internal/...` and `golangci-lint` on touched packages — all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives CIP-1852 root keys from zeroable mnemonic byte slices to avoid immutable strings in signing paths, fixing #591. Standardizes invalid-mnemonic handling and validates the byte decoder against upstream `go-bip39`.

- **Bug Fixes**
  - Added `GetRootKeyFromMnemonicBytes([]byte, string)` in `bursa` with a byte-only BIP39 decode; `GetRootKeyFromMnemonic` now delegates, zeroing transient entropy/password bytes and returning `ErrInvalidMnemonic` uniformly.
  - Exported `wallet.RootKeyFromMnemonicBytes([]byte)` and updated `ui` signing paths (`spend`, `multisig`, `poolops`) and account derivations to use it, removing `string(mnemonicBytes)` conversions.
  - Added tests in `bursa` and `ui/wallet` that validate the byte decoder and derived root keys against upstream `go-bip39` for 12–24 words (with/without password) and reject invalid mnemonics.

<sup>Written for commit 042fb406a6cd6ed64dfcaabcd656d2b6246dca8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for deriving wallet root keys directly from mnemonic byte data.
  - Improved handling of mnemonic data by clearing sensitive temporary values after use.
  - Standardized invalid mnemonic errors for more consistent behavior.

- **Bug Fixes**
  - Wallet, spending, pool, and multisignature operations now use the updated mnemonic processing across supported key-derivation flows.

- **Tests**
  - Added coverage for valid 12-, 15-, 18-, 21-, and 24-word mnemonics, passwords, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->