### PR TITLE
feat(ui): SeedSigner air-gapped QR hardware wallet

### DIFF
--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from "react";
 import type { Account, WalletView } from "./api/types";
 import { useStatus, useVaultStatus, useAutoLock } from "./api/hooks";
 import { lockVault, ApiError } from "./api/client";
+import { getStoredDeviceKind } from "./hw/deviceKind";
 import { useIdleLock } from "./useIdleLock";
 import { Button } from "./components/Button";
 import { SyncBanner } from "./components/SyncBanner";
@@ -262,11 +263,16 @@ export function App() {
     );
   }
 
-  // Staking/governance is gated identically to send: a fully synced node AND an
-  // active (spending-capable) wallet. A read-only or unsynced wallet falls back
-  // to Portfolio. Certificates also aren't supported on hardware yet (see
-  // spend.HardwareSignRequest), so hardware wallets are excluded too.
-  const canStake = isReady && activeWallet?.type === "full";
+  // Staking/governance needs a fully synced node AND a wallet that can witness a
+  // certificate tx: a full (local-seed) wallet, or a SeedSigner hardware wallet
+  // (its air-gapped QR device supports certificates/votes). Ledger/Trezor/
+  // Keystone hardware wallets can't sign certificates on-device yet, so they —
+  // like read-only and unsynced wallets — fall back to Portfolio.
+  const canStake =
+    isReady &&
+    (activeWallet?.type === "full" ||
+      (activeWallet?.type === "hardware" &&
+        getStoredDeviceKind(activeWallet.id) === "seedsigner"));
 
   // --- Unlocked: the normal wallet UI bound to the active wallet ----------
 
@@ -332,7 +338,15 @@ export function App() {
     // Staking/governance is gated like send: a synced node AND a
     // spending-enabled wallet. A read-only or unsynced wallet falls back to
     // Portfolio.
-    content = canStake ? <Staking network={activeWallet.network} /> : <Portfolio />;
+    content = canStake ? (
+      <Staking
+        network={activeWallet.network}
+        isHardware={activeWallet.type === "hardware"}
+        walletId={activeWallet.id}
+      />
+    ) : (
+      <Portfolio />
+    );
   } else if (route === "rewards") {
     // Read-only per-epoch reward history for the active wallet's stake
     // address. Node-local read (no signing, no spend), so it is available to

--- a/ui/web/src/components/SeedSignerQRModal.tsx
+++ b/ui/web/src/components/SeedSignerQRModal.tsx
@@ -1,0 +1,13 @@
+import { useAirGapQRBridge } from "../hw/qr/AirGapQRModal";
+
+/**
+ * SeedSigner air-gapped QR modal bridge.
+ *
+ * The show-QR/scan-QR modal is the device-agnostic {@link useAirGapQRBridge}
+ * (hw/qr/AirGapQRModal); this is its SeedSigner-labelled binding, so the
+ * on-screen copy names the SeedSigner while the returned `{bridge, element}`
+ * behaves exactly like every other air-gapped-QR device's.
+ */
+export function useSeedSignerQRBridge() {
+  return useAirGapQRBridge("SeedSigner");
+}

--- a/ui/web/src/hw/deviceKind.test.ts
+++ b/ui/web/src/hw/deviceKind.test.ts
@@ -32,6 +32,11 @@ describe("getStoredDeviceKind", () => {
     expect(getStoredDeviceKind("w1")).toBe("keystone");
   });
 
+  test("honors a stored seedsigner hint", () => {
+    setDeviceKind("w1", "seedsigner");
+    expect(getStoredDeviceKind("w1")).toBe("seedsigner");
+  });
+
   test("rejects an unrecognised value", () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ w1: "bogus" }));
     expect(getStoredDeviceKind("w1")).toBeUndefined();

--- a/ui/web/src/hw/deviceKind.ts
+++ b/ui/web/src/hw/deviceKind.ts
@@ -28,7 +28,7 @@ export const STORAGE_KEY = "bursa.hw.deviceKind";
 
 // Kinds we accept from storage. All implemented signers are listed; an
 // unrecognised value falls back to the documented "ledger" default.
-const KNOWN_KINDS: readonly HardwareKind[] = ["ledger", "trezor", "keystone"];
+const KNOWN_KINDS: readonly HardwareKind[] = ["ledger", "trezor", "keystone", "seedsigner"];
 
 type DeviceKindMap = Record<string, HardwareKind>;
 

--- a/ui/web/src/hw/index.test.ts
+++ b/ui/web/src/hw/index.test.ts
@@ -3,27 +3,32 @@ import type { HardwareSigner } from "./types";
 
 // Mock the concrete connectors so the factory can be exercised without opening
 // WebHID or loading connect.trezor.io.
-const { mockConnectLedger, mockConnectTrezor, mockConnectKeystone } = vi.hoisted(() => ({
-  mockConnectLedger: vi.fn(),
-  mockConnectTrezor: vi.fn(),
-  mockConnectKeystone: vi.fn(),
-}));
+const { mockConnectLedger, mockConnectTrezor, mockConnectKeystone, mockConnectSeedSigner } =
+  vi.hoisted(() => ({
+    mockConnectLedger: vi.fn(),
+    mockConnectTrezor: vi.fn(),
+    mockConnectKeystone: vi.fn(),
+    mockConnectSeedSigner: vi.fn(),
+  }));
 
 vi.mock("./ledger", () => ({ connectLedger: mockConnectLedger }));
 vi.mock("./trezor", () => ({ connectTrezor: mockConnectTrezor }));
 vi.mock("./keystone", () => ({ connectKeystone: mockConnectKeystone }));
+vi.mock("./seedsigner", () => ({ connectSeedSigner: mockConnectSeedSigner }));
 
 import { connectDevice, connectHardware } from "./index";
 
 const fakeLedger = { kind: "ledger" } as unknown as HardwareSigner;
 const fakeTrezor = { kind: "trezor" } as unknown as HardwareSigner;
 const fakeKeystone = { kind: "keystone" } as unknown as HardwareSigner;
+const fakeSeedSigner = { kind: "seedsigner" } as unknown as HardwareSigner;
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockConnectLedger.mockResolvedValue(fakeLedger);
   mockConnectTrezor.mockResolvedValue(fakeTrezor);
   mockConnectKeystone.mockResolvedValue(fakeKeystone);
+  mockConnectSeedSigner.mockResolvedValue(fakeSeedSigner);
 });
 
 describe("connectDevice factory", () => {
@@ -53,6 +58,18 @@ describe("connectDevice factory", () => {
     expect(mockConnectLedger).not.toHaveBeenCalled();
     expect(mockConnectTrezor).not.toHaveBeenCalled();
     expect(session).toBe(fakeKeystone);
+  });
+
+  test("seedsigner dispatches to connectSeedSigner, forwarding the bridge options", async () => {
+    const bridge = {
+      displayRequest: () => {},
+      scanResponse: async () => ({ type: "", cborHex: "" }),
+      close: () => {},
+    };
+    const session = await connectDevice("seedsigner", { bridge, xfp: "52744703" });
+    expect(mockConnectSeedSigner).toHaveBeenCalledWith({ bridge, xfp: "52744703" });
+    expect(mockConnectKeystone).not.toHaveBeenCalled();
+    expect(session).toBe(fakeSeedSigner);
   });
 });
 
@@ -95,5 +112,11 @@ describe("connectHardware (dynamic kind)", () => {
     // the air-gapped QR flow is driven directly through connectDevice.
     expect(() => connectHardware("keystone", consent)).toThrow(/air-gapped QR/i);
     expect(mockConnectKeystone).not.toHaveBeenCalled();
+  });
+
+  test("seedsigner is refused here (QR-only, driven via connectDevice with a bridge)", () => {
+    const consent = vi.fn().mockResolvedValue(true);
+    expect(() => connectHardware("seedsigner", consent)).toThrow(/air-gapped QR/i);
+    expect(mockConnectSeedSigner).not.toHaveBeenCalled();
   });
 });

--- a/ui/web/src/hw/index.ts
+++ b/ui/web/src/hw/index.ts
@@ -13,10 +13,12 @@ import type {
   HardwareSigner,
   KeystoneConnectOptions,
   LocalConnectOptions,
+  SeedSignerConnectOptions,
 } from "./types";
 import { connectLedger } from "./ledger";
 import { connectTrezor } from "./trezor";
 import { connectKeystone } from "./keystone";
