### PR TITLE
feat(ui): read-only stake-pool directory (browse/search pools for delegation)

### DIFF
--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -98,6 +98,9 @@ type Spender interface {
 // touches the network; *chain.Client satisfies this interface.
 type NodeLookup interface {
 	Pool(ctx context.Context, poolID string) (chain.PoolInfo, error)
+	// Pools returns the node's full stake-pool directory (from
+	// /pools/extended) for the read-only browse/search screen.
+	Pools(ctx context.Context) ([]chain.PoolInfo, error)
 	DRep(ctx context.Context, drepID string) (chain.DRepInfo, error)
 	AssetAddresses(ctx context.Context, asset string) ([]chain.AssetAddress, error)
 	// Asset returns on-chain identity/metadata for a native asset (unit =
@@ -1157,6 +1160,29 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 		serve(w, v, err)
 	}))
 
+	// Read-only stake-pool directory: browse/search the pools the node has
+	// indexed (from /pools/extended) for delegation. Node-local like the DEX
+	// pools list — nothing leaves 127.0.0.1 — so there is deliberately NO
+	// external-consent gate; it is gated like other reads (a queryable node).
+	// Search (q) and pagination (page/count) are applied server-side over the
+	// node's list. This is a DIFFERENT surface from /wallet/dex/pools (AMM
+	// liquidity pools).
+	mux.HandleFunc("GET /wallet/pools", gated(st, func(w http.ResponseWriter, r *http.Request) {
+		if lookup == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "pool directory unavailable"})
+			return
+		}
+		pools, err := lookup.Pools(r.Context())
+		if err != nil {
+			serveLookup(w, poolDirectoryResponse{}, err)
+			return
+		}
+		q := r.URL.Query()
+		writeJSON(w, http.StatusOK, filterAndPagePools(
+			pools, q.Get("q"), q.Get("page"), q.Get("count"),
+		))
+	}))
+
 	// Staking & governance. Pool/DRep lookups verify a pasted ID through the node
 	// (gated like reads — they only need the node serving queries). Building a
 	// delegation tx and confirming it are gated like sends (a fully synced node),
@@ -1386,6 +1412,68 @@ func serveLookup[T any](w http.ResponseWriter, v T, err error) {
 	default:
 		writeJSON(w, http.StatusBadGateway, errBody(err))
 	}
