### PR TITLE
feat(ui): carry staking/gov/multisig signer data in hardware-sign request

### DIFF
--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -2294,13 +2295,19 @@ func (s *Service) deriveWitnesses(
 	return witnesses, nil
 }
 
-// HardwareSignRequest is the structured signing request the SPA passes to the
-// Ledger device (via ledgerjs). It contains decoded tx fields (NOT raw CBOR)
-// so the device can display them to the user and sign without parsing CBOR.
+// HardwareSignRequest is the structured signing request the SPA passes to a
+// hardware device. It contains decoded tx fields (NOT raw CBOR) so the device
+// can display them to the user and sign without parsing CBOR.
 //
-// Scope: payment transactions (inputs/outputs/fee/ttl/change) only.
-// Certificates and withdrawals are guarded — the caller must check Unsupported
-// before constructing a SignTransactionRequest.
+// Scope: payment transactions plus the signer data staking / governance /
+// multisig transactions need. Beyond inputs/outputs/fee/ttl/change it also
+// carries the wallet's own derivation paths for the keys that must witness the
+// transaction's certificates, reward withdrawals, and governance votes, one
+// entry per change output, and any extra (e.g. CIP-1854 multisig) signer paths.
+// These fields are device-agnostic: a device that only signs payments ignores
+// them. Features a device genuinely cannot express (native-asset outputs,
+// scripts, minting, proposals, …) still set Unsupported, and the caller MUST
+// check it before signing.
 type HardwareSignRequest struct {
 	// Network: "mainnet", "preprod", or "preview".
 	Network string `json:"network"`
@@ -2312,6 +2319,31 @@ type HardwareSignRequest struct {
 	Inputs []HWInput `json:"inputs"`
 	// Outputs: all tx outputs.
 	Outputs []HWOutput `json:"outputs"`
+	// ChangeOutputs identifies, by their index in Outputs, the outputs that pay
+	// back to this wallet, with the derivation path of the change address, so a
+	// device can verify the change is genuinely ours. Empty for a tx with no
+	// wallet-owned outputs.
+	ChangeOutputs []HWChangeOutput `json:"change_outputs,omitempty"`
+	// CertificateSigners are the wallet's own derivation paths for the keys that
+	// must witness the transaction's certificates (stake registration/
+	// delegation, DRep vote-delegation, DRep registration, and — for a self-owned
+	// pool — the pool owner). One entry per (certificate, owned key) pair; empty
+	// for a tx with no certificates the wallet signs.
+	CertificateSigners []HWCertSigner `json:"certificate_signers,omitempty"`
+	// WithdrawalSigners are the wallet's stake-key paths that must witness reward
+	// withdrawals, one entry per reward account the wallet owns.
+	WithdrawalSigners []HWWithdrawalSigner `json:"withdrawal_signers,omitempty"`
+	// VoteSigners are the wallet's own paths for the keys that must witness the
+	// transaction's governance votes (a Conway DRep vote is an ordinary tx; the
+	// DRep key is expressed here as a signer path).
+	VoteSigners []HWVoteSigner `json:"vote_signers,omitempty"`
+	// ExtraSigners are wallet-owned keys the transaction requires as explicit
+	// signers (body key 14) that are not already covered by an input — notably
+	// the participating key of a CIP-1854 native-multisig spend. Script-locked
+	// inputs carry no path (their HWInput.Path is empty). The XFP is filled in by
+	// the client from its per-wallet fingerprint store before the request reaches
+	// the device.
+	ExtraSigners []HWExtraSigner `json:"extra_signers,omitempty"`
 	// Fee: lovelace as decimal string.
 	Fee string `json:"fee"`
 	// TTL: slot number as decimal string, empty if absent.
@@ -2372,6 +2404,69 @@ type HWAsset struct {
 	PolicyIDHex  string `json:"policy_id_hex"`
 	AssetNameHex string `json:"asset_name_hex"`
 	Amount       string `json:"amount"` // decimal string
+}
+
+// HWChangeOutput points at a wallet-owned output (by its index in Outputs) and
+// gives the derivation path of its change address so a device can confirm the
+// change returns to this wallet without re-deriving every output.
+type HWChangeOutput struct {
+	// Index is the position of the output in the Outputs slice.
+	Index int `json:"index"`
+	// Path is the CIP-1852 payment-key path of the change address.
+	Path string `json:"path"`
+	// StakePath is the CIP-1852 stake-key path of the change address (base
+	// addresses only).
+	StakePath string `json:"stake_path,omitempty"`
+}
+
+// HWCertSigner is one wallet-owned key that must witness a certificate.
+type HWCertSigner struct {
+	// CertKind is the certificate's snake_case kind (e.g. "stake_delegation",
+	// "registration_drep", "pool_registration").
+	CertKind string `json:"cert_kind"`
+	// Role is the CIP-1852 role of the required key: "stake" or "drep".
+	Role string `json:"role"`
+	// Path is the CIP-1852 derivation path of the key.
+	Path string `json:"path"`
+	// KeyHashHex is the hex-encoded key hash the certificate references.
+	KeyHashHex string `json:"key_hash_hex"`
+}
+
+// HWWithdrawalSigner is the wallet's stake key that must witness a reward
+// withdrawal.
+type HWWithdrawalSigner struct {
+	// RewardAddressBech32 is the reward (stake) address the withdrawal drains.
+	RewardAddressBech32 string `json:"reward_address_bech32,omitempty"`
+	// Role is always "stake".
+	Role string `json:"role"`
+	// Path is the CIP-1852 stake-key path.
+	Path string `json:"path"`
+	// KeyHashHex is the hex-encoded stake key hash.
+	KeyHashHex string `json:"key_hash_hex"`
+}
+
+// HWVoteSigner is the wallet's key that must witness a governance vote.
+type HWVoteSigner struct {
+	// Voter is the voter role: "drep" (the only self-signable voter kind for a
+	// wallet — committee and pool voters are not derived here).
+	Voter string `json:"voter"`
+	// Role is the CIP-1852 role of the required key ("drep").
+	Role string `json:"role"`
+	// Path is the CIP-1852 derivation path of the key.
+	Path string `json:"path"`
+	// KeyHashHex is the hex-encoded voter key hash.
+	KeyHashHex string `json:"key_hash_hex"`
+}
+
+// HWExtraSigner is a wallet-owned key required as an explicit signer (body key
+// 14) but not already covered by an input — e.g. a CIP-1854 native-multisig
+// participant. XFP is the 4-byte master-key fingerprint (hex); it is left empty
+// here and filled in client-side from the per-wallet fingerprint store.
+type HWExtraSigner struct {
+	XFP        string `json:"xfp,omitempty"`
+	Role       string `json:"role"`
+	Path       string `json:"path"`
+	KeyHashHex string `json:"key_hash_hex"`
 }
 
 // HardwareSignRequest returns the structured signing request the SPA passes to
@@ -2441,15 +2536,11 @@ func (s *Service) HardwareSignRequest(pendingID string) (HardwareSignRequest, er
 	}
 
 	// Guard unsupported features — still populate UnsignedTxCBOR so the SPA can
-	// show the user what was attempted.
-	if len(tx.Body.TxCertificates) > 0 {
-		result.Unsupported = "certificates are not supported on hardware yet"
-		return result, nil
-	}
-	if len(tx.Body.TxWithdrawals) > 0 {
-		result.Unsupported = "withdrawals are not supported on hardware yet"
-		return result, nil
-	}
+	// show the user what was attempted. Certificates, reward withdrawals, and
+	// governance votes are NOT guarded: the wallet's signer paths for them are
+	// resolved below (resolveSignerData) so staking / governance / multisig txs
+	// can be signed on hardware. Features a device cannot express are still
+	// rejected.
 	// Note: TxWithdrawals is a map[*Address]uint64; len works on nil maps (returns 0).
 	var unsupportedBodyFeature string
 	switch {
@@ -2471,8 +2562,6 @@ func (s *Service) HardwareSignRequest(pendingID string) (HardwareSignRequest, er
 		unsupportedBodyFeature = "total collateral"
 	case len(tx.Body.TxReferenceInputs.Items()) > 0:
 		unsupportedBodyFeature = "reference inputs"
-	case len(tx.Body.TxVotingProcedures) > 0:
-		unsupportedBodyFeature = "voting procedures"
 	case len(tx.Body.TxProposalProcedures) > 0:
 		unsupportedBodyFeature = "proposal procedures"
 	case tx.Body.TxCurrentTreasuryValue != 0:
@@ -2486,8 +2575,7 @@ func (s *Service) HardwareSignRequest(pendingID string) (HardwareSignRequest, er
 	}
 
 	// Guard: native assets in outputs are not supported yet. Check before
-	// building inputs so no signing paths are leaked (symmetric with the cert
-	// and withdrawal guards above).
+	// building inputs so no signing paths are leaked.
 	for _, out := range tx.Body.TxOutputs {
 		if out.OutputAmount.Assets != nil {
 			result.Unsupported = "outputs with native assets are not supported on hardware yet"
@@ -2542,9 +2630,11 @@ func (s *Service) HardwareSignRequest(pendingID string) (HardwareSignRequest, er
 	}
 	result.Inputs = inputs
 
-	// Build outputs.
+	// Build outputs. Every wallet-owned output is also recorded in ChangeOutputs
+	// (by its index) so a device can verify the change returns to this wallet.
 	outputs := make([]HWOutput, 0, len(tx.Body.TxOutputs))
-	for _, out := range tx.Body.TxOutputs {
+	var changeOutputs []HWChangeOutput
+	for i, out := range tx.Body.TxOutputs {
 		addr := out.OutputAddress
 		addrBytes, bytesErr := addr.Bytes()
 		if bytesErr != nil {
@@ -2558,10 +2648,23 @@ func (s *Service) HardwareSignRequest(pendingID string) (HardwareSignRequest, er
 		if paymentPath, owned := pathOf[addr.String()]; owned {
 			hwOut.PaymentPath = paymentPath
 			hwOut.StakePath = stakePath
+			changeOutputs = append(changeOutputs, HWChangeOutput{
+				Index:     i,
+				Path:      paymentPath,
+				StakePath: stakePath,
+			})
 		}
 		outputs = append(outputs, hwOut)
 	}
 	result.Outputs = outputs
+	result.ChangeOutputs = changeOutputs
+
+	// Resolve the wallet's own signer paths for certificates, reward
+	// withdrawals, governance votes, and any extra required signers (e.g. a
+	// CIP-1854 multisig participant). A device that only signs payments ignores
+	// these; staking / governance / multisig flows use them to derive the exact
+	// keys that must witness the transaction.
+	resolveSignerData(tx, acct, &result)
 
 	// Fee and TTL.
 	result.Fee = strconv.FormatUint(tx.Body.TxFee, 10)
@@ -2570,6 +2673,315 @@ func (s *Service) HardwareSignRequest(pendingID string) (HardwareSignRequest, er
 	}
 
 	return result, nil
+}
+
+// Reasons set on HardwareSignRequest.Unsupported when a required certificate,
+// withdrawal, or vote witness has no resolvable wallet path. They are per-
+// category (not per-credential) so the value is deterministic regardless of Go
+// map iteration order.
+const (
+	unsupportedCertReason       = "certificate requires a key this wallet cannot derive"
+	unsupportedWithdrawalReason = "reward withdrawal requires a key this wallet cannot derive"
+	unsupportedVoteReason       = "governance vote requires a key this wallet cannot derive"
+)
+
+// resolveSignerData populates the request's certificate, withdrawal, vote, and
+// extra-signer paths by matching the credentials in the transaction body
+// against the wallet's own key hashes. It is derived entirely from the real tx
+// being signed and the account's derived keys — nothing is fabricated.
+//
+// A REQUIRED witness the wallet cannot derive (a script-hash or foreign-key
+// certificate/withdrawal credential, or a non-DRep-key voter) sets
+// result.Unsupported and returns: the device could never produce that witness,
+// so the request must not be presented as signable with the missing signer
+// silently absent. An explicit body-key-14 required signer this wallet does not
+// own is different — in a native-multisig spend that is a co-signer's key,
+// legitimately signed on their own device — so it is skipped, not flagged.
+func resolveSignerData(
+	tx *conway.ConwayTransaction,
+	acct *wallet.Account,
+	result *HardwareSignRequest,
+) {
+	accountNum := acct.AccountIndex
+	stakePath := fmt.Sprintf("1852'/%d'/%d'/2/0", 1815, accountNum)
+	drepPath := fmt.Sprintf("1852'/%d'/%d'/3/0", 1815, accountNum)
+
+	// The wallet's own key hashes, keyed by hex, mapped to their role + path.
+	// Payment key hashes cover every derived receive/change address, so an extra
+	// required signer that is one of the wallet's payment keys is resolvable too.
+	// Population order (receive → change → stake → DRep) is intentional: the four
+	// roles derive to distinct key hashes so they do not collide, and the later
+	// stake/DRep writes deliberately take precedence over any earlier entry if a
+	// hash ever coincided — a cert/withdrawal/vote must resolve to its stake or
+	// DRep role, never be masked by a payment entry.
+	type roleKey struct{ role, path string }
+	owned := make(map[string]roleKey)
+	for i, addrStr := range acct.ReceiveAddresses {
+		if addr, err := lcommon.NewAddress(addrStr); err == nil {
+			owned[hex.EncodeToString(addr.PaymentKeyHash().Bytes())] = roleKey{
+				role: "payment",
+				path: fmt.Sprintf("1852'/%d'/%d'/0/%d", 1815, accountNum, i),
+			}
+		}
+	}
+	for i, addrStr := range acct.ChangeAddresses {
+		if addr, err := lcommon.NewAddress(addrStr); err == nil {
+			owned[hex.EncodeToString(addr.PaymentKeyHash().Bytes())] = roleKey{
+				role: "payment",
+				path: fmt.Sprintf("1852'/%d'/%d'/1/%d", 1815, accountNum, i),
+			}
+		}
+	}
+	var stakeKeyHashHex string
+	if len(acct.ReceiveAddresses) > 0 {
+		if addr, err := lcommon.NewAddress(acct.ReceiveAddresses[0]); err == nil {
+			stakeKeyHashHex = hex.EncodeToString(addr.StakeKeyHash().Bytes())
+			owned[stakeKeyHashHex] = roleKey{role: "stake", path: stakePath}
+		}
+	}
+	drepKeyHashHex := strings.ToLower(acct.DRepKeyHash)
+	if drepKeyHashHex != "" {
+		owned[drepKeyHashHex] = roleKey{role: "drep", path: drepPath}
+	}
+
+	hexHash := func(kh lcommon.Blake2b224) string { return hex.EncodeToString(kh.Bytes()) }
+
+	// Certificates: every certificate whose signing credential is a stake- or
+	// DRep-key credential MUST be witnessed by that key. If the credential is a
+	// script hash, or a key hash this wallet does not own (a co-signer's key),
+	// the device can never produce the witness — flag the whole request
+	// Unsupported rather than returning a signer slice that silently omits it,
+	// which the SPA would present as signable. Certificate types keyed on a
+	// non-CIP-1852 key (pool cold key, committee, genesis, MIR) fall through to
+	// owned-key-hash resolution below (e.g. a self-owned pool owner witness) and
+	// are not flagged here.
+	for _, cert := range tx.Body.Certificates() {
+		kind := certLabel(cert)
+		if cred, isKeyCert := certSigningCredential(cert); isKeyCert {
+			if cred.CredType != lcommon.CredentialTypeAddrKeyHash {
+				result.Unsupported = unsupportedCertReason
+				return
+			}
+			khHex := hex.EncodeToString(cred.Credential[:])
+			rk, owns := owned[khHex]
+			if !owns || (rk.role != "stake" && rk.role != "drep") {
+				result.Unsupported = unsupportedCertReason
+				return
+			}
+			result.CertificateSigners = append(result.CertificateSigners, HWCertSigner{
+				CertKind:   kind,
+				Role:       rk.role,
+				Path:       rk.path,
+				KeyHashHex: khHex,
+			})
+			continue
+		}
+		// Non-key-credential certificate (e.g. pool registration): surface each
+		// wallet-owned addr-key-hash credential it references (self-owned pool
+		// owner / reward account). Foreign key hashes here belong to co-owners or
+		// the pool operator's cold key and are simply not this wallet's to sign.
+		for _, khHex := range certRequiredKeyHashes(cert) {
+			rk, ok := owned[khHex]
+			if !ok || rk.role == "payment" {
+				continue
+			}
+			result.CertificateSigners = append(result.CertificateSigners, HWCertSigner{
+				CertKind:   kind,
+				Role:       rk.role,
+				Path:       rk.path,
+				KeyHashHex: khHex,
+			})
+		}
+	}
+
+	// Reward withdrawals: every withdrawal MUST be witnessed by its reward
+	// account's stake key. A script-hash reward account or a foreign stake key is
+	// not wallet-derivable — flag Unsupported rather than dropping it silently.
+	// TxWithdrawals is a Go map (randomized iteration); collect then sort by
+	// KeyHashHex so WithdrawalSigners is deterministic.
+	var withdrawalSigners []HWWithdrawalSigner
+	for addr := range tx.Body.TxWithdrawals {
+		if addr == nil {
+			continue
+		}
+		payload, ok := addr.StakingPayload().(lcommon.AddressPayloadKeyHash)
+		if !ok {
+			result.Unsupported = unsupportedWithdrawalReason
+			return
+		}
+		khHex := hexHash(payload.Hash)
+		rk, owns := owned[khHex]
+		if !owns || rk.role != "stake" {
+			result.Unsupported = unsupportedWithdrawalReason
+			return
+		}
+		withdrawalSigners = append(withdrawalSigners, HWWithdrawalSigner{
+			RewardAddressBech32: addr.String(),
+			Role:                rk.role,
+			Path:                rk.path,
+			KeyHashHex:          khHex,
+		})
+	}
+	sort.Slice(withdrawalSigners, func(i, j int) bool {
+		return withdrawalSigners[i].KeyHashHex < withdrawalSigners[j].KeyHashHex
+	})
+	result.WithdrawalSigners = withdrawalSigners
+
+	// Governance votes: every voting procedure MUST be witnessed by its voter.
+	// Only a DRep key-hash voter that is this wallet's DRep key is wallet-
+	// derivable (CIP-1852 role 3); constitutional-committee-hot voters, stake-
+	// pool voters, and DRep script hashes are witnessed by keys/scripts this
+	// wallet cannot derive — flag Unsupported instead of returning no signer.
+	// VotingProcedures is a Go map (randomized iteration); collect then sort by
+	// KeyHashHex so VoteSigners is deterministic.
+	var voteSigners []HWVoteSigner
+	for voter := range tx.Body.VotingProcedures() {
+		if voter == nil {
+			continue
+		}
+		if voter.Type != lcommon.VoterTypeDRepKeyHash {
+			result.Unsupported = unsupportedVoteReason
+			return
+		}
+		khHex := hex.EncodeToString(voter.Hash[:])
+		rk, owns := owned[khHex]
+		if !owns || rk.role != "drep" {
+			result.Unsupported = unsupportedVoteReason
+			return
+		}
+		voteSigners = append(voteSigners, HWVoteSigner{
+			Voter:      "drep",
+			Role:       rk.role,
+			Path:       rk.path,
+			KeyHashHex: khHex,
+		})
+	}
+	sort.Slice(voteSigners, func(i, j int) bool {
+		return voteSigners[i].KeyHashHex < voteSigners[j].KeyHashHex
+	})
+	result.VoteSigners = voteSigners
+
+	// Extra signers: explicit required signers (body key 14) that this wallet
+	// owns but that are not already covered by an input path — notably the
+	// participating key of a CIP-1854 native-multisig spend, where the input is
+	// script-locked (and so carries no path of its own). A payment key that is
+	// already an input signer is not repeated here.
+	//
+	// Dedup is by derivation path. That is correct for the single-account request
+	// this builds (one account's keys derive to distinct paths); a future multi-
+	// account request that could surface two accounts' keys with the same relative
+	// path would need key-hash dedup instead — out of scope here.
+	coveredPath := make(map[string]bool, len(result.Inputs))
+	for _, inp := range result.Inputs {
+		if inp.Path != "" {
+			coveredPath[inp.Path] = true
+		}
+	}
+	for _, kh := range tx.Body.RequiredSigners() {
+		khHex := hexHash(kh)
+		rk, owns := owned[khHex]
+		if !owns || coveredPath[rk.path] {
+			continue
+		}
+		result.ExtraSigners = append(result.ExtraSigners, HWExtraSigner{
+			Role:       rk.role,
+			Path:       rk.path,
+			KeyHashHex: khHex,
+		})
+	}
+}
+
+// certSigningCredential returns the single stake- or DRep-key credential that a
+// certificate must be witnessed by, for the certificate types a CIP-1852 wallet
+// signs directly. The bool is false for certificate types whose required
+// witness is not one such credential — pool registration/retirement (operator
+// cold key + owner key hashes), committee auth/resign, genesis-key delegation,
+// and MIR — which resolveSignerData resolves through their owned addr-key-hash
+// credentials (e.g. a self-owned pool owner) instead.
+func certSigningCredential(cert lcommon.Certificate) (lcommon.Credential, bool) {
+	switch c := cert.(type) {
+	case *lcommon.StakeRegistrationCertificate:
+		return c.StakeCredential, true
+	case *lcommon.StakeDeregistrationCertificate:
+		return c.StakeCredential, true
+	case *lcommon.StakeDelegationCertificate:
+		if c.StakeCredential == nil {
+			return lcommon.Credential{}, false
+		}
+		return *c.StakeCredential, true
+	case *lcommon.RegistrationCertificate:
+		return c.StakeCredential, true
+	case *lcommon.DeregistrationCertificate:
+		return c.StakeCredential, true
+	case *lcommon.VoteDelegationCertificate:
+		return c.StakeCredential, true
+	case *lcommon.StakeVoteDelegationCertificate:
+		return c.StakeCredential, true
+	case *lcommon.StakeRegistrationDelegationCertificate:
+		return c.StakeCredential, true
+	case *lcommon.VoteRegistrationDelegationCertificate:
+		return c.StakeCredential, true
+	case *lcommon.StakeVoteRegistrationDelegationCertificate:
+		return c.StakeCredential, true
+	case *lcommon.RegistrationDrepCertificate:
+		return c.DrepCredential, true
+	case *lcommon.DeregistrationDrepCertificate:
+		return c.DrepCredential, true
+	case *lcommon.UpdateDrepCertificate:
+		return c.DrepCredential, true
+	default:
+		return lcommon.Credential{}, false
+	}
+}
+
+// certRequiredKeyHashes returns the hex-encoded addr-key-hash credentials a
+// certificate needs witnessed. Script-hash credentials are omitted (a device
+// derives only key paths). It mirrors the credential extraction in
+// neededKeyHashes and adds the pool-owner / reward-account key hashes of a pool
+// registration so a self-owned pool's owner witness resolves.
+func certRequiredKeyHashes(cert lcommon.Certificate) []string {
+	var out []string
+	add := func(cred *lcommon.Credential) {
+		if cred != nil && cred.CredType == lcommon.CredentialTypeAddrKeyHash {
+			out = append(out, hex.EncodeToString(cred.Credential[:]))
+		}
+	}
+	switch c := cert.(type) {
+	case *lcommon.StakeRegistrationCertificate:
+		add(&c.StakeCredential)
+	case *lcommon.StakeDeregistrationCertificate:
+		add(&c.StakeCredential)
+	case *lcommon.StakeDelegationCertificate:
+		add(c.StakeCredential)
+	case *lcommon.RegistrationCertificate:
+		add(&c.StakeCredential)
+	case *lcommon.DeregistrationCertificate:
+		add(&c.StakeCredential)
+	case *lcommon.VoteDelegationCertificate:
+		add(&c.StakeCredential)
+	case *lcommon.StakeVoteDelegationCertificate:
+		add(&c.StakeCredential)
+	case *lcommon.StakeRegistrationDelegationCertificate:
+		add(&c.StakeCredential)
+	case *lcommon.VoteRegistrationDelegationCertificate:
+		add(&c.StakeCredential)
+	case *lcommon.StakeVoteRegistrationDelegationCertificate:
+		add(&c.StakeCredential)
+	case *lcommon.RegistrationDrepCertificate:
+		add(&c.DrepCredential)
+	case *lcommon.DeregistrationDrepCertificate:
+		add(&c.DrepCredential)
+	case *lcommon.UpdateDrepCertificate:
+		add(&c.DrepCredential)
+	case *lcommon.PoolRegistrationCertificate:
+		for _, owner := range c.PoolOwners {
+			out = append(out, hex.EncodeToString(owner.Bytes()))
+		}
+		out = append(out, hex.EncodeToString(c.RewardAccount.Bytes()))
+	case *lcommon.PoolRetirementCertificate:
+		// The pool cold key is not a CIP-1852 wallet key, so nothing to resolve.
+	}
+	return out
 }
 
 // randID generates a 16-byte random hex string for pending IDs.

--- a/ui/internal/spend/spend_test.go
+++ b/ui/internal/spend/spend_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Salvionied/apollo/v2/backend"
 	"github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/bursa/bip32"
+	"github.com/blinklabs-io/bursa/ui/internal/chain"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -2044,140 +2045,17 @@ func TestHardwareSignRequestUnknownPending(t *testing.T) {
 }
 
 // TestHardwareSignRequestGuard verifies the safety property: txs with
-// certificates, withdrawals, or native-asset outputs set Unsupported and do
-// NOT leak signing inputs/paths for the certificate and withdrawal cases
-// (where the guard fires before inputs are built).
+// native-asset outputs (which a device cannot yet express) set Unsupported and
+// do NOT leak signing inputs/paths (the guard fires before inputs are built).
+// Certificates, withdrawals, and votes are no longer rejected — see the
+// signer-path tests below.
 func TestHardwareSignRequestGuard(t *testing.T) {
 	acct, err := wallet.Derive(testMnemonic, "preview", 5)
 	if err != nil {
 		t.Fatalf("wallet.Derive: %v", err)
 	}
 	addr0 := acct.ReceiveAddresses[0]
-	addr3 := acct.ReceiveAddresses[3]
 	recvAddr := acct.ReceiveAddresses[4]
-
-	t.Run("certificate tx is rejected", func(t *testing.T) {
-		// Two 3 ADA inputs so the 4 ADA send unambiguously requires both and
-		// leaves comfortable change (avoids a min-UTxO dead-zone change amount).
-		fc := newFakeChain(3_000_000, addr0)
-		fc.addUTxO(3_000_000, addr3, "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc03", 0)
-		s := NewService(fc, nil, acct)
-
-		// Build an initial pending, then replace the builder with one that
-		// includes a stake-registration certificate.
-		pv, err := s.Build(context.Background(), SendRequest{To: recvAddr, Lovelace: "4000000"})
-		if err != nil {
-			t.Fatalf("Build: %v", err)
-		}
-		s.mu.Lock()
-		p := s.pending[pv.PendingID]
-		s.mu.Unlock()
-
-		changeAddr, _ := lcommon.NewAddress(addr0)
-		a := apollo.New(fc).
-			SetWallet(apollo.NewExternalWallet(changeAddr)).
-			SetChangeAddress(changeAddr).
-			SetFeePadding(feePaddingLovelace).
-			AddLoadedUTxOs(fc.utxos[addr0]...).
-			AddLoadedUTxOs(fc.utxos[addr3]...).
-			PayToAddress(mustNewAddress(t, recvAddr), 1_000_000)
-		a, err = a.RegisterStake(acct.StakeAddress)
-		if err != nil {
-			t.Fatalf("RegisterStake: %v", err)
-		}
-		a, err = a.WithContext(context.Background()).Complete()
-		if err != nil {
-			t.Fatalf("Complete with cert: %v", err)
-		}
-		utxoAddr := make(map[string]string)
-		for _, u := range fc.utxos[addr0] {
-			utxoAddr[makeUtxoRef(u)] = addr0
-		}
-		for _, u := range fc.utxos[addr3] {
-			utxoAddr[makeUtxoRef(u)] = addr3
-		}
-		s.mu.Lock()
-		s.pending[pv.PendingID] = &pending{
-			tx:       a,
-			utxoAddr: utxoAddr,
-			created:  p.created,
-			walletID: p.walletID,
-			account:  p.account,
-		}
-		s.mu.Unlock()
-
-		req, err := s.HardwareSignRequest(pv.PendingID)
-		if err != nil {
-			t.Fatalf("HardwareSignRequest: %v", err)
-		}
-		if req.Unsupported == "" {
-			t.Fatal("expected Unsupported to be set for a cert tx")
-		}
-		// Guard fires before inputs are built: no paths should leak.
-		for _, inp := range req.Inputs {
-			if inp.Path != "" {
-				t.Fatalf("cert guard leaked a signing path: %q", inp.Path)
-			}
-		}
-		if len(req.Inputs) > 0 {
-			t.Fatalf("cert guard: expected no inputs in result, got %d", len(req.Inputs))
-		}
-	})
-
-	t.Run("withdrawal tx is rejected", func(t *testing.T) {
-		fc := newFakeChain(5_000_000, addr0)
-		s := NewService(fc, nil, acct)
-
-		pv, err := s.Build(context.Background(), SendRequest{To: recvAddr, Lovelace: "1000000"})
-		if err != nil {
-			t.Fatalf("Build: %v", err)
-		}
-		s.mu.Lock()
-		p := s.pending[pv.PendingID]
-		s.mu.Unlock()
-
-		stakeAddr, err := lcommon.NewAddress(acct.StakeAddress)
-		if err != nil {
-			t.Fatalf("NewAddress(stake): %v", err)
-		}
-		changeAddr, _ := lcommon.NewAddress(addr0)
-		a := apollo.New(fc).
-			SetWallet(apollo.NewExternalWallet(changeAddr)).
-			SetChangeAddress(changeAddr).
-			SetFeePadding(feePaddingLovelace).
-			AddLoadedUTxOs(fc.utxos[addr0]...).
-			PayToAddress(mustNewAddress(t, recvAddr), 1_000_000).
-			AddWithdrawal(stakeAddr, 500_000, nil, nil)
-		a, err = a.WithContext(context.Background()).Complete()
-		if err != nil {
-			t.Fatalf("Complete with withdrawal: %v", err)
-		}
-		utxoAddr := make(map[string]string)
-		for _, u := range fc.utxos[addr0] {
-			utxoAddr[makeUtxoRef(u)] = addr0
-		}
-		s.mu.Lock()
-		s.pending[pv.PendingID] = &pending{
-			tx:       a,
-			utxoAddr: utxoAddr,
-			created:  p.created,
-			walletID: p.walletID,
-			account:  p.account,
-		}
-		s.mu.Unlock()
-
-		req, err := s.HardwareSignRequest(pv.PendingID)
-		if err != nil {
-			t.Fatalf("HardwareSignRequest: %v", err)
-		}
-		if req.Unsupported == "" {
-			t.Fatal("expected Unsupported to be set for a withdrawal tx")
-		}
-		// Guard fires before inputs are built: no inputs should leak.
-		if len(req.Inputs) > 0 {
-			t.Fatalf("withdrawal guard: expected no inputs in result, got %d", len(req.Inputs))
-		}
-	})
 
 	t.Run("native-asset output is rejected", func(t *testing.T) {
 		// Fund addr0 with 5 ADA + 1 native token. Apollo needs the token in the
@@ -2271,9 +2149,6 @@ func TestHardwareSignRequestRejectsOtherConwayFeatures(t *testing.T) {
 		{"collateral return", func(b *conway.ConwayTransactionBody) { out := b.TxOutputs[0]; b.TxCollateralReturn = &out }},
 		{"total collateral", func(b *conway.ConwayTransactionBody) { b.TxTotalCollateral = 1 }},
 		{"reference inputs", func(b *conway.ConwayTransactionBody) { b.TxReferenceInputs = cbor.NewSetType(b.TxInputs.Items(), true) }},
-		{"voting procedures", func(b *conway.ConwayTransactionBody) {
-			b.TxVotingProcedures = lcommon.VotingProcedures{new(lcommon.Voter): {new(lcommon.GovActionId): {}}}
-		}},
 		{"proposal procedures", func(b *conway.ConwayTransactionBody) { b.TxProposalProcedures = []conway.ConwayProposalProcedure{{}} }},
 		{"current treasury value", func(b *conway.ConwayTransactionBody) { b.TxCurrentTreasuryValue = 1 }},
 		{"donation", func(b *conway.ConwayTransactionBody) { b.TxDonation = 1 }},
@@ -2349,5 +2224,363 @@ func TestHardwareSignRequestRejectsOtherConwayFeatures(t *testing.T) {
 				t.Fatalf("guard returned %d signing inputs", len(req.Inputs))
 			}
 		})
+	}
+}
+
+// TestHardwareSignRequestStakeDelegationCarriesCertSigners verifies a
+// stake-delegation transaction is signable on hardware (not Unsupported) and
+// that the request carries the wallet's stake-key derivation path for every
+// certificate it must witness, plus the change-output path.
+func TestHardwareSignRequestStakeDelegationCarriesCertSigners(t *testing.T) {
+	acct := mustDeriveTestAccount(t)
+	fc := newFakeChain(10_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, nil, acct)
+	s.SetChainQuerier(newFakeQuerier()) // fresh wallet → stake registration + delegation
+
+	pv, err := s.BuildDelegation(context.Background(), DelegationRequest{PoolID: validPoolID})
+	if err != nil {
+		t.Fatalf("BuildDelegation: %v", err)
+	}
+	req, err := s.HardwareSignRequest(pv.PendingID)
+	if err != nil {
+		t.Fatalf("HardwareSignRequest: %v", err)
+	}
+	if req.Unsupported != "" {
+		t.Fatalf("staking tx must be signable, got Unsupported = %q", req.Unsupported)
+	}
+
+	addr0 := mustNewAddress(t, acct.ReceiveAddresses[0])
+	wantStakeHash := hex.EncodeToString(addr0.StakeKeyHash().Bytes())
+	const wantStakePath = "1852'/1815'/0'/2/0"
+	seen := map[string]bool{}
+	for _, cs := range req.CertificateSigners {
+		seen[cs.CertKind] = true
+		if cs.Role != "stake" {
+			t.Fatalf("cert signer role = %q, want stake", cs.Role)
+		}
+		if cs.Path != wantStakePath {
+			t.Fatalf("cert signer path = %q, want %q", cs.Path, wantStakePath)
+		}
+		if cs.KeyHashHex != wantStakeHash {
+			t.Fatalf("cert signer key hash = %q, want stake key hash %q", cs.KeyHashHex, wantStakeHash)
+		}
+	}
+	for _, want := range []string{"stake_registration", "stake_delegation"} {
+		if !seen[want] {
+			t.Fatalf("missing cert signer for %q; got %+v", want, req.CertificateSigners)
+		}
+	}
+	// Change returns to the wallet → a change-output path is surfaced.
+	if len(req.ChangeOutputs) == 0 {
+		t.Fatalf("expected at least one change output path; outputs=%+v", req.Outputs)
+	}
+	for _, co := range req.ChangeOutputs {
+		if co.Path == "" || co.StakePath != wantStakePath {
+			t.Fatalf("change output = %+v, want non-empty path and stake path %q", co, wantStakePath)
+		}
+		if co.Index < 0 || co.Index >= len(req.Outputs) {
+			t.Fatalf("change output index %d out of range (%d outputs)", co.Index, len(req.Outputs))
+		}
+		if req.Outputs[co.Index].PaymentPath != co.Path {
+			t.Fatalf("change output index %d path %q != output payment path %q", co.Index, co.Path, req.Outputs[co.Index].PaymentPath)
+		}
+	}
+}
+
+// TestHardwareSignRequestSelfDRepRegistrationCarriesDRepSigner verifies a
+// self-DRep registration surfaces the wallet's DRep-key path (role 3) for the
+// drep_registration certificate.
+func TestHardwareSignRequestSelfDRepRegistrationCarriesDRepSigner(t *testing.T) {
+	acct := mustDeriveTestAccount(t)
+	fc := newFakeChain(700_000_000, acct.ReceiveAddresses[0]) // cover 2₳ + 500₳ deposits + fee
+	s := NewService(fc, nil, acct)
+	q := newFakeQuerier()
+	q.account = chain.AccountInfo{Registered: true, Active: true, WithdrawableAmount: "0"}
+	q.drepErr = chain.ErrNotFound // own DRep not yet registered → emit the reg cert
+	s.SetChainQuerier(q)
+
+	pv, err := s.BuildDelegation(context.Background(), DelegationRequest{Vote: &Vote{Type: VoteRegisterSelf}})
+	if err != nil {
+		t.Fatalf("BuildDelegation register self: %v", err)
+	}
+	req, err := s.HardwareSignRequest(pv.PendingID)
+	if err != nil {
+		t.Fatalf("HardwareSignRequest: %v", err)
+	}
+	if req.Unsupported != "" {
+		t.Fatalf("governance tx must be signable, got Unsupported = %q", req.Unsupported)
+	}
+	const wantDRepPath = "1852'/1815'/0'/3/0"
+	wantDRepHash := strings.ToLower(acct.DRepKeyHash)
+	found := false
+	for _, cs := range req.CertificateSigners {
+		if cs.CertKind != "registration_drep" {
+			continue
+		}
+		found = true
+		if cs.Role != "drep" || cs.Path != wantDRepPath {
+			t.Fatalf("drep cert signer = %+v, want role drep path %q", cs, wantDRepPath)
+		}
+		if cs.KeyHashHex != wantDRepHash {
+			t.Fatalf("drep cert signer key hash = %q, want %q", cs.KeyHashHex, wantDRepHash)
+		}
+	}
+	if !found {
+		t.Fatalf("no registration_drep cert signer; got %+v", req.CertificateSigners)
+	}
+}
+
+// TestHardwareSignRequestWithdrawalCarriesStakeSigner verifies a reward
+// withdrawal surfaces the wallet's stake-key path as a withdrawal signer.
+func TestHardwareSignRequestWithdrawalCarriesStakeSigner(t *testing.T) {
+	acct, err := wallet.Derive(testMnemonic, "preview", 5)
+	if err != nil {
+		t.Fatalf("wallet.Derive: %v", err)
+	}
+	addr0 := acct.ReceiveAddresses[0]
+	recvAddr := acct.ReceiveAddresses[4]
+
+	fc := newFakeChain(5_000_000, addr0)
+	s := NewService(fc, nil, acct)
+	pv, err := s.Build(context.Background(), SendRequest{To: recvAddr, Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	s.mu.Lock()
+	p := s.pending[pv.PendingID]
+	s.mu.Unlock()
+
+	stakeAddr, err := lcommon.NewAddress(acct.StakeAddress)
+	if err != nil {
+		t.Fatalf("NewAddress(stake): %v", err)
+	}
+	changeAddr, _ := lcommon.NewAddress(addr0)
+	a := apollo.New(fc).
+		SetWallet(apollo.NewExternalWallet(changeAddr)).
+		SetChangeAddress(changeAddr).
+		SetFeePadding(feePaddingLovelace).
+		AddLoadedUTxOs(fc.utxos[addr0]...).
+		PayToAddress(mustNewAddress(t, recvAddr), 1_000_000).
+		AddWithdrawal(stakeAddr, 500_000, nil, nil)
+	a, err = a.WithContext(context.Background()).Complete()
+	if err != nil {
+		t.Fatalf("Complete with withdrawal: %v", err)
+	}
+	utxoAddr := make(map[string]string)
+	for _, u := range fc.utxos[addr0] {
+		utxoAddr[makeUtxoRef(u)] = addr0
+	}
+	s.mu.Lock()
+	s.pending[pv.PendingID] = &pending{
+		tx:       a,
+		utxoAddr: utxoAddr,
+		created:  p.created,
+		walletID: p.walletID,
+		account:  p.account,
+	}
+	s.mu.Unlock()
+
+	req, err := s.HardwareSignRequest(pv.PendingID)
+	if err != nil {
+		t.Fatalf("HardwareSignRequest: %v", err)
+	}
+	if req.Unsupported != "" {
+		t.Fatalf("withdrawal tx must be signable, got Unsupported = %q", req.Unsupported)
+	}
+	if len(req.WithdrawalSigners) != 1 {
+		t.Fatalf("want exactly one withdrawal signer, got %+v", req.WithdrawalSigners)
+	}
+	ws := req.WithdrawalSigners[0]
+	addr0Parsed := mustNewAddress(t, addr0)
+	wantStakeHash := hex.EncodeToString(addr0Parsed.StakeKeyHash().Bytes())
+	if ws.Role != "stake" || ws.Path != "1852'/1815'/0'/2/0" || ws.KeyHashHex != wantStakeHash {
+		t.Fatalf("withdrawal signer = %+v, want stake role, path 1852'/1815'/0'/2/0, key hash %q", ws, wantStakeHash)
+	}
+	if ws.RewardAddressBech32 != acct.StakeAddress {
+		t.Fatalf("withdrawal reward address = %q, want %q", ws.RewardAddressBech32, acct.StakeAddress)
+	}
+}
+
+// TestHardwareSignRequestDRepVoteCarriesVoteSigner verifies a Conway
+// governance vote (a voting procedure whose voter is the wallet's DRep key)
+// surfaces the DRep-key path as a vote signer.
+func TestHardwareSignRequestDRepVoteCarriesVoteSigner(t *testing.T) {
+	acct := mustDeriveTestAccount(t)
+	fc := newFakeChain(10_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, nil, acct)
+	pv, err := s.Build(context.Background(), SendRequest{To: acct.ReceiveAddresses[1], Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	// Attach a DRep-key-hash voter for the wallet's own DRep credential.
+	drepHash, err := hex.DecodeString(acct.DRepKeyHash)
+	if err != nil {
+		t.Fatalf("decode drep key hash: %v", err)
+	}
+	var voter lcommon.Voter
+	voter.Type = lcommon.VoterTypeDRepKeyHash
+	copy(voter.Hash[:], drepHash)
+	tx := s.pending[pv.PendingID].tx.GetTx()
+	tx.Body.TxVotingProcedures = lcommon.VotingProcedures{
+		&voter: {new(lcommon.GovActionId): lcommon.VotingProcedure{}},
+	}
+
+	req, err := s.HardwareSignRequest(pv.PendingID)
+	if err != nil {
+		t.Fatalf("HardwareSignRequest: %v", err)
+	}
+	if req.Unsupported != "" {
+		t.Fatalf("vote tx must be signable, got Unsupported = %q", req.Unsupported)
+	}
+	if len(req.VoteSigners) != 1 {
+		t.Fatalf("want exactly one vote signer, got %+v", req.VoteSigners)
+	}
+	vs := req.VoteSigners[0]
+	if vs.Voter != "drep" || vs.Role != "drep" || vs.Path != "1852'/1815'/0'/3/0" {
+		t.Fatalf("vote signer = %+v, want drep voter/role, path 1852'/1815'/0'/3/0", vs)
+	}
+	if vs.KeyHashHex != strings.ToLower(acct.DRepKeyHash) {
+		t.Fatalf("vote signer key hash = %q, want %q", vs.KeyHashHex, acct.DRepKeyHash)
+	}
+}
+
+// TestHardwareSignRequestMultisigExtraSigners verifies a native-multisig-style
+// spend — where the transaction requires an extra key (body key 14) that is not
+// already an input signer — surfaces that participant key as an extra signer,
+// while inputs the wallet spends keep their own paths (and are not repeated).
+func TestHardwareSignRequestMultisigExtraSigners(t *testing.T) {
+	acct := mustDeriveTestAccount(t)
+	fc := newFakeChain(10_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, nil, acct)
+	pv, err := s.Build(context.Background(), SendRequest{To: acct.ReceiveAddresses[1], Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	addr0 := mustNewAddress(t, acct.ReceiveAddresses[0])
+	stakeHash := addr0.StakeKeyHash()
+	tx := s.pending[pv.PendingID].tx.GetTx()
+	// Add the wallet's stake key as an explicit required signer — standing in
+	// for a CIP-1854 multisig participant that is not one of the tx inputs.
+	items := append(tx.Body.TxRequiredSigners.Items(), stakeHash)
+	tx.Body.TxRequiredSigners = cbor.NewSetType[lcommon.Blake2b224](items, true)
+
+	req, err := s.HardwareSignRequest(pv.PendingID)
+	if err != nil {
+		t.Fatalf("HardwareSignRequest: %v", err)
+	}
+	if req.Unsupported != "" {
+		t.Fatalf("multisig-style tx must be signable, got Unsupported = %q", req.Unsupported)
+	}
+
+	// Inputs the wallet spends still carry their derivation path.
+	hasInputPath := false
+	for _, inp := range req.Inputs {
+		if inp.Path == "1852'/1815'/0'/0/0" {
+			hasInputPath = true
+		}
+	}
+	if !hasInputPath {
+		t.Fatalf("expected the owned input to keep its path; inputs=%+v", req.Inputs)
+	}
+
+	// The stake key (not an input signer) is surfaced as an extra signer.
+	wantStakeHash := hex.EncodeToString(stakeHash.Bytes())
+	found := false
+	for _, es := range req.ExtraSigners {
+		if es.KeyHashHex == wantStakeHash {
+			found = true
+			if es.Role != "stake" || es.Path != "1852'/1815'/0'/2/0" {
+				t.Fatalf("extra signer = %+v, want stake role, path 1852'/1815'/0'/2/0", es)
+			}
+		}
+		// A payment key already covered by an input must NOT be duplicated here.
+		if es.Path == "1852'/1815'/0'/0/0" {
+			t.Fatalf("extra signer duplicated an input path: %+v", es)
+		}
+	}
+	if !found {
+		t.Fatalf("stake participant key not surfaced as extra signer; got %+v", req.ExtraSigners)
+	}
+}
+
+// TestHardwareSignRequestForeignDRepVoteUnsupported verifies the safety property
+// behind the vote path: a governance vote whose voter is a DRep key hash the
+// wallet does NOT own must not be presented as signable. resolveSignerData has
+// no derivation path for it, so it must set Unsupported (the device can never
+// produce that witness) rather than return an empty VoteSigners slice — which
+// the SPA would treat as a signable payment with the vote witness silently
+// missing.
+func TestHardwareSignRequestForeignDRepVoteUnsupported(t *testing.T) {
+	acct := mustDeriveTestAccount(t)
+	fc := newFakeChain(10_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, nil, acct)
+	pv, err := s.Build(context.Background(), SendRequest{To: acct.ReceiveAddresses[1], Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	// A DRep key-hash voter whose hash is NOT this wallet's DRep key.
+	var voter lcommon.Voter
+	voter.Type = lcommon.VoterTypeDRepKeyHash
+	for i := range voter.Hash {
+		voter.Hash[i] = 0x11
+	}
+	tx := s.pending[pv.PendingID].tx.GetTx()
+	tx.Body.TxVotingProcedures = lcommon.VotingProcedures{
+		&voter: {new(lcommon.GovActionId): lcommon.VotingProcedure{}},
+	}
+
+	req, err := s.HardwareSignRequest(pv.PendingID)
+	if err != nil {
+		t.Fatalf("HardwareSignRequest: %v", err)
+	}
+	if req.Unsupported == "" {
+		t.Fatal("foreign DRep vote must set Unsupported, not be presented as signable")
+	}
+	if len(req.VoteSigners) != 0 {
+		t.Fatalf("no vote signer may be fabricated for a foreign DRep; got %+v", req.VoteSigners)
+	}
+}
+
+// TestHardwareSignRequestForeignCertCredentialUnsupported verifies the safety
+// property behind the certificate path: a certificate whose signing credential
+// is a stake key the wallet does NOT own (a co-signer's key, or — via the same
+// branch — a script hash) must set Unsupported rather than resolve to an empty
+// CertificateSigners slice the SPA would treat as signable.
+func TestHardwareSignRequestForeignCertCredentialUnsupported(t *testing.T) {
+	acct := mustDeriveTestAccount(t)
+	fc := newFakeChain(10_000_000, acct.ReceiveAddresses[0])
+	s := NewService(fc, nil, acct)
+	pv, err := s.Build(context.Background(), SendRequest{To: acct.ReceiveAddresses[1], Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	// A stake-delegation certificate keyed on a credential this wallet does not
+	// own — it can never witness it.
+	foreignCred := lcommon.Credential{
+		CredType:   lcommon.CredentialTypeAddrKeyHash,
+		Credential: lcommon.Blake2b224Hash([]byte("foreign stake key")),
+	}
+	tx := s.pending[pv.PendingID].tx.GetTx()
+	tx.Body.TxCertificates = []lcommon.CertificateWrapper{{
+		Type: uint(lcommon.CertificateTypeStakeDelegation),
+		Certificate: &lcommon.StakeDelegationCertificate{
+			CertType:        uint(lcommon.CertificateTypeStakeDelegation),
+			StakeCredential: &foreignCred,
+		},
+	}}
+
+	req, err := s.HardwareSignRequest(pv.PendingID)
+	if err != nil {
+		t.Fatalf("HardwareSignRequest: %v", err)
+	}
+	if req.Unsupported == "" {
+		t.Fatal("foreign certificate credential must set Unsupported, not be presented as signable")
+	}
+	if len(req.CertificateSigners) != 0 {
+		t.Fatalf("no cert signer may be fabricated for a foreign credential; got %+v", req.CertificateSigners)
 	}
 }

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -449,6 +449,54 @@ export interface HWOutput {
   assets?: { policy_id_hex: string; asset_name_hex: string; amount: string }[];
 }
 
+// HWChangeOutput identifies a wallet-owned output (by its index in outputs)
+// with the derivation path of its change address, so a device can verify the
+// change returns to this wallet without re-deriving every output.
+export interface HWChangeOutput {
+  index: number; // position in the outputs array
+  path: string; // CIP-1852 payment-key path of the change address
+  stake_path?: string; // CIP-1852 stake-key path (base addresses only)
+}
+
+// HWCertSigner is one wallet-owned key that must witness a certificate.
+export interface HWCertSigner {
+  // cert_kind carries the Go certLabel vocabulary (e.g. "stake_delegation",
+  // "registration_drep", "pool_registration"), NOT the exported CertKind union —
+  // keep it typed string.
+  cert_kind: string;
+  role: string; // CIP-1852 role of the key: "stake" | "drep"
+  path: string; // CIP-1852 derivation path
+  key_hash_hex: string;
+}
+
+// HWWithdrawalSigner is the wallet's stake key that must witness a reward
+// withdrawal.
+export interface HWWithdrawalSigner {
+  reward_address_bech32?: string;
+  role: string; // "stake"
+  path: string;
+  key_hash_hex: string;
+}
+
+// HWVoteSigner is the wallet's key that must witness a governance vote.
+export interface HWVoteSigner {
+  voter: string; // "drep"
+  role: string; // "drep"
+  path: string;
+  key_hash_hex: string;
+}
+
+// HWExtraSigner is a wallet-owned key required as an explicit signer (body key
+// 14) that is not already an input signer — e.g. a CIP-1854 native-multisig
+// participant. xfp (4-byte master-key fingerprint, hex) is filled in
+// client-side from the per-wallet fingerprint store before reaching the device.
+export interface HWExtraSigner {
+  xfp?: string;
+  role: string;
+  path: string;
+  key_hash_hex: string;
+}
+
 export interface HardwareSignResponse {
   network: string;
   network_id: number;
@@ -456,6 +504,15 @@ export interface HardwareSignResponse {
   protocol_magic: number;
   inputs: HWInput[];
   outputs: HWOutput[];
+  // change_outputs, certificate_signers, withdrawal_signers, vote_signers, and
+  // extra_signers carry the wallet's own derivation paths for the keys that
+  // staking / governance / multisig transactions must witness. A device that
+  // only signs payments ignores them.
+  change_outputs?: HWChangeOutput[];
+  certificate_signers?: HWCertSigner[];
+  withdrawal_signers?: HWWithdrawalSigner[];
+  vote_signers?: HWVoteSigner[];
+  extra_signers?: HWExtraSigner[];
   fee: string;
   ttl?: string;
   required_signers: string[];


### PR DESCRIPTION
Extends the neutral hardware-sign request (`HardwareSignRequest` Go / `HardwareSignResponse` TS) beyond payment inputs/outputs. New fields, derived from the tx being built and matched against the wallet's own key hashes:

- `change_outputs`: per-change-output path.
- `certificate_signers`: stake / DRep / pool-owner key paths for cert witnessing.
- `withdrawal_signers`: reward-account stake key paths.
- `vote_signers`: DRep key path for Conway votes.
- `extra_signers`: CIP-1854 multisig participant paths (script-locked inputs carry none).

Certificates, withdrawals, and votes no longer set `Unsupported`; native-asset outputs, scripts, minting, and proposals still do. Fields are optional — send-only devices ignore them. Go/TS shapes mirrored.

Tests: stake-delegation, self-DRep registration, withdrawal, DRep vote, multisig extra-signer. `go build`/`go vet`/`go test ./...` + `golangci-lint` clean in `ui/`; frontend lint/type-check/test pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the neutral `HardwareSignRequest`/`HardwareSignResponse` to include signer paths for staking, governance votes, and native multisig, plus per-change-output paths. Hardware devices can now sign these transactions while still rejecting features they can’t express or witnesses the wallet can’t derive.

- **New Features**
  - Added `change_outputs` with index and address paths so devices can verify change belongs to the wallet.
  - Added `certificate_signers`, `withdrawal_signers`, and `vote_signers` (DRep) when the wallet owns the keys; if a required witness is a script or foreign key, `Unsupported` is set with a clear reason.
  - Added `extra_signers` for CIP-1854 multisig participants not covered by inputs; input signer paths are not duplicated here.
  - Certificates, withdrawals, and DRep votes are now signable; native-asset outputs, scripts, minting, and proposals still set `Unsupported`.
  - Go `HardwareSignRequest` and TS `HardwareSignResponse` stay mirrored; new fields are optional and device-agnostic.

<sup>Written for commit e61d4aef141c666874545139a584264791ac7474. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hardware wallet signing now supports certificate transactions, reward withdrawals, and governance votes.
  * Signing requests include wallet-owned change outputs and the required signer paths for certificates, withdrawals, votes, and multisignature transactions.
  * Additional signing details are available through the hardware-signing interface for compatible wallets.

* **Bug Fixes**
  * Prevented resolvable wallet signer information from being incorrectly rejected as unsupported.
  * Avoided duplicating input signers when identifying additional multisignature participants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