+import { connectSeedSigner } from "./seedsigner";
 
 export type {
   HardwareKind,
@@ -31,6 +33,9 @@ export type {
   KeystoneUSBConnectOptions,
   KeystoneQRBridge,
   KeystoneScannedUR,
+  SeedSignerConnectOptions,
+  SeedSignerQRBridge,
+  SeedSignerScannedUR,
 } from "./types";
 
 /**
@@ -64,8 +69,16 @@ export function connectDevice(
   opts: ConnectOptionsByKind["keystone"],
 ): Promise<HardwareSigner>;
 export function connectDevice(
+  kind: "seedsigner",
+  opts: ConnectOptionsByKind["seedsigner"],
+): Promise<HardwareSigner>;
+export function connectDevice(
   kind: HardwareKind,
-  opts?: LocalConnectOptions | ExternalConnectOptions | KeystoneConnectOptions,
+  opts?:
+    | LocalConnectOptions
+    | ExternalConnectOptions
+    | KeystoneConnectOptions
+    | SeedSignerConnectOptions,
 ): Promise<HardwareSigner> {
   switch (kind) {
     case "ledger":
@@ -79,6 +92,10 @@ export function connectDevice(
       // Both Keystone transports are local; connectKeystone dispatches on the
       // transport in `opts` (QR needs a UI bridge, USB needs nothing).
       return connectKeystone(opts as KeystoneConnectOptions);
+    case "seedsigner":
+      // SeedSigner is air-gapped QR only; connectSeedSigner drives the animated
+      // QR + webcam exchange through the bridge in `opts`.
+      return connectSeedSigner(opts as SeedSignerConnectOptions);
     default: {
       // Exhaustiveness guard: a new HardwareKind must add a case above.
       const never: never = kind;
@@ -115,6 +132,10 @@ export function connectHardware(
     case "keystone":
       throw new Error(
         "Keystone must be connected over its air-gapped QR transport via connectDevice(\"keystone\", { transport: \"qr\", … }); the USB transport is not user-selectable.",
+      );
+    case "seedsigner":
+      throw new Error(
+        "SeedSigner must be connected over its air-gapped QR transport via connectDevice(\"seedsigner\", { bridge, … }); it has no network transport this dispatcher can supply.",
       );
     default: {
       const never: never = kind;

--- a/ui/web/src/hw/seedsigner.test.ts
+++ b/ui/web/src/hw/seedsigner.test.ts
@@ -1,0 +1,398 @@
+import { describe, test, expect, vi } from "vitest";
+import {
+  connectSeedSigner,
+  encodeAccountRequest,
+  encodeTxSigRequest,
+  buildExtraSigners,
+  parseAccountResponse,
+  parseAccountXfp,
+  parseTxSigResponse,
+  importSeedSignerAccount,
+  recoverSeedSignerXfp,
+} from "./seedsigner";
+import { encodeXpub } from "./xpub";
+import { encodeWitnessArray } from "./witness";
+import { encodeCbor } from "./qr/cbor";
+import { bytesToHex, hexToBytes } from "./hex";
+import type { SeedSignerQRBridge, SeedSignerScannedUR } from "./types";
+import type { HardwareSignResponse } from "../api/types";
+
+// Shared parity vector — identical key material to the Ledger/Trezor/Keystone
+// canonical vectors, so SeedSigner MUST produce the same bech32 xpub and, for the
+// same pubkey/sig, the same witness-array CBOR.
+const TEST_PUB_KEY_HEX = "beb7e770b3d0f1932b0a2f3a63285bf9ef7d3e461d55446d6a3911d8f0ee55c0";
+const TEST_CHAIN_CODE_HEX = "b0e2df16538508046649d0e6d5b32969555a23f2f1ebf2db2819359b0d88bd16";
+const TEST_XPUB_BECH32 =
+  "root_xvk1h6m7wu9n6rcex2c29uaxx2zml8hh60jxr425gmt28yga3u8w2hqtpcklzefc2zqyveyapek4kv5kj426y0e0r6ljmv5pjdvmpkyt69s8fpd2x";
+const TEST_SIG_HEX = "aabbccdd".repeat(16); // 64 bytes
+const TEST_XFP = "52744703";
+
+const NEUTRAL_REQ: HardwareSignResponse = {
+  network: "mainnet",
+  network_id: 1,
+  include_network_id: true,
+  protocol_magic: 764824073,
+  inputs: [
+    {
+      tx_hash_hex: "deadbeef".repeat(8),
+      output_index: 0,
+      path: "1852'/1815'/0'/0/0",
+      lovelace: "5000000",
+      address_bech32: "addr1input",
+    },
+  ],
+  outputs: [{ address_hex: "60aabb", address_bech32: "addr1recipient", lovelace: "1000000" }],
+  change_outputs: [{ index: 1, path: "1852'/1815'/0'/1/0" }],
+  fee: "200000",
+  required_signers: [],
+  unsigned_tx_cbor: "84a4008182",
+};
+
+// ── UR fixture builders (what the device would show) ──────────────────────────
+
+const ht = (s: string): string => bytesToHex([...new TextEncoder().encode(s)]);
+
+// A `cardano-account` reply carrying one account record + the master fingerprint.
+function accountCborHex(
+  account: number,
+  pubHex: string,
+  ccHex: string,
+  xfpHex: string,
+  label = "SeedSigner",
+): string {
+  const rec = new Map<number, unknown>();
+  rec.set(1, account);
+  rec.set(2, hexToBytes(pubHex + ccHex));
+  rec.set(3, `1852'/1815'/${account}'`);
+  const m = new Map<number, unknown>();
+  m.set(1, "id");
+  m.set(2, hexToBytes(xfpHex));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  m.set(3, [rec] as any);
+  m.set(4, label);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return bytesToHex([...encodeCbor(m as any)]);
+}
+
+// A `cardano-tx-sig-res` reply: {1:request_id, 2: tag258([[pub,sig]])}. The set
+// tag (d90102) is written by hand since the shared encoder emits no tags.
+function txSigResCborHex(pubHex: string, sigHex: string): string {
+  const witnessSet = "d90102" + "81" + "82" + "5820" + pubHex + "5840" + sigHex;
+  return "a2" + "01" + "62" + ht("id") + "02" + witnessSet;
+}
+
+function makeBridge(): SeedSignerQRBridge & {
+  displayRequest: ReturnType<typeof vi.fn>;
+  scanResponse: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+} {
+  return {
+    displayRequest: vi.fn(),
+    scanResponse: vi.fn(),
+    close: vi.fn(),
+  };
+}
+
+// ── Byte-exact request encodings (untagged, integer-keyed CBOR maps) ──────────
+
+describe("encodeAccountRequest — byte-exact cardano-account-req", () => {
+  test("emits {1:request_id, 2:origin, 3:account_indices, 4:key_purpose} in order", () => {
+    const bytes = encodeAccountRequest({ accounts: [0], origin: "x", keyPurpose: 1852 }, "id");
+    const expected =
+      "a4" + // map(4)
+      "01" + "62" + ht("id") + // 1: "id"
+      "02" + "61" + ht("x") + // 2: "x"
+      "03" + "81" + "00" + // 3: [0]
+      "04" + "19" + "073c"; // 4: 1852
+    expect(bytesToHex([...bytes])).toBe(expected);
+  });
+
+  test("defaults origin to bursa-wallet and key_purpose to 1852", () => {
+    const bytes = encodeAccountRequest({ accounts: [0] }, "id");
+    const expected =
+      "a4" +
+      "01" + "62" + ht("id") +
+      "02" + "6c" + ht("bursa-wallet") + // text(12)
+      "03" + "81" + "00" +
+      "04" + "19" + "073c";
+    expect(bytesToHex([...bytes])).toBe(expected);
+  });
+});
+
+describe("encodeTxSigRequest — byte-exact cardano-tx-sig-req", () => {
+  test("emits the 7-key map with a wallet input, change output, and network", () => {
+    const req: HardwareSignResponse = {
+      network: "mainnet",
+      network_id: 1,
+      protocol_magic: 764824073,
+      inputs: [{ tx_hash_hex: "0011", output_index: 1, path: "1852'/1815'/0'/0/0" }],
+      outputs: [],
+      change_outputs: [{ index: 0, path: "1852'/1815'/0'/1/0" }],
+      fee: "0",
+      required_signers: [],
+      unsigned_tx_cbor: "a0",
+    };
+    const bytes = encodeTxSigRequest(req, { xfp: "aabbccdd", requestId: "id", origin: "x" });
+    const expected =
+      "a7" + // map(7)
+      "01" + "62" + ht("id") + // 1: request_id
+      "02" + "61" + ht("x") + // 2: origin
+      "03" + "41" + "a0" + // 3: sign_data (1 byte)
+      "04" + "81" + // 4: inputs[1]
+        "a4" +
+          "01" + "42" + "0011" + // tx_hash
+          "02" + "01" + // index
+          "03" + "44" + "aabbccdd" + // xfp
+          "04" + "72" + ht("1852'/1815'/0'/0/0") + // path
+      "05" + "81" + // 5: change_outputs[1]
+        "a2" +
+          "01" + "00" + // index
+          "02" + "72" + ht("1852'/1815'/0'/1/0") + // path
+      "06" + "80" + // 6: extra_signers = []
+      "07" + "01"; // 7: network = 1
+    expect(bytesToHex([...bytes])).toBe(expected);
+  });
+
+  test("script-locked (multisig) inputs carry no xfp/path — only tx_hash + index", () => {
+    const req: HardwareSignResponse = {
+      ...NEUTRAL_REQ,
+      inputs: [{ tx_hash_hex: "0011", output_index: 2 }],
+      change_outputs: [],
+    };
+    const bytes = encodeTxSigRequest(req, { xfp: "aabbccdd", requestId: "id", origin: "x" });
+    // Input map has ONLY keys 1 (tx_hash) and 2 (index): a2 01 42 0011 02 02.
+    expect(bytesToHex([...bytes])).toContain("81" + "a2" + "01" + "42" + "0011" + "02" + "02");
+  });
+});
+
+// ── extra_signers aggregation (staking / governance / multisig) ───────────────
+
+describe("buildExtraSigners", () => {
+  test("aggregates cert / withdrawal / vote / explicit signer paths as [xfp, path] tuples", () => {
+    const req: HardwareSignResponse = {
+      ...NEUTRAL_REQ,
+      certificate_signers: [
+        { cert_kind: "stake_delegation", role: "stake", path: "1852'/1815'/0'/2/0", key_hash_hex: "aa" },
+      ],
+      withdrawal_signers: [
+        { role: "stake", path: "1852'/1815'/0'/2/0", key_hash_hex: "bb" },
+      ],
+      vote_signers: [{ voter: "drep", role: "drep", path: "1852'/1815'/0'/3/0", key_hash_hex: "cc" }],
+      extra_signers: [{ role: "payment", path: "1854'/1815'/0'/0/0", key_hash_hex: "dd", xfp: "11223344" }],
+    };
+    const signers = buildExtraSigners(req, TEST_XFP);
+    expect(signers).toEqual([
+      [hexToBytes(TEST_XFP), "1852'/1815'/0'/2/0"],
+      [hexToBytes(TEST_XFP), "1852'/1815'/0'/2/0"],
+      [hexToBytes(TEST_XFP), "1852'/1815'/0'/3/0"],
+      [hexToBytes("11223344"), "1854'/1815'/0'/0/0"], // explicit signer keeps its own xfp
+    ]);
+  });
+
+  test("is empty for a plain payment tx", () => {
+    expect(buildExtraSigners(NEUTRAL_REQ, TEST_XFP)).toEqual([]);
+  });
+});
+
+// ── account response parsing ──────────────────────────────────────────────────
+
+describe("parseAccountResponse", () => {
+  test("splits the 64-byte xpub and matches the shared bech32 vector", () => {
+    const scanned: SeedSignerScannedUR = {
+      type: "cardano-account",
+      cborHex: accountCborHex(0, TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, TEST_XFP),
+    };
+    const acct = parseAccountResponse(scanned, 0);
+    expect(acct.xpub).toBe(TEST_XPUB_BECH32);
+    expect(acct.xfp).toBe(TEST_XFP);
+    expect(acct.account).toBe(0);
+  });
+
+  test("rejects a non-account UR", () => {
+    expect(() =>
+      parseAccountResponse({ type: "cardano-tx-sig-res", cborHex: "a0" }, 0),
+    ).toThrow(/cardano-account/i);
+  });
+
+  test("rejects when the requested account is absent", () => {
+    const scanned: SeedSignerScannedUR = {
+      type: "cardano-account",
+      cborHex: accountCborHex(0, TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, TEST_XFP),
+    };
+    expect(() => parseAccountResponse(scanned, 5)).toThrow(/does not contain account 5/i);
+  });
+
+  test("rejects a malformed (non-8-hex) fingerprint", () => {
+    // xfp of 3 bytes → 6 hex digits, not a valid 4-byte fingerprint.
+    const scanned: SeedSignerScannedUR = {
+      type: "cardano-account",
+      cborHex: accountCborHex(0, TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, "aabbcc"),
+    };
+    expect(() => parseAccountResponse(scanned, 0)).toThrow(/malformed master fingerprint/i);
+  });
+});
+
+describe("parseAccountXfp", () => {
+  test("returns just the (account-independent) master fingerprint", () => {
+    const scanned: SeedSignerScannedUR = {
+      type: "cardano-account",
+      cborHex: accountCborHex(3, TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, TEST_XFP),
+    };
+    expect(parseAccountXfp(scanned)).toBe(TEST_XFP);
+  });
+});
+
+// ── witness-set round-trip ────────────────────────────────────────────────────
+
+describe("parseTxSigResponse", () => {
+  test("reads the tag-258 witness set and re-encodes it identically to the shared encoder", () => {
+    const scanned: SeedSignerScannedUR = {
+      type: "cardano-tx-sig-res",
+      cborHex: txSigResCborHex(TEST_PUB_KEY_HEX, TEST_SIG_HEX),
+    };
+    const result = parseTxSigResponse(scanned);
+    expect(result).toBe(encodeWitnessArray([{ pubKeyHex: TEST_PUB_KEY_HEX, sigHex: TEST_SIG_HEX }]));
+    expect(result.startsWith("8182")).toBe(true);
+    expect(result).toContain(TEST_PUB_KEY_HEX);
+    expect(result).toContain(TEST_SIG_HEX);
+  });
+
+  test("rejects a non-signature UR", () => {
+    expect(() => parseTxSigResponse({ type: "cardano-account", cborHex: "a0" })).toThrow(
+      /cardano-tx-sig-res/i,
+    );
+  });
+
+  test("trims an extended (pubkey||chaincode) vkey to the 32-byte public key", () => {
+    const extended = TEST_PUB_KEY_HEX + TEST_CHAIN_CODE_HEX;
+    const witnessSet = "d90102" + "81" + "82" + "5840" + extended + "5840" + TEST_SIG_HEX;
+    const cborHex = "a2" + "01" + "62" + ht("id") + "02" + witnessSet;
+    const result = parseTxSigResponse({ type: "cardano-tx-sig-res", cborHex });
+    expect(result).toBe(encodeWitnessArray([{ pubKeyHex: TEST_PUB_KEY_HEX, sigHex: TEST_SIG_HEX }]));
+  });
+});
+
+// ── connectSeedSigner (session) ───────────────────────────────────────────────
+
+describe("connectSeedSigner", () => {
+  test("reports kind 'seedsigner' with send/staking/governance/multisig capabilities", async () => {
+    const session = await connectSeedSigner({ bridge: makeBridge() });
+    expect(session.kind).toBe("seedsigner");
+    expect(session.capabilities).toEqual({
+      send: true,
+      staking: true,
+      governance: true,
+      multisig: true,
+      poolReg: false,
+    });
+  });
+
+  test("getAccountXpub shows the account-req QR, scans the reply, returns the shared xpub", async () => {
+    const bridge = makeBridge();
+    bridge.scanResponse.mockResolvedValue({
+      type: "cardano-account",
+      cborHex: accountCborHex(0, TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, TEST_XFP),
+    });
+    const session = await connectSeedSigner({ bridge });
+    const xpub = await session.getAccountXpub(0);
+    expect(xpub).toBe(TEST_XPUB_BECH32);
+    // The animated request QR was shown first.
+    expect(bridge.displayRequest).toHaveBeenCalledOnce();
+    const fragments = bridge.displayRequest.mock.calls[0][0] as string[];
+    expect(fragments[0].toLowerCase()).toMatch(/^ur:cardano-account-req\//);
+    expect(bridge.close).toHaveBeenCalled();
+  });
+
+  test("signTx round-trips: shows the tx-sig-req QR, scans the signature, returns witness-array CBOR", async () => {
+    const bridge = makeBridge();
+    bridge.scanResponse.mockResolvedValue({
+      type: "cardano-tx-sig-res",
+      cborHex: txSigResCborHex(TEST_PUB_KEY_HEX, TEST_SIG_HEX),
+    });
+    const session = await connectSeedSigner({ bridge, xfp: TEST_XFP });
+    const result = await session.signTx(NEUTRAL_REQ);
+
+    expect(bridge.displayRequest).toHaveBeenCalledOnce();
+    const fragments = bridge.displayRequest.mock.calls[0][0] as string[];
+    expect(fragments[0].toLowerCase()).toMatch(/^ur:cardano-tx-sig-req\//);
+
+    expect(result).toBe(encodeWitnessArray([{ pubKeyHex: TEST_PUB_KEY_HEX, sigHex: TEST_SIG_HEX }]));
+    expect(bridge.close).toHaveBeenCalled();
+  });
+
+  test("signTx refuses to build a request with a missing fingerprint (no zero fp)", async () => {
+    const bridge = makeBridge();
+    const session = await connectSeedSigner({ bridge });
+    await expect(session.signTx(NEUTRAL_REQ)).rejects.toThrow(/fingerprint is missing/i);
+    expect(bridge.displayRequest).not.toHaveBeenCalled();
+    expect(bridge.scanResponse).not.toHaveBeenCalled();
+  });
+
+  test("signTx refuses a malformed (non-8-hex) fingerprint", async () => {
+    const bridge = makeBridge();
+    const session = await connectSeedSigner({ bridge, xfp: "xyz" });
+    await expect(session.signTx(NEUTRAL_REQ)).rejects.toThrow(/fingerprint is missing/i);
+    expect(bridge.displayRequest).not.toHaveBeenCalled();
+  });
+
+  test("signTx rejects a scanned UR that is not a signature", async () => {
+    const bridge = makeBridge();
+    bridge.scanResponse.mockResolvedValue({
+      type: "cardano-account",
+      cborHex: accountCborHex(0, TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, TEST_XFP),
+    });
+    const session = await connectSeedSigner({ bridge, xfp: TEST_XFP });
+    await expect(session.signTx(NEUTRAL_REQ)).rejects.toThrow(/cardano-tx-sig-res/i);
+    expect(bridge.close).toHaveBeenCalled();
+  });
+
+  test("is fully local: options carry no consent callback, and one is never invoked", async () => {
+    const bridge = makeBridge();
+    bridge.scanResponse.mockResolvedValue({
+      type: "cardano-tx-sig-res",
+      cborHex: txSigResCborHex(TEST_PUB_KEY_HEX, TEST_SIG_HEX),
+    });
+    const opts = { bridge, xfp: TEST_XFP };
+    expect("requestExternalConsent" in opts).toBe(false);
+    const session = await connectSeedSigner(opts);
+    await expect(session.signTx(NEUTRAL_REQ)).resolves.toBeTypeOf("string");
+  });
+
+  test("session has no signMessage method (CIP-8 lands with a later interface change)", async () => {
+    const session = await connectSeedSigner({ bridge: makeBridge() });
+    expect((session as unknown as { signMessage?: unknown }).signMessage).toBeUndefined();
+  });
+});
+
+// ── account import / xfp recovery helpers ─────────────────────────────────────
+
+describe("importSeedSignerAccount", () => {
+  test("displays the account-req QR then returns xpub + xfp from the scanned reply", async () => {
+    const bridge = makeBridge();
+    bridge.scanResponse.mockResolvedValue({
+      type: "cardano-account",
+      cborHex: accountCborHex(2, TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, TEST_XFP),
+    });
+    const acct = await importSeedSignerAccount(bridge, 2);
+    expect(acct).toEqual({ xpub: TEST_XPUB_BECH32, xfp: TEST_XFP, account: 2 });
+    expect(bridge.displayRequest).toHaveBeenCalledOnce();
+    expect(bridge.close).toHaveBeenCalled();
+  });
+});
+
+describe("recoverSeedSignerXfp", () => {
+  test("re-runs the account exchange and returns only the fingerprint", async () => {
+    const bridge = makeBridge();
+    bridge.scanResponse.mockResolvedValue({
+      type: "cardano-account",
+      cborHex: accountCborHex(0, TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, TEST_XFP),
+    });
+    expect(await recoverSeedSignerXfp(bridge)).toBe(TEST_XFP);
+    expect(bridge.close).toHaveBeenCalled();
+  });
+});
+
+// A sanity check that the shared xpub encoder is the SAME one every device uses.
+test("shared xpub encoder parity guard", () => {
+  expect(encodeXpub(TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX)).toBe(TEST_XPUB_BECH32);
+});

--- a/ui/web/src/hw/seedsigner.ts
+++ b/ui/web/src/hw/seedsigner.ts
@@ -1,0 +1,470 @@
+/**
+ * hw/seedsigner.ts — SeedSigner air-gapped QR hardware-wallet signer.
+ *
+ * SeedSigner is a fully AIR-GAPPED device: it has no cable, no radio, and no
+ * network — every byte in and out travels as an animated QR through the local
+ * webcam. It is therefore local like Keystone (see the consent-law note in
+ * hw/types.ts): NO external-consent gate applies.
+ *
+ * Unlike Keystone (which ships a vendor UR/CBOR registry), SeedSigner speaks a
+ * BESPOKE, untagged, integer-keyed CBOR dialect carried over the standard BC-UR2
+ * transport. Those payloads are built/parsed here with the SHARED, dependency-free
+ * codec (hw/qr/cbor.ts encodeCbor/decodeCbor) and the SHARED transport
+ * (hw/qr/ur.ts). The UR `type` string is the message discriminator:
+ *
+ *   account import (two-way):
+ *     display  cardano-account-req  {1:request_id, 2:origin, 3:account_indices, 4:key_purpose}
+ *     scan     cardano-account      {1:request_id, 2:xfp(4B), 3:[{1:idx, 2:xpub64, 3:path}], 4:device_label}
+ *
+ *   sign (send + staking + governance + multisig — all an ordinary Conway tx):
+ *     display  cardano-tx-sig-req   {1:request_id, 2:origin, 3:sign_data, 4:inputs[{1:tx_hash,2:index,3:xfp,4:path}],
+ *                                     5:change_outputs[{1:index,2:path}], 6:extra_signers[[xfp,path]], 7:network}
+ *     scan     cardano-tx-sig-res   {1:request_id, 2:witness_set (tag 258 [[vkey32, sig64]])}
+ *
+ * Xpub/witness encoding parity with every other device is guaranteed by reusing
+ * the SHARED hw/xpub.ts and hw/witness.ts encoders, so the account-import xpub and
+ * the assembled witness array are byte-for-byte identical for identical key
+ * material (exercised in seedsigner.test.ts).
+ *
+ * NOTE on CIP-8 message signing: `signMessage` is intentionally NOT implemented
+ * here. It is being added to the HardwareSigner interface in a separate in-flight
+ * change; the SeedSigner CIP-8 payloads (cardano-cip8-sig-req/res) land in a
+ * follow-up once that interface method exists on main.
+ */
+
+import type { HardwareSignResponse } from "../api/types";
+import type {
+  AirGapQRBridge,
+  ScannedUR,
+} from "./qr/types";
+import type {
+  HardwareCapabilities,
+  HardwareSigner,
+  SeedSignerConnectOptions,
+} from "./types";
+import { encodeXpub } from "./xpub";
+import { encodeWitnessArray } from "./witness";
+import { hexToBytes } from "./hex";
+import { decodeCbor, encodeCbor, type CborValue, type CborWritable } from "./qr/cbor";
+import { encodeUR } from "./qr/ur";
+import { isValidXfp } from "./qr/xfp";
+
+// ── UR type discriminators (SeedSigner's bespoke dialect) ─────────────────────
+
+export const UR_ACCOUNT_REQ = "cardano-account-req";
+export const UR_ACCOUNT = "cardano-account";
+export const UR_TX_SIG_REQ = "cardano-tx-sig-req";
+export const UR_TX_SIG_RES = "cardano-tx-sig-res";
+
+// CIP-1852 is the "purpose" every Cardano wallet key derives under; SeedSigner
+// echoes it back in the account response so a request states the key family it
+// wants.
+const KEY_PURPOSE_CIP1852 = 1852;
+
+// The origin string stamped on every request so the device can show the user
+// which software asked. It is display-only, not a security control.
+const DEFAULT_ORIGIN = "bursa-wallet";
+
+// UR animated-QR fragment size (bytes of CBOR per frame). Small enough that each
+// frame stays a low-density, reliably-scannable QR; larger payloads simply
+// animate across more frames, which the device reassembles.
+const UR_MAX_FRAGMENT_LEN = 200;
+
+// ── Capabilities ──────────────────────────────────────────────────────────────
+//
+// SeedSigner signs an arbitrary Conway tx body and witnesses every wallet-owned
+// key whose path we hand it (inputs + extra_signers). Certificates, withdrawals,
+// governance votes, and native-multisig participation are all just ordinary
+// Conway txs with the relevant key supplied via an input path or extra_signers,
+// so all four are supported. poolReg (cold-key op-cert issuance) is not.
+const SEEDSIGNER_CAPABILITIES: HardwareCapabilities = {
+  send: true,
+  staking: true,
+  governance: true,
+  multisig: true,
+  poolReg: false,
+};
+
+// ── small helpers ─────────────────────────────────────────────────────────────
+
+function toHex(bytes: Uint8Array): string {
+  let out = "";
+  for (const b of bytes) out += b.toString(16).padStart(2, "0");
+  return out;
+}
+
+/** Normalise a path to the "1852'/1815'/0'/0/0" form (drop any leading "m/"). */
+function normalizePath(path: string): string {
+  return path.replace(/^m\//, "").trim();
+}
+
+// A random-enough request id; the device echoes it back on the reply so a stale
+// scan can be detected. crypto.randomUUID is available in every target
+// (secure-context browsers); fall back to a fixed nil UUID if it is missing.
+function newRequestId(): string {
+  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  return c?.randomUUID ? c.randomUUID() : "00000000-0000-0000-0000-000000000000";
+}
+
+// ── cardano-account-req (display) ─────────────────────────────────────────────
+
+export interface AccountRequestOptions {
+  /** Which CIP-1852 account indices to export (usually a single account). */
+  accounts: number[];
+  /** Display-only origin string. */
+  origin?: string;
+  /** CIP-1852 key purpose (defaults to 1852). */
+  keyPurpose?: number;
+}
+
+/**
+ * Build the bespoke `cardano-account-req` CBOR payload:
+ *   {1:request_id, 2:origin, 3:account_indices, 4:key_purpose}
+ * Untagged, integer-keyed, keys emitted in ascending order for byte stability.
+ */
+export function encodeAccountRequest(opts: AccountRequestOptions, requestId: string): Uint8Array {
+  const map = new Map<number, CborWritable>();
+  map.set(1, requestId);
+  map.set(2, opts.origin ?? DEFAULT_ORIGIN);
+  map.set(3, opts.accounts);
+  map.set(4, opts.keyPurpose ?? KEY_PURPOSE_CIP1852);
+  return encodeCbor(map);
+}
+
+// ── cardano-account (scan) ────────────────────────────────────────────────────
+
+export interface SeedSignerAccount {
+  /** Bech32 "root_xvk" account xpub, byte-identical to Ledger/Trezor/Go. */
+  xpub: string;
+  /** Device master fingerprint (hex) — needed to sign later over QR. */
+  xfp: string;
+  /** The CIP-1852 account index the key was found at. */
+  account: number;
+}
+
+function decodeAccountMap(scanned: ScannedUR): Map<number, CborValue> {
+  if (scanned.type !== UR_ACCOUNT) {
+    throw new Error(
+      `Expected a SeedSigner account QR (${UR_ACCOUNT}), got "${scanned.type}". ` +
+        "On the SeedSigner, choose Export account and scan the code it shows.",
+    );
+  }
+  const { value } = decodeCbor(hexToBytes(scanned.cborHex), 0);
+  if (!(value instanceof Map)) {
+    throw new Error("SeedSigner account payload is not a CBOR map");
+  }
+  return value;
+}
+
+function xfpFromAccountMap(map: Map<number, CborValue>): string {
+  const raw = map.get(2);
+  if (!(raw instanceof Uint8Array)) {
+    throw new Error("SeedSigner account payload has no master fingerprint (key 2)");
+  }
+  const xfp = toHex(raw);
+  if (!isValidXfp(xfp)) {
+    throw new Error(`SeedSigner reported a malformed master fingerprint (${xfp})`);
+  }
+  return xfp;
+}
+
+/**
+ * Read ONLY the master fingerprint (xfp) from a scanned `cardano-account` UR.
+ * Account-independent — used by the Send recovery flow to re-learn the xfp of an
+ * already-added wallet whose local hint was lost, without re-deriving its xpub.
+ */
+export function parseAccountXfp(scanned: ScannedUR): string {
+  return xfpFromAccountMap(decodeAccountMap(scanned));
+}
+
+/**
+ * Parse a scanned `cardano-account` UR into the CIP-1852 account xpub + xfp for
+ * the requested account. The device exports one or more account records
+ * ({1:idx, 2:xpub64, 3:path}); we pick the one matching `account`, split its
+ * 64-byte xpub (pubkey || chaincode) and re-encode it through the shared
+ * hw/xpub.ts helper so it matches every other device byte-for-byte.
+ */
+export function parseAccountResponse(scanned: ScannedUR, account: number): SeedSignerAccount {
+  const map = decodeAccountMap(scanned);
+  const xfp = xfpFromAccountMap(map);
+
+  const records = map.get(3);
+  if (!Array.isArray(records)) {
+    throw new Error("SeedSigner account payload has no account records (key 3)");
+  }
+  for (const rec of records) {
+    if (!(rec instanceof Map)) continue;
+    if (rec.get(1) !== account) continue;
+    const xpub64 = rec.get(2);
+    if (!(xpub64 instanceof Uint8Array) || xpub64.length !== 64) {
+      throw new Error(
+        `SeedSigner account ${account} record has a malformed xpub (expected 64 bytes)`,
+      );
+    }
+    const pubKey = xpub64.slice(0, 32);
+    const chainCode = xpub64.slice(32, 64);
+    return { xpub: encodeXpub(toHex(pubKey), toHex(chainCode)), xfp, account };
+  }
+  throw new Error(
+    `This SeedSigner account QR does not contain account ${account}. ` +
+      "Re-export the account on the device and scan again.",
+  );
+}
+
+// ── cardano-tx-sig-req (display) ──────────────────────────────────────────────
+
+export interface TxSigRequestOptions {
+  /** Device master fingerprint (hex, 8 chars) stamped on every signer. */
+  xfp: string;
+  /** Echoed request id so a stale reply scan can be detected. */
+  requestId: string;
+  /** Display-only origin string. */
+  origin?: string;
+}
+
+/**
+ * Aggregate every wallet-owned key that must witness the tx but is NOT already
+ * covered by an input path into `extra_signers` — each an [xfp(4B), path] tuple.
+ *
+ * PR-A's neutral request carries these as separate typed lists (certificate,
+ * withdrawal, vote, and explicit extra signers); a Conway staking / governance /
+ * multisig tx is signed by the device the same way — supply the key path and it
+ * witnesses. They are all THIS wallet's keys, so they carry the device xfp
+ * (an HWExtraSigner may carry its own, which we honour when present).
+ */
+export function buildExtraSigners(req: HardwareSignResponse, xfp: string): [Uint8Array, string][] {
+  const out: [Uint8Array, string][] = [];
+  const push = (path: string | undefined, signerXfp?: string) => {
+    if (!path) return;
+    out.push([hexToBytes(signerXfp ?? xfp), normalizePath(path)]);
+  };
+  for (const s of req.certificate_signers ?? []) push(s.path);
+  for (const s of req.withdrawal_signers ?? []) push(s.path);
+  for (const s of req.vote_signers ?? []) push(s.path);
+  for (const s of req.extra_signers ?? []) push(s.path, s.xfp);
+  return out;
+}
+
+/**
+ * Build the bespoke `cardano-tx-sig-req` CBOR payload:
+ *   {1:request_id, 2:origin, 3:sign_data, 4:inputs, 5:change_outputs,
+ *    6:extra_signers, 7:network}
+ *
+ *   - sign_data     = the unsigned Conway tx bytes the device signs;
+ *   - inputs        = one map per input: {1:tx_hash, 2:index, 3:xfp, 4:path}.
+ *                     A wallet-owned input carries its xfp + derivation path; a
+ *                     multisig SCRIPT-LOCKED input carries no path (keys 3/4 are
+ *                     omitted) so the device knows not to witness it with a key.
+ *   - change_outputs= {1:index, 2:path} so the device verifies change returns home;
+ *   - extra_signers = the aggregated cert/withdrawal/vote/multisig key paths;
+ *   - network       = the network id (0 testnet, 1 mainnet).
+ *
+ * All seven keys are always emitted, in ascending order, for byte stability.
+ */
+export function encodeTxSigRequest(req: HardwareSignResponse, opts: TxSigRequestOptions): Uint8Array {
+  const xfpBytes = hexToBytes(opts.xfp);
+
+  const inputs: CborWritable[] = req.inputs.map((inp) => {
+    const m = new Map<number, CborWritable>();
+    m.set(1, hexToBytes(inp.tx_hash_hex));
+    m.set(2, inp.output_index);
+    // A script-locked (multisig) input has no derivation path; omit the key +
+    // xfp so the device does not attempt a key witness for it.
+    if (inp.path) {
+      m.set(3, xfpBytes);
+      m.set(4, normalizePath(inp.path));
+    }
+    return m;
+  });
+
+  const changeOutputs: CborWritable[] = (req.change_outputs ?? []).map((c) => {
+    const m = new Map<number, CborWritable>();
+    m.set(1, c.index);
+    m.set(2, normalizePath(c.path));
+    return m;
+  });
+
+  const extraSigners: CborWritable[] = buildExtraSigners(req, opts.xfp).map(
+    ([xfpB, path]) => [xfpB, path] as CborWritable[],
+  );
+
+  const map = new Map<number, CborWritable>();
+  map.set(1, opts.requestId);
+  map.set(2, opts.origin ?? DEFAULT_ORIGIN);
+  map.set(3, hexToBytes(req.unsigned_tx_cbor));
+  map.set(4, inputs);
+  map.set(5, changeOutputs);
+  map.set(6, extraSigners);
+  map.set(7, req.network_id);
+  return encodeCbor(map);
+}
+
+// ── cardano-tx-sig-res (scan) ─────────────────────────────────────────────────
+
+/**
+ * Extract {pubKeyHex, sigHex} pairs from a decoded witness-set value. Accepts
+ * either the Conway set-tagged array [[vkey, sig], …] (the shared decoder unwraps
+ * tag 258) or, defensively, a witness-set map whose key 0 is that array. Each
+ * vkey witness is [pubkey_bytes, sig_bytes]; an extended (pubkey||chaincode) key
+ * is trimmed to the leading 32-byte Ed25519 public key for parity with the other
+ * devices, and wrong-length fields are rejected rather than emitted.
+ */
+function witnessPairsFromValue(value: CborValue): { pubKeyHex: string; sigHex: string }[] {
+  let vkeyWitnesses: CborValue;
+  if (value instanceof Map) {
+    const w = value.get(0);
+    if (!w) throw new Error("SeedSigner witness set has no vkey witnesses (map key 0 absent)");
+    vkeyWitnesses = w;
+  } else if (Array.isArray(value)) {
+    vkeyWitnesses = value;
+  } else {
+    throw new Error("SeedSigner witness set is neither a map nor an array");
+  }
+  if (!Array.isArray(vkeyWitnesses)) {
+    throw new Error("SeedSigner vkey-witness field is not an array");
+  }
+  return vkeyWitnesses.map((w) => {
+    if (!Array.isArray(w) || w.length < 2) {
+      throw new Error("SeedSigner vkey witness is not a [pubkey, sig] pair");
+    }
+    const [pub, sig] = w;
+    if (!(pub instanceof Uint8Array) || !(sig instanceof Uint8Array)) {
+      throw new Error("SeedSigner vkey witness fields are not byte strings");
+    }
+    const pubKey = pub.length > 32 ? pub.slice(0, 32) : pub;
+    if (pubKey.length !== 32) {
+      throw new Error(`SeedSigner vkey witness public key is ${pubKey.length} bytes, expected 32`);
+    }
+    if (sig.length !== 64) {
+      throw new Error(`SeedSigner vkey witness signature is ${sig.length} bytes, expected 64`);
+    }
+    return { pubKeyHex: toHex(pubKey), sigHex: toHex(sig) };
+  });
+}
+
+/**
+ * Parse a scanned `cardano-tx-sig-res` UR into the standard vkey-witness-array
+ * CBOR hex the backend's submit endpoint expects — byte-identical to every other
+ * device's output (via the shared hw/witness.ts encoder).
+ */
+export function parseTxSigResponse(scanned: ScannedUR): string {
+  if (scanned.type !== UR_TX_SIG_RES) {
+    throw new Error(
+      `Expected a SeedSigner signature QR (${UR_TX_SIG_RES}), got "${scanned.type}".`,
+    );
+  }
+  const { value } = decodeCbor(hexToBytes(scanned.cborHex), 0);
+  if (!(value instanceof Map)) {
+    throw new Error("SeedSigner signature payload is not a CBOR map");
+  }
+  const witnessSet = value.get(2);
+  if (witnessSet === undefined) {
+    throw new Error("SeedSigner signature payload has no witness set (key 2)");
+  }
+  return encodeWitnessArray(witnessPairsFromValue(witnessSet));
+}
+
+// ── Account import (display request → scan response) ──────────────────────────
+
+async function displayAccountRequest(bridge: AirGapQRBridge, account: number): Promise<void> {
+  const cbor = encodeAccountRequest({ accounts: [account] }, newRequestId());
+  const fragments = await encodeUR(UR_ACCOUNT_REQ, cbor, UR_MAX_FRAGMENT_LEN);
+  bridge.displayRequest(fragments);
+}
+
+/**
+ * Drive the two-way account import: show the `cardano-account-req` QR, scan the
+ * device's `cardano-account` reply, and return the account xpub + master
+ * fingerprint. Used by AddWallet (which needs both the xpub to store and the xfp
+ * to remember for later QR signing).
+ */
+export async function importSeedSignerAccount(
+  bridge: AirGapQRBridge,
+  account: number,
+): Promise<SeedSignerAccount> {
+  await displayAccountRequest(bridge, account);
+  try {
+    const scanned = await bridge.scanResponse();
+    return parseAccountResponse(scanned, account);
+  } finally {
+    bridge.close();
+  }
+}
+
+/**
+ * Recover ONLY the master fingerprint by re-running the account exchange. The
+ * fingerprint is account-independent, so any account request suffices; used by
+ * Send's recovery flow to re-learn a lost xfp without re-deriving the xpub.
+ */
+export async function recoverSeedSignerXfp(bridge: AirGapQRBridge, account = 0): Promise<string> {
+  await displayAccountRequest(bridge, account);
+  try {
+    const scanned = await bridge.scanResponse();
+    return parseAccountXfp(scanned);
+  } finally {
+    bridge.close();
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Connect a SeedSigner over its air-gapped QR transport. Fully offline: the only
+ * capability touched is the local webcam (through the UI bridge). No consent
+ * gate — nothing leaves the node.
+ */
+export async function connectSeedSigner(
+  opts: SeedSignerConnectOptions,
+): Promise<HardwareSigner> {
+  const { bridge } = opts;
+  if (!bridge) {
+    throw new Error(
+      "SeedSigner requires a UI bridge (animated-QR display + webcam scanner).",
+    );
+  }
+
+  return {
+    kind: "seedsigner",
+    capabilities: SEEDSIGNER_CAPABILITIES,
+
+    async getAccountXpub(account: number): Promise<string> {
+      const acct = await importSeedSignerAccount(bridge, account);
+      return acct.xpub;
+    },
+
+    async signTx(req: HardwareSignResponse): Promise<string> {
+      // The device master fingerprint is mandatory: it is how the SeedSigner
+      // recognises the witness paths as its own. It is learned only at account
+      // import and remembered as a local hint, so it CAN go missing (e.g. a
+      // browser-data wipe). Never FABRICATE a zero fingerprint — a synthesized
+      // all-zero xfp would silently build a request the device cannot match, so
+      // signing would appear to run but fail on-device. Block instead and steer
+      // the user to re-import the account (which yields the fingerprint again).
+      // A genuine device-reported all-zero xfp is a valid (1-in-2^32) value and
+      // is intentionally accepted — this blocks only the ABSENCE of one.
+      const xfp = opts.xfp;
+      if (!isValidXfp(xfp)) {
+        throw new Error(
+          "This SeedSigner wallet's device fingerprint is missing. Re-import the account " +
+            "(Export account on the device and scan its QR) to recover it, then try again.",
+        );
+      }
+
+      const cbor = encodeTxSigRequest(req, { xfp, requestId: newRequestId() });
+      const fragments = await encodeUR(UR_TX_SIG_REQ, cbor, UR_MAX_FRAGMENT_LEN);
+      bridge.displayRequest(fragments);
+      try {
+        const scanned = await bridge.scanResponse();
+        return parseTxSigResponse(scanned);
+      } finally {
+        bridge.close();
+      }
+    },
+
+    async close(): Promise<void> {
+      // No persistent transport for QR; make sure any open modal/camera is torn
+      // down (idempotent — bridge.close guards its own state).
+      bridge.close();
+    },
+  };
+}

--- a/ui/web/src/hw/types.ts
+++ b/ui/web/src/hw/types.ts
@@ -12,7 +12,7 @@ import type { HardwareSignResponse } from "../api/types";
 import type { AirGapQRBridge, ScannedUR } from "./qr/types";
 
 /** Which hardware device a signer talks to. */
-export type HardwareKind = "ledger" | "trezor" | "keystone";
+export type HardwareKind = "ledger" | "trezor" | "keystone" | "seedsigner";
 
 /**
  * What a given device can sign today. Send-parity is the current baseline for
@@ -133,6 +133,40 @@ export type KeystoneConnectOptions =
   | KeystoneQRConnectOptions
   | KeystoneUSBConnectOptions;
 
+// ── SeedSigner (air-gapped QR only) ──────────────────────────────────────────
+//
+// SeedSigner is fully AIR-GAPPED: no cable, no radio, no network — every byte
+// travels as an animated QR through the local webcam. Like Keystone's QR
+// transport it needs a UI bridge (the modal that shows the animated QR and runs
+// the scanner) and, being fully local, carries NO external-consent gate. Unlike
+// Keystone it has no USB transport at all — QR is its only transport.
+
+/**
+ * A single Uniform Resource decoded from a scanned QR. SeedSigner-named alias of
+ * the shared {@link ScannedUR}; hw/seedsigner.ts decodes it into the concrete
+ * bespoke SeedSigner payload.
+ */
+export type SeedSignerScannedUR = ScannedUR;
+
+/**
+ * UI bridge for the SeedSigner air-gapped QR transport. SeedSigner-named alias
+ * of the shared {@link AirGapQRBridge}. Purely local — no method contacts the
+ * network.
+ */
+export type SeedSignerQRBridge = AirGapQRBridge;
+
+/**
+ * Options for connecting a SeedSigner. `bridge` drives the animated-QR + webcam
+ * exchange; `xfp` is the device master fingerprint captured at account import
+ * (needed so the device recognises the witness paths as its own — the screen
+ * sources it from its per-wallet local store). No consent callback: SeedSigner
+ * is local on its only transport.
+ */
+export interface SeedSignerConnectOptions {
+  bridge: SeedSignerQRBridge;
+  xfp?: string;
+}
+
 /**
  * Ties each {@link HardwareKind} to the connect-options it accepts, so the
  * factory can discriminate at compile time: a local device (Ledger) can NEVER
@@ -140,10 +174,12 @@ export type KeystoneConnectOptions =
  * be connected without one. Enforced via the kind-specific `connectDevice`
  * overloads in hw/index.ts. Keystone is local on both transports (QR and USB),
  * so it takes {@link KeystoneConnectOptions} — a transport choice, never a
- * cloud-consent callback.
+ * cloud-consent callback. SeedSigner is air-gapped QR only, so it takes a
+ * {@link SeedSignerConnectOptions} bridge, likewise never a consent callback.
  */
 export interface ConnectOptionsByKind {
   ledger: LocalConnectOptions;
   trezor: ExternalConnectOptions;
   keystone: KeystoneConnectOptions;
+  seedsigner: SeedSignerConnectOptions;
 }

--- a/ui/web/src/screens/AddWallet.test.tsx
+++ b/ui/web/src/screens/AddWallet.test.tsx
@@ -403,3 +403,21 @@ test("Connect hardware: Keystone is air-gapped QR only (no user-selectable USB t
   // The QR flow scans an account QR rather than "connecting".
   expect(screen.getByRole("button", { name: /scan account qr/i })).toBeInTheDocument();
 });
+
+test("Connect hardware: SeedSigner is a selectable air-gapped QR device", async () => {
+  render(<AddWallet network="preview" knownVaultPassword="vault-pw" onAdded={vi.fn()} />);
+  goToHardware();
+
+  // SeedSigner is offered in the device picker.
+  const seedsigner = screen.getByRole("radio", { name: /^seedsigner$/i });
+  expect(seedsigner).toBeEnabled();
+  fireEvent.click(seedsigner);
+
+  // Air-gapped QR only: no USB/QR transport radio, no consent box.
+  expect(screen.queryByRole("radio", { name: /^usb$/i })).not.toBeInTheDocument();
+  expect(screen.queryByRole("checkbox", { name: /connect\.trezor\.io/i })).not.toBeInTheDocument();
+  expect(screen.getByText(/connects air-gapped over qr/i)).toBeInTheDocument();
+  // The account is imported by scanning a QR, not by "connecting".
+  expect(screen.getByText(/export account/i)).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /scan account qr/i })).toBeInTheDocument();
+});

