### PR TITLE
feat(ui): stake reward history screen + API

### DIFF
--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -60,6 +60,9 @@ type Wallet interface {
 	// the node has no record of hash.
 	TransactionDetail(ctx context.Context, hash string) (wallet.TxDetail, error)
 	Delegation(ctx context.Context) (wallet.DelegationView, error)
+	// Rewards returns the per-epoch stake-reward history for the active
+	// wallet's stake address (read node-locally, like Delegation).
+	Rewards(ctx context.Context) (wallet.RewardHistory, error)
 }
 
 // Spender is the spending surface the API exposes for the active wallet:
@@ -839,6 +842,13 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 	}))
 	mux.HandleFunc("GET /wallet/delegation", gated(st, func(w http.ResponseWriter, r *http.Request) {
 		v, err := wl.Delegation(r.Context())
+		serve(w, v, err)
+	}))
+	// Read-only per-epoch stake-reward history for the active wallet, read from
+	// the embedded node (same source as delegation) — no external calls, so no
+	// consent gate; gated like other reads on a queryable node.
+	mux.HandleFunc("GET /wallet/rewards", gated(st, func(w http.ResponseWriter, r *http.Request) {
+		v, err := wl.Rewards(r.Context())
 		serve(w, v, err)
 	}))
 

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -551,6 +551,7 @@ type fakeWallet struct {
 	gotNetwork       string
 	txDetail         wallet.TxDetail
 	txDetailErr      error
+	rewards          wallet.RewardHistory
 }
 
 func (f *fakeWallet) SetAccount(acct *wallet.Account) error {
@@ -605,6 +606,13 @@ func (f *fakeWallet) Delegation(_ context.Context) (wallet.DelegationView, error
 		return wallet.DelegationView{}, wallet.ErrNoWallet
 	}
 	return wallet.DelegationView{}, nil
+}
+
+func (f *fakeWallet) Rewards(_ context.Context) (wallet.RewardHistory, error) {
+	if !f.set {
+		return wallet.RewardHistory{}, wallet.ErrNoWallet
+	}
+	return f.rewards, nil
 }
 
 // --- Vault lifecycle --------------------------------------------------------
@@ -879,6 +887,63 @@ func TestAddWalletEnablesReadsAndSpend(t *testing.T) {
 	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/balance", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /wallet/balance after add = %d, want 200", rec.Code)
+	}
+}
+
+func TestWalletRewardsPopulated(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	fw := &fakeWallet{set: true, rewards: wallet.RewardHistory{
+		Rewards: []wallet.RewardEntry{
+			{Epoch: 500, Amount: "1234567", PoolID: "pool1abc", Type: "member"},
+			{Epoch: 501, Amount: "2345678", PoolID: "pool1abc", Type: "member"},
+		},
+		Provisional: true,
+		Note:        "rewards are provisional",
+	}}
+	h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/rewards", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /wallet/rewards = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+	var got wallet.RewardHistory
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode rewards: %v", err)
+	}
+	if len(got.Rewards) != 2 || got.Rewards[0].Epoch != 500 || got.Rewards[0].Amount != "1234567" {
+		t.Fatalf("unexpected rewards payload: %+v", got)
+	}
+	if !got.Provisional {
+		t.Fatalf("expected provisional=true, got %+v", got)
+	}
+}
+
+func TestWalletRewardsEmptyAndNoWallet(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+
+	// Active wallet with no rewards yet → 200 with an empty list.
+	fw := &fakeWallet{set: true, rewards: wallet.RewardHistory{Rewards: []wallet.RewardEntry{}, Provisional: true}}
+	h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/rewards", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /wallet/rewards (empty) = %d, want 200", rec.Code)
+	}
+	var got wallet.RewardHistory
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode rewards: %v", err)
+	}
+	if len(got.Rewards) != 0 {
+		t.Fatalf("expected empty rewards, got %+v", got.Rewards)
+	}
+
+	// No active wallet → 409 (ErrNoWallet), like the other wallet reads.
+	h = NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/rewards", nil))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("GET /wallet/rewards without wallet = %d, want 409", rec.Code)
 	}
 }
 

