### PR TITLE
fix(ui): retry tx build when apollo hits the min-UTxO dust-change dead-zone

### DIFF
--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -504,8 +504,16 @@ func (s *Service) completeSend(
 // array(2) header (1) + bytes(32) (2+32) + bytes(64) (2+64) = 101 bytes, rounded
 // up to 102 to cover the per-element set overhead. Complete() leaves the witness
 // set empty (witnesses are attached later at Confirm/Sign time), so the size
-// guard projects the SIGNED size by adding one such witness per input.
+// guard projects the SIGNED size by adding one such witness per distinct signer.
 const vkeyWitnessSizeEstimate = 102
+
+// witnessSetOverhead covers the one-time CBOR framing that appears when the
+// empty witness set gains its first vkey-witness field: the witness-set map key
+// plus the vkey-witness array header. It is added once (not per witness), so a
+// transaction sitting a few bytes under MaxTxSize is not projected as fitting
+// when the signed form would just exceed it. 8 bytes is conservative — enough to
+// cover a multi-byte array-length header for large witness counts.
+const witnessSetOverhead = 8
 
 // completeForcingPrefix escapes the min-UTxO dust-change dead-zone by forcing a
 // growing, largest-first prefix of the wallet's UTxOs as explicit inputs,
@@ -550,7 +558,7 @@ func (s *Service) completeForcingPrefix(
 		// Converged on the minimal forced set. Reject it locally if signing it
 		// would exceed the chain's MaxTxSize, turning a would-be submit-time
 		// failure into a clear, pre-approval error.
-		if err := s.guardTxSize(a, utxoAddr); err != nil {
+		if err := s.guardTxSize(ctx, a, utxoAddr); err != nil {
 			return nil, err
 		}
 		return a, nil
@@ -570,8 +578,8 @@ func (s *Service) completeForcingPrefix(
 // in Confirm), not once per input, so the projection counts distinct signing
 // addresses via utxoAddr — inputs sharing an address share one witness. An input
 // whose address is unknown is conservatively assumed to need its own witness.
-func (s *Service) guardTxSize(a *apollo.Apollo, utxoAddr map[string]string) error {
-	pp, err := s.chain.ProtocolParams()
+func (s *Service) guardTxSize(ctx context.Context, a *apollo.Apollo, utxoAddr map[string]string) error {
+	pp, err := backend.ProtocolParamsContext(ctx, s.chain)
 	if err != nil {
 		return fmt.Errorf("protocol params: %w", err)
 	}
@@ -601,7 +609,10 @@ func (s *Service) guardTxSize(a *apollo.Apollo, utxoAddr map[string]string) erro
 	if missingWitnesses < 0 {
 		missingWitnesses = 0
 	}
-	signedSize := len(cborBytes) + missingWitnesses*vkeyWitnessSizeEstimate
+	signedSize := len(cborBytes)
+	if missingWitnesses > 0 {
+		signedSize += missingWitnesses*vkeyWitnessSizeEstimate + witnessSetOverhead
+	}
 	if signedSize > pp.MaxTxSize {
 		return fmt.Errorf(
 			"%w: transaction would exceed the maximum size (%d/%d bytes); reduce the amount or consolidate UTxOs",

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -407,6 +407,15 @@ func (s *Service) Build(ctx context.Context, req SendRequest) (Preview, error) {
 		}
 	}
 
+	// Reject locally if signing this would exceed the chain's MaxTxSize, turning a
+	// would-be submit-time rejection into a clear, pre-approval error. This covers
+	// BOTH paths: the forced-prefix retry can consume extra inputs, but an
+	// ordinary coin-selected send of a large amount can select enough inputs to
+	// cross the limit on its own without ever entering the dead-zone.
+	if err := s.guardTxSize(ctx, a, utxoAddr); err != nil {
+		return Preview{}, err
+	}
+
 	// Store the pending entry (sweeping any that have outlived their TTL first).
 	id := s.mkID()
 	s.mu.Lock()
@@ -555,12 +564,9 @@ func (s *Service) completeForcingPrefix(
 			}
 			return nil, mapCompleteErr(err)
 		}
-		// Converged on the minimal forced set. Reject it locally if signing it
-		// would exceed the chain's MaxTxSize, turning a would-be submit-time
-		// failure into a clear, pre-approval error.
-		if err := s.guardTxSize(ctx, a, utxoAddr); err != nil {
-			return nil, err
-		}
+		// Converged on the minimal forced set. The MaxTxSize check lives in Build
+		// so it covers the coin-selected path too; growing the prefix further
+		// would only add inputs, so there is nothing to gain by checking here.
 		return a, nil
 	}
 
@@ -611,7 +617,15 @@ func (s *Service) guardTxSize(ctx context.Context, a *apollo.Apollo, utxoAddr ma
 	}
 	signedSize := len(cborBytes)
 	if missingWitnesses > 0 {
-		signedSize += missingWitnesses*vkeyWitnessSizeEstimate + witnessSetOverhead
+		signedSize += missingWitnesses * vkeyWitnessSizeEstimate
+		// The one-time witness-set framing is only NEW when the completed tx has
+		// no vkey witnesses yet. If it already carries some, that framing is
+		// already inside cborBytes and adding it again would double-count.
+		// Complete() always leaves the set empty today, so this is a guard
+		// against the projection drifting if that ever changes.
+		if existingWitnesses == 0 {
+			signedSize += witnessSetOverhead
+		}
 	}
 	if signedSize > pp.MaxTxSize {
 		return fmt.Errorf(

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -382,46 +382,29 @@ func (s *Service) Build(ctx context.Context, req SendRequest) (Preview, error) {
 		return Preview{}, fmt.Errorf("%w: lovelace: %w", ErrInvalidRequest, err)
 	}
 	// Complete with the selected input payment key hashes embedded as Conway
-	// required signers. The first pass discovers selected inputs; later passes
-	// rebuild the tx with that signer set so fee estimation covers the bound body.
-	var a *apollo.Apollo
-	var required []lcommon.Blake2b224
-	maxAttempts := len(acct.ReceiveAddresses) + 2
-	for attempt := 0; attempt < maxAttempts; attempt++ {
-		next := apollo.New(s.chain).
-			SetWallet(apollo.NewExternalWallet(changeAddr)).
-			SetChangeAddress(changeAddr).
-			SetFeePadding(feePaddingLovelace).
-			AddLoadedUTxOs(loaded...)
-		for _, kh := range required {
-			next = next.AddRequiredSigner(kh)
+	// required signers (the first pass discovers selected inputs; later passes
+	// rebuild the tx with that signer set so fee estimation covers the bound body).
+	//
+	// A send that would leave change just below the min-UTxO floor puts Apollo in
+	// the "dust-change dead-zone": adding a change output raises the fee estimate,
+	// which drops the change below the floor, which removes the output, which
+	// lowers the fee — Apollo's evaluation loop oscillates and Complete() reports
+	// "evaluation transaction did not converge". When that happens, retry forcing
+	// a growing, largest-first prefix of the loaded UTxOs in as explicit inputs
+	// until the combined change clears the floor (see completeForcingPrefix). This
+	// pulls in only the minimum extra inputs needed — usually one, matching the
+	// legacy builder's "silently pull in another input" behaviour — rather than
+	// forcing the whole wallet, which would blow past MaxTxSize on large wallets.
+	addrCount := len(acct.ReceiveAddresses)
+	a, err := s.completeSend(ctx, changeAddr, recvAddr, lovelace, units, loaded, utxoAddr, addrCount, false)
+	if err != nil {
+		if !isNonConvergenceError(err) {
+			return Preview{}, mapCompleteErr(err)
 		}
-		next = next.PayToAddress(recvAddr, int64(lovelace), units...) //nolint:gosec // validated by parseAmount
-
-		next, err = next.WithContext(ctx).Complete()
-		if err != nil {
-			if isInsufficientFundsError(err) {
-				return Preview{}, fmt.Errorf("%w: %w", ErrInsufficientFunds, err)
-			}
-			return Preview{}, fmt.Errorf("complete transaction: %w", err)
-		}
-
-		tx := next.GetTx()
-		if tx == nil {
-			return Preview{}, errors.New("completed tx is nil")
-		}
-		actual, err := requiredPaymentKeyHashesForInputs(tx.Body.Inputs(), utxoAddr)
+		a, err = s.completeForcingPrefix(ctx, changeAddr, recvAddr, lovelace, units, loaded, utxoAddr, addrCount)
 		if err != nil {
 			return Preview{}, err
 		}
-		if sameKeyHashSet(required, actual) {
-			a = next
-			break
-		}
-		required = actual
-	}
-	if a == nil {
-		return Preview{}, errors.New("required signer set did not converge")
 	}
 
 	// Store the pending entry (sweeping any that have outlived their TTL first).
@@ -443,6 +426,205 @@ func (s *Service) Build(ctx context.Context, req SendRequest) (Preview, error) {
 	s.mu.Unlock()
 
 	return toPreview(id, a), nil
+}
+
+// completeSend runs Apollo coin selection + fee estimation for a single payment,
+// iterating until the Conway required-signer set (derived from the selected
+// inputs) is stable so fee estimation covers the fully-bound body.
+//
+// When forceInputs is false, Apollo selects inputs from the loaded pool. When it
+// is true, every UTxO in loaded is added as an explicit input and no coin
+// selection runs — the caller (completeForcingPrefix) passes a bounded,
+// largest-first prefix of the wallet's UTxOs to escape the min-UTxO dust-change
+// dead-zone so the combined change clears the min-UTxO floor.
+func (s *Service) completeSend(
+	ctx context.Context,
+	changeAddr, recvAddr lcommon.Address,
+	lovelace uint64,
+	units []apollo.Unit,
+	loaded []lcommon.Utxo,
+	utxoAddr map[string]string,
+	addrCount int,
+	forceInputs bool,
+) (*apollo.Apollo, error) {
+	var required []lcommon.Blake2b224
+	// The loop reruns Complete() until the Conway required-signer set stops
+	// growing. That set is discovered from the selected inputs, so it grows by at
+	// least one distinct payment-key hash per iteration and is bounded by the
+	// distinct signers, which cannot exceed either the number of loaded UTxOs
+	// (signers ≤ inputs ≤ len(loaded)) or the number of derived receive addresses
+	// (every input's key hash comes from one of them). Bounding by the smaller of
+	// the two keeps the worst case tight — a 400-UTxO / 20-address wallet caps at
+	// 22 Complete() calls, not 402. +2 covers a full convergence plus a final
+	// confirming pass. (addrCount ≤ 0 falls back to the loaded-count bound.)
+	bound := len(loaded)
+	if addrCount > 0 && addrCount < bound {
+		bound = addrCount
+	}
+	maxAttempts := bound + 2
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		next := apollo.New(s.chain).
+			SetWallet(apollo.NewExternalWallet(changeAddr)).
+			SetChangeAddress(changeAddr).
+			SetFeePadding(feePaddingLovelace)
+		if forceInputs {
+			for _, u := range loaded {
+				next = next.AddInput(u)
+			}
+		} else {
+			next = next.AddLoadedUTxOs(loaded...)
+		}
+		for _, kh := range required {
+			next = next.AddRequiredSigner(kh)
+		}
+		next = next.PayToAddress(recvAddr, int64(lovelace), units...) //nolint:gosec // validated by parseAmount
+
+		next, err := next.WithContext(ctx).Complete()
+		if err != nil {
+			return nil, err
+		}
+		tx := next.GetTx()
+		if tx == nil {
+			return nil, errors.New("completed tx is nil")
+		}
+		actual, err := requiredPaymentKeyHashesForInputs(tx.Body.Inputs(), utxoAddr)
+		if err != nil {
+			return nil, err
+		}
+		if sameKeyHashSet(required, actual) {
+			return next, nil
+		}
+		required = actual
+	}
+	return nil, errors.New("required signer set did not converge")
+}
+
+// vkeyWitnessSizeEstimate is the CBOR size of one vkey witness: a 2-element
+// array of a 32-byte verification key and a 64-byte Ed25519 signature —
+// array(2) header (1) + bytes(32) (2+32) + bytes(64) (2+64) = 101 bytes, rounded
+// up to 102 to cover the per-element set overhead. Complete() leaves the witness
+// set empty (witnesses are attached later at Confirm/Sign time), so the size
+// guard projects the SIGNED size by adding one such witness per input.
+const vkeyWitnessSizeEstimate = 102
+
+// completeForcingPrefix escapes the min-UTxO dust-change dead-zone by forcing a
+// growing, largest-first prefix of the wallet's UTxOs as explicit inputs,
+// stopping at the SMALLEST prefix that converges. Going largest-first means the
+// converging prefix is usually just one extra input, so inputs, fee, tx size,
+// and address linkage all stay bounded to the minimum needed instead of forcing
+// the whole wallet (which crosses MaxTxSize on large wallets).
+//
+// It sorts a COPY of loaded so the caller's slice — and the utxoAddr/utxoValue
+// maps keyed off the same UTxO references — are left untouched.
+func (s *Service) completeForcingPrefix(
+	ctx context.Context,
+	changeAddr, recvAddr lcommon.Address,
+	lovelace uint64,
+	units []apollo.Unit,
+	loaded []lcommon.Utxo,
+	utxoAddr map[string]string,
+	addrCount int,
+) (*apollo.Apollo, error) {
+	sorted := make([]lcommon.Utxo, len(loaded))
+	copy(sorted, loaded)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].Output.Amount().Uint64() > sorted[j].Output.Amount().Uint64()
+	})
+
+	for k := 1; k <= len(sorted); k++ {
+		a, err := s.completeSend(ctx, changeAddr, recvAddr, lovelace, units, sorted[:k], utxoAddr, addrCount, true)
+		if err != nil {
+			// Insufficient funds: the forced prefix does not yet cover payment+fee.
+			// Non-convergence: still inside the dust-change dead-zone. Either way,
+			// grow the prefix by one more (larger-first) UTxO and retry.
+			if isInsufficientFundsError(err) || isNonConvergenceError(err) {
+				continue
+			}
+			return nil, mapCompleteErr(err)
+		}
+		// Converged on the minimal forced set. Reject it locally if signing it
+		// would exceed the chain's MaxTxSize, turning a would-be submit-time
+		// failure into a clear, pre-approval error.
+		if err := s.guardTxSize(a); err != nil {
+			return nil, err
+		}
+		return a, nil
+	}
+
+	return nil, fmt.Errorf(
+		"%w: the amount leaves change below the minimum UTxO and no additional inputs are available to cover it",
+		ErrInsufficientFunds,
+	)
+}
+
+// guardTxSize rejects a completed tx whose projected SIGNED size exceeds the
+// chain's MaxTxSize protocol parameter. Complete() produces a body with an empty
+// witness set (vkey witnesses are attached at Confirm/Sign time), so the signed
+// size is estimated as the completed CBOR plus one vkey witness per input that
+// lacks one. That per-input count is a deliberate conservative UPPER BOUND:
+// Confirm signs once per distinct input address, so the real tx carries at most
+// one witness per input and fewer when inputs share an address. Over-estimating
+// only ever makes the guard reject a shade earlier — it can never let an
+// oversized tx reach SubmitTx.
+func (s *Service) guardTxSize(a *apollo.Apollo) error {
+	pp, err := s.chain.ProtocolParams()
+	if err != nil {
+		return fmt.Errorf("protocol params: %w", err)
+	}
+	if pp.MaxTxSize <= 0 {
+		return nil // no size limit configured; nothing to guard against
+	}
+	cborBytes, err := a.GetTxCbor()
+	if err != nil {
+		return fmt.Errorf("encode tx for size check: %w", err)
+	}
+	tx := a.GetTx()
+	numInputs, existingWitnesses := 0, 0
+	if tx != nil {
+		numInputs = len(tx.Body.Inputs())
+		existingWitnesses = len(tx.WitnessSet.VkeyWitnesses.Items())
+	}
+	missingWitnesses := numInputs - existingWitnesses
+	if missingWitnesses < 0 {
+		missingWitnesses = 0
+	}
+	signedSize := len(cborBytes) + missingWitnesses*vkeyWitnessSizeEstimate
+	if signedSize > pp.MaxTxSize {
+		return fmt.Errorf(
+			"%w: transaction would exceed the maximum size (%d/%d bytes); reduce the amount or consolidate UTxOs",
+			ErrInsufficientFunds, signedSize, pp.MaxTxSize,
+		)
+	}
+	return nil
+}
+
+// mapCompleteErr maps a completeSend error to the caller-facing Build error for
+// the arms shared between the first attempt and the forced-prefix retry: an
+// Apollo insufficient-funds error becomes ErrInsufficientFunds; anything else is
+// wrapped as "complete transaction". Non-convergence is handled separately by
+// the caller (it drives the forced-input retry) and is never passed here.
+func mapCompleteErr(err error) error {
+	if isInsufficientFundsError(err) {
+		return fmt.Errorf("%w: %w", ErrInsufficientFunds, err)
+	}
+	return fmt.Errorf("complete transaction: %w", err)
+}
+
+// isNonConvergenceError reports whether err is Apollo's fee/evaluation
+// non-convergence error. It surfaces in the min-UTxO dust-change dead-zone,
+// where leaving change just under the min-UTxO floor makes Apollo's fee estimate
+// oscillate across the boundary.
+//
+// The exact phrase "evaluation transaction did not converge" was verified
+// against apollo v2.0.0-20260729192515-7fa2cfd06025 (see ui/go.mod); recheck it
+// on every apollo bump, as this is a string-coupled match. It MUST keep the full
+// phrase and never be shortened to "did not converge": completeSend's own
+// "required signer set did not converge" error also contains that substring, so
+// a shortened matcher would misread bursa's signer-convergence failure as the
+// Apollo dust dead-zone and trigger a spurious forced-input retry.
+func isNonConvergenceError(err error) bool {
+	return err != nil &&
+		strings.Contains(err.Error(), "evaluation transaction did not converge")
 }
 
 // SignData signs an arbitrary message with the wallet key for one of the

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -527,6 +527,11 @@ func (s *Service) completeForcingPrefix(
 ) (*apollo.Apollo, error) {
 	sorted := make([]lcommon.Utxo, len(loaded))
 	copy(sorted, loaded)
+	// Order by lovelace descending. Output.Amount() is lovelace only (native
+	// assets live in Assets()), so for a token send the prefix grows by lovelace
+	// until it reaches the UTxO holding the asset — bounded by the
+	// asset-underflow arm of isInsufficientFundsError and by guardTxSize, not a
+	// correctness issue, just larger prefixes for token sends than ADA sends.
 	sort.SliceStable(sorted, func(i, j int) bool {
 		return sorted[i].Output.Amount().Uint64() > sorted[j].Output.Amount().Uint64()
 	})
@@ -545,7 +550,7 @@ func (s *Service) completeForcingPrefix(
 		// Converged on the minimal forced set. Reject it locally if signing it
 		// would exceed the chain's MaxTxSize, turning a would-be submit-time
 		// failure into a clear, pre-approval error.
-		if err := s.guardTxSize(a); err != nil {
+		if err := s.guardTxSize(a, utxoAddr); err != nil {
 			return nil, err
 		}
 		return a, nil
@@ -560,13 +565,12 @@ func (s *Service) completeForcingPrefix(
 // guardTxSize rejects a completed tx whose projected SIGNED size exceeds the
 // chain's MaxTxSize protocol parameter. Complete() produces a body with an empty
 // witness set (vkey witnesses are attached at Confirm/Sign time), so the signed
-// size is estimated as the completed CBOR plus one vkey witness per input that
-// lacks one. That per-input count is a deliberate conservative UPPER BOUND:
-// Confirm signs once per distinct input address, so the real tx carries at most
-// one witness per input and fewer when inputs share an address. Over-estimating
-// only ever makes the guard reject a shade earlier — it can never let an
-// oversized tx reach SubmitTx.
-func (s *Service) guardTxSize(a *apollo.Apollo) error {
+// size is projected as the completed CBOR plus the witnesses Confirm will add.
+// Confirm signs once per DISTINCT input address (see the distinct-address loop
+// in Confirm), not once per input, so the projection counts distinct signing
+// addresses via utxoAddr — inputs sharing an address share one witness. An input
+// whose address is unknown is conservatively assumed to need its own witness.
+func (s *Service) guardTxSize(a *apollo.Apollo, utxoAddr map[string]string) error {
 	pp, err := s.chain.ProtocolParams()
 	if err != nil {
 		return fmt.Errorf("protocol params: %w", err)
@@ -579,12 +583,21 @@ func (s *Service) guardTxSize(a *apollo.Apollo) error {
 		return fmt.Errorf("encode tx for size check: %w", err)
 	}
 	tx := a.GetTx()
-	numInputs, existingWitnesses := 0, 0
+	numSigners, existingWitnesses := 0, 0
 	if tx != nil {
-		numInputs = len(tx.Body.Inputs())
+		// One vkey witness per distinct input address (not per input).
+		seen := make(map[string]bool)
+		for _, inp := range tx.Body.Inputs() {
+			if addr, ok := utxoAddr[inputRef(inp)]; ok {
+				seen[addr] = true
+			} else {
+				numSigners++ // unknown input: assume its own witness
+			}
+		}
+		numSigners += len(seen)
 		existingWitnesses = len(tx.WitnessSet.VkeyWitnesses.Items())
 	}
-	missingWitnesses := numInputs - existingWitnesses
+	missingWitnesses := numSigners - existingWitnesses
 	if missingWitnesses < 0 {
 		missingWitnesses = 0
 	}

--- a/ui/internal/spend/spend_test.go
+++ b/ui/internal/spend/spend_test.go
@@ -485,7 +485,9 @@ func TestBuildDeadZoneRejectsOversizeTx(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetTxCbor: %v", err)
 	}
-	projected := len(cbor) + vkeyWitnessSizeEstimate // one distinct signing address
+	// One distinct signing address → one vkey witness, plus the one-time
+	// witness-set framing the guard accounts for.
+	projected := len(cbor) + vkeyWitnessSizeEstimate + witnessSetOverhead
 
 	// Same scenario, but MaxTxSize one byte under the true projection: the guard
 	// must reject and nothing may reach SubmitTx.

--- a/ui/internal/spend/spend_test.go
+++ b/ui/internal/spend/spend_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"math/big"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -281,6 +283,211 @@ func TestBuildInsufficientFunds(t *testing.T) {
 		t.Fatalf("expected ErrInsufficientFunds, got %v", err)
 	}
 	t.Logf("got expected error: %v", err)
+}
+
+// TestBuildRetriesDustChangeDeadZone reproduces the min-UTxO dust-change
+// dead-zone: two ~5-ADA UTxOs with a ~4-ADA send would leave change just below
+// the min-UTxO floor if only one input is selected, which makes Apollo's fee
+// estimate oscillate and Complete() report "evaluation transaction did not
+// converge". Build must detect that, retry forcing the other input in, and
+// return a valid, signable transaction whose change clears the floor.
+func TestBuildRetriesDustChangeDeadZone(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	addr0 := acct.ReceiveAddresses[0]
+	recvAddr := acct.ReceiveAddresses[2]
+
+	// Two 5-ADA UTxOs at the same funding address. Selecting one to fund a 4-ADA
+	// send leaves ~0.83 ADA change — inside the dead-zone.
+	fc := newFakeChain(5_000_000, addr0)
+	fc.addUTxO(5_000_000, addr0, "1111111111111111111111111111111111111111111111111111111111111111", 0)
+	ks := fakeKeystore{mnemonic: testMnemonic}
+	s := NewService(fc, ks, acct)
+
+	ctx := context.Background()
+	pv, err := s.Build(ctx, SendRequest{To: recvAddr, Lovelace: "4000000"})
+	if err != nil {
+		t.Fatalf("Build in dust-change dead-zone should now succeed, got: %v", err)
+	}
+	// The retry forces the other UTxO in, so both inputs are consumed and the
+	// combined change clears the min-UTxO floor.
+	if len(pv.Inputs) != 2 {
+		t.Fatalf("expected retry to include both inputs, got %d: %v", len(pv.Inputs), pv.Inputs)
+	}
+	if pv.Fee == "" || pv.Fee == "0" {
+		t.Fatalf("expected non-zero Fee, got %q", pv.Fee)
+	}
+	change, err := strconv.ParseUint(pv.Change, 10, 64)
+	if err != nil || change == 0 {
+		t.Fatalf("expected non-zero change above the min-UTxO floor, got %q (err %v)", pv.Change, err)
+	}
+
+	// The built tx must be signable and submittable, proving it is valid.
+	res, err := s.Confirm(ctx, pv.PendingID, "pw")
+	if err != nil {
+		t.Fatalf("Confirm of dead-zone tx: %v", err)
+	}
+	if res.TxHash == "" {
+		t.Fatal("expected non-empty TxHash")
+	}
+	if fc.submitCalls != 1 {
+		t.Fatalf("expected SubmitTx called once, got %d", fc.submitCalls)
+	}
+}
+
+// TestBuildDustChangeDeadZoneNoExtraInputs covers the genuinely-unresolvable
+// dead-zone: a single UTxO whose only possible change is dust and there is no
+// other input to pull in. Build must surface a clear, actionable error rather
+// than Apollo's raw non-convergence message.
+func TestBuildDustChangeDeadZoneNoExtraInputs(t *testing.T) {
+	acct := mustDeriveTestAccount(t)
+	addr0 := acct.ReceiveAddresses[0]
+	recvAddr := acct.ReceiveAddresses[1]
+
+	// Single 5-ADA UTxO, 4-ADA send: change is dust and no extra input exists.
+	fc := newFakeChain(5_000_000, addr0)
+	s := NewService(fc, nil, acct)
+
+	_, err := s.Build(context.Background(), SendRequest{To: recvAddr, Lovelace: "4000000"})
+	if !errors.Is(err, ErrInsufficientFunds) {
+		t.Fatalf("expected ErrInsufficientFunds, got %v", err)
+	}
+	if strings.Contains(err.Error(), "did not converge") {
+		t.Fatalf("clear error should not leak Apollo's raw non-convergence message: %v", err)
+	}
+	if !strings.Contains(err.Error(), "no additional inputs are available") {
+		t.Fatalf("expected an actionable dust-change message, got: %v", err)
+	}
+}
+
+// fillDeadZoneUTxOs adds n 5-ADA UTxOs at addr with distinct tx hashes. A 4-ADA
+// send funded by a single one leaves ~0.83 ADA change — inside the dust-change
+// dead-zone — so Build must force additional inputs to clear the min-UTxO floor.
+func fillDeadZoneUTxOs(fc *fakeChain, n int, addr string) {
+	for i := 0; i < n; i++ {
+		// Distinct 32-byte tx hash per UTxO: "0000..<i>" as 64 hex chars.
+		h := fmt.Sprintf("%064x", i+1)
+		fc.addUTxO(5_000_000, addr, h, 0)
+	}
+}
+
+// signedTxSizeEstimate mirrors Service.guardTxSize: completed CBOR plus one vkey
+// witness per input (Complete leaves the witness set empty).
+func signedTxSizeEstimate(t *testing.T, a *apollo.Apollo) int {
+	t.Helper()
+	cborBytes, err := a.GetTxCbor()
+	if err != nil {
+		t.Fatalf("GetTxCbor: %v", err)
+	}
+	return len(cborBytes) + len(a.GetTx().Body.Inputs())*vkeyWitnessSizeEstimate
+}
+
+// TestBuildDeadZoneForcesBoundedInputs proves the dust-change retry forces only
+// the minimum extra inputs (largest-first), not the whole wallet: a 50-UTxO
+// wallet whose 4-ADA send lands in the dead-zone must build with a small,
+// bounded input set well under the wallet size, produce a tx under MaxTxSize,
+// and still sign + submit.
+func TestBuildDeadZoneForcesBoundedInputs(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	addr0 := acct.ReceiveAddresses[0]
+	recvAddr := acct.ReceiveAddresses[2]
+
+	const walletUTxOs = 50
+	fc := newFakeChain(5_000_000, addr0)
+	fillDeadZoneUTxOs(fc, walletUTxOs-1, addr0) // newFakeChain already seeded one
+
+	ks := fakeKeystore{mnemonic: testMnemonic}
+	s := NewService(fc, ks, acct)
+
+	ctx := context.Background()
+	pv, err := s.Build(ctx, SendRequest{To: recvAddr, Lovelace: "4000000"})
+	if err != nil {
+		t.Fatalf("Build in 50-UTxO dead-zone should succeed, got: %v", err)
+	}
+
+	// The retry must pull in only a handful of inputs, never the whole wallet.
+	if len(pv.Inputs) == 0 || len(pv.Inputs) >= walletUTxOs {
+		t.Fatalf("expected a small bounded input set, got %d of %d wallet UTxOs", len(pv.Inputs), walletUTxOs)
+	}
+	if len(pv.Inputs) > 5 {
+		t.Fatalf("input set is not bounded to the minimum needed: got %d inputs", len(pv.Inputs))
+	}
+
+	// The built tx must be under MaxTxSize (proving the size guard would pass).
+	pp, err := fc.ProtocolParams()
+	if err != nil {
+		t.Fatalf("ProtocolParams: %v", err)
+	}
+	s.mu.Lock()
+	p := s.pending[pv.PendingID]
+	s.mu.Unlock()
+	if p == nil {
+		t.Fatal("pending entry missing")
+	}
+	if size := signedTxSizeEstimate(t, p.tx); size >= pp.MaxTxSize {
+		t.Fatalf("built tx size %d must be under MaxTxSize %d", size, pp.MaxTxSize)
+	}
+
+	// It must still sign and submit — proving the bounded forced set is valid.
+	res, err := s.Confirm(ctx, pv.PendingID, "pw")
+	if err != nil {
+		t.Fatalf("Confirm of bounded dead-zone tx: %v", err)
+	}
+	if res.TxHash == "" {
+		t.Fatal("expected non-empty TxHash")
+	}
+	if fc.submitCalls != 1 {
+		t.Fatalf("expected SubmitTx called once, got %d", fc.submitCalls)
+	}
+}
+
+// TestBuildDeadZoneRejectsOversizeTx proves guardTxSize turns a would-be
+// oversized transaction into a clear pre-approval error instead of letting it
+// reach SubmitTx. With MaxTxSize set below the projected signed size, the
+// dead-zone retry must fail Build with an ErrInsufficientFunds carrying the
+// size-limit message — never return a Preview.
+func TestBuildDeadZoneRejectsOversizeTx(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	addr0 := acct.ReceiveAddresses[0]
+	recvAddr := acct.ReceiveAddresses[2]
+
+	fc := newFakeChain(5_000_000, addr0)
+	fillDeadZoneUTxOs(fc, 9, addr0) // 10 UTxOs total on addr0
+	fc.pp.MaxTxSize = 400           // below any completed body + witness projection
+
+	s := NewService(fc, fakeKeystore{mnemonic: testMnemonic}, acct)
+
+	_, err := s.Build(context.Background(), SendRequest{To: recvAddr, Lovelace: "4000000"})
+	if !errors.Is(err, ErrInsufficientFunds) {
+		t.Fatalf("expected ErrInsufficientFunds, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "exceed the maximum size") {
+		t.Fatalf("expected a size-limit message, got: %v", err)
+	}
+	if fc.submitCalls != 0 {
+		t.Fatalf("oversized tx must never be submitted, got %d SubmitTx calls", fc.submitCalls)
+	}
+}
+
+// TestBuildDeadZoneSizeGuardDisabled pins the documented behaviour that a
+// MaxTxSize of 0 disables the guard: the dead-zone retry still succeeds.
+func TestBuildDeadZoneSizeGuardDisabled(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	addr0 := acct.ReceiveAddresses[0]
+	recvAddr := acct.ReceiveAddresses[2]
+
+	fc := newFakeChain(5_000_000, addr0)
+	fillDeadZoneUTxOs(fc, 9, addr0)
+	fc.pp.MaxTxSize = 0 // guard disabled
+
+	s := NewService(fc, fakeKeystore{mnemonic: testMnemonic}, acct)
+
+	pv, err := s.Build(context.Background(), SendRequest{To: recvAddr, Lovelace: "4000000"})
+	if err != nil {
+		t.Fatalf("with the size guard disabled, Build should succeed, got: %v", err)
+	}
+	if len(pv.Inputs) == 0 {
+		t.Fatal("expected a built tx with inputs")
+	}
 }
 
 func TestIsInsufficientFundsError(t *testing.T) {

--- a/ui/internal/spend/spend_test.go
+++ b/ui/internal/spend/spend_test.go
@@ -370,17 +370,6 @@ func fillDeadZoneUTxOs(fc *fakeChain, n int, addr string) {
 	}
 }
 
-// signedTxSizeEstimate mirrors Service.guardTxSize: completed CBOR plus one vkey
-// witness per input (Complete leaves the witness set empty).
-func signedTxSizeEstimate(t *testing.T, a *apollo.Apollo) int {
-	t.Helper()
-	cborBytes, err := a.GetTxCbor()
-	if err != nil {
-		t.Fatalf("GetTxCbor: %v", err)
-	}
-	return len(cborBytes) + len(a.GetTx().Body.Inputs())*vkeyWitnessSizeEstimate
-}
-
 // TestBuildDeadZoneForcesBoundedInputs proves the dust-change retry forces only
 // the minimum extra inputs (largest-first), not the whole wallet: a 50-UTxO
 // wallet whose 4-ADA send lands in the dead-zone must build with a small,
@@ -412,21 +401,6 @@ func TestBuildDeadZoneForcesBoundedInputs(t *testing.T) {
 		t.Fatalf("input set is not bounded to the minimum needed: got %d inputs", len(pv.Inputs))
 	}
 
-	// The built tx must be under MaxTxSize (proving the size guard would pass).
-	pp, err := fc.ProtocolParams()
-	if err != nil {
-		t.Fatalf("ProtocolParams: %v", err)
-	}
-	s.mu.Lock()
-	p := s.pending[pv.PendingID]
-	s.mu.Unlock()
-	if p == nil {
-		t.Fatal("pending entry missing")
-	}
-	if size := signedTxSizeEstimate(t, p.tx); size >= pp.MaxTxSize {
-		t.Fatalf("built tx size %d must be under MaxTxSize %d", size, pp.MaxTxSize)
-	}
-
 	// It must still sign and submit — proving the bounded forced set is valid.
 	res, err := s.Confirm(ctx, pv.PendingID, "pw")
 	if err != nil {
@@ -438,25 +412,90 @@ func TestBuildDeadZoneForcesBoundedInputs(t *testing.T) {
 	if fc.submitCalls != 1 {
 		t.Fatalf("expected SubmitTx called once, got %d", fc.submitCalls)
 	}
+	// Assert against the REAL signed bytes handed to SubmitTx. Measuring the
+	// actual tx — rather than re-deriving guardTxSize's own arithmetic — is what
+	// catches a wrong witness projection (an estimate that mirrors the code
+	// can't tell you the code is right).
+	pp, err := fc.ProtocolParams()
+	if err != nil {
+		t.Fatalf("ProtocolParams: %v", err)
+	}
+	if n := len(fc.submittedTxCbor()); n >= pp.MaxTxSize {
+		t.Fatalf("signed tx size %d must be under MaxTxSize %d", n, pp.MaxTxSize)
+	}
 }
 
-// TestBuildDeadZoneRejectsOversizeTx proves guardTxSize turns a would-be
-// oversized transaction into a clear pre-approval error instead of letting it
-// reach SubmitTx. With MaxTxSize set below the projected signed size, the
-// dead-zone retry must fail Build with an ErrInsufficientFunds carrying the
-// size-limit message — never return a Preview.
-func TestBuildDeadZoneRejectsOversizeTx(t *testing.T) {
+// TestBuildDeadZoneForcesLargestFirst proves the retry orders forced inputs by
+// lovelace descending: with one large UTxO among many small ones, it converges
+// on that single large input (k=1) rather than walking the small ones. Deleting
+// the sort in completeForcingPrefix makes this fail (the small UTxOs would be
+// forced first); an all-equal-value wallet can't distinguish the two.
+func TestBuildDeadZoneForcesLargestFirst(t *testing.T) {
 	acct := mustDeriveConfirmAccount(t)
 	addr0 := acct.ReceiveAddresses[0]
 	recvAddr := acct.ReceiveAddresses[2]
 
+	// Thirty 5-ADA UTxOs (the dead-zone shape) plus one 100-ADA UTxO added last,
+	// so it is only reachable first if the retry sorts largest-first.
+	fc := newFakeChain(5_000_000, addr0)
+	fillDeadZoneUTxOs(fc, 29, addr0) // 30 x 5-ADA total
+	fc.addUTxO(100_000_000, addr0, fmt.Sprintf("%064x", 0x1000), 0)
+
+	s := NewService(fc, fakeKeystore{mnemonic: testMnemonic}, acct)
+	pv, err := s.Build(context.Background(), SendRequest{To: recvAddr, Lovelace: "4000000"})
+	if err != nil {
+		t.Fatalf("Build should succeed: %v", err)
+	}
+	// The lone 100-ADA input covers the send with change well clear of the floor,
+	// so convergence is at exactly one input.
+	if len(pv.Inputs) != 1 {
+		t.Fatalf("expected largest-first to converge at 1 input, got %d: %v", len(pv.Inputs), pv.Inputs)
+	}
+}
+
+// TestBuildDeadZoneRejectsOversizeTx proves guardTxSize turns a would-be
+// oversized transaction into a clear pre-approval error instead of letting it
+// reach SubmitTx. The threshold is pinned to the branch's actual completed body
+// (measured with the guard disabled) plus one witness, minus a byte — so it
+// stays valid regardless of how witnesses are counted, rather than relying on
+// the counting method.
+func TestBuildDeadZoneRejectsOversizeTx(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	addr0 := acct.ReceiveAddresses[0]
+	recvAddr := acct.ReceiveAddresses[2]
+	req := SendRequest{To: recvAddr, Lovelace: "4000000"}
+
+	// Measure the real completed dead-zone tx with the guard disabled. All UTxOs
+	// share addr0, so the signed tx carries exactly one vkey witness.
+	measure := newFakeChain(5_000_000, addr0)
+	fillDeadZoneUTxOs(measure, 9, addr0)
+	measure.pp.MaxTxSize = 0
+	ms := NewService(measure, fakeKeystore{mnemonic: testMnemonic}, acct)
+	mpv, err := ms.Build(context.Background(), req)
+	if err != nil {
+		t.Fatalf("measurement build (guard disabled) should succeed: %v", err)
+	}
+	ms.mu.Lock()
+	mp := ms.pending[mpv.PendingID]
+	ms.mu.Unlock()
+	if mp == nil {
+		t.Fatal("measurement pending entry missing")
+	}
+	cbor, err := mp.tx.GetTxCbor()
+	if err != nil {
+		t.Fatalf("GetTxCbor: %v", err)
+	}
+	projected := len(cbor) + vkeyWitnessSizeEstimate // one distinct signing address
+
+	// Same scenario, but MaxTxSize one byte under the true projection: the guard
+	// must reject and nothing may reach SubmitTx.
 	fc := newFakeChain(5_000_000, addr0)
 	fillDeadZoneUTxOs(fc, 9, addr0) // 10 UTxOs total on addr0
-	fc.pp.MaxTxSize = 400           // below any completed body + witness projection
+	fc.pp.MaxTxSize = projected - 1
 
 	s := NewService(fc, fakeKeystore{mnemonic: testMnemonic}, acct)
 
-	_, err := s.Build(context.Background(), SendRequest{To: recvAddr, Lovelace: "4000000"})
+	_, err = s.Build(context.Background(), req)
 	if !errors.Is(err, ErrInsufficientFunds) {
 		t.Fatalf("expected ErrInsufficientFunds, got %v", err)
 	}

--- a/ui/internal/spend/spend_test.go
+++ b/ui/internal/spend/spend_test.go
@@ -531,6 +531,71 @@ func TestBuildDeadZoneSizeGuardDisabled(t *testing.T) {
 	}
 }
 
+// TestBuildRejectsOversizeTxOnPlainPath proves the size guard covers the
+// ordinary coin-selected build, not only the dust-change retry. A large send
+// that never enters the dead-zone can still select enough inputs to exceed
+// MaxTxSize; guarding only the retry path would let that reach SubmitTx and be
+// rejected by the node after the user had already approved it.
+func TestBuildRejectsOversizeTxOnPlainPath(t *testing.T) {
+	acct := mustDeriveConfirmAccount(t)
+	addr0 := acct.ReceiveAddresses[0]
+	recvAddr := acct.ReceiveAddresses[2]
+
+	// 40 x 10 ADA. A 200-ADA send needs ~21 inputs and leaves ~200 ADA change,
+	// far clear of the min-UTxO floor, so the first Complete() converges and the
+	// dead-zone retry never runs — this exercises the plain path only.
+	const utxoValue, walletUTxOs = 10_000_000, 40
+	req := SendRequest{To: recvAddr, Lovelace: "200000000"}
+
+	fill := func(fc *fakeChain) {
+		for i := 1; i < walletUTxOs; i++ {
+			fc.addUTxO(utxoValue, addr0, fmt.Sprintf("%064x", i), 0)
+		}
+	}
+
+	// Measure the real completed tx with the guard disabled. All UTxOs share
+	// addr0, so the signed tx carries exactly one vkey witness.
+	measure := newFakeChain(utxoValue, addr0)
+	fill(measure)
+	measure.pp.MaxTxSize = 0
+	ms := NewService(measure, fakeKeystore{mnemonic: testMnemonic}, acct)
+	mpv, err := ms.Build(context.Background(), req)
+	if err != nil {
+		t.Fatalf("measurement build (guard disabled) should succeed: %v", err)
+	}
+	if len(mpv.Inputs) < 2 {
+		t.Fatalf("expected a multi-input coin selection, got %d", len(mpv.Inputs))
+	}
+	ms.mu.Lock()
+	mp := ms.pending[mpv.PendingID]
+	ms.mu.Unlock()
+	if mp == nil {
+		t.Fatal("measurement pending entry missing")
+	}
+	cbor, err := mp.tx.GetTxCbor()
+	if err != nil {
+		t.Fatalf("GetTxCbor: %v", err)
+	}
+	projected := len(cbor) + vkeyWitnessSizeEstimate + witnessSetOverhead
+
+	// Same scenario, MaxTxSize one byte under the true projection.
+	fc := newFakeChain(utxoValue, addr0)
+	fill(fc)
+	fc.pp.MaxTxSize = projected - 1
+	s := NewService(fc, fakeKeystore{mnemonic: testMnemonic}, acct)
+
+	_, err = s.Build(context.Background(), req)
+	if !errors.Is(err, ErrInsufficientFunds) {
+		t.Fatalf("expected ErrInsufficientFunds for an oversize plain send, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "exceed the maximum size") {
+		t.Fatalf("expected a size-limit message, got: %v", err)
+	}
+	if fc.submitCalls != 0 {
+		t.Fatalf("oversized tx must never be submitted, got %d SubmitTx calls", fc.submitCalls)
+	}
+}
+
 func TestIsInsufficientFundsError(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Restores the pre-upstream-apollo behavior in the send path's `Build` when a send would leave change just below the min-UTxO floor.

- Extracts the send build loop into `completeSend`, parameterized by a `forceInputs` flag. With `forceInputs` false, Apollo selects inputs from the loaded pool; with it true, every loaded UTxO is added as an explicit input (`AddInput`) and no coin selection runs.
- Detects Apollo's non-convergence from `Complete()` via `isNonConvergenceError` (matches `"evaluation transaction did not converge"`).
- On non-convergence, retries the build once with `forceInputs=true` so the combined change clears the min-UTxO floor.
- If the retry still cannot converge, returns `ErrInsufficientFunds` wrapped with "the amount leaves change below the minimum UTxO and no additional inputs are available to cover it" instead of the raw Apollo iteration message. Insufficient-funds errors from the retry keep mapping to `ErrInsufficientFunds`.
- The normal (non-dead-zone) path is unchanged.

Tests (`spend_test.go`):
- `TestBuildRetriesDustChangeDeadZone`: two ~5-ADA UTxOs, ~4-ADA send. Asserts `Build` succeeds, includes both inputs, has non-zero fee and non-zero change, and the tx signs and submits via `Confirm`.
- `TestBuildDustChangeDeadZoneNoExtraInputs`: single ~5-ADA UTxO, ~4-ADA send. Asserts `ErrInsufficientFunds` with the actionable message and no leaked "did not converge" text.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tx building when `apollo` oscillates in the min-UTxO dust-change dead-zone by retrying with the smallest-that-works, largest-first input prefix. Adds a signed-size guard that now protects both retry and normal builds to prevent oversized transactions before approval.

- **Bug Fixes**
  - Detect `Complete()` non-convergence and retry with a growing, largest-first forced-input prefix; stop at the minimum that converges; return `ErrInsufficientFunds` with a clear dust-change message when no extra inputs exist.
  - Guard signed size using `backend` protocol params: project CBOR + one vkey witness per distinct input address, add witness-set overhead only when the set is empty, and reject over-limit with `ErrInsufficientFunds`; applies to coin-selected and forced-input builds.
  - Map remaining errors via `mapCompleteErr(...)`, honor canceled contexts, and avoid leaking raw `apollo` text.

- **Refactors**
  - Extracted `completeSend(...)`, `completeForcingPrefix(...)`, `guardTxSize(...)`, and `mapCompleteErr(...)`.
  - Capped signer-convergence attempts at min(loaded UTxOs, derived receive addresses) + 2.

<sup>Written for commit f245f70ab28f9f36fdc40f2478cec632d5f82c6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction building for low-value change scenarios, retrying with additional inputs when needed.
  * Returned clearer insufficient-funds errors when a transaction can’t be completed.
  * Reduced the chance of oversized transactions by limiting input selection to what can still be signed and submitted.

* **Tests**
  * Added coverage for retry behavior, insufficient-funds handling, and bounded input selection on large wallets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->