### PR TITLE
feat(ui): node diagnostics + log export

### DIFF
--- a/ui/cmd/bursa-wallet/main.go
+++ b/ui/cmd/bursa-wallet/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -43,14 +44,25 @@ func main() {
 }
 
 func run() error {
-	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return err
 	}
 	network := envOr("BURSA_NETWORK", "preview")
 	dataDir := filepath.Join(home, ".bursa-wallet", network)
+
+	// Log to a file under the data dir in addition to stderr, so the
+	// Diagnostics screen can export the logs. A failure to open the file is
+	// non-fatal: fall back to stderr-only and leave log export disabled.
+	logFilePath, logCloser := openLogFile(dataDir)
+	if logCloser != nil {
+		defer func() { _ = logCloser.Close() }()
+	}
+	var logDst io.Writer = os.Stderr
+	if logCloser != nil {
+		logDst = io.MultiWriter(os.Stderr, logCloser)
+	}
+	logger := slog.New(slog.NewTextHandler(logDst, nil))
 
 	// Mithril fast-sync is on by default; BURSA_SYNC=genesis opts out.
 	mithrilEnabled := !strings.EqualFold(envOr("BURSA_SYNC", "mithril"), "genesis")
@@ -71,6 +83,7 @@ func run() error {
 		// (default off) is the source of truth thereafter.
 		LeanDefault:      envBool("BURSA_LEAN", false),
 		ConnectorEnabled: envBool("BURSA_CONNECTOR", false),
+		LogFilePath:      logFilePath,
 	})
 	if err != nil {
 		return err
@@ -82,6 +95,25 @@ func run() error {
 	// opens a native window onto the same loopback UI and waits for it to close.
 	uiErr := awaitUI(ctx, app.URL(), logger, app.Err())
 	return uiErr
+}
+
+// openLogFile creates <dataDir>/logs/bursa-wallet.log (appending) and returns
+// its path plus the open file for the logger to also write to. On any failure
+// it returns ("", nil): logging then stays stderr-only and log export is
+// disabled, rather than blocking startup.
+func openLogFile(dataDir string) (string, *os.File) {
+	logDir := filepath.Join(dataDir, "logs")
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
+		fmt.Fprintln(os.Stderr, "bursa-wallet: could not create log dir:", err)
+		return "", nil
+	}
+	path := filepath.Join(logDir, "bursa-wallet.log")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "bursa-wallet: could not open log file:", err)
+		return "", nil
+	}
+	return path, f
 }
 
 func envOr(key, def string) string {

--- a/ui/cmd/bursa-wallet/ui_webview.go
+++ b/ui/cmd/bursa-wallet/ui_webview.go
@@ -23,12 +23,11 @@ package main
 import (
 	"context"
 	"log/slog"
-	"net/url"
-	"os/exec"
 	"runtime"
 	"time"
 
 	"github.com/blinklabs-io/bursa/ui/internal/desktoptray"
+	"github.com/blinklabs-io/bursa/ui/internal/openexternal"
 	webview "github.com/webview/webview_go"
 )
 
@@ -57,7 +56,7 @@ func awaitUI(ctx context.Context, url string, logger *slog.Logger, srvErr <-chan
 	// browser. Bind before Navigate so the function exists for the first
 	// page load, not just subsequent ones.
 	if err := w.Bind("bursaOpenExternal", func(rawurl string) {
-		openExternal(logger, rawurl)
+		openexternal.Open(logger, rawurl)
 	}); err != nil {
 		logger.Warn("failed to bind bursaOpenExternal", "error", err)
 	}
@@ -115,44 +114,4 @@ func awaitUI(ctx context.Context, url string, logger *slog.Logger, srvErr <-chan
 	default:
 		return nil
 	}
-}
-
-// openExternal opens rawurl in the OS's default browser, never in the
-// embedded webview. It is the Go side of the `bursaOpenExternal` JS bridge
-// bound above: the frontend calls this instead of letting an anchor's own
-// `target="_blank"` navigate the wallet window.
-//
-// rawurl is validated before use — it must parse as an absolute http(s) URL —
-// so a compromised or buggy frontend can't smuggle a `file://` path or an
-// arbitrary shell-meaningful string into an external command. Anything else
-// is logged and dropped rather than opened.
-func openExternal(logger *slog.Logger, rawurl string) {
-	u, err := url.Parse(rawurl)
-	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Hostname() == "" {
-		logger.Warn("refusing to open external URL", "url", rawurl)
-		return
-	}
-
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "linux":
-		cmd = exec.Command("xdg-open", u.String())
-	case "darwin":
-		cmd = exec.Command("open", u.String())
-	case "windows":
-		// rundll32's url.dll opener takes the URL as its sole argument; it
-		// does not go through a shell, so no extra quoting is needed.
-		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", u.String())
-	default:
-		logger.Warn("no external-browser opener for this OS", "os", runtime.GOOS, "url", u.String())
-		return
-	}
-
-	// Fire-and-forget: the wallet doesn't wait on or manage the browser
-	// process's lifetime, it only launches it.
-	if err := cmd.Start(); err != nil {
-		logger.Warn("failed to open external URL", "url", u.String(), "error", err)
-		return
-	}
-	go func() { _ = cmd.Wait() }()
 }

--- a/ui/go.mod
+++ b/ui/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/libp2p/go-libp2p v0.48.0
 	github.com/libp2p/go-libp2p-kad-dht v0.40.0
 	github.com/multiformats/go-multiaddr v0.16.1
+	github.com/prometheus/client_golang v1.23.2
 	github.com/utxorpc/go-codegen v0.19.2
 	github.com/webview/webview_go v0.0.0-20240831120633-6173450d4dd6
 	golang.org/x/crypto v0.54.0
@@ -245,7 +246,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/polydawn/refmt v0.90.0 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect

--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -29,6 +29,7 @@ import (
 	"github.com/blinklabs-io/bursa/ui/internal/connector"
 	"github.com/blinklabs-io/bursa/ui/internal/contacts"
 	"github.com/blinklabs-io/bursa/ui/internal/dex"
+	"github.com/blinklabs-io/bursa/ui/internal/diagnostics"
 	"github.com/blinklabs-io/bursa/ui/internal/handle"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/multisig"
@@ -151,10 +152,24 @@ type LegacyKeystore interface {
 	Unlock(password string) ([]byte, error)
 }
 
+// Diagnostics is the node-local diagnostics surface: a point-in-time report
+// (versions, network, sync, peers, listen ports, uptime, log path) and a log
+// export. It is entirely node-local (no external calls), so it needs no
+// external-consent gate. May be nil, in which case the /diagnostics routes are
+// not registered.
+type Diagnostics interface {
+	Report(ctx context.Context) diagnostics.Report
+	// LogAvailable reports whether an exportable log file exists.
+	LogAvailable() bool
+	// WriteLogsZip streams the log file(s) as a zip archive to w.
+	WriteLogsZip(w io.Writer) error
+}
+
 type handlerOptions struct {
-	legacy    LegacyKeystore
-	connector *connector.Service
-	nfts      NFTs
+	legacy      LegacyKeystore
+	connector   *connector.Service
+	nfts        NFTs
+	diagnostics Diagnostics
 }
 
 type HandlerOption func(*handlerOptions)
@@ -176,6 +191,11 @@ func WithConnector(svc *connector.Service) HandlerOption {
 // WithNFTs enables the optional NFT discovery and media endpoints.
 func WithNFTs(nfts NFTs) HandlerOption {
 	return func(cfg *handlerOptions) { cfg.nfts = nfts }
+}
+
+// WithDiagnostics enables the node-local diagnostics + log-export endpoints.
+func WithDiagnostics(d Diagnostics) HandlerOption {
+	return func(cfg *handlerOptions) { cfg.diagnostics = d }
 }
 
 // SettingsController is the user-facing app-settings surface. It exposes the
@@ -440,6 +460,37 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 	mux.HandleFunc("/status", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusOK, statusResponse{Status: st.Status(), Network: network})
 	})
+
+	// Node diagnostics + log export. Deliberately UNGATED (like /status): a
+	// diagnostics view must work in every node state — especially while syncing,
+	// bootstrapping, or after an error, which is exactly when a user reaches for
+	// it. It is node-local only (no external calls), so there is no
+	// external-consent gate; the sameOriginGuard wrapping the whole mux still
+	// applies. Like /status, these routes are intentionally not vault-unlock
+	// gated: they expose only node/process telemetry (never key material), and
+	// must work before/without a wallet being unlocked. Registered only when a
+	// Diagnostics provider is supplied.
+	if cfg.diagnostics != nil {
+		diag := cfg.diagnostics
+		mux.HandleFunc("GET /diagnostics", func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(w, http.StatusOK, diag.Report(r.Context()))
+		})
+		// GET /diagnostics/logs streams the wallet's log file(s) as a zip for a
+		// browser download. 404 when there is no log file to export (e.g. the
+		// wallet is not configured to write logs to a file).
+		mux.HandleFunc("GET /diagnostics/logs", func(w http.ResponseWriter, _ *http.Request) {
+			if !diag.LogAvailable() {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "log export unavailable"})
+				return
+			}
+			w.Header().Set("Content-Type", "application/zip")
+			w.Header().Set("Content-Disposition", `attachment; filename="bursa-wallet-logs.zip"`)
+			// Headers are committed before streaming; a mid-stream write error
+			// (rare — existence was just checked) truncates the download rather
+			// than rewriting the status, which is the best a stream can do.
+			_ = diag.WriteLogsZip(w)
+		})
+	}
 
 	// bindActive pushes the active wallet's read-only account onto the read and
 	// spend services so existing endpoints operate on it. Called after unlock,

