### PR TITLE
fix(deps): bump shai to a resolvable revision (unbreak ui build)

### DIFF
--- a/ui/go.mod
+++ b/ui/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/blinklabs-io/go-bip39 v0.2.0
 	github.com/blinklabs-io/gouroboros v0.188.0
 	github.com/blinklabs-io/plutigo v0.1.16
-	github.com/blinklabs-io/shai v0.0.0-20260628035521-fe7bb3b9cf94
+	github.com/blinklabs-io/shai v0.0.0-20260724152428-02e3f7d23dd8
 	github.com/btcsuite/btcd/btcutil v1.2.0
 	github.com/glebarez/go-sqlite v1.21.2
 	github.com/google/go-tpm v0.9.8

--- a/ui/go.sum
+++ b/ui/go.sum
@@ -153,8 +153,8 @@ github.com/blinklabs-io/ouroboros-mock v0.14.0 h1:tWOjItzHmdcGv1HfH23jJxumOQ0wbe
 github.com/blinklabs-io/ouroboros-mock v0.14.0/go.mod h1:nvY6cwqImZekjCfuutzTjdMR4/gOkNUO9lZuOGlQGl4=
 github.com/blinklabs-io/plutigo v0.1.16 h1:SgBN2S1f2AeUxuI4UupVY/0rPYBTFtfj+ALQPCi7XaU=
 github.com/blinklabs-io/plutigo v0.1.16/go.mod h1:8HELNkpXOulMF9p5E79gSX9G1OsPnpqLI9ztdDGMnn4=
-github.com/blinklabs-io/shai v0.0.0-20260628035521-fe7bb3b9cf94 h1:Qu2PNyHtdqtn3GT+xjceFWyOZ7c9QvVVyexfZfki4H0=
-github.com/blinklabs-io/shai v0.0.0-20260628035521-fe7bb3b9cf94/go.mod h1:CibuTDKb7wNnLAlY/gz51teoJj0oQCVlnCWhzyGwg7c=
+github.com/blinklabs-io/shai v0.0.0-20260724152428-02e3f7d23dd8 h1:Z5Bq6fTeX/hlviFFrvSqrPrAvVHxdu/g/2Jp1kf17CY=
+github.com/blinklabs-io/shai v0.0.0-20260724152428-02e3f7d23dd8/go.mod h1:1O5SvQa/FuQMGYehvtQ8O1s9eIE3EmACFyN/csSzNoY=
 github.com/blockfrost/blockfrost-go v0.4.0 h1:sJuxmtoWUJ3sXfqTuFhYcFMdDNdo938nSX/KcLcAPQ0=
 github.com/blockfrost/blockfrost-go v0.4.0/go.mod h1:XdD+mryM/Rd/MqW1MfSQ0+Xfu2YnOGuwqMpLQa0jHvM=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=


### PR DESCRIPTION
## Root cause
`ui/go.mod` pinned `github.com/blinklabs-io/shai` at `v0.0.0-20260628035521-fe7bb3b9cf94`, a revision no longer reachable from any ref in the shai repo. `go mod download` now fails with `invalid version: unknown revision fe7bb3b9cf94`. Because `internal/dex` imports `shai/common` and `shai/dex`, the whole `ui` module fails to build and lint in fresh CI — breaking the `ui-go` and `ui-lint` jobs on `main` and on every open PR. This is not any single PR's fault.

## Fix
Bump shai to a current, resolvable revision and `go mod tidy`:

- `v0.0.0-20260628035521-fe7bb3b9cf94` → `v0.0.0-20260724152428-02e3f7d23dd8` (current default-branch tip)

The shai API is source-compatible across this delta — **no changes to `internal/dex`** (or any other shai consumer) were required. The root `bursa` module is untouched.

## Verification (from `ui/`)
- `go mod download` — succeeds (no unknown-revision error)
- `go build ./cmd/... ./internal/...` — passes
- `go vet ./cmd/... ./internal/...` — passes
- `go test ./cmd/... ./internal/...` — all packages pass (incl. `internal/dex`)
- `golangci-lint run ./cmd/... ./internal/...` — 0 issues
- root: `CGO_ENABLED=0 go build ./...` — passes

Unblocks `main` and all open PRs.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `github.com/blinklabs-io/shai` in `ui` to a reachable revision to fix “unknown revision” errors and restore CI builds and linting. No code changes needed; API remains source-compatible.

- **Dependencies**
  - Update `github.com/blinklabs-io/shai` from `v0.0.0-20260628035521-fe7bb3b9cf94` to `v0.0.0-20260724152428-02e3f7d23dd8` and run `go mod tidy` (updates `go.sum`).

<sup>Written for commit c8104eeab20040fba91e920c6d0847001c28ca8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

