### PR TITLE
chore(ui): set Trezor manifest contact to support@blinklabs.io

### DIFF
--- a/ui/web/src/hw/trezor.ts
+++ b/ui/web/src/hw/trezor.ts
@@ -43,10 +43,9 @@ function parseBip32Path(pathStr: string): number[] {
 
 // ── Trezor Connect manifest / init ────────────────────────────────────────────
 
-// Placeholder contact advertised in the Trezor Connect manifest.
-// TODO: production contact — replace with the approved production
-// support/attribution address before shipping.
-const TREZOR_MANIFEST_CONTACT_EMAIL = "wallet@blinklabs.io";
+// Contact advertised in the Trezor Connect manifest so Trezor can reach the
+// maintainers about integration issues.
+const TREZOR_MANIFEST_CONTACT_EMAIL = "support@blinklabs.io";
 
 // Trezor requires a manifest identifying the calling app so it can reach out if
 // an integration misbehaves. This is the local Bursa wallet's identity; appUrl


### PR DESCRIPTION
The Trezor Connect manifest (`ui/web/src/hw/trezor.ts`) advertised a placeholder contact `wallet@blinklabs.io`. Set it to the standard `support@blinklabs.io` used elsewhere in the project (API docs/swagger contact), and drop the placeholder/TODO comment.

## Verification
`tsc --noEmit` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the Trezor Connect manifest contact to support@blinklabs.io so Trezor can reach maintainers and to align with our docs; removed the placeholder email and TODO.

<sup>Written for commit 56e0c22e34e86c73e89f3e940605c2a1a24389d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