--- a/ui/internal/api/connector_test.go
+++ b/ui/internal/api/connector_test.go
@@ -46,6 +46,7 @@ func (f *fakeConnectorBackend) RewardAddresses(_ context.Context) ([]string, err
 func (f *fakeConnectorBackend) Collateral(_ context.Context, _ string) ([]string, error) {
 	return nil, nil
 }
+
 func (f *fakeConnectorBackend) SignTx(_ context.Context, _ string, _ bool, _ string) (string, error) {
 	return "", nil
 }
@@ -55,6 +56,7 @@ func (f *fakeConnectorBackend) PubDRepKey(_ string) (string, error)             
 func (f *fakeConnectorBackend) RegisteredPubStakeKeys(_ string) ([]string, error) {
 	return nil, nil
 }
+
 func (f *fakeConnectorBackend) UnregisteredPubStakeKeys(_ string) ([]string, error) {
 	return nil, nil
 }

--- a/ui/internal/api/diagnostics_test.go
+++ b/ui/internal/api/diagnostics_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/blinklabs-io/bursa/ui/internal/diagnostics"
+)
+
+type fakeDiagnostics struct {
+	report      diagnostics.Report
+	logAvail    bool
+	zipBytes    []byte
+	zipErr      error
+	reportCalls int
+}
+
+func (f *fakeDiagnostics) Report(context.Context) diagnostics.Report {
+	f.reportCalls++
+	return f.report
+}
+func (f *fakeDiagnostics) LogAvailable() bool { return f.logAvail }
+func (f *fakeDiagnostics) WriteLogsZip(w io.Writer) error {
+	if f.zipErr != nil {
+		return f.zipErr
+	}
+	_, _ = w.Write(f.zipBytes)
+	return nil
+}
+
+// diagHandler builds a handler wired only with a diagnostics provider (the rest
+// are the shared fakes). st drives the (deliberately absent) gate so the test
+// can confirm /diagnostics works in a non-ready state.
+func diagHandler(st Statuser, d Diagnostics) http.Handler {
+	return NewHandler(
+		st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{},
+		nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler(),
+		WithDiagnostics(d),
+	)
+}
+
+func TestDiagnosticsReport(t *testing.T) {
+	d := &fakeDiagnostics{report: diagnostics.Report{
+		Node:  diagnostics.NodeInfo{Network: "preview", DingoVersion: "v0.66.2"},
+		Sync:  diagnostics.SyncInfo{State: "syncing", Tip: 42},
+		Peers: diagnostics.PeersInfo{Available: true, Total: 7, Configured: []diagnostics.ConfiguredPeer{}},
+	}}
+	// A non-ready node: /diagnostics must still respond (it is ungated like
+	// /status), which is exactly when a user needs it.
+	h := diagHandler(fakeStatuser{}, d)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/diagnostics", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var got diagnostics.Report
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Node.Network != "preview" || got.Sync.State != "syncing" || got.Peers.Total != 7 {
+		t.Errorf("unexpected report: %+v", got)
+	}
+	if d.reportCalls != 1 {
+		t.Errorf("Report calls = %d, want 1", d.reportCalls)
+	}
+}
+
+func TestDiagnosticsLogsExport(t *testing.T) {
+	d := &fakeDiagnostics{logAvail: true, zipBytes: []byte("PK\x03\x04zip")}
+	h := diagHandler(fakeStatuser{}, d)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/diagnostics/logs", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/zip" {
+		t.Errorf("Content-Type = %q, want application/zip", ct)
+	}
+	if cd := rec.Header().Get("Content-Disposition"); cd == "" {
+		t.Error("missing Content-Disposition")
+	}
+	if rec.Body.String() != "PK\x03\x04zip" {
+		t.Errorf("unexpected body %q", rec.Body.String())
+	}
+}
+
+func TestDiagnosticsLogsUnavailable(t *testing.T) {
+	d := &fakeDiagnostics{logAvail: false}
+	h := diagHandler(fakeStatuser{}, d)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/diagnostics/logs", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+// TestDiagnosticsCrossOriginRefused confirms the diagnostics routes inherit the
+// mux-wide sameOriginGuard (a non-loopback Host is refused).
+func TestDiagnosticsCrossOriginRefused(t *testing.T) {
+	h := diagHandler(fakeStatuser{}, &fakeDiagnostics{})
+	req := httptest.NewRequest(http.MethodGet, "/diagnostics", nil)
+	req.Host = "evil.example"
+	req.Header.Set("Origin", "http://evil.example")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}

--- a/ui/internal/boot/boot.go
+++ b/ui/internal/boot/boot.go
@@ -39,6 +39,7 @@ import (
 	"github.com/blinklabs-io/bursa/ui/internal/connector"
 	"github.com/blinklabs-io/bursa/ui/internal/contacts"
 	"github.com/blinklabs-io/bursa/ui/internal/dex"
+	"github.com/blinklabs-io/bursa/ui/internal/diagnostics"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/multisig"
 	"github.com/blinklabs-io/bursa/ui/internal/nft"
@@ -109,6 +110,11 @@ type Config struct {
 	// It is disabled by default so the extension-facing routes are absent unless
 	// the caller explicitly enables them.
 	ConnectorEnabled bool
+	// LogFilePath is the file the Logger also writes to. When set, the
+	// diagnostics screen exposes it and the /diagnostics/logs endpoint can
+	// export it. Empty (the default, e.g. mobile / stderr-only) disables log
+	// export; the caller owns the file's lifecycle.
+	LogFilePath string
 }
 
 // App is a booted wallet stack: a running supervised node and an HTTP control
@@ -154,6 +160,7 @@ type App struct {
 // has already given up on (see ui/mobile's cleanupLateStart, which relies on
 // this to make its unconditional wait for Boot's result safe).
 func Boot(ctx context.Context, cfg Config) (*App, error) {
+	startedAt := time.Now()
 	if cfg.Network == "" {
 		return nil, errors.New("boot: network is required")
 	}
@@ -336,7 +343,23 @@ func Boot(ctx context.Context, cfg Config) (*App, error) {
 		return nil, err
 	}
 
-	handlerOpts := []api.HandlerOption{api.WithLegacyKeystore(legacyKeyStore)}
+	// Node-local diagnostics: versions/network/sync/peers/ports/uptime + log
+	// export. Everything it reports is node-local, so it needs no consent gate.
+	diagSvc := diagnostics.New(sup, diagnostics.Config{
+		Network:        cfg.Network,
+		ControlAddr:    func() string { return listener.Addr().String() },
+		BlockfrostPort: blockfrostPort,
+		UtxorpcPort:    utxorpcPort,
+		NodeSocket:     filepath.Join(cfg.DataDir, "node.socket"),
+		LogPath:        cfg.LogFilePath,
+		StartedAt:      startedAt,
+		Chain:          diagChain{c: chainClient},
+	})
+
+	handlerOpts := []api.HandlerOption{
+		api.WithLegacyKeystore(legacyKeyStore),
+		api.WithDiagnostics(diagSvc),
+	}
 	if connectorSvc != nil {
 		handlerOpts = append(handlerOpts, api.WithConnector(connectorSvc))
 	}
@@ -489,6 +512,28 @@ func (c *settingsController) AutoLockMinutes() int { return c.store.AutoLockMinu
 
 func (c *settingsController) SetAutoLockMinutes(minutes int) error {
 	return c.store.SetAutoLockMinutes(minutes)
+}
+
+// diagChain adapts the loopback Blockfrost chain client to the diagnostics
+// ChainQuery surface (current epoch + tip block height). Both are best-effort:
+// diagnostics omits the field when the lookup fails (e.g. the node is not yet
+// serving queries), so these never fabricate a value.
+type diagChain struct{ c *chain.Client }
+
+func (d diagChain) LatestEpoch(ctx context.Context) (uint64, error) {
+	info, err := d.c.LatestEpoch(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return info.Epoch, nil
+}
+
+func (d diagChain) LatestBlockHeight(ctx context.Context) (uint64, error) {
+	tip, err := d.c.LatestBlock(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return tip.Height, nil
 }
 
 // genesisAdapter adapts the loopback Blockfrost chain client to the genesis

--- a/ui/internal/diagnostics/diagnostics.go
+++ b/ui/internal/diagnostics/diagnostics.go
@@ -1,0 +1,344 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package diagnostics assembles a node-local diagnostics report for the
+// full-node wallet: node/library versions, network, sync progress, live peer
+// counts, configured peers, listen ports, uptime, and the log-file location.
+// Everything it reports comes from the embedded node, the supervisor, and the
+// process itself — it makes NO external calls, so there is deliberately no
+// external-consent gate. It also packages the wallet's log file(s) into a zip
+// for a browser download.
+package diagnostics
+
+import (
+	"archive/zip"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"time"
+
+	"github.com/blinklabs-io/bursa/ui/internal/supervisor"
+)
+
+const (
+	dingoModulePath      = "github.com/blinklabs-io/dingo"
+	gouroborosModulePath = "github.com/blinklabs-io/gouroboros"
+	// chainQueryTimeout bounds the optional epoch/height lookup so a slow or
+	// stuck node never stalls the diagnostics handler.
+	chainQueryTimeout = 2 * time.Second
+)
+
+// NodeStatus is the node surface Diagnostics reads: the supervisor's status
+// snapshot plus its live connection counts and configured peers.
+type NodeStatus interface {
+	Status() supervisor.Status
+	Peers() supervisor.PeerCounts
+	ConfiguredPeers() []supervisor.ConfiguredPeer
+}
+
+// ChainQuery optionally supplies node-queried chain facts the supervisor's tip
+// poller does not track (the current epoch and the tip block height). It is
+// optional: when nil, or when a lookup fails (e.g. the node is not serving
+// queries yet), those fields are simply omitted from the report rather than
+// invented.
+type ChainQuery interface {
+	LatestEpoch(ctx context.Context) (uint64, error)
+	LatestBlockHeight(ctx context.Context) (uint64, error)
+}
+
+// Config wires the Service to its data sources. Everything here is known at
+// boot; ControlAddr is a func because the control-surface port may be assigned
+// by the OS (127.0.0.1:0) and is only known once the listener is bound.
+type Config struct {
+	Network        string
+	ControlAddr    func() string
+	BlockfrostPort uint
+	UtxorpcPort    uint
+	NodeSocket     string
+	// LogPath is the file the wallet's logger writes to, or "" when logs are not
+	// written to a file (e.g. mobile / stderr-only) — in which case log export
+	// reports unavailable.
+	LogPath   string
+	StartedAt time.Time
+	Now       func() time.Time // injectable clock; defaults to time.Now
+	Chain     ChainQuery       // optional
+}
+
+// Service produces diagnostics reports and log-export archives.
+type Service struct {
+	node NodeStatus
+	cfg  Config
+}
+
+// New builds a Service. now defaults to time.Now when cfg.Now is nil.
+func New(node NodeStatus, cfg Config) *Service {
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	return &Service{node: node, cfg: cfg}
+}
+
+// --- Report shape (also the JSON response of GET /diagnostics) ---------------
+
+// Report is the full diagnostics snapshot.
+type Report struct {
+	Node   NodeInfo   `json:"node"`
+	Sync   SyncInfo   `json:"sync"`
+	Peers  PeersInfo  `json:"peers"`
+	Listen ListenInfo `json:"listen"`
+	Uptime UptimeInfo `json:"uptime"`
+	Log    LogInfo    `json:"log"`
+}
+
+// NodeInfo is the network and the embedded node/library versions. A version is
+// omitted when it cannot be read from the build info (e.g. an unversioned
+// `go run` / `go build` of a dev tree).
+type NodeInfo struct {
+	Network           string `json:"network"`
+	DingoVersion      string `json:"dingoVersion,omitempty"`
+	GouroborosVersion string `json:"gouroborosVersion,omitempty"`
+	GoVersion         string `json:"goVersion,omitempty"`
+}
+
+// SyncInfo mirrors the supervisor's tip snapshot, plus a node-queried epoch and
+// block height when obtainable. Epoch/BlockHeight are pointers so an
+// unavailable lookup is JSON null rather than a fabricated zero.
+type SyncInfo struct {
+	State            string     `json:"state"`
+	Tip              uint64     `json:"tip"` // latest block slot
+	Epoch            *uint64    `json:"epoch,omitempty"`
+	BlockHeight      *uint64    `json:"blockHeight,omitempty"`
+	LatestBlockTime  *time.Time `json:"latestBlockTime,omitempty"`
+	CaughtUp         bool       `json:"caughtUp"`
+	SecondsBehind    *int64     `json:"secondsBehind,omitempty"`
+	BootstrapPercent *float64   `json:"bootstrapPercent,omitempty"`
+	BootstrapPhase   string     `json:"bootstrapPhase,omitempty"`
+	Error            string     `json:"error,omitempty"`
+}
+
+// PeersInfo carries the node's live connection-manager counts and its
+// configured outbound peers. Available is false when no node has been launched
+// yet (no metrics). Per-connection detail (a live per-peer address/direction/
+// state list) is NOT exposed by the embedded node's public API, so Configured
+// is the peer address list (labelled as configured, not live-connected).
+type PeersInfo struct {
+	Available      bool             `json:"available"`
+	Total          int              `json:"total"`
+	Inbound        int              `json:"inbound"`
+	Outbound       int              `json:"outbound"`
+	Duplex         int              `json:"duplex"`
+	FullDuplex     int              `json:"fullDuplex"`
+	Unidirectional int              `json:"unidirectional"`
+	Configured     []ConfiguredPeer `json:"configured"`
+}
+
+// ConfiguredPeer is one outbound access point from the node's topology.
+type ConfiguredPeer struct {
+	Address string `json:"address"`
+	Port    uint   `json:"port"`
+	Source  string `json:"source"` // "bootstrap" | "localRoot" | "publicRoot"
+}
+
+// ListenInfo is where the wallet and its embedded node listen. Every endpoint
+// binds to loopback (127.0.0.1); the node socket is a unix domain socket path.
+type ListenInfo struct {
+	ControlSurface string `json:"controlSurface"`
+	BlockfrostPort uint   `json:"blockfrostPort"`
+	UtxorpcPort    uint   `json:"utxorpcPort"`
+	NodeSocket     string `json:"nodeSocket"`
+}
+
+// UptimeInfo is how long this wallet process has been running.
+type UptimeInfo struct {
+	StartedAt time.Time `json:"startedAt"`
+	Seconds   int64     `json:"seconds"`
+}
+
+// LogInfo locates the wallet's log file for export / "open folder". Available
+// is false when the wallet is not writing logs to a file.
+type LogInfo struct {
+	Available bool   `json:"available"`
+	Path      string `json:"path,omitempty"`
+	Dir       string `json:"dir,omitempty"`
+}
+
+// Report assembles the current diagnostics snapshot. It makes at most one
+// (bounded, loopback) node query — for the epoch and block height — and only
+// when a ChainQuery is configured; that failing just omits those two fields.
+func (s *Service) Report(ctx context.Context) Report {
+	st := s.node.Status()
+	now := s.cfg.Now()
+
+	sync := SyncInfo{
+		State:           string(st.State),
+		Tip:             st.Tip,
+		LatestBlockTime: st.LatestBlockTime,
+		CaughtUp:        st.CaughtUp,
+		Error:           st.Err,
+	}
+	if st.LatestBlockTime != nil {
+		behind := int64(now.Sub(*st.LatestBlockTime).Seconds())
+		if behind < 0 {
+			behind = 0
+		}
+		sync.SecondsBehind = &behind
+	}
+	if st.Bootstrap != nil {
+		p := st.Bootstrap.Percent
+		sync.BootstrapPercent = &p
+		sync.BootstrapPhase = st.Bootstrap.Phase
+	}
+	if s.cfg.Chain != nil {
+		qctx, cancel := context.WithTimeout(ctx, chainQueryTimeout)
+		if epoch, err := s.cfg.Chain.LatestEpoch(qctx); err == nil {
+			sync.Epoch = &epoch
+		}
+		if height, err := s.cfg.Chain.LatestBlockHeight(qctx); err == nil {
+			sync.BlockHeight = &height
+		}
+		cancel()
+	}
+
+	pc := s.node.Peers()
+	peers := PeersInfo{
+		Available:      pc.Available,
+		Total:          pc.Total(),
+		Inbound:        pc.Inbound,
+		Outbound:       pc.Outbound,
+		Duplex:         pc.Duplex,
+		FullDuplex:     pc.FullDuplex,
+		Unidirectional: pc.Unidirectional,
+		Configured:     []ConfiguredPeer{},
+	}
+	for _, cp := range s.node.ConfiguredPeers() {
+		peers.Configured = append(peers.Configured, ConfiguredPeer{
+			Address: cp.Address, Port: cp.Port, Source: cp.Source,
+		})
+	}
+
+	controlAddr := ""
+	if s.cfg.ControlAddr != nil {
+		controlAddr = s.cfg.ControlAddr()
+	}
+
+	// Clamp to 0: the clock moving backwards or a StartedAt in the future
+	// would otherwise report a negative uptime (as secondsBehind is clamped).
+	uptimeSeconds := int64(now.Sub(s.cfg.StartedAt).Seconds())
+	if uptimeSeconds < 0 {
+		uptimeSeconds = 0
+	}
+
+	log := LogInfo{}
+	if s.cfg.LogPath != "" {
+		log.Available = true
+		log.Path = s.cfg.LogPath
+		log.Dir = filepath.Dir(s.cfg.LogPath)
+	}
+
+	return Report{
+		Node: NodeInfo{
+			Network:           s.cfg.Network,
+			DingoVersion:      depVersion(dingoModulePath),
+			GouroborosVersion: depVersion(gouroborosModulePath),
+			GoVersion:         runtime.Version(),
+		},
+		Sync:  sync,
+		Peers: peers,
+		Listen: ListenInfo{
+			ControlSurface: controlAddr,
+			BlockfrostPort: s.cfg.BlockfrostPort,
+			UtxorpcPort:    s.cfg.UtxorpcPort,
+			NodeSocket:     s.cfg.NodeSocket,
+		},
+		Uptime: UptimeInfo{
+			StartedAt: s.cfg.StartedAt,
+			Seconds:   uptimeSeconds,
+		},
+		Log: log,
+	}
+}
+
+// LogAvailable reports whether the wallet has a log file that exists on disk
+// and can be exported. It is the gate the API uses to decide 404 vs. stream,
+// so it checks existence (not merely that a path was configured).
+func (s *Service) LogAvailable() bool { return len(s.LogFiles()) > 0 }
+
+// LogFiles returns the log file(s) to include in an export, skipping any that
+// do not currently exist on disk.
+func (s *Service) LogFiles() []string {
+	if s.cfg.LogPath == "" {
+		return nil
+	}
+	if _, err := os.Stat(s.cfg.LogPath); err != nil {
+		return nil
+	}
+	return []string{s.cfg.LogPath}
+}
+
+// WriteLogsZip streams the log file(s) as a zip archive to w. It returns
+// os.ErrNotExist when there is nothing to export (no configured/existing log).
+func (s *Service) WriteLogsZip(w io.Writer) error {
+	files := s.LogFiles()
+	if len(files) == 0 {
+		return os.ErrNotExist
+	}
+	zw := zip.NewWriter(w)
+	for _, path := range files {
+		if err := addFileToZip(zw, path); err != nil {
+			_ = zw.Close()
+			return err
+		}
+	}
+	return zw.Close()
+}
+
+func addFileToZip(zw *zip.Writer, path string) error {
+	f, err := os.Open(path) //nolint:gosec // path is the wallet's own configured log file
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	hdr := &zip.FileHeader{Name: filepath.Base(path), Method: zip.Deflate}
+	if info, err := f.Stat(); err == nil {
+		hdr.Modified = info.ModTime()
+	}
+	dst, err := zw.CreateHeader(hdr)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(dst, f)
+	return err
+}
+
+// depVersion returns the module version of the given import path from the
+// binary's build info, or "" when it cannot be determined.
+func depVersion(path string) string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	for _, d := range bi.Deps {
+		if d.Path != path {
+			continue
+		}
+		if d.Replace != nil && d.Replace.Version != "" {
+			return d.Replace.Version
+		}
+		return d.Version
+	}
+	return ""
+}

--- a/ui/internal/diagnostics/diagnostics_test.go
+++ b/ui/internal/diagnostics/diagnostics_test.go
@@ -1,0 +1,223 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package diagnostics
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/bursa/ui/internal/supervisor"
+)
+
+type fakeNode struct {
+	status     supervisor.Status
+	peers      supervisor.PeerCounts
+	configured []supervisor.ConfiguredPeer
+}
+
+func (f fakeNode) Status() supervisor.Status                    { return f.status }
+func (f fakeNode) Peers() supervisor.PeerCounts                 { return f.peers }
+func (f fakeNode) ConfiguredPeers() []supervisor.ConfiguredPeer { return f.configured }
+
+type fakeChain struct {
+	epoch     uint64
+	height    uint64
+	epochErr  error
+	heightErr error
+}
+
+func (f fakeChain) LatestEpoch(context.Context) (uint64, error) {
+	return f.epoch, f.epochErr
+}
+func (f fakeChain) LatestBlockHeight(context.Context) (uint64, error) {
+	return f.height, f.heightErr
+}
+
+func TestReportAssemblesRealFields(t *testing.T) {
+	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	blkTime := now.Add(-30 * time.Second)
+	started := now.Add(-10 * time.Minute)
+
+	node := fakeNode{
+		status: supervisor.Status{
+			State:           supervisor.StateSyncing,
+			Tip:             123456,
+			LatestBlockTime: &blkTime,
+			CaughtUp:        false,
+		},
+		peers: supervisor.PeerCounts{
+			Available: true, Inbound: 2, Outbound: 5, Duplex: 1, FullDuplex: 1, Unidirectional: 4,
+		},
+		configured: []supervisor.ConfiguredPeer{
+			{Address: "relay.example", Port: 3001, Source: "bootstrap"},
+		},
+	}
+	svc := New(node, Config{
+		Network:        "preview",
+		ControlAddr:    func() string { return "127.0.0.1:8090" },
+		BlockfrostPort: 5556,
+		UtxorpcPort:    5555,
+		NodeSocket:     "/data/node.socket",
+		StartedAt:      started,
+		Now:            func() time.Time { return now },
+		Chain:          fakeChain{epoch: 812, height: 99000},
+	})
+
+	rep := svc.Report(context.Background())
+
+	if rep.Node.Network != "preview" {
+		t.Errorf("network = %q, want preview", rep.Node.Network)
+	}
+	if rep.Node.GoVersion == "" {
+		t.Error("GoVersion should be populated from runtime")
+	}
+	if rep.Sync.State != "syncing" || rep.Sync.Tip != 123456 {
+		t.Errorf("unexpected sync: %+v", rep.Sync)
+	}
+	if rep.Sync.Epoch == nil || *rep.Sync.Epoch != 812 {
+		t.Errorf("epoch = %v, want 812", rep.Sync.Epoch)
+	}
+	if rep.Sync.BlockHeight == nil || *rep.Sync.BlockHeight != 99000 {
+		t.Errorf("blockHeight = %v, want 99000", rep.Sync.BlockHeight)
+	}
+	if rep.Sync.SecondsBehind == nil || *rep.Sync.SecondsBehind != 30 {
+		t.Errorf("secondsBehind = %v, want 30", rep.Sync.SecondsBehind)
+	}
+	if !rep.Peers.Available || rep.Peers.Total != 7 || rep.Peers.Outbound != 5 {
+		t.Errorf("unexpected peers: %+v", rep.Peers)
+	}
+	if len(rep.Peers.Configured) != 1 || rep.Peers.Configured[0].Source != "bootstrap" {
+		t.Errorf("unexpected configured peers: %+v", rep.Peers.Configured)
+	}
+	if rep.Listen.ControlSurface != "127.0.0.1:8090" || rep.Listen.BlockfrostPort != 5556 {
+		t.Errorf("unexpected listen: %+v", rep.Listen)
+	}
+	if rep.Listen.NodeSocket != "/data/node.socket" {
+		t.Errorf("nodeSocket = %q, want /data/node.socket", rep.Listen.NodeSocket)
+	}
+	if rep.Uptime.Seconds != 600 {
+		t.Errorf("uptime = %d, want 600", rep.Uptime.Seconds)
+	}
+	if rep.Log.Available {
+		t.Error("log should be unavailable when no LogPath is set")
+	}
+}
+
+func TestReportOmitsChainFieldsOnError(t *testing.T) {
+	svc := New(fakeNode{status: supervisor.Status{State: supervisor.StateError, Err: "boom"}}, Config{
+		Network: "preview",
+		Now:     time.Now,
+		Chain:   fakeChain{epochErr: errors.New("node down"), heightErr: errors.New("node down")},
+	})
+	rep := svc.Report(context.Background())
+	if rep.Sync.Epoch != nil || rep.Sync.BlockHeight != nil {
+		t.Errorf("chain fields must be nil when lookups fail: %+v", rep.Sync)
+	}
+	if rep.Sync.Error != "boom" {
+		t.Errorf("error passthrough = %q", rep.Sync.Error)
+	}
+	// Configured is always a (possibly empty) slice, never nil, so the JSON is [].
+	if rep.Peers.Configured == nil {
+		t.Error("configured peers should be an empty slice, not nil")
+	}
+}
+
+func TestReportBootstrapPercent(t *testing.T) {
+	svc := New(fakeNode{status: supervisor.Status{
+		State:     supervisor.StateBootstrapping,
+		Bootstrap: &supervisor.BootstrapProgress{Phase: "bootstrap", Percent: 42.5},
+	}}, Config{Now: time.Now})
+	rep := svc.Report(context.Background())
+	if rep.Sync.BootstrapPercent == nil || *rep.Sync.BootstrapPercent != 42.5 {
+		t.Errorf("bootstrapPercent = %v, want 42.5", rep.Sync.BootstrapPercent)
+	}
+	if rep.Sync.BootstrapPhase != "bootstrap" {
+		t.Errorf("bootstrapPhase = %q", rep.Sync.BootstrapPhase)
+	}
+}
+
+func TestUptimeClampedToZero(t *testing.T) {
+	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	// StartedAt in the future (e.g. a clock that moved backwards) must not
+	// produce a negative uptime.
+	svc := New(fakeNode{}, Config{
+		StartedAt: now.Add(5 * time.Minute),
+		Now:       func() time.Time { return now },
+	})
+	rep := svc.Report(context.Background())
+	if rep.Uptime.Seconds != 0 {
+		t.Errorf("uptime = %d, want 0 (clamped)", rep.Uptime.Seconds)
+	}
+}
+
+func TestLogExport(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "bursa-wallet.log")
+	if err := os.WriteFile(logPath, []byte("hello log\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	svc := New(fakeNode{}, Config{LogPath: logPath, Now: time.Now})
+
+	if !svc.LogAvailable() {
+		t.Fatal("LogAvailable should be true for an existing log file")
+	}
+	rep := svc.Report(context.Background())
+	if !rep.Log.Available || rep.Log.Path != logPath || rep.Log.Dir != dir {
+		t.Errorf("unexpected log info: %+v", rep.Log)
+	}
+
+	var buf bytes.Buffer
+	if err := svc.WriteLogsZip(&buf); err != nil {
+		t.Fatalf("WriteLogsZip: %v", err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("zip.NewReader: %v", err)
+	}
+	if len(zr.File) != 1 || zr.File[0].Name != "bursa-wallet.log" {
+		t.Fatalf("unexpected zip contents: %+v", zr.File)
+	}
+	rc, err := zr.File[0].Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	got, _ := os.ReadFile(logPath)
+	var zipped bytes.Buffer
+	_, _ = zipped.ReadFrom(rc)
+	if zipped.String() != string(got) {
+		t.Errorf("zipped content mismatch: %q vs %q", zipped.String(), string(got))
+	}
+}
+
+func TestLogUnavailable(t *testing.T) {
+	// No LogPath configured.
+	if New(fakeNode{}, Config{}).LogAvailable() {
+		t.Error("LogAvailable should be false with no LogPath")
+	}
+	// LogPath set but file does not exist.
+	svc := New(fakeNode{}, Config{LogPath: filepath.Join(t.TempDir(), "missing.log")})
+	if svc.LogAvailable() {
+		t.Error("LogAvailable should be false when the file is missing")
+	}
+	if err := svc.WriteLogsZip(&bytes.Buffer{}); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("WriteLogsZip err = %v, want ErrNotExist", err)
+	}
+}

--- a/ui/internal/openexternal/openexternal.go
+++ b/ui/internal/openexternal/openexternal.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package openexternal opens a URL in the host OS's default handler on behalf
+// of the desktop (webview) build. It lives in its own pure-Go package — no
+// webview/CGO dependency — so its URL validation is unit-testable without a
+// GUI. Only the webview build calls Open (via the bursaOpenExternal JS
+// bridge); the headless build serves the UI in a real browser and never needs
+// it.
+package openexternal
+
+import (
+	"log/slog"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// Open opens rawurl in the OS's default handler, never in the embedded webview.
+// It is the Go side of the `bursaOpenExternal` JS bridge: the frontend calls it
+// for explorer links (http/https, opened in the default browser) and for the
+// Diagnostics screen's "Open log folder" action (a `file://` URL of the log
+// directory, opened in the OS file manager).
+//
+// The target is validated by ResolveTarget before use so a compromised or buggy
+// frontend can't smuggle an arbitrary shell-meaningful string into an external
+// command. Anything that does not validate is logged and dropped.
+func Open(logger *slog.Logger, rawurl string) {
+	target, isFile, ok := ResolveTarget(rawurl)
+	if !ok {
+		logger.Warn("refusing to open external URL", "url", rawurl)
+		return
+	}
+
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "linux":
+		// xdg-open opens a URL in the default browser and a directory path in
+		// the default file manager.
+		cmd = exec.Command("xdg-open", target) //nolint:gosec // target is a validated http(s) URL or an existing directory
+	case "darwin":
+		cmd = exec.Command("open", target) //nolint:gosec // target is a validated http(s) URL or an existing directory
+	case "windows":
+		if isFile {
+			// target is a validated, absolute, existing directory, so explorer
+			// opens a folder view — never executes a file.
+			cmd = exec.Command("explorer", target) //nolint:gosec // target is a validated existing directory
+		} else {
+			// rundll32's url.dll opener takes the URL as its sole argument; it
+			// does not go through a shell, so no extra quoting is needed.
+			cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", target) //nolint:gosec // target is a validated http(s) URL
+		}
+	default:
+		logger.Warn("no external opener for this OS", "os", runtime.GOOS, "url", target)
+		return
+	}
+
+	// Fire-and-forget: the wallet doesn't wait on or manage the opened
+	// process's lifetime, it only launches it.
+	if err := cmd.Start(); err != nil {
+		logger.Warn("failed to open external URL", "url", target, "error", err)
+		return
+	}
+	go func() { _ = cmd.Wait() }()
+}
+
+// ResolveTarget validates rawurl and returns the concrete argument to hand to
+// the OS opener, whether that argument is a local file path (isFile), and
+// whether the URL is allowed at all (ok). The accepted forms are:
+//
+//   - http/https with a hostname → opened in the default browser.
+//   - file:// whose path is an existing directory → opened as a folder view.
+//     It can never open — let alone execute — a file.
+//
+// Everything else returns ok=false.
+func ResolveTarget(rawurl string) (target string, isFile bool, ok bool) {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return "", false, false
+	}
+	switch {
+	case (u.Scheme == "http" || u.Scheme == "https") && u.Hostname() != "":
+		return u.String(), false, true
+	case u.Scheme == "file":
+		p, ok := fileURLDir(u)
+		if !ok {
+			return "", false, false
+		}
+		return p, true, true
+	default:
+		return "", false, false
+	}
+}
+
+// fileURLDir extracts, normalizes, and validates the local directory path from
+// a file:// URL. It returns ok=false unless the URL resolves to an existing,
+// absolute directory.
+//
+// url.Parse already percent-decodes u.Path, so spaces and other escaped
+// characters are restored to the real filesystem name — there is no second
+// unescape (that would double-decode). On Windows a drive path arrives as
+// "/C:/Users/…"; the leading slash is stripped so os/filepath see a real
+// "C:\Users\…" path.
+func fileURLDir(u *url.URL) (string, bool) {
+	// A file URL's authority is empty (file:///path) or "localhost"; anything
+	// else names a remote host we won't dereference.
+	if u.Host != "" && !strings.EqualFold(u.Host, "localhost") {
+		return "", false
+	}
+
+	p := u.Path
+	if runtime.GOOS == "windows" && len(p) >= 3 && p[0] == '/' && p[2] == ':' {
+		p = p[1:]
+	}
+	p = filepath.Clean(p)
+
+	// Belt-and-suspenders: only ever open an absolute path that is a real,
+	// existing directory.
+	if !filepath.IsAbs(p) {
+		return "", false
+	}
+	info, err := os.Stat(p)
+	if err != nil || !info.IsDir() {
+		return "", false
+	}
+	return p, true
+}

--- a/ui/internal/openexternal/openexternal_test.go
+++ b/ui/internal/openexternal/openexternal_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package openexternal
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fileURL builds a correctly percent-encoded file:// URL for a local path,
+// exactly as the frontend (pathToFileUrl) does before calling the
+// bursaOpenExternal bridge.
+func fileURL(p string) string {
+	return (&url.URL{Scheme: "file", Path: p}).String()
+}
+
+func TestResolveTargetFileScheme(t *testing.T) {
+	dir := t.TempDir()
+
+	spacedDir := filepath.Join(dir, "logs with spaces")
+	if err := os.Mkdir(spacedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	filePath := filepath.Join(dir, "bursa-wallet.log")
+	if err := os.WriteFile(filePath, []byte("log\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		rawurl     string
+		wantOK     bool
+		wantIsFile bool
+		wantTarget string // only checked when wantOK
+	}{
+		{
+			name:       "existing directory accepted",
+			rawurl:     fileURL(dir),
+			wantOK:     true,
+			wantIsFile: true,
+			wantTarget: dir,
+		},
+		{
+			name:       "directory path with spaces is decoded and accepted",
+			rawurl:     fileURL(spacedDir),
+			wantOK:     true,
+			wantIsFile: true,
+			wantTarget: spacedDir,
+		},
+		{
+			name:   "existing file (not a directory) refused",
+			rawurl: fileURL(filePath),
+			wantOK: false,
+		},
+		{
+			name:   "nonexistent path refused",
+			rawurl: fileURL(filepath.Join(dir, "does-not-exist")),
+			wantOK: false,
+		},
+		{
+			name:   "remote host refused",
+			rawurl: "file://evil.example/etc",
+			wantOK: false,
+		},
+		{
+			name:       "http url accepted as a browser link",
+			rawurl:     "https://cardanoscan.io/",
+			wantOK:     true,
+			wantIsFile: false,
+			wantTarget: "https://cardanoscan.io/",
+		},
+		{
+			name:   "unsupported scheme refused",
+			rawurl: "javascript:alert(1)",
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			target, isFile, ok := ResolveTarget(tc.rawurl)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (target=%q)", ok, tc.wantOK, target)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if isFile != tc.wantIsFile {
+				t.Errorf("isFile = %v, want %v", isFile, tc.wantIsFile)
+			}
+			if target != tc.wantTarget {
+				t.Errorf("target = %q, want %q", target, tc.wantTarget)
+			}
+		})
+	}
+}

--- a/ui/internal/supervisor/peers.go
+++ b/ui/internal/supervisor/peers.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package supervisor
+
+// metricConnPrefix is the name prefix Dingo's connection manager gives its
+// Prometheus gauges (see dingo/connmanager). We gather them from the node's
+// per-launch registry to read live connection counts, since the embedded
+// node's public API exposes no direct peer accessor. It is a var (not a
+// const) so it is overridable and so a test can assert it still matches what
+// the pinned dingo dep emits — a rename there would otherwise silently zero
+// the peer counts (see peers_test.go).
+var metricConnPrefix = "cardano_node_metrics_connectionManager_"
+
+// PeerCounts is a point-in-time snapshot of the embedded node's live
+// connection-manager gauges. Dingo does not expose a per-peer accessor on its
+// public Node type, so these aggregate counts are the live peer signal the
+// wallet can read; the per-peer address list comes from the configured
+// topology (ConfiguredPeers). Available is false when no node has been
+// launched yet (no registry) or the gauges are not present.
+type PeerCounts struct {
+	Available      bool
+	Inbound        int
+	Outbound       int
+	Duplex         int
+	FullDuplex     int
+	Unidirectional int
+	Prunable       int
+}
+
+// Total is the live connection count (inbound + outbound).
+func (p PeerCounts) Total() int { return p.Inbound + p.Outbound }
+
+// ConfiguredPeer is one outbound access point the node is configured to dial,
+// from the embedded topology. Source is "bootstrap", "localRoot", or
+// "publicRoot". These are the peers the node MAY connect to, not a live
+// connection list (which the node's public API does not expose).
+type ConfiguredPeer struct {
+	Address string
+	Port    uint
+	Source  string
+}
+
+// Peers gathers the running node's connection-manager gauges into a PeerCounts.
+// It returns {Available: false} when no node has been launched (no registry).
+func (s *Supervisor) Peers() PeerCounts {
+	s.mu.RLock()
+	reg := s.promRegistry
+	s.mu.RUnlock()
+	if reg == nil {
+		return PeerCounts{}
+	}
+	families, err := reg.Gather()
+	if err != nil {
+		return PeerCounts{}
+	}
+	gauge := func(name string) (float64, bool) {
+		for _, mf := range families {
+			if mf.GetName() != metricConnPrefix+name {
+				continue
+			}
+			for _, m := range mf.GetMetric() {
+				if g := m.GetGauge(); g != nil {
+					return g.GetValue(), true
+				}
+			}
+		}
+		return 0, false
+	}
+	pc := PeerCounts{}
+	// The gauges only exist once the connection manager has initialised its
+	// metrics; treat their presence as "peer data available".
+	if v, ok := gauge("incomingConns"); ok {
+		pc.Available = true
+		pc.Inbound = int(v)
+	}
+	if v, ok := gauge("outgoingConns"); ok {
+		pc.Available = true
+		pc.Outbound = int(v)
+	}
+	if v, ok := gauge("duplexConns"); ok {
+		pc.Duplex = int(v)
+	}
+	if v, ok := gauge("fullDuplexConns"); ok {
+		pc.FullDuplex = int(v)
+	}
+	if v, ok := gauge("unidirectionalConns"); ok {
+		pc.Unidirectional = int(v)
+	}
+	if v, ok := gauge("prunableConns"); ok {
+		pc.Prunable = int(v)
+	}
+	return pc
+}
+
+// ConfiguredPeers flattens the embedded topology's bootstrap, local-root, and
+// public-root access points into a single list for Diagnostics. It returns nil
+// before the node has been started (no topology loaded yet).
+func (s *Supervisor) ConfiguredPeers() []ConfiguredPeer {
+	s.mu.RLock()
+	topo := s.topologyCfg
+	s.mu.RUnlock()
+	if topo == nil {
+		return nil
+	}
+	var out []ConfiguredPeer
+	for _, bp := range topo.BootstrapPeers {
+		out = append(out, ConfiguredPeer{Address: bp.Address, Port: bp.Port, Source: "bootstrap"})
+	}
+	for _, lr := range topo.LocalRoots {
+		for _, ap := range lr.AccessPoints {
+			out = append(out, ConfiguredPeer{Address: ap.Address, Port: ap.Port, Source: "localRoot"})
+		}
+	}
+	for _, pr := range topo.PublicRoots {
+		for _, ap := range pr.AccessPoints {
+			out = append(out, ConfiguredPeer{Address: ap.Address, Port: ap.Port, Source: "publicRoot"})
+		}
+	}
+	return out
+}

--- a/ui/internal/supervisor/peers_test.go
+++ b/ui/internal/supervisor/peers_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package supervisor
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/dingo/connmanager"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// TestMetricConnPrefixMatchesDingo guards the coupling between peers.go and
+// dingo's connection-manager Prometheus gauges: the live peer counts are read
+// by matching metricConnPrefix+suffix against the node's registry. If dingo
+// renames the prefix or any of these gauges, the counts would silently read
+// zero — so we build a real connection manager against a throwaway registry
+// and assert the exact names we depend on are still emitted. A rename in the
+// dingo dep therefore fails this test loudly instead of shipping a broken
+// peers panel.
+func TestMetricConnPrefixMatchesDingo(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	// Constructing with a registry registers the gauges; we don't need a
+	// running node to read their names.
+	_ = connmanager.NewConnectionManager(connmanager.ConnectionManagerConfig{
+		PromRegistry: reg,
+	})
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	got := make(map[string]bool, len(families))
+	for _, mf := range families {
+		got[mf.GetName()] = true
+	}
+
+	// The suffixes peers.go looks up via gauge().
+	for _, suffix := range []string{
+		"incomingConns",
+		"outgoingConns",
+		"duplexConns",
+		"fullDuplexConns",
+		"unidirectionalConns",
+		"prunableConns",
+	} {
+		name := metricConnPrefix + suffix
+		if !got[name] {
+			t.Errorf("dingo no longer emits %q; the diagnostics peer counts "+
+				"depend on it — update metricConnPrefix / peers.go to match "+
+				"the current dingo connmanager metric names", name)
+		}
+	}
+}

--- a/ui/internal/supervisor/supervisor.go
+++ b/ui/internal/supervisor/supervisor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/connmanager"
 	"github.com/blinklabs-io/dingo/topology"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Config configures the embedded node. All network endpoints bind to loopback.
@@ -97,6 +98,15 @@ type Supervisor struct {
 		ran           bool
 	}
 
+	// promRegistry is the Prometheus registry the currently-running node was
+	// built with (a fresh one per launch, so a Reconnect never re-registers
+	// metrics on a shared registry). Diagnostics gathers it for the node's live
+	// connection-manager counts. nil until the first launch. topologyCfg is the
+	// embedded topology the node dials its outbound peers from; Diagnostics
+	// reports those as the configured-peer list. Both are guarded by mu.
+	promRegistry *prometheus.Registry
+	topologyCfg  *topology.TopologyConfig
+
 	now          func() time.Time // injectable clock for tests
 	bootstrapper Bootstrapper     // injectable for tests
 	nodeFactory  NodeFactory      // injectable for tests
@@ -134,11 +144,16 @@ func nodeConfigOptions(
 	historyExpiry bool,
 	cardanoCfg *cardano.CardanoNodeConfig,
 	topologyCfg *topology.TopologyConfig,
+	promRegistry prometheus.Registerer,
 ) []dingo.ConfigOptionFunc {
 	opts := []dingo.ConfigOptionFunc{
 		dingo.WithNetwork(cfg.Network),
 		dingo.WithCardanoNodeConfig(cardanoCfg),
 		dingo.WithTopologyConfig(topologyCfg),
+		// A per-launch Prometheus registry so Diagnostics can read the node's
+		// live connection-manager gauges (peer counts). Nothing scrapes this
+		// over the network; the wallet gathers it in-process on demand.
+		dingo.WithPrometheusRegistry(promRegistry),
 		dingo.WithDatabasePath(cfg.DataDir),
 		dingo.WithStorageMode(dingo.StorageModeAPI),
 		// Without an explicit capacity the mempool defaults to 0 bytes and
@@ -258,6 +273,11 @@ func (s *Supervisor) start(ctx context.Context) error {
 	if err != nil {
 		return fail(fmt.Errorf("load Dingo topology config: %w", err))
 	}
+	// Remember the topology so Diagnostics can report the node's configured
+	// outbound peers (bootstrap / local-root / public-root access points).
+	s.mu.Lock()
+	s.topologyCfg = topologyCfg
+	s.mu.Unlock()
 
 	// launch creates the node, marks it starting, and begins serving + polling.
 	// Used by both the direct and post-bootstrap paths.
@@ -267,7 +287,11 @@ func (s *Supervisor) start(ctx context.Context) error {
 		// bootstrap is still running, so reading earlier can freeze a stale value
 		// before the first node exists.
 		historyExpiry := s.cfg.historyExpiryEnabled()
-		nodeCfg := dingo.NewConfig(nodeConfigOptions(s.cfg, historyExpiry, cardanoCfg, topologyCfg)...)
+		// Fresh registry per launch: a Reconnect (Stop-then-relaunch) builds a
+		// new node, and reusing one registry would panic on duplicate metric
+		// registration. Diagnostics reads whichever registry is current.
+		reg := prometheus.NewRegistry()
+		nodeCfg := dingo.NewConfig(nodeConfigOptions(s.cfg, historyExpiry, cardanoCfg, topologyCfg, reg)...)
 		node, err := s.nodeFactory.New(nodeCfg)
 		if err != nil {
 			return err
@@ -275,6 +299,7 @@ func (s *Supervisor) start(ctx context.Context) error {
 		s.mu.Lock()
 		s.applied.historyExpiry = historyExpiry
 		s.applied.ran = true
+		s.promRegistry = reg
 		s.mu.Unlock()
 		s.setStateForRun(runID, StateStarting)
 		go func() {

--- a/ui/internal/supervisor/supervisor_test.go
+++ b/ui/internal/supervisor/supervisor_test.go
@@ -40,8 +40,8 @@ func baseConfig() Config {
 // history-expiry setting unexported with no getter, so the option set is the
 // smallest observable seam for the wiring.
 func TestNodeConfigOptionsHistoryExpiryOptIn(t *testing.T) {
-	off := nodeConfigOptions(baseConfig(), false, nil, nil)
-	on := nodeConfigOptions(baseConfig(), true, nil, nil)
+	off := nodeConfigOptions(baseConfig(), false, nil, nil, nil)
+	on := nodeConfigOptions(baseConfig(), true, nil, nil, nil)
 
 	if len(on) != len(off)+1 {
 		t.Fatalf(

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -61,6 +61,7 @@ import type {
   CosignResult,
   NFT,
   NftMediaSetting,
+  Diagnostics,
 } from "./types";
 
 export class ApiError extends Error {
@@ -332,3 +333,9 @@ export const getNftMedia = () => apiGet<NftMediaSetting>("/wallet/settings/nft-m
 export const setNftMedia = (enabled: boolean) =>
   apiPut<NftMediaSetting>("/wallet/settings/nft-media", { enabled });
 export const nftImageUrl = (unit: string) => `/wallet/nft/${encodeURIComponent(unit)}/image`;
+
+// Node diagnostics (node-local; no external calls). getDiagnostics polls the
+// full report; diagnosticsLogsUrl is the direct download URL for the log-export
+// zip (used as an <a href> / bridge target rather than a JSON fetch).
+export const getDiagnostics = () => apiGet<Diagnostics>("/diagnostics");
+export const diagnosticsLogsUrl = () => "/diagnostics/logs";

--- a/ui/web/src/api/hooks.ts
+++ b/ui/web/src/api/hooks.ts
@@ -13,6 +13,7 @@ import type {
   DexPoolsResponse,
   AssetInfo,
   NFT,
+  Diagnostics,
 } from "./types";
 import {
   getStatus,
@@ -30,6 +31,7 @@ import {
   getNfts,
   getNftMedia,
   setNftMedia,
+  getDiagnostics,
 } from "./client";
 
 export interface AsyncState<T> {
@@ -151,6 +153,10 @@ export const useContacts = (): AsyncState<Contact[]> => useAsync(getContacts);
 export const useDexPools = (): AsyncState<DexPoolsResponse> =>
   useAsync(getDexPools, { pollMs: 15000 });
 export const useNfts = (): AsyncState<NFT[]> => useAsync(getNfts);
+// Diagnostics live-polls like status (node-local, cheap). 5s is frequent
+// enough to watch peers/sync move without hammering the node.
+export const useDiagnostics = (): AsyncState<Diagnostics> =>
+  useAsync(getDiagnostics, { pollMs: 5000 });
 
 export interface NftMediaState {
   enabled: boolean;

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -775,3 +775,77 @@ export interface CosignResult {
   signed_count?: number;
   threshold?: number;
 }
+
+// --- Node diagnostics (GET /diagnostics) -------------------------------------
+// Mirrors ui/internal/diagnostics.Report. Everything here is node-local (no
+// external calls). Optional fields are omitted by the backend when a value is
+// not obtainable (e.g. epoch/blockHeight while the node cannot serve queries,
+// or a library version in an unversioned dev build) — never fabricated.
+
+export interface DiagnosticsNode {
+  network: string;
+  dingoVersion?: string;
+  gouroborosVersion?: string;
+  goVersion?: string;
+}
+
+export interface DiagnosticsSync {
+  state: NodeState;
+  tip: number;
+  epoch?: number;
+  blockHeight?: number;
+  latestBlockTime?: string;
+  caughtUp: boolean;
+  secondsBehind?: number;
+  bootstrapPercent?: number;
+  bootstrapPhase?: string;
+  error?: string;
+}
+
+// ConfiguredPeer is one outbound access point from the node's topology
+// (bootstrap / local-root / public-root). It is a CONFIGURED peer, not proof of
+// a live connection — the embedded node's public API exposes no per-peer live
+// connection list, so the live signal is the aggregate counts above.
+export interface ConfiguredPeer {
+  address: string;
+  port: number;
+  source: string;
+}
+
+export interface DiagnosticsPeers {
+  available: boolean;
+  total: number;
+  inbound: number;
+  outbound: number;
+  duplex: number;
+  fullDuplex: number;
+  unidirectional: number;
+  configured: ConfiguredPeer[];
+}
+
+export interface DiagnosticsListen {
+  controlSurface: string;
+  blockfrostPort: number;
+  utxorpcPort: number;
+  nodeSocket: string;
+}
+
+export interface DiagnosticsUptime {
+  startedAt: string;
+  seconds: number;
+}
+
+export interface DiagnosticsLog {
+  available: boolean;
+  path?: string;
+  dir?: string;
+}
+
+export interface Diagnostics {
+  node: DiagnosticsNode;
+  sync: DiagnosticsSync;
+  peers: DiagnosticsPeers;
+  listen: DiagnosticsListen;
+  uptime: DiagnosticsUptime;
+  log: DiagnosticsLog;
+}

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -28,6 +28,7 @@ import { Operate } from "./screens/Operate";
 import { MultiSig } from "./screens/MultiSig";
 import { ImportTransaction } from "./screens/ImportTransaction";
 import { Settings } from "./screens/Settings";
+import { Diagnostics } from "./screens/Diagnostics";
 import { ConnectorApproval } from "./screens/ConnectorApproval";
 
 // A Map (not a plain object) so a crafted hash like "#/constructor" or
@@ -51,6 +52,10 @@ const ROUTES = new Map<string, () => ReactElement>([
   ["send", Send],
   ["swap", Swap],
   ["contacts", Contacts],
+  // Diagnostics is node-level and takes no props, so it resolves straight from
+  // this map (via the final content-selection else) and is highlighted through
+  // ROUTES.has below.
+  ["diagnostics", Diagnostics],
 ]);
 
 const NAV: { key: string; label: string }[] = [
@@ -67,6 +72,7 @@ const NAV: { key: string; label: string }[] = [
   { key: "operate", label: "Operate" },
   { key: "multisig", label: "Multi-sig" },
   { key: "import", label: "Import Tx" },
+  { key: "diagnostics", label: "Diagnostics" },
   { key: "settings", label: "Settings" },
 ];
 

--- a/ui/web/src/screens/Diagnostics.test.tsx
+++ b/ui/web/src/screens/Diagnostics.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Diagnostics } from "./Diagnostics";
+import * as hooks from "../api/hooks";
+import type { AsyncState } from "../api/hooks";
+import type { Diagnostics as DiagnosticsData } from "../api/types";
+
+function baseData(): DiagnosticsData {
+  return {
+    node: {
+      network: "preview",
+      dingoVersion: "v0.66.2",
+      gouroborosVersion: "v0.188.0",
+      goVersion: "go1.25.8",
+    },
+    sync: {
+      state: "syncing",
+      tip: 123456,
+      epoch: 812,
+      blockHeight: 99000,
+      latestBlockTime: "2026-07-28T11:59:30Z",
+      caughtUp: false,
+      secondsBehind: 45,
+    },
+    peers: {
+      available: true,
+      total: 7,
+      inbound: 2,
+      outbound: 5,
+      duplex: 1,
+      fullDuplex: 1,
+      unidirectional: 4,
+      configured: [{ address: "relay.example", port: 3001, source: "bootstrap" }],
+    },
+    listen: {
+      controlSurface: "127.0.0.1:8090",
+      blockfrostPort: 5556,
+      utxorpcPort: 5555,
+      nodeSocket: "/home/u/.bursa-wallet/preview/node.socket",
+    },
+    uptime: { startedAt: "2026-07-28T11:50:00Z", seconds: 630 },
+    log: {
+      available: true,
+      path: "/home/u/.bursa-wallet/preview/logs/bursa-wallet.log",
+      dir: "/home/u/.bursa-wallet/preview/logs",
+    },
+  };
+}
+
+function mockDiagnostics(data: DiagnosticsData | null, opts: Partial<AsyncState<DiagnosticsData>> = {}) {
+  vi.spyOn(hooks, "useDiagnostics").mockReturnValue({
+    data,
+    error: opts.error ?? null,
+    loading: opts.loading ?? false,
+    refresh: vi.fn(),
+    setData: vi.fn(),
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (window as { bursaOpenExternal?: unknown }).bursaOpenExternal;
+});
+
+test("renders sync, network, peers, ports and logs from the report", () => {
+  mockDiagnostics(baseData());
+  render(<Diagnostics />);
+
+  // Sync
+  expect(screen.getByText("syncing")).toBeInTheDocument();
+  expect(screen.getByText("123,456")).toBeInTheDocument(); // tip slot
+  expect(screen.getByText("812")).toBeInTheDocument(); // epoch
+  // Network & node versions
+  expect(screen.getByText("v0.66.2")).toBeInTheDocument();
+  expect(screen.getByText("v0.188.0")).toBeInTheDocument();
+  // Peers counts + configured table
+  expect(screen.getByText("relay.example")).toBeInTheDocument();
+  expect(screen.getByText("bootstrap")).toBeInTheDocument();
+  // Ports
+  expect(screen.getByText("127.0.0.1:8090")).toBeInTheDocument();
+  expect(screen.getByText("5556")).toBeInTheDocument();
+});
+
+test("log export link points at the logs endpoint", () => {
+  mockDiagnostics(baseData());
+  render(<Diagnostics />);
+  const link = screen.getByText(/Export logs/i).closest("a");
+  expect(link).not.toBeNull();
+  expect(link).toHaveAttribute("href", "/diagnostics/logs");
+});
+
+test("shows 'Open log folder' only when the webview bridge is present and calls it with a file URL", () => {
+  const bridge = vi.fn();
+  (window as { bursaOpenExternal?: (url: string) => void }).bursaOpenExternal = bridge;
+  mockDiagnostics(baseData());
+  render(<Diagnostics />);
+
+  const btn = screen.getByRole("button", { name: /Open log folder/i });
+  fireEvent.click(btn);
+  expect(bridge).toHaveBeenCalledWith("file:///home/u/.bursa-wallet/preview/logs");
+});
+
+test("'Open log folder' percent-encodes spaces/special chars in the file URL", () => {
+  const bridge = vi.fn();
+  (window as { bursaOpenExternal?: (url: string) => void }).bursaOpenExternal = bridge;
+  const data = baseData();
+  data.log = {
+    available: true,
+    path: "/home/My Logs/bursa#1/bursa-wallet.log",
+    dir: "/home/My Logs/bursa#1",
+  };
+  mockDiagnostics(data);
+  render(<Diagnostics />);
+
+  fireEvent.click(screen.getByRole("button", { name: /Open log folder/i }));
+  expect(bridge).toHaveBeenCalledWith("file:///home/My%20Logs/bursa%231");
+});
+
+test("hides 'Open log folder' when no webview bridge is present", () => {
+  mockDiagnostics(baseData());
+  render(<Diagnostics />);
+  expect(screen.queryByRole("button", { name: /Open log folder/i })).toBeNull();
+});
+
+test("peers panel notes when live counts are unavailable", () => {
+  const data = baseData();
+  data.peers.available = false;
+  mockDiagnostics(data);
+  render(<Diagnostics />);
+  expect(screen.getByText(/Live connection counts are unavailable/i)).toBeInTheDocument();
+});
+
+test("log export is hidden when no log file is available", () => {
+  const data = baseData();
+  data.log = { available: false };
+  mockDiagnostics(data);
+  render(<Diagnostics />);
+  expect(screen.queryByText(/Export logs/i)).toBeNull();
+  expect(screen.getByText(/Log export is unavailable/i)).toBeInTheDocument();
+});
+
+test("shows a loading state before the first report arrives", () => {
+  mockDiagnostics(null, { loading: true });
+  render(<Diagnostics />);
+  expect(screen.getByText(/Loading node diagnostics/i)).toBeInTheDocument();
+});

--- a/ui/web/src/screens/Diagnostics.tsx
+++ b/ui/web/src/screens/Diagnostics.tsx
@@ -1,0 +1,252 @@
+import { Card } from "../components/Card";
+import { Table } from "../components/Table";
+import { StatusPill, type Tone } from "../components/StatusPill";
+import { CopyButton } from "../components/CopyButton";
+import { useDiagnostics } from "../api/hooks";
+import { diagnosticsLogsUrl } from "../api/client";
+import type { DiagnosticsSync, NodeState } from "../api/types";
+
+// Node diagnostics: a live, node-local view of the embedded node and this
+// wallet process. Everything shown comes from the node/supervisor/process — no
+// external calls — so there is no consent gate. Live-polls via useDiagnostics.
+
+const STATE_TONE: Record<NodeState, Tone> = {
+  ready: "ok",
+  syncing: "warn",
+  bootstrapping: "warn",
+  starting: "warn",
+  stopped: "muted",
+  error: "error",
+};
+
+function fmtUptime(seconds: number): string {
+  if (!isFinite(seconds) || seconds < 0) return "—";
+  const d = Math.floor(seconds / 86400);
+  const h = Math.floor((seconds % 86400) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  const parts: string[] = [];
+  if (d) parts.push(`${d}d`);
+  if (h) parts.push(`${h}h`);
+  if (m) parts.push(`${m}m`);
+  if (!d && !h) parts.push(`${s}s`);
+  return parts.join(" ");
+}
+
+function fmtBehind(sync: DiagnosticsSync): string {
+  if (sync.caughtUp) return "at the chain tip";
+  if (sync.secondsBehind == null) return "—";
+  return `${fmtUptime(sync.secondsBehind)} behind`;
+}
+
+function fmtInt(n?: number): string {
+  return n == null ? "—" : n.toLocaleString();
+}
+
+// Build a correctly percent-encoded file:// URL for an absolute filesystem
+// path so spaces and other special characters survive the JS→Go bridge and a
+// POSIX path yields the canonical file:///… (not file:////…). The Go side
+// (resolveOpenTarget) percent-decodes it and normalizes Windows drive paths.
+export function pathToFileUrl(path: string): string {
+  // Normalize Windows separators, then ensure a single leading slash so both
+  // "/var/log" and "C:/Users/…" become file:///…
+  const normalized = path.replace(/\\/g, "/").replace(/^\/+/, "");
+  const encoded = normalized.split("/").map(encodeURIComponent).join("/");
+  return `file:///${encoded}`;
+}
+
+// A definition-list row grid, reusing the sync-stats styling used elsewhere.
+function Stats({ items }: { items: [string, React.ReactNode][] }) {
+  return (
+    <dl className="sync-stats">
+      {items.map(([label, value]) => (
+        <div key={label}>
+          <dt>{label}</dt>
+          <dd>{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+export function Diagnostics() {
+  const { data, error, loading } = useDiagnostics();
+
+  if (loading && !data) {
+    return (
+      <Card title="Diagnostics">
+        <p className="helper-text">Loading node diagnostics…</p>
+      </Card>
+    );
+  }
+  if (!data) {
+    return (
+      <Card title="Diagnostics">
+        <p className="error-text" role="alert">
+          {error?.message || "Could not load diagnostics"}
+        </p>
+      </Card>
+    );
+  }
+
+  const { node, sync, peers, listen, uptime, log } = data;
+  const canOpenFolder =
+    typeof window.bursaOpenExternal === "function" && log.available && !!log.dir;
+
+  return (
+    <div className="diagnostics">
+      <header className="sync-head">
+        <h1 className="sync-title">Diagnostics</h1>
+        <p className="helper-text">
+          Live status of your embedded node and this wallet. All data is local
+          to your machine.
+        </p>
+      </header>
+
+      <Card title="Sync">
+        <p>
+          <StatusPill tone={STATE_TONE[sync.state] ?? "muted"}>{sync.state}</StatusPill>
+        </p>
+        {sync.state === "bootstrapping" && sync.bootstrapPercent != null && (
+          <p className="helper-text">
+            Bootstrap {sync.bootstrapPhase ? `(${sync.bootstrapPhase}) ` : ""}
+            {sync.bootstrapPercent.toFixed(1)}%
+          </p>
+        )}
+        {sync.error && (
+          <p className="error-text" role="alert">
+            {sync.error}
+          </p>
+        )}
+        <Stats
+          items={[
+            ["Block slot", sync.tip > 0 ? fmtInt(sync.tip) : "—"],
+            ["Epoch", fmtInt(sync.epoch)],
+            ["Block height", fmtInt(sync.blockHeight)],
+            [
+              "Latest block",
+              sync.latestBlockTime
+                ? new Date(sync.latestBlockTime).toLocaleString()
+                : "—",
+            ],
+            ["Chain lag", fmtBehind(sync)],
+          ]}
+        />
+      </Card>
+
+      <Card title="Network & Node">
+        <Stats
+          items={[
+            ["Network", node.network || "—"],
+            ["Dingo", node.dingoVersion || "unknown"],
+            ["gouroboros", node.gouroborosVersion || "unknown"],
+            ["Go runtime", node.goVersion || "unknown"],
+          ]}
+        />
+      </Card>
+
+      <Card title="Peers">
+        {peers.available ? (
+          <Stats
+            items={[
+              ["Connections", fmtInt(peers.total)],
+              ["Inbound", fmtInt(peers.inbound)],
+              ["Outbound", fmtInt(peers.outbound)],
+              ["Duplex", fmtInt(peers.duplex)],
+              ["Full duplex", fmtInt(peers.fullDuplex)],
+              ["Unidirectional", fmtInt(peers.unidirectional)],
+            ]}
+          />
+        ) : (
+          <p className="helper-text">
+            Live connection counts are unavailable until the node is running.
+          </p>
+        )}
+        <h3>Configured peers</h3>
+        <p className="helper-text">
+          Outbound peers your node is configured to dial (from its topology).
+          This is the configured set, not a live-connection list — the embedded
+          node does not expose per-peer connection detail.
+        </p>
+        {peers.configured.length > 0 ? (
+          <Table
+            columns={[
+              { key: "address", label: "Address" },
+              { key: "port", label: "Port" },
+              { key: "source", label: "Source" },
+            ]}
+            rows={peers.configured.map((p) => ({
+              address: p.address,
+              port: p.port,
+              source: p.source,
+            }))}
+          />
+        ) : (
+          <p className="helper-text">No configured peers reported yet.</p>
+        )}
+      </Card>
+
+      <Card title="Ports & Uptime">
+        <Stats
+          items={[
+            ["Control surface", listen.controlSurface || "—"],
+            ["Blockfrost port", listen.blockfrostPort || "—"],
+            ["UTxO-RPC port", listen.utxorpcPort || "—"],
+            [
+              "Node socket",
+              listen.nodeSocket ? (
+                <span className="mono">{listen.nodeSocket}</span>
+              ) : (
+                "—"
+              ),
+            ],
+            [
+              "Started",
+              uptime.startedAt ? new Date(uptime.startedAt).toLocaleString() : "—",
+            ],
+            ["Uptime", fmtUptime(uptime.seconds)],
+          ]}
+        />
+      </Card>
+
+      <Card title="Logs">
+        {log.available ? (
+          <>
+            <p className="helper-text">
+              Log file: <span className="mono">{log.path}</span>
+              {log.path && (
+                <>
+                  {" "}
+                  <CopyButton value={log.path} aria-label="Copy log path" />
+                </>
+              )}
+            </p>
+            <div className="preview-actions">
+              {/* Direct download of the zipped log(s). A plain download anchor
+                  works in the browser build; the webview build offers "Open log
+                  folder" below instead (its downloads are not surfaced). */}
+              <a className="btn ghost" href={diagnosticsLogsUrl()} download>
+                Export logs (.zip)
+              </a>
+              {canOpenFolder && (
+                <button
+                  type="button"
+                  className="btn ghost"
+                  onClick={() =>
+                    log.dir && window.bursaOpenExternal?.(pathToFileUrl(log.dir))
+                  }
+                >
+                  Open log folder
+                </button>
+              )}
+            </div>
+          </>
+        ) : (
+          <p className="helper-text">
+            Log export is unavailable (this build is not writing logs to a file).
+          </p>
+        )}
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
Node-local Diagnostics screen + API. All data from the embedded node / supervisor / process — no external calls, no consent gate.

Backend:
- `GET /diagnostics`: versions (Dingo, gouroboros, Go), network, sync (state, slot/tip, epoch, height, seconds-behind, bootstrap %), live peer connection counts, configured peers (node topology), listen ports, node socket, uptime, log path. Ungated like `/status`, behind `sameOriginGuard`.
- `GET /diagnostics/logs`: zip of the wallet log file(s); 404 when none.
- Live counts via a per-launch Prometheus registry on the node connection manager, gathered by the supervisor.
- Desktop binary logs to a file under the data dir; webview "Open log folder" via `bursaOpenExternal` extended to `file://` directories.

Frontend:
- Diagnostics nav route — Sync, Network/Node, Peers (counts + configured table), Ports/Uptime, Logs (Export / Open folder) panels; `useDiagnostics` hook; new types + client fns.

Root `CGO_ENABLED=0 go build ./...`; `ui` build/vet/test; `ui/web` lint/test/type-check/build pass. Adds `github.com/prometheus/client_golang`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a node‑local Diagnostics screen and API with safe log export for the full‑node wallet. It shows node/library/Go versions, network, sync (state, tip slot, epoch, height, lag, bootstrap), peers, listen ports/socket/control surface, uptime, and the log path — with no external calls.

- **New Features**
  - Backend: `GET /diagnostics` returns versions (Dingo, gouroboros, Go), network, sync (state, tip, epoch/height best‑effort, latest‑block time, seconds‑behind, bootstrap %/phase), peers (live counts + configured topology peers), listen (control surface, Blockfrost/UTxO‑RPC ports, node socket), uptime (startedAt, seconds), and log info (available, path, dir). `GET /diagnostics/logs` streams a zipped log download (404 if none). Ungated like `/status` (same‑origin; not vault‑gated).
  - Supervisor: per‑launch Prometheus registry wired to the connection manager for live peer counts; exposes configured peers from the embedded topology. New registry on each launch avoids re‑register panics on reconnects.
  - Desktop: wallet also logs to `<dataDir>/logs/bursa-wallet.log`; `bursaOpenExternal` now accepts validated `file://` directories and opens the folder with the OS handler.
  - Frontend: Diagnostics route with Sync, Network/Node, Peers, Ports/Uptime, and Logs panels; `useDiagnostics` polls every 5s; export logs link and “Open log folder” via the webview bridge when present.

- **Dependencies**
  - Add `github.com/prometheus/client_golang`.

<sup>Written for commit 23e7a3cde75f6df000253178e6d722e216ace170. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Screenshots

Real Playwright renders of the new Diagnostics screen (`#/diagnostics`), 1280×800 viewport, running the SPA against a mock backend serving `GET /diagnostics`.

Full screen — Sync, Network & Node, Peers (live counts + configured-peer topology table), Ports & Uptime, and Logs (Copy path + Export logs .zip):

![Diagnostics — full screen](https://raw.githubusercontent.com/blinklabs-io/bursa/ci/screenshots/screenshots/pr-639/diagnostics-full.png)

Top of the screen (viewport) — Sync and Network & Node panels:

![Diagnostics — Sync and Network](https://raw.githubusercontent.com/blinklabs-io/bursa/ci/screenshots/screenshots/pr-639/diagnostics-top.png)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Diagnostics screen with live node status, sync progress, peer connections, configured peers, ports, uptime, and version details.
  * Added downloadable ZIP log exports and an option to open the log folder.
  * Added on-disk wallet logging with graceful fallback when logs cannot be created.
  * Improved external link and folder opening with safer URL validation.

* **Bug Fixes**
  * Diagnostics and log downloads are protected against unauthorized cross-origin requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->