### PR TITLE
feat(signer): cold-signer opcert sign type

### DIFF
--- a/internal/signer/api/server.go
+++ b/internal/signer/api/server.go
@@ -30,12 +30,19 @@ import (
 
 // SignRequest is the POST /v1/sign body.
 type SignRequest struct {
-	Type    string   `json:"type"`    // "tx" | "cip8"
+	Type    string   `json:"type"`    // "tx" | "cip8" | "opcert"
 	Cbor    string   `json:"cbor"`    // tx: hex CBOR or JSON envelope
 	Signers []string `json:"signers"` // tx: key hashes / addresses
 	Payload string   `json:"payload"` // cip8: hex
 	Address string   `json:"address"` // cip8: bech32
-	Key     string   `json:"key"`     // cip8: key hash
+	Key     string   `json:"key"`     // cip8 + opcert: cold/signing key hash
+
+	// opcert: cold-sign an operational certificate. The cold key (identified by
+	// Key) signs the canonical OCertSignable bytes; the cold key itself never
+	// leaves its custody backend.
+	KesVkey      string `json:"kes_vkey"`      // opcert: hex-encoded 32-byte KES verification key
+	IssueCounter uint64 `json:"issue_counter"` // opcert: operational certificate issue counter
+	KesPeriod    uint64 `json:"kes_period"`    // opcert: KES period
 }
 
 // SignTxResponse is returned for type=tx.
@@ -51,6 +58,18 @@ type SignTxResponse struct {
 type SignCIP8Response struct {
 	AuditID   string `json:"audit_id"`
 	Signature string `json:"signature"`
+	Key       string `json:"key"`
+}
+
+// SignOpCertResponse is returned for type=opcert. Signature is the 64-byte
+// cold-key Ed25519 signature over the OCertSignable bytes; ColdVkey is the
+// 32-byte cold verification key. Both are hex-encoded. Together with the
+// request's KES vkey/counter/period they form the opcert envelope
+// [[kes_vkey, counter, period, sig], cold_vkey].
+type SignOpCertResponse struct {
+	AuditID   string `json:"audit_id"`
+	Signature string `json:"signature"`
+	ColdVkey  string `json:"cold_vkey"`
 	Key       string `json:"key"`
 }
 
@@ -282,6 +301,47 @@ func (s *Server) handleSign(w http.ResponseWriter, r *http.Request) {
 		}
 		s.audit(r, caller, "cip8", "signed", "audit_id", auditID, "key", req.Key, "address", req.Address)
 		writeJSON(w, http.StatusOK, SignCIP8Response{AuditID: auditID, Signature: res.SignatureHex, Key: res.KeyHex})
+	case "opcert":
+		kesVkey, err := hex.DecodeString(req.KesVkey)
+		if err != nil {
+			s.audit(r, caller, "opcert", "bad_request", "audit_id", auditID, "key", req.Key)
+			writeErr(w, http.StatusBadRequest, "invalid kes_vkey hex")
+			return
+		}
+		// Enforce the caller ACL against the cold key exactly like the cip8 path.
+		if s.acl.Restricted() {
+			h, err := backend.ParseKeyHash(req.Key)
+			if err == nil && !s.acl.Allows(caller, h) {
+				s.coord.Metrics().ObserveDeny("acl")
+				s.audit(r, caller, "opcert", "denied", "audit_id", auditID, "key", req.Key, "reason", "caller ACL")
+				writeErr(w, http.StatusForbidden, "caller is not authorized for this key")
+				return
+			}
+		}
+		res, code, err := s.coord.SignOpCert(r.Context(), kesVkey, req.IssueCounter, req.KesPeriod, req.Key)
+		if err != nil {
+			st := codeToStatus(code)
+			if st >= 500 {
+				s.logger.Error("SignOpCert error",
+					"caller", caller,
+					"audit_id", auditID,
+					"code", code,
+					"error", err,
+				)
+				s.audit(r, caller, "opcert", "error", "audit_id", auditID, "key", req.Key)
+				if st == http.StatusBadGateway {
+					writeErr(w, st, "backend error")
+				} else {
+					writeErr(w, st, "internal server error")
+				}
+				return
+			}
+			s.audit(r, caller, "opcert", string(code), "audit_id", auditID, "key", req.Key, "error", err.Error())
+			writeErr(w, st, err.Error())
+			return
+		}
+		s.audit(r, caller, "opcert", "signed", "audit_id", auditID, "key", req.Key)
+		writeJSON(w, http.StatusOK, SignOpCertResponse{AuditID: auditID, Signature: res.SignatureHex, ColdVkey: res.ColdVKeyHex, Key: res.KeyHex})
 	default:
 		s.audit(r, caller, req.Type, "bad_request", "audit_id", auditID)
 		writeErr(w, http.StatusBadRequest, "unknown request type")

--- a/internal/signer/api/server_test.go
+++ b/internal/signer/api/server_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -207,6 +208,198 @@ func TestHandleGetKey(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 		if rr.Code != http.StatusNotFound {
 			t.Fatalf("expected 404, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+}
+
+// newOpCertServer builds a server whose cold key allows the given request
+// types. It returns the server, the cold key hash, and the cold public key so
+// tests can verify produced signatures.
+func newOpCertServer(t *testing.T, allowedRequests []string, acl *CallerACL) (*Server, backend.KeyHash, ed25519.PublicKey) {
+	t.Helper()
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	b := backend.NewSoftwareBackend("software")
+	h, err := b.AddKey(&bursa.LoadedKey{SKey: []byte(priv), VKey: pub}, backend.KeyTypePool)
+	if err != nil {
+		t.Fatalf("AddKey: %v", err)
+	}
+	pol := policy.KeyPolicy{Hash: h.String(), AllowedRequests: allowedRequests}
+	eng, err := policy.NewEngine([]policy.KeyPolicy{pol})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	coord := signer.New(signer.Deps{
+		Resolver:  backend.NewResolver(b),
+		Policy:    eng,
+		Watermark: watermark.NewMemWatermark(),
+		Cardano:   operation.Cardano(fakeCardano{pub: pub}),
+	})
+	srv := NewServer(coord, backend.NewResolver(b), eng, acl, func(string) (string, error) { return "tester", nil })
+	return srv, h, pub
+}
+
+// TestHandleSignOpCert_Valid verifies a cold-sign request returns a signature
+// that verifies against the KES vkey/counter/period with the cold public key.
+func TestHandleSignOpCert_Valid(t *testing.T) {
+	srv, h, coldPub := newOpCertServer(t, []string{"opcert"}, nil)
+
+	kesVkey := bytes.Repeat([]byte{0xAB}, 32)
+	const issueCounter = uint64(7)
+	const kesPeriod = uint64(42)
+
+	body, _ := json.Marshal(SignRequest{
+		Type:         "opcert",
+		Key:          h.String(),
+		KesVkey:      hex.EncodeToString(kesVkey),
+		IssueCounter: issueCounter,
+		KesPeriod:    kesPeriod,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/sign", bytes.NewReader(body))
+	req = req.WithContext(context.Background())
+	rr := httptest.NewRecorder()
+	srv.handleSign(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp SignOpCertResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Key != h.String() {
+		t.Errorf("expected key %s, got %s", h.String(), resp.Key)
+	}
+	if resp.ColdVkey != hex.EncodeToString(coldPub) {
+		t.Errorf("cold_vkey mismatch: got %s", resp.ColdVkey)
+	}
+	sig, err := hex.DecodeString(resp.Signature)
+	if err != nil {
+		t.Fatalf("signature not hex: %v", err)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		t.Fatalf("expected %d-byte signature, got %d", ed25519.SignatureSize, len(sig))
+	}
+	// The signature must verify over the canonical OCertSignable bytes.
+	signable := lcommon.OpCertSignableBytes(kesVkey, issueCounter, kesPeriod)
+	if !ed25519.Verify(coldPub, signable, sig) {
+		t.Fatal("cold-key signature failed to verify over OCertSignable bytes")
+	}
+	// A signature over different opcert parameters must NOT verify (guards
+	// against signing the wrong payload).
+	wrong := lcommon.OpCertSignableBytes(kesVkey, issueCounter+1, kesPeriod)
+	if ed25519.Verify(coldPub, wrong, sig) {
+		t.Fatal("signature unexpectedly verified over mismatched parameters")
+	}
+}
+
+// TestHandleSignOpCert_MalformedInput rejects bad KES vkey hex and wrong-length
+// KES vkeys with 400.
+func TestHandleSignOpCert_MalformedInput(t *testing.T) {
+	srv, h, _ := newOpCertServer(t, []string{"opcert"}, nil)
+
+	t.Run("non-hex kes_vkey", func(t *testing.T) {
+		body, _ := json.Marshal(SignRequest{Type: "opcert", Key: h.String(), KesVkey: "zzzz"})
+		req := httptest.NewRequest(http.MethodPost, "/v1/sign", bytes.NewReader(body))
+		rr := httptest.NewRecorder()
+		srv.handleSign(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("wrong-length kes_vkey", func(t *testing.T) {
+		body, _ := json.Marshal(SignRequest{
+			Type:    "opcert",
+			Key:     h.String(),
+			KesVkey: hex.EncodeToString(bytes.Repeat([]byte{0x01}, 16)),
+		})
+		req := httptest.NewRequest(http.MethodPost, "/v1/sign", bytes.NewReader(body))
+		rr := httptest.NewRecorder()
+		srv.handleSign(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for short KES vkey, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("invalid key id", func(t *testing.T) {
+		body, _ := json.Marshal(SignRequest{
+			Type:    "opcert",
+			Key:     "nothex",
+			KesVkey: hex.EncodeToString(bytes.Repeat([]byte{0x01}, 32)),
+		})
+		req := httptest.NewRequest(http.MethodPost, "/v1/sign", bytes.NewReader(body))
+		rr := httptest.NewRecorder()
+		srv.handleSign(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for invalid key id, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+}
+
+// TestHandleSignOpCert_PolicyDenied verifies deny-by-default: a cold key whose
+// policy does not list "opcert" cannot cold-sign (403).
+func TestHandleSignOpCert_PolicyDenied(t *testing.T) {
+	// Key allows only "tx", not "opcert".
+	srv, h, _ := newOpCertServer(t, []string{"tx"}, nil)
+
+	body, _ := json.Marshal(SignRequest{
+		Type:    "opcert",
+		Key:     h.String(),
+		KesVkey: hex.EncodeToString(bytes.Repeat([]byte{0x02}, 32)),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/sign", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	srv.handleSign(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for policy denial, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHandleSignOpCert_ACLDenied verifies the caller ACL gates opcert exactly
+// like the other sign types: an unlisted caller gets 403.
+func TestHandleSignOpCert_ACLDenied(t *testing.T) {
+	// Build with a placeholder ACL, then rebuild with an ACL keyed on the real
+	// cold key hash.
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	b := backend.NewSoftwareBackend("software")
+	h, err := b.AddKey(&bursa.LoadedKey{SKey: []byte(priv), VKey: pub}, backend.KeyTypePool)
+	if err != nil {
+		t.Fatalf("AddKey: %v", err)
+	}
+	pol := policy.KeyPolicy{Hash: h.String(), AllowedRequests: []string{"opcert"}}
+	eng, _ := policy.NewEngine([]policy.KeyPolicy{pol})
+	coord := signer.New(signer.Deps{
+		Resolver:  backend.NewResolver(b),
+		Policy:    eng,
+		Watermark: watermark.NewMemWatermark(),
+		Cardano:   operation.Cardano(fakeCardano{pub: pub}),
+	})
+	acl := NewCallerACL(map[string][]backend.KeyHash{"alice": {h}})
+	srv := NewServer(coord, backend.NewResolver(b), eng, acl, func(string) (string, error) { return "tester", nil })
+
+	body, _ := json.Marshal(SignRequest{
+		Type:    "opcert",
+		Key:     h.String(),
+		KesVkey: hex.EncodeToString(bytes.Repeat([]byte{0x03}, 32)),
+	})
+
+	t.Run("bob denied", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/v1/sign", bytes.NewReader(body))
+		req = withCaller(req, "bob")
+		rr := httptest.NewRecorder()
+		srv.handleSign(rr, req)
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("expected 403 for bob, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("alice allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/v1/sign", bytes.NewReader(body))
+		req = withCaller(req, "alice")
+		rr := httptest.NewRecorder()
+		srv.handleSign(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200 for alice, got %d: %s", rr.Code, rr.Body.String())
 		}
 	})
 }

--- a/internal/signer/coordinator_opcert.go
+++ b/internal/signer/coordinator_opcert.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signer
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/blinklabs-io/bursa/internal/signer/backend"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// kesVkeySize is the length in bytes of a KES verification key (Ed25519-sized).
+const kesVkeySize = 32
+
+// OpCertResult is the outcome of an operational-certificate cold-signing request.
+type OpCertResult struct {
+	// SignatureHex is the 64-byte Ed25519 cold-key signature over the
+	// OCertSignable bytes, hex-encoded.
+	SignatureHex string
+	// ColdVKeyHex is the 32-byte cold verification key, hex-encoded. It is the
+	// value that goes in the cold_vkey slot of the opcert envelope so the caller
+	// can assemble [[kes_vkey, counter, period, sig], cold_vkey].
+	ColdVKeyHex string
+	// KeyHex is the blake2b-224 hash (hex) of the cold key that produced the
+	// signature.
+	KeyHex string
+}
+
+// SignOpCert produces the pool COLD-key Ed25519 signature over the canonical
+// OCertSignable bytes (kesVkey || issueCounter || kesPeriod, cardano-ledger
+// getSignableRepresentation) using the cold key identified by keyID. The cold
+// key never leaves its custody backend: the request carries only the KES
+// verification key plus the counter/period, and the backend performs the
+// signature.
+//
+// Every decision (allow or deny) is emitted as a structured audit-log line.
+// Secrets (private key material) are never logged.
+func (c *Coordinator) SignOpCert(ctx context.Context, kesVkey []byte, issueCounter, kesPeriod uint64, keyID string) (*OpCertResult, ErrorCode, error) {
+	if len(kesVkey) != kesVkeySize {
+		c.deps.Logger.Info("sign", "type", "opcert", "caller-key", keyID, "result", "denied", "reason", "invalid KES vkey length")
+		c.deps.Metrics.observe("opcert", string(CodeBadRequest))
+		c.deps.Metrics.observeDeny(string(CodeBadRequest))
+		return nil, CodeBadRequest, fmt.Errorf("KES vkey must be %d bytes, got %d", kesVkeySize, len(kesVkey))
+	}
+	hash, err := backend.ParseKeyHash(keyID)
+	if err != nil {
+		c.deps.Logger.Info("sign", "type", "opcert", "caller-key", keyID, "result", "denied", "reason", "invalid key id")
+		c.deps.Metrics.observe("opcert", string(CodeBadRequest))
+		c.deps.Metrics.observeDeny(string(CodeBadRequest))
+		return nil, CodeBadRequest, fmt.Errorf("invalid key id: %w", err)
+	}
+	ref, err := c.deps.Resolver.Resolve(ctx, hash)
+	if errors.Is(err, backend.ErrKeyNotFound) {
+		c.deps.Logger.Info("sign", "type", "opcert", "caller-key", hash.String(), "result", "denied", "reason", "key not found")
+		c.deps.Metrics.observe("opcert", string(CodeNotFound))
+		c.deps.Metrics.observeDeny(string(CodeNotFound))
+		return nil, CodeNotFound, errors.New("key not found")
+	}
+	if err != nil {
+		c.deps.Logger.Info("sign", "type", "opcert", "caller-key", hash.String(), "result", "error", "reason", err.Error())
+		c.deps.Metrics.observe("opcert", string(CodeBackend))
+		c.deps.Metrics.observeBackendError("resolver")
+		return nil, CodeBackend, err
+	}
+
+	if dec := c.deps.Policy.EvaluateOpCert(hash); !dec.Allow {
+		c.deps.Logger.Info("sign", "type", "opcert", "caller-key", hash.String(), "result", "denied", "reason", dec.Reason)
+		c.deps.Metrics.observe("opcert", string(CodeDenied))
+		c.deps.Metrics.observeDeny(string(CodeDenied))
+		return nil, CodeDenied, fmt.Errorf("%s", dec.Reason)
+	}
+
+	// Operational certificates are signed only by stake-pool COLD keys. Guard
+	// against a misconfigured policy granting opcert to a key of any other role
+	// (payment, stake, committee, etc.); such a key must never produce an opcert
+	// signature regardless of what the ACL permits.
+	if ref.Type() != backend.KeyTypePool {
+		c.deps.Logger.Info("sign", "type", "opcert", "caller-key", hash.String(), "result", "denied", "reason", "key is not a stake-pool cold key")
+		c.deps.Metrics.observe("opcert", string(CodeBadRequest))
+		c.deps.Metrics.observeDeny(string(CodeBadRequest))
+		return nil, CodeBadRequest, fmt.Errorf("opcert signing requires a %q key, got %q", backend.KeyTypePool, ref.Type())
+	}
+
+	// The cold key signs the raw OCertSignable bytes directly (this is NOT a
+	// CBOR encoding). Building it via gouroboros keeps the byte layout identical
+	// to cardano-node / cardano-ledger and to Part A's canonical envelope.
+	signable := lcommon.OpCertSignableBytes(kesVkey, issueCounter, kesPeriod)
+
+	signStart := time.Now()
+	sig, err := ref.Sign(ctx, signable)
+	// Attempt latency, including failures — not successful-sign latency.
+	c.deps.Metrics.observeSignDuration(ref.Backend(), time.Since(signStart).Seconds())
+	if err != nil {
+		code := CodeBackend
+		if errors.Is(err, backend.ErrUnsupportedExtended) {
+			code = CodeUnsupported
+		}
+		c.deps.Logger.Info("sign", "type", "opcert", "caller-key", hash.String(), "result", "error", "reason", err.Error())
+		c.deps.Metrics.observe("opcert", string(code))
+		if code == CodeBackend {
+			c.deps.Metrics.observeBackendError(ref.Backend())
+		} else {
+			c.deps.Metrics.observeDeny(string(code))
+		}
+		return nil, code, fmt.Errorf("opcert sign: %w", err)
+	}
+
+	pub := ref.PublicKey()
+	if len(pub) != ed25519.PublicKeySize {
+		c.deps.Logger.Error("sign", "type", "opcert", "caller-key", hash.String(), "result", "internal-error", "reason", "malformed public key from backend")
+		c.deps.Metrics.observe("opcert", string(CodeInternal))
+		return nil, CodeInternal, errors.New("backend returned malformed public key")
+	}
+	if !ed25519.Verify(pub, signable, sig) {
+		c.deps.Logger.Error("sign", "type", "opcert", "caller-key", hash.String(), "result", "internal-error", "reason", "produced signature failed ed25519 verification")
+		c.deps.Metrics.observe("opcert", string(CodeInternal))
+		return nil, CodeInternal, errors.New("produced signature failed verification")
+	}
+
+	c.deps.Logger.Info("sign", "type", "opcert", "caller-key", hash.String(), "result", "signed")
+	c.deps.Metrics.observe("opcert", "signed")
+	return &OpCertResult{
+		SignatureHex: hex.EncodeToString(sig),
+		ColdVKeyHex:  hex.EncodeToString(pub),
+		KeyHex:       hash.String(),
+	}, "", nil
+}

--- a/internal/signer/coordinator_test.go
+++ b/internal/signer/coordinator_test.go
@@ -49,12 +49,18 @@ type fakeKey struct {
 	pub     ed25519.PublicKey
 	priv    ed25519.PrivateKey
 	hash    backend.KeyHash
+	typ     backend.KeyType
 	signErr error
 }
 
 func (k *fakeKey) Hash() backend.KeyHash        { return k.hash }
 func (k *fakeKey) PublicKey() ed25519.PublicKey { return k.pub }
-func (k *fakeKey) Type() backend.KeyType        { return backend.KeyTypePayment }
+func (k *fakeKey) Type() backend.KeyType {
+	if k.typ != "" {
+		return k.typ
+	}
+	return backend.KeyTypePayment
+}
 func (k *fakeKey) Extended() bool               { return false }
 func (k *fakeKey) Backend() string              { return "fake" }
 func (k *fakeKey) Sign(_ context.Context, d []byte) ([]byte, error) {
@@ -416,5 +422,47 @@ func TestSignTx_NoSigners(t *testing.T) {
 	}
 	if !IsBadRequest(err) {
 		t.Fatalf("expected IsBadRequest true, got false; err=%v", err)
+	}
+}
+
+// TestSignOpCert_PoolKeySucceeds: a stake-pool cold key with the opcert
+// permission produces a cold signature.
+func TestSignOpCert_PoolKeySucceeds(t *testing.T) {
+	k := newFakeKey(t)
+	k.typ = backend.KeyTypePool
+	c, _ := newCoordinator(t, k,
+		policy.KeyPolicy{AllowedRequests: []string{"opcert"}},
+		watermark.NewMemWatermark(), fakeCardano{})
+
+	res, code, err := c.SignOpCert(context.Background(), make([]byte, kesVkeySize), 1, 2, k.hash.String())
+	if err != nil {
+		t.Fatalf("SignOpCert: unexpected error: %v (code=%s)", err, code)
+	}
+	if res == nil || res.SignatureHex == "" {
+		t.Fatalf("expected a signature result, got %+v", res)
+	}
+}
+
+// TestSignOpCert_NonPoolKeyRejected: even when a (misconfigured) policy grants
+// the opcert permission to a non-pool key, opcert signing must be refused
+// because operational certificates are signed only by stake-pool cold keys.
+func TestSignOpCert_NonPoolKeyRejected(t *testing.T) {
+	k := newFakeKey(t) // Type() defaults to KeyTypePayment
+	c, m := newCoordinator(t, k,
+		policy.KeyPolicy{AllowedRequests: []string{"opcert"}},
+		watermark.NewMemWatermark(), fakeCardano{})
+
+	res, code, err := c.SignOpCert(context.Background(), make([]byte, kesVkeySize), 1, 2, k.hash.String())
+	if err == nil {
+		t.Fatal("expected error for non-pool key, got nil")
+	}
+	if code != CodeBadRequest {
+		t.Fatalf("expected CodeBadRequest, got %s", code)
+	}
+	if res != nil {
+		t.Fatalf("expected nil result, got %+v", res)
+	}
+	if got := testutil.ToFloat64(m.denials.WithLabelValues(string(CodeBadRequest))); got != 1 {
+		t.Fatalf("expected 1 bad_request denial metric, got %v", got)
 	}
 }

--- a/internal/signer/policy/policy.go
+++ b/internal/signer/policy/policy.go
@@ -239,6 +239,23 @@ func (e *Engine) EvaluateTx(hash backend.KeyHash, insp *bursa.TxInspection) Deci
 	return allow()
 }
 
+// EvaluateOpCert authorizes (or denies) an operational-certificate cold-signing
+// request for the key identified by hash. Deny-by-default: a key may produce a
+// cold signature over the OCertSignable bytes only when it has a policy entry
+// that lists "opcert" in allowed_requests. Unlike tx/cip8 there is no bounded
+// sub-policy: the KES vkey, issue counter, and KES period are operator-supplied
+// values with no ledger-value semantics to constrain here.
+func (e *Engine) EvaluateOpCert(hash backend.KeyHash) Decision {
+	p, ok := e.byHash[hash]
+	if !ok {
+		return deny("no policy configured for key %s", hash)
+	}
+	if !p.allows("opcert") {
+		return deny("key %s may not sign operational certificates", hash)
+	}
+	return allow()
+}
+
 // EvaluateCIP8 authorizes (or denies) a CIP-8/CIP-30 data-signing request.
 func (e *Engine) EvaluateCIP8(hash backend.KeyHash, payloadLen int, addressMatches bool) Decision {
 	p, ok := e.byHash[hash]

--- a/internal/signer/policy/policy_test.go
+++ b/internal/signer/policy/policy_test.go
@@ -311,3 +311,26 @@ func TestEvaluateCIP8(t *testing.T) {
 		t.Fatalf("expected deny: cip8 not in allowed_requests")
 	}
 }
+
+func TestEvaluateOpCert(t *testing.T) {
+	// Deny-by-default: no policy entry at all.
+	e, err := NewEngine(nil)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	if e.EvaluateOpCert(mustHash(t, hashA)).Allow {
+		t.Fatalf("expected deny: no policy configured")
+	}
+
+	// Policy entry present but opcert not in allowed_requests.
+	e2, h2 := engineWith(t, KeyPolicy{AllowedRequests: []string{"tx"}})
+	if e2.EvaluateOpCert(h2).Allow {
+		t.Fatalf("expected deny: opcert not in allowed_requests")
+	}
+
+	// Explicitly allowed.
+	e3, h3 := engineWith(t, KeyPolicy{AllowedRequests: []string{"opcert"}})
+	if !e3.EvaluateOpCert(h3).Allow {
+		t.Fatalf("expected allow when opcert is in allowed_requests")
+	}
+}


### PR DESCRIPTION
Adds `type=opcert` to `POST /v1/sign` (signer-side companion to #610).

- `internal/signer/api/server.go`: `type=opcert` accepts `kes_vkey` (32-byte hex), `issue_counter` (uint64), `kes_period` (uint64), `key`; returns `{signature, cold_vkey, key, audit_id}`.
- `internal/signer/coordinator_opcert.go`: `SignOpCert` resolves the cold key via `backend.Resolver`, builds the payload with `gouroboros ledger/common.OpCertSignableBytes`, signs via `KeyRef.Sign`, verifies against the cold public key.
- `internal/signer/policy/policy.go`: `EvaluateOpCert` — deny-by-default; key must list `opcert` in `allowed_requests`.
- ACL scopes the cold key as the `cip8` path does.

Tests: `TestHandleSignOpCert_Valid`, `_MalformedInput`, `_PolicyDenied`, `_ACLDenied`, `TestEvaluateOpCert`.
`CGO_ENABLED=0 go build ./...`, `go test ./...`, `golangci-lint run ./...` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opcert signing to the mTLS signer so operators can get a cold Ed25519 signature for operational certificates without the cold key leaving its backend. Enforces ACL/policy gates and restricts signing to stake-pool cold keys only.

- New Features
  - `POST /v1/sign` with `type=opcert`; accepts `kes_vkey` (32-byte hex), `issue_counter` (uint64), `kes_period` (uint64), and `key`; returns `{signature, cold_vkey, key, audit_id}`.
  - Coordinator builds `OCertSignable` bytes via `github.com/blinklabs-io/gouroboros/ledger/common.OpCertSignableBytes`, signs in the backend, verifies with the cold public key, and returns the cold vkey so callers can assemble `[[kes_vkey, counter, period, sig], cold_vkey]`. ACL gates like `cip8`; policy `EvaluateOpCert` deny-by-default requires `opcert` in `allowed_requests`.

- Bug Fixes
  - Restricts opcert signing to stake-pool cold keys; non-pool keys are rejected even if policy is misconfigured.

<sup>Written for commit d4641b32be9371663576da778e2bcf66f917f6fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