--- a/ui/web/src/screens/AddWallet.tsx
+++ b/ui/web/src/screens/AddWallet.tsx
@@ -8,8 +8,11 @@ import { addWallet, addHardwareWallet, generateMnemonic, ApiError } from "../api
 import { connectHardware } from "../hw";
 import type { HardwareKind, HardwareSigner } from "../hw";
 import { setDeviceKind, setKeystoneXfp } from "../hw/deviceKind";
+import { setWalletXfp } from "../hw/qr/xfp";
 import { parseAccountSyncUR } from "../hw/keystone";
+import { importSeedSignerAccount } from "../hw/seedsigner";
 import { useKeystoneQRBridge } from "../components/KeystoneQRModal";
+import { useSeedSignerQRBridge } from "../components/SeedSignerQRModal";
 import type { WalletView } from "../api/types";
 import { MIN_PASSWORD_LEN, passwordLength } from "../password";
 import { CHALLENGE_WORD_COUNT, isChallengeAnswerCorrect, pickChallengeIndices, validateChallenge } from "../phraseChallenge";
@@ -58,12 +61,14 @@ const DEVICE_OPTIONS: { kind: HardwareKind; label: string; disabled?: boolean }[
   { kind: "ledger", label: "Ledger" },
   { kind: "trezor", label: "Trezor" },
   { kind: "keystone", label: "Keystone" },
+  { kind: "seedsigner", label: "SeedSigner" },
 ];
 
 const DEVICE_LABELS: Record<HardwareKind, string> = {
   ledger: "Ledger",
   trezor: "Trezor",
   keystone: "Keystone",
+  seedsigner: "SeedSigner",
 };
 
 export function AddWallet({
@@ -104,6 +109,9 @@ export function AddWallet({
   // The QR modal bridge is always mounted (hooks can't be conditional); it
   // renders nothing until a Keystone QR flow drives it.
   const { bridge: keystoneBridge, element: keystoneModal } = useKeystoneQRBridge();
+  // SeedSigner is likewise air-gapped QR only; its own bridge drives the
+  // account-request → account-response exchange for the import below.
+  const { bridge: seedSignerBridge, element: seedSignerModal } = useSeedSignerQRBridge();
 
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -248,6 +256,27 @@ export function AddWallet({
         // (needsKeystoneResync) and prompts an account-sync re-scan to recover
         // it before any QR signing — so a lost hint is non-fatal.
         setKeystoneXfp(wallet.id, xfp);
+        onAdded(wallet);
+        return;
+      }
+
+      if (deviceKind === "seedsigner") {
+        // Air-gapped account import: display a `cardano-account-req` QR, then
+        // scan the device's `cardano-account` reply. importSeedSignerAccount
+        // re-encodes the xpub through the shared helper (byte-identical to every
+        // other device) and hands back the master fingerprint we must remember
+        // so Send can sign over QR later. Same client-only-hint semantics as
+        // Keystone: a lost xfp is recoverable by re-importing.
+        const acct = await importSeedSignerAccount(seedSignerBridge, account);
+        const wallet = await addHardwareWallet(
+          name.trim() || defaultName,
+          acct.xpub,
+          account,
+          network,
+          vaultPw,
+        );
+        setDeviceKind(wallet.id, "seedsigner");
+        setWalletXfp(wallet.id, acct.xfp);
         onAdded(wallet);
         return;
       }
@@ -512,10 +541,11 @@ export function AddWallet({
     // need no such gate.
     const needsExternalConsent = deviceKind === "trezor";
     const isKeystone = deviceKind === "keystone";
-    // Keystone is air-gapped QR only (USB is not user-selectable — see the note
-    // at the keystoneTransport removal above), so "is Keystone" implies QR.
-    const isKeystoneQR = isKeystone;
-    const connectVerb = isKeystoneQR ? "Scan account QR" : `Connect ${deviceLabel}`;
+    const isSeedSigner = deviceKind === "seedsigner";
+    // Keystone and SeedSigner are air-gapped QR only, so account import is a
+    // scan-a-QR flow rather than a live cable connect.
+    const isAirGapQR = isKeystone || isSeedSigner;
+    const connectVerb = isAirGapQR ? "Scan account QR" : `Connect ${deviceLabel}`;
     return (
       <Card title="Connect hardware wallet">
         <form onSubmit={handleHardwareConnect}>
@@ -541,9 +571,9 @@ export function AddWallet({
             ))}
           </fieldset>
 
-          {isKeystone && (
+          {isAirGapQR && (
             <p className="helper-text">
-              Keystone connects air-gapped over QR — no cable, nothing leaves your node.
+              {deviceLabel} connects air-gapped over QR — no cable, nothing leaves your node.
             </p>
           )}
 
@@ -603,9 +633,11 @@ export function AddWallet({
           )}
 
           <p className="helper-text">
-            {isKeystoneQR
+            {isKeystone
               ? "On your Keystone, open the Cardano account and choose Sync / Connect Software Wallet, then scan the account QR it shows. No spending password is needed — the device signs every transaction."
-              : `Connect your ${deviceLabel} device, open the Cardano app, then click Connect. No spending password is needed — the device signs every transaction.`}
+              : isSeedSigner
+                ? "On your SeedSigner, load your seed and choose Export account, then scan the account QR it shows. No spending password is needed — the device signs every transaction."
+                : `Connect your ${deviceLabel} device, open the Cardano app, then click Connect. No spending password is needed — the device signs every transaction.`}
           </p>
 
           {error && (
@@ -619,7 +651,7 @@ export function AddWallet({
               type="submit"
               disabled={loading || (needsExternalConsent && !externalConsent)}
             >
-              {loading ? (isKeystoneQR ? "Scanning…" : "Connecting…") : connectVerb}
+              {loading ? (isAirGapQR ? "Scanning…" : "Connecting…") : connectVerb}
             </Button>
             <Button
               type="button"
@@ -637,6 +669,7 @@ export function AddWallet({
           </div>
         </form>
         {keystoneModal}
+        {seedSignerModal}
       </Card>
     );
   }

--- a/ui/web/src/screens/Send.tsx
+++ b/ui/web/src/screens/Send.tsx
@@ -15,7 +15,9 @@ import { connectHardware, connectDevice } from "../hw";
 import type { HardwareKind, HardwareSigner } from "../hw";
 import { getStoredDeviceKind, setDeviceKind, getKeystoneXfp, setKeystoneXfp } from "../hw/deviceKind";
 import { parseAccountSyncXfp } from "../hw/keystone";
+import { recoverSeedSignerXfp } from "../hw/seedsigner";
 import { useKeystoneQRBridge } from "../components/KeystoneQRModal";
+import { useSeedSignerQRBridge } from "../components/SeedSignerQRModal";
 import { Card } from "../components/Card";
 import { Input } from "../components/Input";
 import { Button } from "../components/Button";
@@ -30,6 +32,7 @@ const DEVICE_LABELS: Record<HardwareKind, string> = {
   ledger: "Ledger",
   trezor: "Trezor",
   keystone: "Keystone",
+  seedsigner: "SeedSigner",
 };
 
 type Phase = "compose" | "preview" | "done";
@@ -364,50 +367,64 @@ function PreviewPhase({
   // acknowledgement (consent law); local devices (Ledger, Keystone) need none.
   const needsExternalConsent = deviceKind === "trezor";
   const isKeystone = deviceKind === "keystone";
+  const isSeedSigner = deviceKind === "seedsigner";
+  // Keystone and SeedSigner both sign fully air-gapped over QR (fully local, no
+  // consent gate). They share the same fingerprint store and recovery pattern;
+  // only the account-recovery exchange differs (Keystone: scan an account-sync
+  // QR; SeedSigner: show an account-request QR, then scan the reply).
+  const isAirGap = isKeystone || isSeedSigner;
 
   // password is only used in the software (!isHardware) confirm path; hooks cannot be conditional.
   const [password, setPassword] = useState("");
   const [externalConsent, setExternalConsent] = useState(false);
-  // Keystone signs air-gapped over QR ONLY. A USB signer exists in the code
-  // (hw/keystone.ts connectKeystoneUSB) but rides a young, unverified vendor SDK
-  // never exercised against real hardware, so it is NOT user-selectable here.
-  // The Keystone device master fingerprint (xfp) for this wallet, sourced from
-  // the per-wallet local hint. QR signing REQUIRES it (the device matches its
-  // witness paths by it); when it is missing — e.g. after a browser-data wipe —
-  // we must NOT sign with a zero fingerprint. Instead the user re-scans the
-  // account-sync QR here to recover it (see handleKeystoneResync). Kept in state
-  // so a recovery updates the UI immediately.
-  const [keystoneXfp, setKeystoneXfpState] = useState<string | undefined>(() =>
+  // The air-gapped device master fingerprint (xfp) for this wallet, sourced from
+  // the per-wallet local hint (a single store shared by every air-gapped-QR
+  // device). QR signing REQUIRES it (the device matches its witness paths by it);
+  // when it is missing — e.g. after a browser-data wipe — we must NOT sign with a
+  // zero fingerprint. Instead the user re-imports the account here to recover it
+  // (see handleAirGapResync). Kept in state so a recovery updates the UI at once.
+  const [airGapXfp, setAirGapXfp] = useState<string | undefined>(() =>
     walletId ? getKeystoneXfp(walletId) : undefined,
   );
-  // The QR modal bridge is always mounted (hooks can't be conditional); it
-  // renders nothing until a Keystone QR flow drives it.
+  // Both QR modal bridges are always mounted (hooks can't be conditional); each
+  // renders nothing until its device's QR flow drives it.
   const { bridge: keystoneBridge, element: keystoneModal } = useKeystoneQRBridge();
+  const { bridge: seedSignerBridge, element: seedSignerModal } = useSeedSignerQRBridge();
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [exported, setExported] = useState<UnsignedTx | null>(null);
 
   // QR signing needs the device fingerprint; when it is missing the user must
-  // re-scan the account-sync QR before they can sign (see handleKeystoneResync).
-  const needsKeystoneResync = isKeystone && keystoneXfp === undefined;
+  // re-import the account before they can sign (see handleAirGapResync).
+  const needsAirGapResync = isAirGap && airGapXfp === undefined;
 
-  // Recover a lost Keystone fingerprint: re-scan the account-sync QR, read just
-  // the master fingerprint (account-independent), and persist it so QR signing
-  // can proceed. Mirrors the device-picker recovery pattern — no need to abandon
-  // and re-add the wallet.
-  async function handleKeystoneResync() {
+  // Recover a lost air-gapped fingerprint: re-run the device's account exchange,
+  // read just the master fingerprint (account-independent), and persist it so QR
+  // signing can proceed. Mirrors the device-picker recovery pattern — no need to
+  // abandon and re-add the wallet.
+  async function handleAirGapResync() {
     setError(null);
     setLoading(true);
     try {
-      const scanned = await keystoneBridge.scanResponse();
-      const xfp = await parseAccountSyncXfp(scanned);
+      let xfp: string;
+      if (isSeedSigner) {
+        // SeedSigner recovery re-runs the account-request → account-response
+        // exchange (recoverSeedSignerXfp tears the bridge down itself).
+        xfp = await recoverSeedSignerXfp(seedSignerBridge);
+      } else {
+        try {
+          const scanned = await keystoneBridge.scanResponse();
+          xfp = await parseAccountSyncXfp(scanned);
+        } finally {
+          keystoneBridge.close();
+        }
+      }
       if (walletId) setKeystoneXfp(walletId, xfp);
-      setKeystoneXfpState(xfp);
+      setAirGapXfp(xfp);
     } catch (e) {
       setError(errorMessage(e));
     } finally {
-      keystoneBridge.close();
       setLoading(false);
     }
   }
@@ -464,25 +481,28 @@ function PreviewPhase({
       // grant WebHID/WebUSB permission while browser user activation is still
       // live. The device kind is the one recorded when this wallet was added
       // (or the one the user just chose when no hint was stored).
-      if (kind === "keystone") {
-        // Keystone is air-gapped QR only — fully local, no consent gate. The
-        // animated-QR + webcam modal drives the exchange; the sign-request needs
-        // the device master fingerprint captured at account-sync (hw/keystone.ts).
-        // Never start a QR sign flow without a real fingerprint: a missing fp
-        // would build a request the device cannot match. The button is disabled
-        // while it is missing (needsKeystoneResync), so this is defensive —
-        // steer the user to the recovery re-scan.
-        if (keystoneXfp === undefined) {
+      if (isAirGap) {
+        // Keystone and SeedSigner are air-gapped QR only — fully local, no
+        // consent gate. The animated-QR + webcam modal drives the exchange; the
+        // sign-request needs the device master fingerprint captured at account
+        // import. Never start a QR sign flow without a real fingerprint: a
+        // missing fp would build a request the device cannot match. The button is
+        // disabled while it is missing (needsAirGapResync), so this is defensive
+        // — steer the user to the recovery re-import.
+        if (airGapXfp === undefined) {
           setError(
-            "This Keystone wallet's device fingerprint is missing. Re-scan the account-sync QR to recover it before signing.",
+            `This ${deviceLabel} wallet's device fingerprint is missing. Re-import the account to recover it before signing.`,
           );
           return;
         }
-        session = await connectDevice("keystone", {
-          transport: "qr",
-          bridge: keystoneBridge,
-          xfp: keystoneXfp,
-        });
+        session =
+          kind === "seedsigner"
+            ? await connectDevice("seedsigner", { bridge: seedSignerBridge, xfp: airGapXfp })
+            : await connectDevice("keystone", {
+                transport: "qr",
+                bridge: keystoneBridge,
+                xfp: airGapXfp,
+              });
       } else {
         // The confirm button is disabled until the Trezor consent box is
         // ticked, so this simply reports the already-given approval; the real
@@ -571,7 +591,7 @@ function PreviewPhase({
                   device you used to add it; you can change this if a connection
                   attempt fails.
                 </p>
-                {(["ledger", "trezor", "keystone"] as const).map((k) => (
+                {(["ledger", "trezor", "keystone", "seedsigner"] as const).map((k) => (
                   <label className="checkbox-row" key={k}>
                     <input
                       type="radio"
@@ -586,27 +606,33 @@ function PreviewPhase({
                 ))}
               </fieldset>
             )}
-            {needsKeystoneResync && (
+            {needsAirGapResync && (
               // The device fingerprint hint was lost (e.g. browser-data wipe).
               // QR signing cannot proceed without it, so recover it in place by
-              // re-scanning the account-sync QR rather than sending a request the
-              // device cannot match.
+              // re-importing the account rather than sending a request the device
+              // cannot match.
               <fieldset className="field-group" style={{ border: "none", padding: 0, margin: 0 }}>
-                <legend className="field-label">Reconnect this Keystone</legend>
+                <legend className="field-label">Reconnect this {deviceLabel}</legend>
                 <p className="helper-text">
-                  We could not find this wallet&apos;s Keystone fingerprint on this browser
-                  (it may have been cleared). On the Keystone, open the Cardano account and
-                  choose Sync / Connect Software Wallet, then scan that QR to reconnect.
+                  We could not find this wallet&apos;s {deviceLabel} fingerprint on this browser
+                  (it may have been cleared).{" "}
+                  {isSeedSigner
+                    ? "On the SeedSigner, load your seed and choose Export account, then scan that QR to reconnect."
+                    : "On the Keystone, open the Cardano account and choose Sync / Connect Software Wallet, then scan that QR to reconnect."}
                 </p>
-                <Button onClick={handleKeystoneResync} disabled={loading}>
-                  {loading ? "Scanning…" : "Scan account-sync QR"}
+                <Button onClick={handleAirGapResync} disabled={loading}>
+                  {loading
+                    ? "Scanning…"
+                    : isSeedSigner
+                      ? "Scan account QR"
+                      : "Scan account-sync QR"}
                 </Button>
               </fieldset>
             )}
-            {deviceKind !== undefined && !needsKeystoneResync && (
+            {deviceKind !== undefined && !needsAirGapResync && (
               <p className="helper-text">
-                {isKeystone
-                  ? "Confirm to show the transaction as a QR for your Keystone, then scan its signature back."
+                {isAirGap
+                  ? `Confirm to show the transaction as a QR for your ${deviceLabel}, then scan its signature back.`
                   : `Connect your ${deviceLabel} and confirm the transaction on the device.`}
               </p>
             )}
@@ -653,7 +679,7 @@ function PreviewPhase({
                 loading ||
                 exporting ||
                 needsDeviceChoice ||
-                needsKeystoneResync ||
+                needsAirGapResync ||
                 (needsExternalConsent && !externalConsent)
               }
             >
@@ -661,8 +687,8 @@ function PreviewPhase({
                 ? "Signing…"
                 : needsDeviceChoice
                   ? "Choose a device"
-                  : needsKeystoneResync
-                    ? "Reconnect Keystone"
+                  : needsAirGapResync
+                    ? `Reconnect ${deviceLabel}`
                     : `Confirm on ${deviceLabel}`}
             </Button>
           ) : (
@@ -711,6 +737,7 @@ function PreviewPhase({
         )}
       </div>
       {keystoneModal}
+      {seedSignerModal}
     </Card>
   );
 }

--- a/ui/web/src/screens/Staking.test.tsx
+++ b/ui/web/src/screens/Staking.test.tsx
@@ -2,7 +2,21 @@ import { act, render, screen, fireEvent, waitFor } from "@testing-library/react"
 import { Staking } from "./Staking";
 import * as client from "../api/client";
 import * as hooks from "../api/hooks";
-import type { DelegationPreview, TxResult, PoolInfo, DRepInfo } from "../api/types";
+import type {
+  DelegationPreview,
+  TxResult,
+  PoolInfo,
+  DRepInfo,
+  HardwareSignResponse,
+} from "../api/types";
+
+// Mock the hardware factory so the SeedSigner staking path signs via a stubbed
+// session rather than driving a real QR exchange. Software tests never call it.
+const { mockSeedSignerSignTx, mockConnectDevice } = vi.hoisted(() => ({
+  mockSeedSignerSignTx: vi.fn(),
+  mockConnectDevice: vi.fn(),
+}));
+vi.mock("../hw", () => ({ connectDevice: mockConnectDevice }));
 
 const MOCK_POOL: PoolInfo = {
   pool_id: "pool1abc",
@@ -415,4 +429,84 @@ test("(l) a buildDelegation error (e.g. no change) is shown inline on the form",
   await waitFor(() => expect(screen.getByText(/nothing to do/i)).toBeInTheDocument());
   // Still on the set-up form.
   expect(screen.getByRole("button", { name: /review delegation/i })).toBeInTheDocument();
+});
+
+// --- SeedSigner hardware delegation (air-gapped QR) ---
+
+const MOCK_HW_SIGN_RESP: HardwareSignResponse = {
+  network: "preview",
+  network_id: 0,
+  protocol_magic: 2,
+  inputs: [{ tx_hash_hex: "deadbeef", output_index: 0, path: "1852'/1815'/0'/0/0" }],
+  outputs: [],
+  change_outputs: [{ index: 0, path: "1852'/1815'/0'/1/0" }],
+  certificate_signers: [
+    { cert_kind: "stake_delegation", role: "stake", path: "1852'/1815'/0'/2/0", key_hash_hex: "aa" },
+  ],
+  fee: "174000",
+  required_signers: [],
+  unsigned_tx_cbor: "84a4deadbeef",
+};
+
+test("(m) SeedSigner hardware wallet signs the delegation air-gapped and submits the witness", async () => {
+  mockDelegation({ active: false });
+  vi.spyOn(client, "buildDelegation").mockResolvedValue(MOCK_PREVIEW);
+  const getReq = vi.spyOn(client, "getHardwareSignRequest").mockResolvedValue(MOCK_HW_SIGN_RESP);
+  const submit = vi.spyOn(client, "submitHardware").mockResolvedValue(MOCK_TX_RESULT);
+  localStorage.clear();
+  // A valid stored fingerprint means no recovery prompt — signing can proceed.
+  localStorage.setItem("bursa.hw.keystoneXfp", JSON.stringify({ "hw-stk": "52744703" }));
+  mockSeedSignerSignTx.mockReset().mockResolvedValue("81825820aabb");
+  mockConnectDevice.mockReset().mockResolvedValue({
+    kind: "seedsigner",
+    capabilities: { send: true, staking: true, governance: true, multisig: true, poolReg: false },
+    getAccountXpub: vi.fn(),
+    signTx: mockSeedSignerSignTx,
+    close: vi.fn().mockResolvedValue(undefined),
+  });
+
+  render(<Staking isHardware walletId="hw-stk" />);
+
+  fireEvent.change(screen.getByPlaceholderText(/pool1\.\.\./i), { target: { value: "pool1abc" } });
+  fireEvent.click(screen.getByRole("button", { name: /review delegation/i }));
+
+  // A hardware wallet has no spending-password field — it signs on the device.
+  await waitFor(() => expect(screen.getByText(/register stake key/i)).toBeInTheDocument());
+  expect(screen.queryByPlaceholderText(/spending password/i)).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("button", { name: /confirm on seedsigner/i }));
+
+  await waitFor(() => {
+    expect(mockConnectDevice.mock.calls[0][0]).toBe("seedsigner");
+    expect(getReq).toHaveBeenCalledWith("del-pending-1");
+    // The NEUTRAL backend request is passed straight to the device signer.
+    expect(mockSeedSignerSignTx).toHaveBeenCalledWith(MOCK_HW_SIGN_RESP);
+    expect(submit).toHaveBeenCalledWith("del-pending-1", "81825820aabb");
+  });
+  await waitFor(() =>
+    expect(screen.getByText(new RegExp(MOCK_TX_RESULT.tx_hash))).toBeInTheDocument(),
+  );
+
+  localStorage.clear();
+});
+
+test("(n) SeedSigner staking with a missing fingerprint prompts a re-import, no device connect", async () => {
+  mockDelegation({ active: false });
+  vi.spyOn(client, "buildDelegation").mockResolvedValue(MOCK_PREVIEW);
+  localStorage.clear();
+  mockConnectDevice.mockReset();
+
+  render(<Staking isHardware walletId="hw-stk-noxfp" />);
+
+  fireEvent.change(screen.getByPlaceholderText(/pool1\.\.\./i), { target: { value: "pool1abc" } });
+  fireEvent.click(screen.getByRole("button", { name: /review delegation/i }));
+
+  await waitFor(() => expect(screen.getByText(/register stake key/i)).toBeInTheDocument());
+  // A missing fingerprint shows the re-import prompt, never a confirm button, and
+  // never starts a device connection with a fabricated zero fingerprint.
+  expect(screen.getByRole("button", { name: /scan account qr/i })).toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /confirm on seedsigner/i })).not.toBeInTheDocument();
+  expect(mockConnectDevice).not.toHaveBeenCalled();
+
+  localStorage.clear();
 });

--- a/ui/web/src/screens/Staking.tsx
+++ b/ui/web/src/screens/Staking.tsx
@@ -14,9 +14,16 @@ import {
   getDRep,
   buildDelegation,
   confirmDelegation,
+  getHardwareSignRequest,
+  submitHardware,
   ApiError,
 } from "../api/client";
 import { useDelegation } from "../api/hooks";
+import { connectDevice } from "../hw";
+import type { HardwareSigner } from "../hw";
+import { getKeystoneXfp, setKeystoneXfp } from "../hw/deviceKind";
+import { recoverSeedSignerXfp } from "../hw/seedsigner";
+import { useSeedSignerQRBridge } from "../components/SeedSignerQRModal";
 import { Card } from "../components/Card";
 import { Input } from "../components/Input";
 import { Button } from "../components/Button";
@@ -403,14 +410,44 @@ const CERT_MARK: Record<Cert["kind"], string> = {
 
 interface PreviewPhaseProps {
   preview: DelegationPreview;
+  // A SeedSigner hardware wallet signs the delegation air-gapped over QR
+  // (its device supports certificates / votes); a full wallet signs locally
+  // with its spending password. Only SeedSigner reaches here as hardware (the
+  // app's canStake gate excludes the certificate-incapable hardware devices).
+  isHardware?: boolean;
+  walletId?: string;
   onBack: () => void;
   onDone: (result: TxResult) => void;
 }
 
-function PreviewPhase({ preview, onBack, onDone }: PreviewPhaseProps) {
+function PreviewPhase({ preview, isHardware, walletId, onBack, onDone }: PreviewPhaseProps) {
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  // SeedSigner air-gapped signing: the device master fingerprint (xfp) is
+  // required so the device matches its witness paths; it is a per-wallet local
+  // hint that can go missing (browser-data wipe), in which case the user
+  // re-imports the account to recover it before signing.
+  const [airGapXfp, setAirGapXfp] = useState<string | undefined>(() =>
+    walletId ? getKeystoneXfp(walletId) : undefined,
+  );
+  const { bridge: seedSignerBridge, element: seedSignerModal } = useSeedSignerQRBridge();
+  const needsAirGapResync = (isHardware ?? false) && airGapXfp === undefined;
+
+  async function handleAirGapResync() {
+    setError(null);
+    setLoading(true);
+    try {
+      const xfp = await recoverSeedSignerXfp(seedSignerBridge);
+      if (walletId) setKeystoneXfp(walletId, xfp);
+      setAirGapXfp(xfp);
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }
 
   async function handleConfirm() {
     setError(null);
@@ -420,6 +457,37 @@ function PreviewPhase({ preview, onBack, onDone }: PreviewPhaseProps) {
     } catch (e) {
       setError(errorMessage(e));
     } finally {
+      setLoading(false);
+    }
+  }
+
+  // Hardware confirm: connect the SeedSigner over QR → fetch the neutral signing
+  // request for this delegation pending id → sign on the device → submit the
+  // witness. This reuses the exact neutral hardware-signing flow Send uses; the
+  // delegation shares the same pending store, so the send-scoped endpoints apply.
+  async function handleHardwareConfirm() {
+    setError(null);
+    if (airGapXfp === undefined) {
+      setError(
+        "This SeedSigner wallet's device fingerprint is missing. Re-import the account to recover it before signing.",
+      );
+      return;
+    }
+    setLoading(true);
+    let session: HardwareSigner | null = null;
+    try {
+      session = await connectDevice("seedsigner", { bridge: seedSignerBridge, xfp: airGapXfp });
+      const signResp = await getHardwareSignRequest(preview.pending_id);
+      if (signResp.unsupported) {
+        setError(`This transaction cannot be signed on hardware: ${signResp.unsupported}`);
+        return;
+      }
+      const witnessCbor = await session.signTx(signResp);
+      onDone(await submitHardware(preview.pending_id, witnessCbor));
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      if (session) await session.close().catch(() => {});
       setLoading(false);
     }
   }
@@ -467,37 +535,85 @@ function PreviewPhase({ preview, onBack, onDone }: PreviewPhaseProps) {
         </dl>
       </Card>
 
-      <Card title="Spending password">
+      <Card title={isHardware ? "Sign on your SeedSigner" : "Spending password"}>
         <div className="staking-form">
-          <label htmlFor="staking-password">Spending password</label>
-          <Input
-            id="staking-password"
-            type="password"
-            placeholder="Spending password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            disabled={loading}
-          />
-          <p className="helper-text">
-            Signs locally; the transaction is submitted through your own node.
-          </p>
+          {isHardware ? (
+            needsAirGapResync ? (
+              <>
+                <p className="helper-text">
+                  We could not find this wallet&apos;s SeedSigner fingerprint on this browser
+                  (it may have been cleared). On the SeedSigner, load your seed and choose
+                  Export account, then scan that QR to reconnect.
+                </p>
+                {error && (
+                  <p role="alert" className="error-text">
+                    {error}
+                  </p>
+                )}
+                <div className="preview-actions">
+                  <Button variant="ghost" onClick={onBack} disabled={loading}>
+                    Back
+                  </Button>
+                  <Button onClick={handleAirGapResync} disabled={loading}>
+                    {loading ? "Scanning…" : "Scan account QR"}
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <>
+                <p className="helper-text">
+                  Confirm to show the transaction as a QR for your SeedSigner, then scan its
+                  signature back. Submitted through your own node.
+                </p>
+                {error && (
+                  <p role="alert" className="error-text">
+                    {error}
+                  </p>
+                )}
+                <div className="preview-actions">
+                  <Button variant="ghost" onClick={onBack} disabled={loading}>
+                    Back
+                  </Button>
+                  <Button onClick={handleHardwareConfirm} disabled={loading}>
+                    {loading ? "Signing…" : "Confirm on SeedSigner"}
+                  </Button>
+                </div>
+              </>
+            )
+          ) : (
+            <>
+              <label htmlFor="staking-password">Spending password</label>
+              <Input
+                id="staking-password"
+                type="password"
+                placeholder="Spending password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                disabled={loading}
+              />
+              <p className="helper-text">
+                Signs locally; the transaction is submitted through your own node.
+              </p>
 
-          {error && (
-            <p role="alert" className="error-text">
-              {error}
-            </p>
+              {error && (
+                <p role="alert" className="error-text">
+                  {error}
+                </p>
+              )}
+
+              <div className="preview-actions">
+                <Button variant="ghost" onClick={onBack} disabled={loading}>
+                  Back
+                </Button>
+                <Button onClick={handleConfirm} disabled={loading || !password}>
+                  {loading ? "Submitting…" : "Confirm & sign"}
+                </Button>
+              </div>
+            </>
           )}
-
-          <div className="preview-actions">
-            <Button variant="ghost" onClick={onBack} disabled={loading}>
-              Back
-            </Button>
-            <Button onClick={handleConfirm} disabled={loading || !password}>
-              {loading ? "Submitting…" : "Confirm & sign"}
-            </Button>
-          </div>
         </div>
       </Card>
+      {seedSignerModal}
     </div>
   );
 }
@@ -583,9 +699,14 @@ interface StakingProps {
   // Optional so existing no-prop callers/tests keep working; the app always
   // passes the active wallet's real network when routing to this screen.
   network?: string;
+  // A SeedSigner hardware wallet delegates by signing air-gapped over QR
+  // (the app only routes staking to a hardware wallet whose device supports
+  // certificates — i.e. SeedSigner); walletId keys its per-wallet fingerprint.
+  isHardware?: boolean;
+  walletId?: string;
 }
 
-export function Staking({ network = "preview" }: StakingProps = {}) {
+export function Staking({ network = "preview", isHardware, walletId }: StakingProps = {}) {
   const delegation = useDelegation();
 
   const [phase, setPhase] = useState<Phase>("status");
@@ -653,6 +774,8 @@ export function Staking({ network = "preview" }: StakingProps = {}) {
     return (
       <PreviewPhase
         preview={preview}
+        isHardware={isHardware}
+        walletId={walletId}
         onBack={() => setPhase(previewFrom)}
         onDone={handleDone}
       />


### PR DESCRIPTION
Adds a SeedSigner air-gapped-QR hardware wallet on the existing `HardwareSigner` abstraction and the shared `hw/qr/*` scaffolding.

## Device (`hw/seedsigner.ts`, kind `seedsigner`)

Bespoke, untagged, integer-keyed CBOR payloads carried over the shared BC-UR2 transport (`hw/qr/ur.ts`) and codec (`hw/qr/cbor.ts`); the UR type string is the discriminator.

- Account import: displays `cardano-account-req` `{1:request_id, 2:origin, 3:account_indices, 4:key_purpose}`, scans `cardano-account` `{1:request_id, 2:xfp(4B), 3:[{1:idx, 2:xpub64, 3:path}], 4:device_label}`. Splits the 64-byte xpub and re-encodes it through the shared `encodeXpub` (byte-identical to Ledger/Trezor/Keystone); records the xfp in the shared per-wallet fingerprint store.
- signTx: displays `cardano-tx-sig-req` `{1:request_id, 2:origin, 3:sign_data, 4:inputs[{1:tx_hash, 2:index, 3:xfp, 4:path}], 5:change_outputs[{1:index, 2:path}], 6:extra_signers[[xfp, path]], 7:network}` built from the neutral backend `HardwareSignRequest`. Script-locked inputs carry no xfp/path; `extra_signers` aggregates the certificate / withdrawal / vote / multisig signer paths. Scans `cardano-tx-sig-res` `{1:request_id, 2:witness_set (tag 258 [[vkey32, sig64]])}` and re-encodes it through the shared `encodeWitnessArray`.
- `capabilities: { send: true, staking: true, governance: true, multisig: true, poolReg: false }`. No external-consent gate (fully local / air-gapped). A missing device fingerprint blocks signing and prompts a re-import (never a fabricated zero fingerprint).

## Wiring

- `hw/types.ts` / `hw/index.ts`: `seedsigner` added to `HardwareKind`, `ConnectOptionsByKind`, the `connectDevice("seedsigner", …)` overload + factory case, and `connectHardware` (refused — QR-only, driven through `connectDevice`). `hw/deviceKind.ts` recognises the `seedsigner` hint.
- AddWallet: SeedSigner added to the hardware-device picker; imports the account by scanning its QR.
- Send: a SeedSigner wallet is routed through the shared air-gapped-QR signing flow (with lost-fingerprint re-import recovery).
- Staking: a SeedSigner wallet signs the delegation over QR via the same neutral hardware-signing flow (`app.tsx` opens the Staking route to a SeedSigner hardware wallet; Ledger/Trezor/Keystone hardware wallets remain excluded).

## Tests

`hw/seedsigner.test.ts`, plus additions to `hw/index.test.ts`, `hw/deviceKind.test.ts`, `screens/AddWallet.test.tsx`, `screens/Staking.test.tsx`:

- Byte-exact `cardano-account-req` and `cardano-tx-sig-req` encodings (untagged integer-keyed maps for a known input).
- `cardano-tx-sig-res` witness-set round-trip to the shared witness-array CBOR.
- xpub parity for the `abandon … about` vector.
- `extra_signers` aggregation across certificate / withdrawal / vote / explicit signers; script-locked input carries only tx_hash + index.
- Capability gating (send / staking / governance / multisig true); missing-xfp re-import recovery; no consent gate invoked.
- SeedSigner AddWallet picker; SeedSigner staking confirm connects the device, fetches the neutral request, signs, and submits.

## Screenshot

AddWallet SeedSigner device picker:

![AddWallet SeedSigner picker](https://raw.githubusercontent.com/blinklabs-io/bursa/ci/screenshots/screenshots/pr-651/addwallet-seedsigner-picker.png)
