### PR TITLE
chore(deps): bump shai + dingo v0.68 (adapt supervisor API)

### DIFF
--- a/ui/go.mod
+++ b/ui/go.mod
@@ -6,11 +6,11 @@ require (
 	fyne.io/systray v1.12.1
 	github.com/Salvionied/apollo/v2 v2.0.0-20260729192515-7fa2cfd06025
 	github.com/blinklabs-io/bursa v0.16.1-0.20260723122856-2f8b123a98ae
-	github.com/blinklabs-io/dingo v0.66.2
+	github.com/blinklabs-io/dingo v0.68.0
 	github.com/blinklabs-io/go-bip39 v0.2.0
 	github.com/blinklabs-io/gouroboros v0.190.0
 	github.com/blinklabs-io/plutigo v0.1.17
-	github.com/blinklabs-io/shai v0.0.0-20260724152428-02e3f7d23dd8
+	github.com/blinklabs-io/shai v0.0.0-20260802142328-c23aaf4bf701
 	github.com/btcsuite/btcd/btcutil v1.2.0
 	github.com/glebarez/go-sqlite v1.21.2
 	github.com/google/go-tpm v0.9.8
@@ -104,7 +104,7 @@ require (
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.1.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 // indirect
-	github.com/dgraph-io/badger/v4 v4.9.4 // indirect
+	github.com/dgraph-io/badger/v4 v4.9.5 // indirect
 	github.com/dgraph-io/ristretto/v2 v2.2.0 // indirect
 	github.com/dunglas/httpsfv v1.1.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/ui/go.sum
+++ b/ui/go.sum
@@ -145,8 +145,8 @@ github.com/blinklabs-io/bark v0.1.0 h1:hnFSOcnOlEUoHz7dFsT67aNVip+oYyPo6iKk6y1/T
 github.com/blinklabs-io/bark v0.1.0/go.mod h1:Csm/dR5sdx4T/N9cZ3ZO+3tFmSWFul2HnmWDQtugWms=
 github.com/blinklabs-io/bursa v0.16.1-0.20260723122856-2f8b123a98ae h1:QtuiW1YnvpMfp28liHcTPb2A/UUP4HeZDWpC6QP5XmM=
 github.com/blinklabs-io/bursa v0.16.1-0.20260723122856-2f8b123a98ae/go.mod h1:mcUIQifk8bNmCZ1tgh2IbxJa1GmRoDu6De5WUiboDHs=
-github.com/blinklabs-io/dingo v0.66.2 h1:x5QtTiID8dmPu0flt0HsuPb+n63edEAFVaFiAJgtcz4=
-github.com/blinklabs-io/dingo v0.66.2/go.mod h1:AwP/Sjq6SAgweq/ArLMakVKH6PmjqYMqWFKvET6OtvE=
+github.com/blinklabs-io/dingo v0.68.0 h1:wBqr3Sjii7o3BATUpjAN45i9eOn62jHDjipKEx05Jww=
+github.com/blinklabs-io/dingo v0.68.0/go.mod h1:mccpEtnTEeDCbFCeMPUXQNXW6lvvnL/bDnQRMQtSemA=
 github.com/blinklabs-io/go-bip39 v0.2.0 h1:rHYih+JzqaFVuP+UfvByKTAdJPeYtlvZu49yUGrZUk8=
 github.com/blinklabs-io/go-bip39 v0.2.0/go.mod h1:9Bp7a+XDc/KTPOqNnS7T/v1vH2lDXpmjM0GArwvOQL4=
 github.com/blinklabs-io/gouroboros v0.189.4 h1:9zW9iu+7c/Xou9jH9VoC71CZ9IdvcHvbf4u58u6tnzU=
@@ -155,8 +155,8 @@ github.com/blinklabs-io/ouroboros-mock v0.15.0 h1:IB35erNGObqilpOLkrmdp0fH2aKKoV
 github.com/blinklabs-io/ouroboros-mock v0.15.0/go.mod h1:ysGU8dMjG8ShMQco/aarR1xIRH7GPCIdhrnkM+J4IVA=
 github.com/blinklabs-io/plutigo v0.1.17 h1:44JJf9Y4G7fminNJp4H6fBQbW8nzrevSlap9a1V0EHs=
 github.com/blinklabs-io/plutigo v0.1.17/go.mod h1:X+Ydplpgftjjq5Y1Oc3dRebGgdBSeAbOi1+ItJhQths=
-github.com/blinklabs-io/shai v0.0.0-20260724152428-02e3f7d23dd8 h1:Z5Bq6fTeX/hlviFFrvSqrPrAvVHxdu/g/2Jp1kf17CY=
-github.com/blinklabs-io/shai v0.0.0-20260724152428-02e3f7d23dd8/go.mod h1:1O5SvQa/FuQMGYehvtQ8O1s9eIE3EmACFyN/csSzNoY=
+github.com/blinklabs-io/shai v0.0.0-20260802142328-c23aaf4bf701 h1:qR+6pyb1aipUHJAn4l6EYi8quPC3ECrY2l4Vmot/3M4=
+github.com/blinklabs-io/shai v0.0.0-20260802142328-c23aaf4bf701/go.mod h1:acY1CUd5+xNxdJsMT3IqdyGCndJGz/xSbvZHyHCp000=
 github.com/blockfrost/blockfrost-go v0.4.0 h1:sJuxmtoWUJ3sXfqTuFhYcFMdDNdo938nSX/KcLcAPQ0=
 github.com/blockfrost/blockfrost-go v0.4.0/go.mod h1:XdD+mryM/Rd/MqW1MfSQ0+Xfu2YnOGuwqMpLQa0jHvM=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=
@@ -207,8 +207,8 @@ github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U
 github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 h1:5RVFMOWjMyRy8cARdy79nAmgYw3hK/4HUq48LQ6Wwqo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
-github.com/dgraph-io/badger/v4 v4.9.4 h1:bcw+waCpzRZ2nmcSPbnPvDVhiEsn98TKmvnAhK7r7LM=
-github.com/dgraph-io/badger/v4 v4.9.4/go.mod h1:nJjaJTUOSsQEBhsq209FmwCvMJzEA3e74RjZw6V2pQI=
+github.com/dgraph-io/badger/v4 v4.9.5 h1:zT46OMrF3ntqsfI3ynKp7hUkQrGlcK2CX5psQmH0iW0=
+github.com/dgraph-io/badger/v4 v4.9.5/go.mod h1:Xa9dAupjbwAacupWFCpa6YEn9E1PjBXkfZYr2I/8aWg=
 github.com/dgraph-io/ristretto/v2 v2.2.0 h1:bkY3XzJcXoMuELV8F+vS8kzNgicwQFAaGINAEJdWGOM=
 github.com/dgraph-io/ristretto/v2 v2.2.0/go.mod h1:RZrm63UmcBAaYWC1DotLYBmTvgkrs0+XhBd7Npn7/zI=
 github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa512G+w+Pxci9hJPB8oMnkcP3iZF38=

--- a/ui/internal/supervisor/bootstrap.go
+++ b/ui/internal/supervisor/bootstrap.go
@@ -22,8 +22,8 @@ import (
 	"path/filepath"
 
 	"github.com/blinklabs-io/dingo"
-	"github.com/blinklabs-io/dingo/database"
 	"github.com/blinklabs-io/dingo/mithril"
+	"github.com/blinklabs-io/dingo/plugin"
 )
 
 // bootstrapMarker is written inside the node DB dir once a Mithril bootstrap
@@ -54,16 +54,19 @@ func (b mithrilBootstrapper) Bootstrap(ctx context.Context, p BootstrapParams) e
 // syncConfigFor builds the mithril.SyncConfig for a bootstrap. The storage mode
 // and blob/metadata plugins MUST match the node's, or the imported DB will not
 // open; we bind them to the same dingo defaults the supervisor's node uses
-// (StorageModeAPI + database.DefaultConfig) so they can't silently drift.
-// CardanoNodeConfig is left nil so mithril.Sync loads it from the embedded
-// config for Network (same source the node uses).
+// (StorageModeAPI + badger blob / sqlite metadata, dingo's default plugin
+// selections) so they can't silently drift. CardanoNodeConfig is left nil so
+// mithril.Sync loads it from the embedded config for Network (same source the
+// node uses).
 func syncConfigFor(p BootstrapParams, logger *slog.Logger) mithril.SyncConfig {
 	return mithril.SyncConfig{
-		Network:          p.Network,
-		DataDir:          p.DataDir,
-		StorageMode:      string(dingo.StorageModeAPI),
-		BlobPlugin:       database.DefaultConfig.BlobPlugin,
-		MetadataPlugin:   database.DefaultConfig.MetadataPlugin,
+		Network:     p.Network,
+		DataDir:     p.DataDir,
+		StorageMode: string(dingo.StorageModeAPI),
+		StoragePlugins: mithril.StoragePlugins{
+			Blob:     plugin.Selection{Provider: "badger"},
+			Metadata: plugin.Selection{Provider: "sqlite"},
+		},
 		VerifyCertChain:  true,
 		CleanupAfterLoad: true,
 		// dingo v0.55.0's API-mode backfill phase requires a positive batch size

--- a/ui/internal/supervisor/bootstrap_test.go
+++ b/ui/internal/supervisor/bootstrap_test.go
@@ -28,7 +28,9 @@ func TestSyncConfigForMapsFields(t *testing.T) {
 	if sc.Network != "preview" || sc.DataDir != "/data/db" {
 		t.Fatalf("network/datadir: %+v", sc)
 	}
-	if sc.StorageMode != "api" || sc.BlobPlugin != "badger" || sc.MetadataPlugin != "sqlite" {
+	if sc.StorageMode != "api" ||
+		sc.StoragePlugins.Blob.Provider != "badger" ||
+		sc.StoragePlugins.Metadata.Provider != "sqlite" {
 		t.Fatalf("storage/plugins: %+v", sc)
 	}
 	if !sc.VerifyCertChain || !sc.CleanupAfterLoad {

--- a/ui/internal/supervisor/supervisor.go
+++ b/ui/internal/supervisor/supervisor.go
@@ -27,6 +27,7 @@ import (
 	"github.com/blinklabs-io/dingo"
 	"github.com/blinklabs-io/dingo/config/cardano"
 	"github.com/blinklabs-io/dingo/connmanager"
+	"github.com/blinklabs-io/dingo/plugin"
 	"github.com/blinklabs-io/dingo/topology"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -156,14 +157,28 @@ func nodeConfigOptions(
 		dingo.WithPrometheusRegistry(promRegistry),
 		dingo.WithDatabasePath(cfg.DataDir),
 		dingo.WithStorageMode(dingo.StorageModeAPI),
-		// Without an explicit capacity the mempool defaults to 0 bytes and
-		// rejects every transaction ("mempool full: capacity=0 bytes"), so the
-		// wallet could never submit a spend. Match Dingo's own Praos default
-		// (1 MiB) — ample for a single-user wallet submitting its own txs.
-		dingo.WithMempoolCapacity(1 << 20),
+		// Match Dingo's own Praos default mempool capacity (1 MiB) — ample for a
+		// single-user wallet submitting its own txs. In dingo v0.68 the mempool,
+		// blockfrost, and utxorpc APIs are configured as plugin selections rather
+		// than dedicated options; the default provider config carries capacity
+		// (mempool) and port (blockfrost/utxorpc).
+		dingo.WithPluginSelection(plugin.CapabilityMempool, plugin.Selection{
+			Provider: "default",
+			Config: map[string]any{
+				"capacity":           int64(1 << 20),
+				"evictionWatermark":  0.90,
+				"rejectionWatermark": 0.95,
+			},
+		}),
 		dingo.WithBindAddr("127.0.0.1"),
-		dingo.WithUtxorpcPort(cfg.UtxorpcPort),
-		dingo.WithBlockfrostPort(cfg.BlockfrostPort),
+		dingo.WithPluginSelection(plugin.CapabilityAPIUtxorpc, plugin.Selection{
+			Provider: "builtin",
+			Config:   map[string]any{"port": cfg.UtxorpcPort},
+		}),
+		dingo.WithPluginSelection(plugin.CapabilityAPIBlockfrost, plugin.Selection{
+			Provider: "builtin",
+			Config:   map[string]any{"port": cfg.BlockfrostPort},
+		}),
 		dingo.WithListeners(connmanager.ListenerConfig{
 			ListenNetwork: "unix",
 			ListenAddress: cfg.SocketPath,


### PR DESCRIPTION
## Dependency bumps (ui module)

- `github.com/blinklabs-io/shai` → `v0.0.0-20260802142328-c23aaf4bf701`
- `github.com/blinklabs-io/dingo` `v0.66.2` → `v0.68.0` (transitive via shai)
- `github.com/dgraph-io/badger/v4` `v4.9.4` → `v4.9.5` (indirect)

## dingo v0.68 API adaptations (`ui/internal/supervisor`)

dingo v0.68 replaced the dedicated mempool/API options and the `SyncConfig`/`database.Config` plugin fields with the plugin-selection model (`dingo.WithPluginSelection(capability, plugin.Selection{...})` and `mithril.StoragePlugins`).

Old → new mappings:

- `dingo.WithMempoolCapacity(1 << 20)` → `dingo.WithPluginSelection(plugin.CapabilityMempool, plugin.Selection{Provider: "default", Config: {"capacity": int64(1<<20), "evictionWatermark": 0.90, "rejectionWatermark": 0.95}})`
- `dingo.WithUtxorpcPort(cfg.UtxorpcPort)` → `dingo.WithPluginSelection(plugin.CapabilityAPIUtxorpc, plugin.Selection{Provider: "builtin", Config: {"port": cfg.UtxorpcPort}})`
- `dingo.WithBlockfrostPort(cfg.BlockfrostPort)` → `dingo.WithPluginSelection(plugin.CapabilityAPIBlockfrost, plugin.Selection{Provider: "builtin", Config: {"port": cfg.BlockfrostPort}})`
- `mithril.SyncConfig{BlobPlugin: database.DefaultConfig.BlobPlugin, MetadataPlugin: database.DefaultConfig.MetadataPlugin}` → `mithril.SyncConfig{StoragePlugins: mithril.StoragePlugins{Blob: plugin.Selection{Provider: "badger"}, Metadata: plugin.Selection{Provider: "sqlite"}}}`

Behavior preserved: mempool capacity 1 MiB (dingo Praos default) with default watermarks; port 0 still disables the utxorpc/blockfrost listeners (node gates on `port > 0`, reading the explicit port from the selection config); blob=badger / metadata=sqlite match the node's default plugin selections. `bootstrap_test.go` updated to assert the new `StoragePlugins` fields.

## gouroboros replace

Not dropped. dingo v0.68 still uses the single-return `consensus.CertifiedNatThresholdWithMode` / `IsVRFOutputBelowThresholdWithMode` API; gouroboros v0.190.0 changed both to return two values, so building without the replace fails in `dingo/ledger` and `dingo/ledger/leader`. `replace github.com/blinklabs-io/gouroboros => v0.189.4` retained.

## govulncheck delta

No change. Before (main) and after (this branch), from `ui/` with `GOTOOLCHAIN=go1.26.0`: 18 called vulnerabilities, all Go standard library (go1.26, fixed in go1.26.x — toolchain-related, unrelated to these deps), plus 6 in imported packages and 3 in required modules, none called. Identical vulnerability ID set on both; the only diff is dep version strings and a shifted line number.

## Verification

From `ui/`: `go build ./...`, `go vet ./...`, `golangci-lint run ./cmd/... ./internal/...` (0 issues), `go test ./...` all pass. Repo root `CGO_ENABLED=0 go build ./...` passes; root go.mod/go.sum unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `shai` and `dingo` to v0.68 and adapt the supervisor/bootstrapping code to the new plugin-selection API while keeping existing behavior (1 MiB mempool, port gating, badger/sqlite storage).

- **Dependencies**
  - Bumped `github.com/blinklabs-io/shai` to `v0.0.0-20260802142328-c23aaf4bf701`.
  - Bumped `github.com/blinklabs-io/dingo` to `v0.68.0`.
  - Updated indirect `github.com/dgraph-io/badger/v4` to `v4.9.5`.
  - Kept `replace github.com/blinklabs-io/gouroboros => v0.189.4` due to `dingo`’s current API usage.

- **Refactors**
  - Migrated mempool and API config to `dingo.WithPluginSelection(...)` using `plugin.CapabilityMempool`, `CapabilityAPIUtxorpc`, and `CapabilityAPIBlockfrost`.
  - Preserved mempool capacity (1 MiB) and default watermarks; `port == 0` still disables UtxoRPC/Blockfrost listeners.
  - Switched Mithril bootstrap to `mithril.StoragePlugins` with `badger` (blob) and `sqlite` (metadata); updated test to assert the new fields.

<sup>Written for commit 804ed88369f69f52229746b006f888967850f301. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified configuration for storage, mempool, UTxO-RPC, and Blockfrost service providers.
  * Added configurable mempool capacity and watermark settings.
  * Added support for selecting storage providers separately for blobs and metadata.
  * Added configurable built-in API providers and ports.

* **Bug Fixes**
  * Improved consistency when applying service and storage configuration during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->