--- a/ui/internal/chain/blockfrost.go
+++ b/ui/internal/chain/blockfrost.go
@@ -134,11 +134,14 @@ type Delegation struct {
 	PoolID      string `json:"pool_id"`
 }
 
-// Reward mirrors one entry of GET /api/v0/accounts/{stake}/rewards.
+// Reward mirrors one entry of GET /api/v0/accounts/{stake}/rewards. Type is the
+// reward kind (e.g. "member"/"leader") when the node reports it; it is optional
+// because not every reward source populates it.
 type Reward struct {
 	Epoch  int32  `json:"epoch"`
 	Amount string `json:"amount"`
 	PoolID string `json:"pool_id"`
+	Type   string `json:"type"`
 }
 
 // PoolInfo describes a stake pool's on-chain parameters, as the wallet needs

--- a/ui/internal/chain/blockfrost_test.go
+++ b/ui/internal/chain/blockfrost_test.go
@@ -300,6 +300,33 @@ func TestAccountRewards(t *testing.T) {
 	}
 }
 
+func TestAccountRewardsType(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v0/accounts/stake_test1xyz/rewards" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// First row reports a reward type, second omits the field entirely.
+		_, _ = w.Write([]byte(`[
+			{"epoch":42,"amount":"2000","pool_id":"pool1abc","type":"member"},
+			{"epoch":43,"amount":"3000","pool_id":"pool1abc"}
+		]`))
+	})
+	got, err := c.AccountRewards(context.Background(), "stake_test1xyz")
+	if err != nil {
+		t.Fatalf("AccountRewards: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Type != "member" {
+		t.Fatalf("got[0].Type = %q, want member", got[0].Type)
+	}
+	if got[1].Type != "" {
+		t.Fatalf("got[1].Type = %q, want empty (type omitted)", got[1].Type)
+	}
+}
+
 func TestAccountRewardsNotFound(t *testing.T) {
 	t.Parallel()
 	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/ui/internal/connector/backend_test.go
+++ b/ui/internal/connector/backend_test.go
@@ -106,6 +106,10 @@ func (b *walletChainBridge) AddressTransactions(_ context.Context, _ string) ([]
 	return nil, nil
 }
 
+func (b *walletChainBridge) AccountRewards(_ context.Context, _ string) ([]chain.Reward, error) {
+	return nil, nil
+}
+
 // twoKnownUTxOs returns two deterministic chain.UTxO values and their
 // expected tx hashes / indices / lovelace amounts for round-trip assertions.
 func twoKnownUTxOs(addr string) []chain.UTxO {

--- a/ui/internal/wallet/service.go
+++ b/ui/internal/wallet/service.go
@@ -23,6 +23,7 @@ type chainQuerier interface {
 	Transaction(ctx context.Context, hash string) (chain.TxInfo, error)
 	TransactionUTxOs(ctx context.Context, hash string) (chain.TxUTxOs, error)
 	LatestBlock(ctx context.Context) (chain.BlockTip, error)
+	AccountRewards(ctx context.Context, stakeAddr string) ([]chain.Reward, error)
 }
 
 // AddressView is the receive-address view: the derived window, the chain-seen
@@ -44,6 +45,25 @@ type DelegationView struct {
 	Withdrawable string  `json:"withdrawable_amount"`
 	Provisional  bool    `json:"provisional"`
 	Note         string  `json:"note"`
+}
+
+// RewardEntry is one epoch's stake reward for the active wallet's stake
+// address, mirroring one chain.Reward. Type is the reward kind (e.g.
+// "member"/"leader") when the node reports it; empty otherwise.
+type RewardEntry struct {
+	Epoch  int32  `json:"epoch"`
+	Amount string `json:"amount"`
+	PoolID string `json:"pool_id"`
+	Type   string `json:"type,omitempty"`
+}
+
+// RewardHistory is the per-epoch stake-reward history (newest epochs last, as
+// the node returns them). Provisional mirrors DelegationView: dingo's reward
+// accounting has open issues, so the amounts are advisory.
+type RewardHistory struct {
+	Rewards     []RewardEntry `json:"rewards"`
+	Provisional bool          `json:"provisional"`
+	Note        string        `json:"note"`
 }
 
 // Service holds the active read-only account and queries the chain for views.
@@ -470,5 +490,34 @@ func (s *Service) Delegation(ctx context.Context) (DelegationView, error) {
 		Withdrawable: info.WithdrawableAmount,
 		Provisional:  true,
 		Note:         "rewards are provisional; dingo reward accounting has open issues (#2373-#2376)",
+	}, nil
+}
+
+// Rewards returns the per-epoch stake-reward history for the active wallet's
+// stake address, read node-locally through the chain client. A stake key not
+// yet seen on chain (ErrNotFound) yields an empty history rather than an error.
+func (s *Service) Rewards(ctx context.Context) (RewardHistory, error) {
+	acct, err := s.currentAccount()
+	if err != nil {
+		return RewardHistory{}, err
+	}
+	rewards, err := s.chain.AccountRewards(ctx, acct.StakeAddress)
+	if err != nil && !errors.Is(err, chain.ErrNotFound) {
+		return RewardHistory{}, err
+	}
+	// ErrNotFound: stake key not registered / no rewards yet → empty history.
+	entries := make([]RewardEntry, 0, len(rewards))
+	for _, r := range rewards {
+		entries = append(entries, RewardEntry{
+			Epoch:  r.Epoch,
+			Amount: r.Amount,
+			PoolID: r.PoolID,
+			Type:   r.Type,
+		})
+	}
+	return RewardHistory{
+		Rewards:     entries,
+		Provisional: true,
+		Note:        "rewards are provisional; dingo reward accounting has open issues (#2373-#2376)",
 	}, nil
 }

--- a/ui/internal/wallet/service_test.go
+++ b/ui/internal/wallet/service_test.go
@@ -27,6 +27,9 @@ type fakeChain struct {
 	txUTxOErrs  map[string]error
 	latestBlock chain.BlockTip
 	latestErr   error
+
+	rewards    []chain.Reward
+	rewardsErr error
 }
 
 func (f *fakeChain) Account(_ context.Context, _ string) (chain.AccountInfo, error) {
@@ -70,6 +73,10 @@ func (f *fakeChain) TransactionUTxOs(_ context.Context, hash string) (chain.TxUT
 
 func (f *fakeChain) LatestBlock(_ context.Context) (chain.BlockTip, error) {
 	return f.latestBlock, f.latestErr
+}
+
+func (f *fakeChain) AccountRewards(_ context.Context, _ string) ([]chain.Reward, error) {
+	return f.rewards, f.rewardsErr
 }
 
 func TestServiceNoWallet(t *testing.T) {
@@ -182,6 +189,48 @@ func TestServiceEmptyAccount(t *testing.T) {
 	}
 	if dv.PoolID != nil || dv.Active || dv.RewardsSum != "0" || dv.Withdrawable != "0" {
 		t.Fatalf("delegation on empty account = %+v, want not active / no pool / zero amounts", dv)
+	}
+}
+
+func TestServiceRewards(t *testing.T) {
+	// No wallet set → ErrNoWallet.
+	s := NewService(&fakeChain{})
+	if _, err := s.Rewards(context.Background()); !errors.Is(err, ErrNoWallet) {
+		t.Fatalf("Rewards without wallet: err = %v, want ErrNoWallet", err)
+	}
+
+	// Populated history: entries pass through, marked provisional.
+	fc := &fakeChain{rewards: []chain.Reward{
+		{Epoch: 500, Amount: "1234567", PoolID: "pool1abc", Type: "member"},
+		{Epoch: 501, Amount: "2345678", PoolID: "pool1abc"},
+	}}
+	s = NewService(fc)
+	if _, err := s.SetWallet(testMnemonic, "preview", 3); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	rh, err := s.Rewards(context.Background())
+	if err != nil {
+		t.Fatalf("Rewards: %v", err)
+	}
+	if len(rh.Rewards) != 2 || rh.Rewards[0].Epoch != 500 || rh.Rewards[0].Type != "member" {
+		t.Fatalf("rewards = %+v, want two entries with epoch 500 member first", rh.Rewards)
+	}
+	if !rh.Provisional {
+		t.Fatalf("rewards should be provisional: %+v", rh)
+	}
+
+	// Stake key not yet on chain (ErrNotFound) → empty history, no error.
+	fc = &fakeChain{rewardsErr: chain.ErrNotFound}
+	s = NewService(fc)
+	if _, err := s.SetWallet(testMnemonic, "preview", 3); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	rh, err = s.Rewards(context.Background())
+	if err != nil {
+		t.Fatalf("Rewards on empty account: %v", err)
+	}
+	if len(rh.Rewards) != 0 {
+		t.Fatalf("rewards on empty account = %+v, want empty", rh.Rewards)
 	}
 }
 

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -5,6 +5,7 @@ import type {
   Tx,
   TxDetail,
   DelegationView,
+  RewardHistory,
   Preview,
   TxResult,
   SendRequest,
@@ -183,6 +184,7 @@ export const getTransactions = () => apiGet<Tx[]>("/wallet/transactions");
 export const getTransactionDetail = (hash: string) =>
   apiGet<TxDetail>(`/wallet/transactions/${encodeURIComponent(hash)}`);
 export const getDelegation = () => apiGet<DelegationView>("/wallet/delegation");
+export const getRewards = () => apiGet<RewardHistory>("/wallet/rewards");
 export const buildSend = (req: SendRequest) => apiPost<Preview>("/wallet/send", req);
 export const confirmSend = (id: string, password: string) =>
   apiPost<TxResult>(`/wallet/send/${encodeURIComponent(id)}/confirm`, { password });

--- a/ui/web/src/api/hooks.ts
+++ b/ui/web/src/api/hooks.ts
@@ -5,6 +5,7 @@ import type {
   AddressView,
   Tx,
   DelegationView,
+  RewardHistory,
   VaultStatus,
   HistoryExpirySetting,
   AutoLockSetting,
@@ -22,6 +23,7 @@ import {
   getAddresses,
   getTransactions,
   getDelegation,
+  getRewards,
   getHistoryExpiry,
   getAutoLock,
   getTPMStatus,
@@ -146,6 +148,7 @@ export const useBalance = (): AsyncState<Balance> => useAsync(getBalance);
 export const useAddresses = (): AsyncState<AddressView> => useAsync(getAddresses);
 export const useTransactions = (): AsyncState<Tx[]> => useAsync(getTransactions);
 export const useDelegation = (): AsyncState<DelegationView> => useAsync(getDelegation);
+export const useRewards = (): AsyncState<RewardHistory> => useAsync(getRewards);
 export const useHistoryExpiry = (): AsyncState<HistoryExpirySetting> => useAsync(getHistoryExpiry);
 export const useAutoLock = (): AsyncState<AutoLockSetting> => useAsync(getAutoLock);
 export const useTPMStatus = (): AsyncState<TPMStatus> => useAsync(getTPMStatus);

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -103,6 +103,21 @@ export interface DelegationView {
   note: string;
 }
 
+// One epoch's stake reward (amount is a decimal lovelace STRING; type is
+// "member"/"leader" when the node reports it).
+export interface RewardEntry {
+  epoch: number;
+  amount: string;
+  pool_id: string;
+  type?: string;
+}
+
+export interface RewardHistory {
+  rewards: RewardEntry[];
+  provisional: boolean;
+  note: string;
+}
+
 // spend: quantity / lovelace are decimal STRINGS (uint64 server-side), matching
 // the read side — so values beyond the JS safe-integer range (2^53) survive the
 // JSON round-trip without being silently rounded.

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -21,6 +21,7 @@ import { Send } from "./screens/Send";
 import { Swap } from "./screens/Swap";
 import { Contacts } from "./screens/Contacts";
 import { Staking } from "./screens/Staking";
+import { RewardHistory } from "./screens/RewardHistory";
 import { SignMessage } from "./screens/SignMessage";
 import { VerifyMessage } from "./screens/VerifyMessage";
 import { Offline } from "./screens/Offline";
@@ -66,6 +67,7 @@ const NAV: { key: string; label: string }[] = [
   { key: "swap", label: "Swap" },
   { key: "contacts", label: "Contacts" },
   { key: "staking", label: "Staking" },
+  { key: "rewards", label: "Rewards" },
   { key: "sign", label: "Sign" },
   { key: "verify", label: "Verify" },
   { key: "offline", label: "Offline" },
@@ -274,6 +276,7 @@ export function App() {
     else if (route === "send" && canSend) activeRoute = "send";
     else if (route === "swap" && canSwap) activeRoute = "swap";
     else if (route === "staking" && canStake) activeRoute = "staking";
+    else if (route === "rewards") activeRoute = "rewards";
     else if (route === "sign" && canSign) activeRoute = "sign";
     else if (route === "verify") activeRoute = "verify";
     else if (route === "offline" && canSign) activeRoute = "offline";
@@ -327,6 +330,11 @@ export function App() {
     // spending-enabled wallet. A read-only or unsynced wallet falls back to
     // Portfolio.
     content = canStake ? <Staking network={activeWallet.network} /> : <Portfolio />;
+  } else if (route === "rewards") {
+    // Read-only per-epoch reward history for the active wallet's stake
+    // address. Node-local read (no signing, no spend), so it is available to
+    // any active wallet; the pool explorer links need the wallet's network.
+    content = <RewardHistory network={activeWallet.network} />;
   } else if (route === "sign") {
     content = canSign ? <SignMessage account={toAccount(activeWallet)} /> : <Portfolio />;
   } else if (route === "verify") {

--- a/ui/web/src/screens/RewardHistory.test.tsx
+++ b/ui/web/src/screens/RewardHistory.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/react";
+import { RewardHistory } from "./RewardHistory";
+import * as hooks from "../api/hooks";
+import type { RewardHistory as RewardHistoryData, RewardEntry } from "../api/types";
+
+const REWARD1: RewardEntry = {
+  epoch: 500,
+  amount: "1234567",
+  pool_id: "pool1abcdefghijklmnopqrstuvwxyz0123456789abcdefghij",
+  type: "member",
+};
+
+const REWARD2: RewardEntry = {
+  epoch: 502,
+  amount: "9876543",
+  pool_id: "pool1abcdefghijklmnopqrstuvwxyz0123456789abcdefghij",
+  type: "member",
+};
+
+function mockRewards(data: Partial<RewardHistoryData> | null, over: Partial<{ loading: boolean; error: Error | null }> = {}) {
+  vi.spyOn(hooks, "useRewards").mockReturnValue({
+    data: data
+      ? { rewards: [], provisional: false, note: "", ...data }
+      : null,
+    error: over.error ?? null,
+    loading: over.loading ?? false,
+    refresh: vi.fn(),
+    setData: vi.fn(),
+  } as never);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("(a) renders an epoch row per reward, newest epoch first", () => {
+  mockRewards({ rewards: [REWARD1, REWARD2], provisional: true, note: "provisional" });
+  render(<RewardHistory network="preview" />);
+
+  const cells = screen.getAllByRole("cell");
+  // First data cell of the first row is the newest epoch (502).
+  expect(cells[0]).toHaveTextContent("502");
+  expect(screen.getByText("500")).toBeInTheDocument();
+});
+
+test("(b) formats reward amounts as ADA", () => {
+  mockRewards({ rewards: [REWARD1] });
+  render(<RewardHistory network="preview" />);
+  // 1234567 lovelace → 1.234567 ADA. With a single reward the per-epoch row
+  // and the total banner both show this value, so it appears twice.
+  expect(screen.getAllByText(/1\.234567 ADA/).length).toBe(2);
+});
+
+test("(b2) sums reward amounts into the total banner", () => {
+  mockRewards({ rewards: [REWARD1, REWARD2] });
+  render(<RewardHistory network="preview" />);
+  // 1234567 + 9876543 = 11111110 lovelace → 11.11111 ADA
+  expect(screen.getByText(/11\.11111 ADA/)).toBeInTheDocument();
+});
+
+test("(c) shows the provisional note when present", () => {
+  mockRewards({ rewards: [REWARD1], provisional: true, note: "rewards are provisional" });
+  render(<RewardHistory network="preview" />);
+  expect(screen.getByText("rewards are provisional")).toBeInTheDocument();
+});
+
+test("(d) shows an empty state when there are no rewards", () => {
+  mockRewards({ rewards: [] });
+  render(<RewardHistory network="preview" />);
+  expect(screen.getByText("No rewards yet")).toBeInTheDocument();
+});
+
+test("(d2) shows the provisional note on an empty provisional result", () => {
+  mockRewards({ rewards: [], provisional: true, note: "rewards are provisional" });
+  render(<RewardHistory network="preview" />);
+  expect(screen.getByText("No rewards yet")).toBeInTheDocument();
+  expect(screen.getByText("rewards are provisional")).toBeInTheDocument();
+});
+
+test("(e) shows a loading state", () => {
+  mockRewards(null, { loading: true });
+  render(<RewardHistory network="preview" />);
+  expect(screen.getByText("Loading…")).toBeInTheDocument();
+});
+
+test("(f) shows an error state", () => {
+  mockRewards(null, { error: new Error("node unavailable") });
+  render(<RewardHistory network="preview" />);
+  expect(screen.getByRole("alert")).toHaveTextContent("node unavailable");
+});

--- a/ui/web/src/screens/RewardHistory.tsx
+++ b/ui/web/src/screens/RewardHistory.tsx
@@ -1,0 +1,105 @@
+import { useMemo } from "react";
+import { useRewards } from "../api/hooks";
+import type { RewardEntry } from "../api/types";
+import { Table } from "../components/Table";
+import { CopyButton } from "../components/CopyButton";
+import { ExplorerLink } from "../components/ExplorerLink";
+import { formatAda } from "../format";
+
+interface RewardHistoryProps {
+  // Optional so no-prop callers/tests keep working; the app always passes the
+  // active wallet's real network so the pool explorer links resolve.
+  network?: string;
+}
+
+/** Truncate a bech32 pool id for display: first 10 … last 6 chars. */
+function truncatePool(id: string): string {
+  if (id.length <= 20) return id;
+  return id.slice(0, 10) + "…" + id.slice(-6);
+}
+
+/** Sum reward amounts (decimal lovelace strings) with BigInt precision. */
+function totalLovelace(rewards: RewardEntry[]): string {
+  let sum = 0n;
+  for (const r of rewards) {
+    if (/^\d+$/.test(r.amount)) sum += BigInt(r.amount);
+  }
+  return sum.toString();
+}
+
+export function RewardHistory({ network = "preview" }: RewardHistoryProps = {}) {
+  const rewards = useRewards();
+
+  const list = useMemo(() => {
+    const rows = rewards.data?.rewards ?? [];
+    // Node returns oldest-first; show newest epoch first, like Activity.
+    return [...rows].sort((a, b) => b.epoch - a.epoch);
+  }, [rewards.data]);
+
+  if (rewards.loading) {
+    return <p>Loading…</p>;
+  }
+
+  if (rewards.error) {
+    return (
+      <p role="alert" className="error-text">
+        {rewards.error.message}
+      </p>
+    );
+  }
+
+  if (list.length === 0) {
+    return (
+      <div className="reward-history">
+        <p className="muted">No rewards yet</p>
+        {rewards.data?.provisional && rewards.data.note && (
+          <p className="helper-text">{rewards.data.note}</p>
+        )}
+      </div>
+    );
+  }
+
+  const columns = [
+    { key: "epoch", label: "Epoch" },
+    { key: "amount", label: "Reward" },
+    { key: "type", label: "Type" },
+    { key: "pool", label: "Pool" },
+  ];
+
+  const rows = list.map((r) => ({
+    epoch: r.epoch,
+    amount: <span className="mono">{formatAda(r.amount)} ADA</span>,
+    type: r.type ? r.type : <span className="muted">—</span>,
+    pool: r.pool_id ? (
+      <span className="hash-cell">
+        <span className="mono">{truncatePool(r.pool_id)}</span>
+        <CopyButton value={r.pool_id} />
+        <ExplorerLink
+          network={network}
+          kind="pool"
+          id={r.pool_id}
+          label={`View pool ${truncatePool(r.pool_id)} on block explorer`}
+        />
+      </span>
+    ) : (
+      <span className="muted">—</span>
+    ),
+  }));
+
+  const total = totalLovelace(list);
+
+  return (
+    <div className="reward-history">
+      <div className="reward-summary">
+        <span className="field-label">Total rewards</span>
+        <span className="total-accent mono">{formatAda(total)} ADA</span>
+      </div>
+
+      <Table columns={columns} rows={rows} />
+
+      {rewards.data?.provisional && rewards.data.note && (
+        <p className="helper-text">{rewards.data.note}</p>
+      )}
+    </div>
+  );
+}

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -260,6 +260,7 @@ a:hover {
 .portfolio,
 .receive,
 .activity,
+.reward-history,
 .staking,
 .screen-settings,
 .send-form,
@@ -1335,6 +1336,14 @@ a:hover {
 }
 .activity-filters select.field {
   flex: 0 1 180px;
+}
+
+/* Reward-history summary: total rewards banner above the per-epoch table. */
+.reward-summary {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
 }
 
 /* Direction indicator: a small arrow + label, color-coded like a ledger


### PR DESCRIPTION
Read-only per-epoch stake reward history for the active wallet, read node-locally through the existing chain client (no external calls).

## Backend
- `GET /wallet/rewards` (gated, node-local) returns `{ rewards[], provisional, note }` for the active wallet's stake address.
- `wallet.Service.Rewards` + `RewardHistory` / `RewardEntry` types over the chain client's existing `AccountRewards` fetch; `ErrNotFound` yields an empty history.
- `chain.Reward` gains an optional `type` field (member/leader when the node reports it).
- Registered in `ui/internal/api/api.go`; `Rewards` added to the `Wallet` interface.

## Frontend
- New Reward history screen (`ui/web/src/screens/RewardHistory.tsx`) + `rewards` nav route in `ui/web/src/app.tsx`.
- Per-epoch table (epoch, reward, type, pool) with total, pool explorer links, and loading/empty/error states.
- `getRewards` client fn, `useRewards` hook, `RewardHistory` / `RewardEntry` types.

## Tests
- Go: `TestWalletRewardsPopulated`, `TestWalletRewardsEmptyAndNoWallet` (handler, via `localReq`), `TestServiceRewards` (service).
- Frontend: `ui/web/src/screens/RewardHistory.test.tsx` (rows/order, ADA formatting, total, provisional note, empty/loading/error).

## Files
- `ui/internal/chain/blockfrost.go`
- `ui/internal/wallet/service.go`, `ui/internal/wallet/service_test.go`
- `ui/internal/api/api.go`, `ui/internal/api/api_test.go`
- `ui/internal/connector/backend_test.go`
- `ui/web/src/api/{client.ts,hooks.ts,types.ts}`
- `ui/web/src/app.tsx`, `ui/web/src/styles/global.css`
- `ui/web/src/screens/RewardHistory.tsx`, `ui/web/src/screens/RewardHistory.test.tsx`

## Screenshots
Reward history screen (preview network, unlocked wallet):

![Reward history](https://raw.githubusercontent.com/blinklabs-io/bursa/ci/screenshots/screenshots/pr-644/reward-history.png)