+}
+
+// poolDirectoryResponse is the GET /wallet/pools response: one page of the
+// node's stake-pool directory plus the total number of pools that matched the
+// search, so the client can page through them.
+type poolDirectoryResponse struct {
+	Pools []chain.PoolInfo `json:"pools"`
+	Total int              `json:"total"`
+	Page  int              `json:"page"`
+	Count int              `json:"count"`
+}
+
+const (
+	poolDirDefaultCount = 50
+	poolDirMaxCount     = 200
+)
+
+// filterAndPagePools applies the read-only directory's server-side search and
+// pagination over the node's full pool list. The search (q) is a
+// case-insensitive substring match against the pool's bech32 ID and hex ID —
+// the identity fields the node's /pools/extended list exposes. page is 1-based;
+// count is clamped to [1, poolDirMaxCount]. Invalid/absent page or count fall
+// back to their defaults rather than erroring.
+func filterAndPagePools(pools []chain.PoolInfo, q, pageStr, countStr string) poolDirectoryResponse {
+	needle := strings.ToLower(strings.TrimSpace(q))
+	matched := make([]chain.PoolInfo, 0, len(pools))
+	for _, p := range pools {
+		if needle == "" ||
+			strings.Contains(strings.ToLower(p.PoolID), needle) ||
+			strings.Contains(strings.ToLower(p.Hex), needle) {
+			matched = append(matched, p)
+		}
+	}
+
+	count := poolDirDefaultCount
+	if n, err := strconv.Atoi(countStr); err == nil && n > 0 {
+		count = n
+	}
+	if count > poolDirMaxCount {
+		count = poolDirMaxCount
+	}
+	page := 1
+	if n, err := strconv.Atoi(pageStr); err == nil && n > 1 {
+		page = n
+	}
+
+	total := len(matched)
+	// (page-1)*count can overflow to a negative int for a very large page, so
+	// clamp start on both sides before slicing to avoid an out-of-range panic.
+	start := (page - 1) * count
+	if start < 0 || start > total {
+		start = total
+	}
+	end := start + count
+	if end < start || end > total {
+		end = total
+	}
+	pageItems := matched[start:end]
+	if pageItems == nil {
+		pageItems = []chain.PoolInfo{}
+	}
+	return poolDirectoryResponse{Pools: pageItems, Total: total, Page: page, Count: count}
 }
 
 // registerPoolRoutes wires the Stake Pool Operations (SPO) endpoints under

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -466,10 +466,12 @@ func (f *fakeVault) DisableTPM(password string) error {
 // fakeLookup implements the api.NodeLookup interface (pool/DRep/asset
 // node-verified lookups) for handler tests.
 type fakeLookup struct {
-	pool    chain.PoolInfo
-	poolErr error
-	drep    chain.DRepInfo
-	drepErr error
+	pool     chain.PoolInfo
+	poolErr  error
+	pools    []chain.PoolInfo
+	poolsErr error
+	drep     chain.DRepInfo
+	drepErr  error
 
 	asset    chain.AssetInfo
 	assetErr error
@@ -478,6 +480,10 @@ type fakeLookup struct {
 
 func (f *fakeLookup) Pool(_ context.Context, _ string) (chain.PoolInfo, error) {
 	return f.pool, f.poolErr
+}
+
+func (f *fakeLookup) Pools(_ context.Context) ([]chain.PoolInfo, error) {
+	return f.pools, f.poolsErr
 }
 
 func (f *fakeLookup) DRep(_ context.Context, _ string) (chain.DRepInfo, error) {
@@ -491,6 +497,116 @@ func (f *fakeLookup) AssetAddresses(_ context.Context, _ string) ([]chain.AssetA
 func (f *fakeLookup) Asset(_ context.Context, unit string) (chain.AssetInfo, error) {
 	f.gotUnit = unit
 	return f.asset, f.assetErr
+}
+
+// poolDirectoryResult mirrors the GET /wallet/pools JSON response for tests.
+type poolDirectoryResult struct {
+	Pools []chain.PoolInfo `json:"pools"`
+	Total int              `json:"total"`
+	Page  int              `json:"page"`
+	Count int              `json:"count"`
+}
+
+func decodePoolDirectory(t *testing.T, rec *httptest.ResponseRecorder) poolDirectoryResult {
+	t.Helper()
+	var got poolDirectoryResult
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return got
+}
+
+func TestGetPoolDirectory(t *testing.T) {
+	lookup := &fakeLookup{pools: []chain.PoolInfo{
+		{PoolID: "pool1aaa", Hex: "aa", LiveStake: "5000000000", MarginCost: 0.05, LiveSaturation: 0.42},
+		{PoolID: "pool1bbb", Hex: "bb", LiveStake: "9000000000", MarginCost: 0.02, LiveSaturation: 0.90},
+	}}
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lookup, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/pools", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /wallet/pools = %d, want 200", rec.Code)
+	}
+	got := decodePoolDirectory(t, rec)
+	if got.Total != 2 || len(got.Pools) != 2 || got.Page != 1 {
+		t.Fatalf("directory = %+v, want 2 pools on page 1", got)
+	}
+	if got.Pools[1].PoolID != "pool1bbb" || got.Pools[1].LiveSaturation != 0.90 {
+		t.Fatalf("pool[1] = %+v, want pool1bbb with saturation 0.90", got.Pools[1])
+	}
+}
+
+func TestGetPoolDirectorySearchFilter(t *testing.T) {
+	lookup := &fakeLookup{pools: []chain.PoolInfo{
+		{PoolID: "pool1aaa", Hex: "aa"},
+		{PoolID: "pool1bbb", Hex: "bb"},
+	}}
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lookup, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/pools?q=BBB", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /wallet/pools?q=BBB = %d, want 200", rec.Code)
+	}
+	got := decodePoolDirectory(t, rec)
+	if got.Total != 1 || len(got.Pools) != 1 || got.Pools[0].PoolID != "pool1bbb" {
+		t.Fatalf("filtered directory = %+v, want only pool1bbb", got)
+	}
+}
+
+func TestGetPoolDirectoryEmpty(t *testing.T) {
+	lookup := &fakeLookup{pools: nil}
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lookup, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/pools", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /wallet/pools = %d, want 200", rec.Code)
+	}
+	got := decodePoolDirectory(t, rec)
+	if got.Total != 0 || len(got.Pools) != 0 {
+		t.Fatalf("empty directory = %+v, want 0 pools", got)
+	}
+}
+
+func TestGetPoolDirectoryPageOverflow(t *testing.T) {
+	lookup := &fakeLookup{pools: []chain.PoolInfo{
+		{PoolID: "pool1aaa", Hex: "aa"},
+		{PoolID: "pool1bbb", Hex: "bb"},
+	}}
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, lookup, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		// (page-1)*count overflows int64 to a negative start; must not panic.
+		{"overflow", "/wallet/pools?page=9223372036854775807&count=50"},
+		// One page past the end: a valid but empty page.
+		{"just-past-end", "/wallet/pools?page=2&count=50"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, localReq(http.MethodGet, tc.path, nil))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("GET %s = %d, want 200", tc.path, rec.Code)
+			}
+			got := decodePoolDirectory(t, rec)
+			if got.Total != 2 || len(got.Pools) != 0 {
+				t.Fatalf("overflow page = %+v, want total 2 with an empty page", got)
+			}
+		})
+	}
+}
+
+func TestGetPoolDirectoryNilLookup(t *testing.T) {
+	h := NewHandler(readyStatuser(), &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/pools", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /wallet/pools with nil lookup = %d, want 503", rec.Code)
+	}
 }
 
 func (f *fakeVault) AddHardwareWallet(name, accountXpubBech32, network, vaultPw string, accountIndex uint32, _ int) (vault.WalletMeta, error) {
@@ -3076,6 +3192,10 @@ type fakeNodeLookup struct {
 
 func (f *fakeNodeLookup) Pool(_ context.Context, _ string) (chain.PoolInfo, error) {
 	return f.pool, f.poolErr
+}
+
+func (f *fakeNodeLookup) Pools(_ context.Context) ([]chain.PoolInfo, error) {
+	return nil, chain.ErrNotFound
 }
 
 func (f *fakeNodeLookup) DRep(_ context.Context, _ string) (chain.DRepInfo, error) {

--- a/ui/internal/chain/blockfrost.go
+++ b/ui/internal/chain/blockfrost.go
@@ -159,6 +159,10 @@ type PoolInfo struct {
 	DeclaredPledge string  `json:"declared_pledge"`
 	FixedCost      string  `json:"fixed_cost"`
 	MarginCost     float64 `json:"margin_cost"`
+	// LiveSaturation is the pool's live stake as a fraction of the saturation
+	// point (1.0 = fully saturated), as reported by /pools/extended. It is 0
+	// when the node's list omits it.
+	LiveSaturation float64 `json:"live_saturation"`
 }
 
 // ProtocolParams holds the protocol parameters the wallet needs for delegation:
@@ -583,6 +587,15 @@ func (c *Client) Pool(ctx context.Context, poolID string) (PoolInfo, error) {
 		}
 	}
 	return PoolInfo{}, fmt.Errorf("%w: /api/v0/pools/extended exceeded %d pages", errPageLimitExceeded, maxPages)
+}
+
+// Pools returns the full stake-pool directory the node has indexed, drawn from
+// the paginated GET /api/v0/pools/extended list (the same source Pool filters).
+// It is used by the read-only pool-directory browser; the per-page cache Pool
+// maintains is deliberately not consulted or populated here, since the directory
+// wants the complete list rather than a single lookup.
+func (c *Client) Pools(ctx context.Context) ([]PoolInfo, error) {
+	return getAllPages[PoolInfo](ctx, c, "/api/v0/pools/extended")
 }
 
 func (c *Client) cachedPool(poolID string) (PoolInfo, bool, bool) {

--- a/ui/internal/chain/blockfrost_test.go
+++ b/ui/internal/chain/blockfrost_test.go
@@ -472,6 +472,29 @@ func TestPoolNotInList(t *testing.T) {
 	}
 }
 
+func TestPoolsReturnsFullList(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v0/pools/extended" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"pool_id":"pool1aaa","hex":"aa","margin_cost":0.05,"live_stake":"5000000000","live_saturation":0.42},
+			{"pool_id":"pool1bbb","hex":"bb","margin_cost":0.02,"live_stake":"9000000000","live_saturation":0.90}
+		]`))
+	})
+	got, err := c.Pools(context.Background())
+	if err != nil {
+		t.Fatalf("Pools: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("Pools returned %d pools, want 2", len(got))
+	}
+	if got[1].PoolID != "pool1bbb" || got[1].LiveSaturation != 0.90 || got[1].LiveStake != "9000000000" {
+		t.Fatalf("pool[1] = %+v, want pool1bbb / saturation 0.90 / live 9000000000", got[1])
+	}
+}
+
 func TestDRep(t *testing.T) {
 	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {

--- a/ui/web/src/api/client.ts
+++ b/ui/web/src/api/client.ts
@@ -27,6 +27,7 @@ import type {
   SignTxRequest,
   SubmitSignedRequest,
   PoolInfo,
+  PoolDirectoryResponse,
   DRepInfo,
   AssetInfo,
   DelegationRequest,
@@ -223,6 +224,18 @@ export const resolveHandle = (name: string) =>
 // through the same Confirm path the send flow uses.
 export const getPool = (id: string) => apiGet<PoolInfo>(`/wallet/pool/${encodeURIComponent(id)}`);
 export const getDRep = (id: string) => apiGet<DRepInfo>(`/wallet/drep/${encodeURIComponent(id)}`);
+
+// Read-only stake-pool directory (node-local; distinct from the DEX AMM pools).
+// Browse/search the pools the node has indexed, for delegation. Search (q) and
+// pagination (page/count) are applied server-side over the node's list.
+export const getPoolDirectory = (params?: { q?: string; page?: number; count?: number }) => {
+  const qs = new URLSearchParams();
+  if (params?.q) qs.set("q", params.q);
+  if (params?.page && params.page > 1) qs.set("page", String(params.page));
+  if (params?.count) qs.set("count", String(params.count));
+  const suffix = qs.toString() ? `?${qs.toString()}` : "";
+  return apiGet<PoolDirectoryResponse>(`/wallet/pools${suffix}`);
+};
 
 // Native-asset on-chain metadata (node-only; see ../tokenMeta.ts for how the
 // Portfolio screen interprets it, with a fallback when it's absent).

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -235,8 +235,10 @@ export interface SubmitSignedRequest {
 
 // --- staking & governance ---
 
-// PoolInfo mirrors GET /wallet/pool/{id}: a node-verified stake pool readout.
-// margin_cost is a fraction (0.02 = 2%); the lovelace fields are decimal strings.
+// PoolInfo mirrors GET /wallet/pool/{id} and one entry of the GET /wallet/pools
+// directory: a node-verified stake pool readout. margin_cost / live_saturation
+// are fractions (0.02 = 2%, 1.0 = fully saturated); the lovelace fields are
+// decimal strings.
 export interface PoolInfo {
   pool_id: string;
   hex: string;
@@ -246,6 +248,19 @@ export interface PoolInfo {
   declared_pledge: string;
   fixed_cost: string;
   margin_cost: number;
+  live_saturation: number;
+}
+
+// PoolDirectoryResponse mirrors GET /wallet/pools: one page of the node's
+// stake-pool directory (from /pools/extended) plus the total number of pools
+// matching the search, for the read-only browse/search screen. This is the
+// stake-pool directory for delegation — distinct from the DEX AMM pools
+// (DexPoolsResponse).
+export interface PoolDirectoryResponse {
+  pools: PoolInfo[];
+  total: number;
+  page: number;
+  count: number;
 }
 
 // DRepInfo mirrors GET /wallet/drep/{id}: confirms a DRep exists on chain.

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -22,6 +22,7 @@ import { Swap } from "./screens/Swap";
 import { Contacts } from "./screens/Contacts";
 import { Staking } from "./screens/Staking";
 import { RewardHistory } from "./screens/RewardHistory";
+import { PoolDirectory } from "./screens/PoolDirectory";
 import { SignMessage } from "./screens/SignMessage";
 import { VerifyMessage } from "./screens/VerifyMessage";
 import { Offline } from "./screens/Offline";
@@ -68,6 +69,7 @@ const NAV: { key: string; label: string }[] = [
   { key: "contacts", label: "Contacts" },
   { key: "staking", label: "Staking" },
   { key: "rewards", label: "Rewards" },
+  { key: "pools", label: "Stake Pools" },
   { key: "sign", label: "Sign" },
   { key: "verify", label: "Verify" },
   { key: "offline", label: "Offline" },
@@ -277,6 +279,7 @@ export function App() {
     else if (route === "swap" && canSwap) activeRoute = "swap";
     else if (route === "staking" && canStake) activeRoute = "staking";
     else if (route === "rewards") activeRoute = "rewards";
+    else if (route === "pools" && canQueryNode) activeRoute = "pools";
     else if (route === "sign" && canSign) activeRoute = "sign";
     else if (route === "verify") activeRoute = "verify";
     else if (route === "offline" && canSign) activeRoute = "offline";
@@ -335,6 +338,12 @@ export function App() {
     // address. Node-local read (no signing, no spend), so it is available to
     // any active wallet; the pool explorer links need the wallet's network.
     content = <RewardHistory network={activeWallet.network} />;
+  } else if (route === "pools") {
+    // Read-only stake-pool directory: browse/search pools the node has indexed.
+    // Needs only a queryable node (not a full sync, no spending), so it works
+    // for any active wallet — including read-only ones. Falls back to Portfolio
+    // while the node cannot serve queries.
+    content = canQueryNode ? <PoolDirectory network={activeWallet.network} /> : <Portfolio />;
   } else if (route === "sign") {
     content = canSign ? <SignMessage account={toAccount(activeWallet)} /> : <Portfolio />;
   } else if (route === "verify") {
@@ -384,6 +393,7 @@ export function App() {
       (key === "send" && !canSend) ||
       (key === "swap" && !canSwap) ||
       (key === "staking" && !canStake) ||
+      (key === "pools" && !canQueryNode) ||
       (key === "sign" && !canSign) ||
       (key === "offline" && !canSign) ||
       (key === "operate" && !canSign) ||

--- a/ui/web/src/screens/PoolDirectory.test.tsx
+++ b/ui/web/src/screens/PoolDirectory.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { PoolDirectory } from "./PoolDirectory";
+import * as client from "../api/client";
+import type { PoolInfo, PoolDirectoryResponse } from "../api/types";
+
+const POOL_A: PoolInfo = {
+  pool_id: "pool1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0001",
+  hex: "aa",
+  vrf_key: "",
+  active_stake: "4800000000",
+  live_stake: "5000000000",
+  declared_pledge: "100000000",
+  fixed_cost: "340000000",
+  margin_cost: 0.05,
+  live_saturation: 0.42,
+};
+
+const POOL_B: PoolInfo = {
+  pool_id: "pool1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0002",
+  hex: "bb",
+  vrf_key: "",
+  active_stake: "8800000000",
+  live_stake: "9000000000",
+  declared_pledge: "200000000",
+  fixed_cost: "170000000",
+  margin_cost: 0.02,
+  live_saturation: 0.9,
+};
+
+function directory(pools: PoolInfo[], overrides?: Partial<PoolDirectoryResponse>): PoolDirectoryResponse {
+  return { pools, total: pools.length, page: 1, count: 50, ...overrides };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("lists stake pools read from the node with formatted margin/pledge/saturation", async () => {
+  vi.spyOn(client, "getPoolDirectory").mockResolvedValue(directory([POOL_A, POOL_B]));
+
+  render(<PoolDirectory network="preview" />);
+
+  // margin 0.05 → 5.0%, saturation 0.42 → 42.0%, pledge/live in ADA.
+  expect(await screen.findByText("5.0%")).toBeInTheDocument();
+  expect(screen.getByText("42.0%")).toBeInTheDocument();
+  expect(screen.getByText("100")).toBeInTheDocument(); // 100000000 lovelace pledge → 100 ADA
+  expect(screen.getByText("5000")).toBeInTheDocument(); // 5000000000 → 5000 ADA
+  // Copy affordance carries the full (untruncated) pool id.
+  expect(
+    screen.getByRole("button", { name: `Copy pool id ${POOL_A.pool_id}` }),
+  ).toBeInTheDocument();
+});
+
+test("search box queries the node server-side with the typed term", async () => {
+  const getPoolDirectory = vi
+    .spyOn(client, "getPoolDirectory")
+    .mockResolvedValue(directory([POOL_A, POOL_B]));
+
+  render(<PoolDirectory network="preview" />);
+  await screen.findByText("5.0%");
+
+  getPoolDirectory.mockResolvedValue(directory([POOL_B]));
+  fireEvent.change(screen.getByLabelText(/search by pool id/i), {
+    target: { value: "bbb" },
+  });
+
+  await waitFor(() =>
+    expect(getPoolDirectory).toHaveBeenLastCalledWith({ q: "bbb", page: 1 }),
+  );
+  await waitFor(() =>
+    expect(
+      screen.getByRole("button", { name: `Copy pool id ${POOL_B.pool_id}` }),
+    ).toBeInTheDocument(),
+  );
+});
+
+test("shows an empty-search message when nothing matches", async () => {
+  vi.spyOn(client, "getPoolDirectory").mockResolvedValue(directory([], { total: 0 }));
+
+  render(<PoolDirectory network="preview" />);
+  // With no query typed, the generic empty state shows.
+  expect(await screen.findByText(/no pools found/i)).toBeInTheDocument();
+});
+
+test("surfaces an API error", async () => {
+  vi.spyOn(client, "getPoolDirectory").mockRejectedValue(
+    new client.ApiError(503, "node not ready"),
+  );
+
+  render(<PoolDirectory network="preview" />);
+  expect(await screen.findByRole("alert")).toHaveTextContent(/node not ready/i);
+});

--- a/ui/web/src/screens/PoolDirectory.tsx
+++ b/ui/web/src/screens/PoolDirectory.tsx
@@ -1,0 +1,158 @@
+import { useState, useEffect } from "react";
+import type { PoolDirectoryResponse } from "../api/types";
+import { getPoolDirectory } from "../api/client";
+import { Card } from "../components/Card";
+import { Input } from "../components/Input";
+import { Button } from "../components/Button";
+import { Table } from "../components/Table";
+import { CopyButton } from "../components/CopyButton";
+import { ExplorerLink } from "../components/ExplorerLink";
+import { formatAda } from "../format";
+import { errorMessage } from "../errorMessage";
+
+// Debounce for the search box so each keystroke doesn't fire a request.
+const SEARCH_DEBOUNCE_MS = 250;
+
+// Percent display for a fraction (0.02 → "2.0%"). Non-finite/absent → "—".
+function pct(fraction: number): string {
+  if (!Number.isFinite(fraction)) return "—";
+  return `${(fraction * 100).toFixed(1)}%`;
+}
+
+// Truncate a long bech32 pool id in the middle so rows stay scannable.
+function shortId(id: string): string {
+  if (id.length <= 24) return id;
+  return `${id.slice(0, 14)}…${id.slice(-6)}`;
+}
+
+const POOL_COLUMNS = [
+  { key: "pool", label: "Pool ID" },
+  { key: "margin", label: "Margin" },
+  { key: "pledge", label: "Pledge (ADA)" },
+  { key: "live_stake", label: "Live stake (ADA)" },
+  { key: "saturation", label: "Saturation" },
+  { key: "actions", label: "" },
+];
+
+interface PoolDirectoryProps {
+  network: string;
+}
+
+// PoolDirectory is a read-only browse/search screen for the stake pools the
+// embedded node has indexed. Data comes entirely from the local node (no
+// external service), so it needs no consent gate. It does not delegate: copy a
+// pool ID and paste it into Staking to delegate to it.
+export function PoolDirectory({ network }: PoolDirectoryProps) {
+  const [query, setQuery] = useState("");
+  const [page, setPage] = useState(1);
+  const [data, setData] = useState<PoolDirectoryResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const q = query.trim();
+    let cancelled = false;
+    setLoading(true);
+    const timer = setTimeout(() => {
+      getPoolDirectory({ q, page })
+        .then((d) => {
+          if (!cancelled) {
+            setData(d);
+            setError(null);
+          }
+        })
+        .catch((e) => {
+          if (!cancelled) setError(errorMessage(e));
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [query, page]);
+
+  const pools = data?.pools ?? [];
+  const count = data?.count ?? 0;
+  const total = data?.total ?? 0;
+  const pageCount = count > 0 ? Math.ceil(total / count) : 1;
+  const hasPrev = page > 1;
+  const hasNext = page < pageCount;
+
+  const rows = pools.map((p) => ({
+    pool: (
+      <span className="pool-id-cell">
+        <code>{shortId(p.pool_id)}</code>
+        <ExplorerLink network={network} kind="pool" id={p.pool_id} />
+      </span>
+    ),
+    margin: pct(p.margin_cost),
+    pledge: formatAda(p.declared_pledge),
+    live_stake: formatAda(p.live_stake),
+    saturation: pct(p.live_saturation),
+    actions: <CopyButton value={p.pool_id} aria-label={`Copy pool id ${p.pool_id}`} />,
+  }));
+
+  return (
+    <div className="send-form">
+      <Card title="Stake Pool Directory">
+        <p className="helper-text">
+          Browse and search stake pools your embedded node has indexed — read
+          directly from the node, no external service is contacted. To delegate,
+          copy a pool ID and paste it into <strong>Staking</strong>.
+        </p>
+
+        <label htmlFor="pool-search">Search by pool ID</label>
+        <Input
+          id="pool-search"
+          type="text"
+          placeholder="pool1… or hex id"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setPage(1);
+          }}
+        />
+
+        {error && (
+          <p role="alert" className="error-text">
+            {error}
+          </p>
+        )}
+
+        {loading && !data ? (
+          <p className="muted">Reading pools from the local node…</p>
+        ) : rows.length === 0 ? (
+          <p className="muted">
+            {query.trim() ? "No pools match your search." : "No pools found."}
+          </p>
+        ) : (
+          <>
+            <Table columns={POOL_COLUMNS} rows={rows} />
+            <div className="pager">
+              <Button
+                variant="ghost"
+                disabled={!hasPrev}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+              >
+                Previous
+              </Button>
+              <span className="muted">
+                Page {page} of {pageCount} · {total} pool{total === 1 ? "" : "s"}
+              </span>
+              <Button
+                variant="ghost"
+                disabled={!hasNext}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next
+              </Button>
+            </div>
+          </>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/ui/web/src/screens/Staking.test.tsx
+++ b/ui/web/src/screens/Staking.test.tsx
@@ -13,6 +13,7 @@ const MOCK_POOL: PoolInfo = {
   declared_pledge: "100000000000",
   fixed_cost: "340000000",
   margin_cost: 0.02,
+  live_saturation: 0.42,
 };
 
 const MOCK_DREP: DRepInfo = {

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -543,6 +543,22 @@ a:hover {
   color: var(--accent);
 }
 
+/* Inline pool id + explorer link inside a directory table cell. */
+.pool-id-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+/* Pager for the stake-pool directory (Previous / status / Next). */
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
 /* ---------------------------------------------------------------- tables -- */
 .table-wrap {
   overflow-x: auto;


### PR DESCRIPTION
## Adds

- `GET /wallet/pools` — read-only stake-pool directory served from the embedded node (`/pools/extended`). Server-side search (`q`, case-insensitive over pool id + hex) and pagination (`page`/`count`, `count` capped at 200). Node-local, no external-consent gate. Separate from `/wallet/dex/pools`.
- `chain.Client.Pools` fetches the full `/pools/extended` list; `live_saturation` added to `chain.PoolInfo`.
- Stake Pools screen + nav route (`pools`): searchable, paginated table (pool id, margin, pledge, live stake, saturation) with per-row copy-id and public-explorer link; loading / empty / error states. Copy an ID to delegate via Staking.
- `getPoolDirectory` client fn + `PoolDirectoryResponse` type; `live_saturation` added to the `PoolInfo` type.

## Files

- `ui/internal/chain/blockfrost.go` (+ `blockfrost_test.go`)
- `ui/internal/api/api.go` (+ `api_test.go`)
- `ui/web/src/api/client.ts`, `ui/web/src/api/types.ts`
- `ui/web/src/screens/PoolDirectory.tsx` (+ `PoolDirectory.test.tsx`)
- `ui/web/src/app.tsx`, `ui/web/src/styles/global.css`
- `ui/web/src/screens/Staking.test.tsx` (fixture updated for the new field)

## Tests

- Go: `TestPoolsReturnsFullList`; `TestGetPoolDirectory`, `TestGetPoolDirectorySearchFilter`, `TestGetPoolDirectoryEmpty`, `TestGetPoolDirectoryNilLookup`.
- Frontend: `PoolDirectory.test.tsx` — populated list, server-side search, empty state, API error.

## Verify

- `ui/`: `go build ./...`, `go vet ./...`, `golangci-lint run ./cmd/... ./internal/...` (0 issues), `go test ./...` — pass.
- `ui/web`: `npm run lint`, `npm run type-check`, `npm test` (589 pass), `npm run build` — pass.
- root: `CGO_ENABLED=0 go build ./...` — pass.

## Screenshots

Stake Pool Directory (full list):

![Stake Pool Directory](https://raw.githubusercontent.com/blinklabs-io/bursa/ci/screenshots/screenshots/pr-645/pool-directory.png)

Search filter applied:

![Stake Pool Directory search](https://raw.githubusercontent.com/blinklabs-io/bursa/ci/screenshots/screenshots/pr-645/pool-directory-search.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only Stake Pools directory accessible from the application navigation.
  * Browse pools with searchable, paginated results.
  * View pool IDs, explorer links, margins, pledge, live stake, and saturation.
  * Copy pool identifiers directly from the directory.
* **Bug Fixes**
  * Added clear loading, empty-result, unavailable-service, and error states.
  * Improved handling of invalid pagination values and unavailable node lookup services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->