### PR TITLE
feat(signer): enforce opcert issue-counter monotonicity

### DIFF
--- a/internal/signer/coordinator_opcert.go
+++ b/internal/signer/coordinator_opcert.go
@@ -108,7 +108,10 @@ func (c *Coordinator) SignOpCert(ctx context.Context, kesVkey []byte, issueCount
 	// increase per cold key. A stale or duplicate counter is refused before the
 	// cold key ever signs, so a compromised or buggy caller cannot re-issue an
 	// opcert for a counter already used.
-	var counterWM watermark.CounterWatermark
+	var (
+		counterWM               watermark.CounterWatermark
+		counterConflictReported bool
+	)
 	if c.deps.WMMode != watermark.ModeOff {
 		cw, ok := c.deps.Watermark.(watermark.CounterWatermark)
 		if !ok {
@@ -125,6 +128,7 @@ func (c *Coordinator) SignOpCert(ctx context.Context, kesVkey []byte, issueCount
 			return nil, CodeBackend, fmt.Errorf("opcert counter lookup: %w", cerr)
 		}
 		if exists && issueCounter <= stored {
+			counterConflictReported = true
 			c.deps.Metrics.observeWatermarkConflict()
 			if c.deps.WMMode == watermark.ModeEnforce {
 				c.deps.Logger.Info("sign", "type", "opcert", "caller-key", hash.String(), "issue-counter", issueCounter, "stored-counter", stored, "result", "denied", "reason", "issue counter is not strictly greater than the highest signed")
@@ -189,7 +193,14 @@ func (c *Coordinator) SignOpCert(ctx context.Context, kesVkey []byte, issueCount
 					return nil, CodeConflict, fmt.Errorf("opcert issue counter %d is not greater than the highest signed for this cold key", issueCounter)
 				}
 				// warn mode: the stored counter already meets or exceeds ours;
-				// nothing to advance. The signature is still returned.
+				// nothing to advance. The signature is still returned. Only log
+				// and meter here if the pre-sign check did not already do so for
+				// this same request, so a request that was stale from the start
+				// is not double-counted.
+				if !counterConflictReported {
+					c.deps.Logger.Warn("sign", "type", "opcert", "caller-key", hash.String(), "issue-counter", issueCounter, "result", "warn", "reason", "issue counter regression detected at commit (concurrent signer; warn mode)")
+					c.deps.Metrics.observeWatermarkConflict()
+				}
 			} else {
 				c.deps.Logger.Error("sign", "type", "opcert", "caller-key", hash.String(), "result", "error", "reason", werr.Error())
 				if c.deps.WMMode == watermark.ModeEnforce {

--- a/internal/signer/coordinator_opcert.go
+++ b/internal/signer/coordinator_opcert.go
@@ -23,11 +23,17 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/bursa/internal/signer/backend"
+	"github.com/blinklabs-io/bursa/internal/signer/watermark"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
 // kesVkeySize is the length in bytes of a KES verification key (Ed25519-sized).
 const kesVkeySize = 32
+
+// opcertCounterScope namespaces the monotonic issue-counter watermark. The
+// record key already embeds the cold-key hash, so this scope only separates
+// opcert-counter records from tx/cip8 payload watermarks for the same key.
+const opcertCounterScope = "opcert-counter"
 
 // OpCertResult is the outcome of an operational-certificate cold-signing request.
 type OpCertResult struct {
@@ -98,6 +104,39 @@ func (c *Coordinator) SignOpCert(ctx context.Context, kesVkey []byte, issueCount
 		return nil, CodeBadRequest, fmt.Errorf("opcert signing requires a %q key, got %q", backend.KeyTypePool, ref.Type())
 	}
 
+	// Anti-double-sign: the operational-certificate issue counter must strictly
+	// increase per cold key. A stale or duplicate counter is refused before the
+	// cold key ever signs, so a compromised or buggy caller cannot re-issue an
+	// opcert for a counter already used.
+	var counterWM watermark.CounterWatermark
+	if c.deps.WMMode != watermark.ModeOff {
+		cw, ok := c.deps.Watermark.(watermark.CounterWatermark)
+		if !ok {
+			c.deps.Logger.Error("sign", "type", "opcert", "caller-key", hash.String(), "result", "internal-error", "reason", "watermark store does not support monotonic counters")
+			c.deps.Metrics.observe("opcert", string(CodeInternal))
+			return nil, CodeInternal, errors.New("watermark store does not support opcert issue counters")
+		}
+		counterWM = cw
+		stored, exists, cerr := cw.CounterFor(ctx, hash, opcertCounterScope)
+		if cerr != nil {
+			c.deps.Logger.Info("sign", "type", "opcert", "caller-key", hash.String(), "result", "error", "reason", cerr.Error())
+			c.deps.Metrics.observe("opcert", string(CodeBackend))
+			c.deps.Metrics.observeBackendError("watermark")
+			return nil, CodeBackend, fmt.Errorf("opcert counter lookup: %w", cerr)
+		}
+		if exists && issueCounter <= stored {
+			c.deps.Metrics.observeWatermarkConflict()
+			if c.deps.WMMode == watermark.ModeEnforce {
+				c.deps.Logger.Info("sign", "type", "opcert", "caller-key", hash.String(), "issue-counter", issueCounter, "stored-counter", stored, "result", "denied", "reason", "issue counter is not strictly greater than the highest signed")
+				c.deps.Metrics.observe("opcert", string(CodeConflict))
+				c.deps.Metrics.observeDeny(string(CodeConflict))
+				return nil, CodeConflict, fmt.Errorf("opcert issue counter %d is not greater than the highest signed %d for this cold key", issueCounter, stored)
+			}
+			// warn mode: log and allow; the signature is still produced.
+			c.deps.Logger.Warn("sign", "type", "opcert", "caller-key", hash.String(), "issue-counter", issueCounter, "stored-counter", stored, "result", "warn", "reason", "issue counter is not strictly greater than the highest signed (warn mode)")
+		}
+	}
+
 	// The cold key signs the raw OCertSignable bytes directly (this is NOT a
 	// CBOR encoding). Building it via gouroboros keeps the byte layout identical
 	// to cardano-node / cardano-ledger and to Part A's canonical envelope.
@@ -134,7 +173,35 @@ func (c *Coordinator) SignOpCert(ctx context.Context, kesVkey []byte, issueCount
 		return nil, CodeInternal, errors.New("produced signature failed verification")
 	}
 
-	c.deps.Logger.Info("sign", "type", "opcert", "caller-key", hash.String(), "result", "signed")
+	// Persist the new highest counter only after a verified signature. The commit
+	// is an atomic advance-if-greater, so if a concurrent request advanced the
+	// counter past ours between the pre-sign check and here, we lose the race and
+	// must discard this signature rather than return a second opcert for a
+	// now-stale counter.
+	if counterWM != nil {
+		if werr := counterWM.CheckAndCommitCounter(ctx, hash, opcertCounterScope, issueCounter); werr != nil {
+			if errors.Is(werr, watermark.ErrCounterRegression) {
+				if c.deps.WMMode == watermark.ModeEnforce {
+					c.deps.Logger.Info("sign", "type", "opcert", "caller-key", hash.String(), "issue-counter", issueCounter, "result", "denied", "reason", "issue counter regression detected at commit (concurrent signer)")
+					c.deps.Metrics.observe("opcert", string(CodeConflict))
+					c.deps.Metrics.observeDeny(string(CodeConflict))
+					c.deps.Metrics.observeWatermarkConflict()
+					return nil, CodeConflict, fmt.Errorf("opcert issue counter %d is not greater than the highest signed for this cold key", issueCounter)
+				}
+				// warn mode: the stored counter already meets or exceeds ours;
+				// nothing to advance. The signature is still returned.
+			} else {
+				c.deps.Logger.Error("sign", "type", "opcert", "caller-key", hash.String(), "result", "error", "reason", werr.Error())
+				if c.deps.WMMode == watermark.ModeEnforce {
+					c.deps.Metrics.observe("opcert", string(CodeBackend))
+					c.deps.Metrics.observeBackendError("watermark")
+					return nil, CodeBackend, fmt.Errorf("opcert counter commit: %w", werr)
+				}
+			}
+		}
+	}
+
+	c.deps.Logger.Info("sign", "type", "opcert", "caller-key", hash.String(), "issue-counter", issueCounter, "result", "signed")
 	c.deps.Metrics.observe("opcert", "signed")
 	return &OpCertResult{
 		SignatureHex: hex.EncodeToString(sig),

--- a/internal/signer/coordinator_opcert.go
+++ b/internal/signer/coordinator_opcert.go
@@ -198,7 +198,16 @@ func (c *Coordinator) SignOpCert(ctx context.Context, kesVkey []byte, issueCount
 				// this same request, so a request that was stale from the start
 				// is not double-counted.
 				if !counterConflictReported {
-					c.deps.Logger.Warn("sign", "type", "opcert", "caller-key", hash.String(), "issue-counter", issueCounter, "result", "warn", "reason", "issue counter regression detected at commit (concurrent signer; warn mode)")
+					args := []any{"type", "opcert", "caller-key", hash.String(), "issue-counter", issueCounter}
+					// Best-effort: include the counter that won the race so this
+					// audit record can be correlated to it, matching the fields
+					// the pre-sign warn path records. A lookup failure here must
+					// not block returning the already-produced signature.
+					if stored, ok, cerr := counterWM.CounterFor(ctx, hash, opcertCounterScope); cerr == nil && ok {
+						args = append(args, "stored-counter", stored)
+					}
+					args = append(args, "result", "warn", "reason", "issue counter regression detected at commit (concurrent signer; warn mode)")
+					c.deps.Logger.Warn("sign", args...)
 					c.deps.Metrics.observeWatermarkConflict()
 				}
 			} else {

--- a/internal/signer/coordinator_opcert_watermark_test.go
+++ b/internal/signer/coordinator_opcert_watermark_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blinklabs-io/bursa/internal/signer/backend"
+	"github.com/blinklabs-io/bursa/internal/signer/policy"
+	"github.com/blinklabs-io/bursa/internal/signer/watermark"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func newOpCertCoordinator(t *testing.T, k *fakeKey, wm watermark.Watermark, mode watermark.Mode) (*Coordinator, *Metrics) {
+	t.Helper()
+	k.typ = backend.KeyTypePool
+	eng, err := policy.NewEngine([]policy.KeyPolicy{{
+		Hash:            k.hash.String(),
+		AllowedRequests: []string{"opcert"},
+	}})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	m := NewMetrics()
+	return New(Deps{
+		Resolver:  backend.NewResolver(fakeBackend{key: k}),
+		Policy:    eng,
+		Watermark: wm,
+		WMMode:    mode,
+		Cardano:   fakeCardano{},
+		Metrics:   m,
+	}), m
+}
+
+// TestSignOpCert_CounterMonotonicity_Enforce covers the core anti-double-sign
+// guard: a counter must be strictly greater than the highest already signed.
+func TestSignOpCert_CounterMonotonicity_Enforce(t *testing.T) {
+	k := newFakeKey(t)
+	c, m := newOpCertCoordinator(t, k, watermark.NewMemWatermark(), watermark.ModeEnforce)
+	ctx := context.Background()
+	kes := make([]byte, kesVkeySize)
+
+	// First opcert at counter 3 signs and stores 3.
+	if _, code, err := c.SignOpCert(ctx, kes, 3, 100, k.hash.String()); err != nil {
+		t.Fatalf("counter 3: unexpected error %v (code=%s)", err, code)
+	}
+
+	// Same counter 3 -> conflict.
+	if res, code, err := c.SignOpCert(ctx, kes, 3, 101, k.hash.String()); err == nil || code != CodeConflict || res != nil {
+		t.Fatalf("counter 3 repeat: want CodeConflict/nil, got (res=%v, code=%s, err=%v)", res, code, err)
+	}
+	// Lower counter 2 -> conflict.
+	if res, code, err := c.SignOpCert(ctx, kes, 2, 102, k.hash.String()); err == nil || code != CodeConflict || res != nil {
+		t.Fatalf("counter 2: want CodeConflict/nil, got (res=%v, code=%s, err=%v)", res, code, err)
+	}
+
+	// Higher counter 4 -> signs and advances.
+	if res, code, err := c.SignOpCert(ctx, kes, 4, 103, k.hash.String()); err != nil || res == nil || res.SignatureHex == "" {
+		t.Fatalf("counter 4: want signature, got (res=%v, code=%s, err=%v)", res, code, err)
+	}
+	// After advancing, counter 4 is now stale.
+	if _, code, err := c.SignOpCert(ctx, kes, 4, 104, k.hash.String()); err == nil || code != CodeConflict {
+		t.Fatalf("counter 4 repeat: want CodeConflict, got (code=%s, err=%v)", code, err)
+	}
+
+	// Two rejections each incremented the conflict metric (repeat-3, lower-2,
+	// repeat-4 = 3 conflicts).
+	if got := testutil.ToFloat64(m.watermarkConflicts); got != 3 {
+		t.Fatalf("watermark_conflicts_total = %v, want 3", got)
+	}
+	if got := testutil.ToFloat64(m.denials.WithLabelValues(string(CodeConflict))); got != 3 {
+		t.Fatalf("conflict denials = %v, want 3", got)
+	}
+}
+
+// TestSignOpCert_CounterPerKeyIsolation: one cold key's counter does not gate
+// another's.
+func TestSignOpCert_CounterPerKeyIsolation(t *testing.T) {
+	wm := watermark.NewMemWatermark()
+	ctx := context.Background()
+	kes := make([]byte, kesVkeySize)
+
+	kA := newFakeKey(t)
+	cA, _ := newOpCertCoordinator(t, kA, wm, watermark.ModeEnforce)
+	kB := newFakeKey(t)
+	cB, _ := newOpCertCoordinator(t, kB, wm, watermark.ModeEnforce)
+
+	if _, code, err := cA.SignOpCert(ctx, kes, 50, 1, kA.hash.String()); err != nil {
+		t.Fatalf("keyA counter 50: %v (code=%s)", err, code)
+	}
+	// keyB at a much lower counter is unaffected by keyA's watermark.
+	if _, code, err := cB.SignOpCert(ctx, kes, 1, 1, kB.hash.String()); err != nil {
+		t.Fatalf("keyB counter 1: %v (code=%s)", err, code)
+	}
+}
+
+// TestSignOpCert_CounterWarnMode: a regression is logged and metered but the
+// signature is still produced.
+func TestSignOpCert_CounterWarnMode(t *testing.T) {
+	k := newFakeKey(t)
+	c, m := newOpCertCoordinator(t, k, watermark.NewMemWatermark(), watermark.ModeWarn)
+	ctx := context.Background()
+	kes := make([]byte, kesVkeySize)
+
+	if _, code, err := c.SignOpCert(ctx, kes, 9, 1, k.hash.String()); err != nil {
+		t.Fatalf("counter 9: %v (code=%s)", err, code)
+	}
+	// Repeat counter 9: warn mode allows the signature.
+	res, code, err := c.SignOpCert(ctx, kes, 9, 2, k.hash.String())
+	if err != nil || res == nil || res.SignatureHex == "" {
+		t.Fatalf("warn-mode repeat: want signature, got (res=%v, code=%s, err=%v)", res, code, err)
+	}
+	if got := testutil.ToFloat64(m.watermarkConflicts); got != 1 {
+		t.Fatalf("watermark_conflicts_total = %v, want 1", got)
+	}
+}
+
+// TestSignOpCert_CounterOffMode: no counter enforcement at all.
+func TestSignOpCert_CounterOffMode(t *testing.T) {
+	k := newFakeKey(t)
+	c, m := newOpCertCoordinator(t, k, watermark.NewMemWatermark(), watermark.ModeOff)
+	ctx := context.Background()
+	kes := make([]byte, kesVkeySize)
+
+	if _, code, err := c.SignOpCert(ctx, kes, 5, 1, k.hash.String()); err != nil {
+		t.Fatalf("counter 5: %v (code=%s)", err, code)
+	}
+	// A stale counter still signs when the guard is off.
+	if res, code, err := c.SignOpCert(ctx, kes, 5, 2, k.hash.String()); err != nil || res == nil {
+		t.Fatalf("off-mode repeat: want signature, got (res=%v, code=%s, err=%v)", res, code, err)
+	}
+	if got := testutil.ToFloat64(m.watermarkConflicts); got != 0 {
+		t.Fatalf("watermark_conflicts_total = %v, want 0", got)
+	}
+}

--- a/internal/signer/coordinator_opcert_watermark_test.go
+++ b/internal/signer/coordinator_opcert_watermark_test.go
@@ -16,6 +16,7 @@ package signer
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -25,6 +26,47 @@ import (
 	"github.com/blinklabs-io/bursa/internal/signer/watermark"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
+
+// capturingHandler is a minimal slog.Handler that retains every record it
+// receives, so tests can assert on the exact audit fields a log line
+// carries (not just that some log call happened).
+type capturingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *capturingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(_ string) slog.Handler      { return h }
+
+// findByReason returns the first captured record carrying a "reason" attr
+// equal to reason, if any.
+func (h *capturingHandler) findByReason(reason string) (slog.Record, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, r := range h.records {
+		match := false
+		r.Attrs(func(a slog.Attr) bool {
+			if a.Key == "reason" && a.Value.String() == reason {
+				match = true
+				return false
+			}
+			return true
+		})
+		if match {
+			return r, true
+		}
+	}
+	return slog.Record{}, false
+}
 
 // pausingCounterWatermark wraps a CounterWatermark and, on the first call to
 // CounterFor, blocks the caller until released. Tests use it to force a
@@ -62,6 +104,15 @@ func (p *pausingCounterWatermark) CheckAndCommitCounter(ctx context.Context, key
 
 func newOpCertCoordinator(t *testing.T, k *fakeKey, wm watermark.Watermark, mode watermark.Mode) (*Coordinator, *Metrics) {
 	t.Helper()
+	return newOpCertCoordinatorWithLogger(t, k, wm, mode, nil)
+}
+
+// newOpCertCoordinatorWithLogger is like newOpCertCoordinator but lets a test
+// inject a logger (e.g. one backed by capturingHandler) to assert on the
+// exact fields an audit log line carries. A nil logger defaults to
+// slog.Default(), matching newOpCertCoordinator's prior behavior.
+func newOpCertCoordinatorWithLogger(t *testing.T, k *fakeKey, wm watermark.Watermark, mode watermark.Mode, logger *slog.Logger) (*Coordinator, *Metrics) {
+	t.Helper()
 	k.typ = backend.KeyTypePool
 	eng, err := policy.NewEngine([]policy.KeyPolicy{{
 		Hash:            k.hash.String(),
@@ -78,6 +129,7 @@ func newOpCertCoordinator(t *testing.T, k *fakeKey, wm watermark.Watermark, mode
 		WMMode:    mode,
 		Cardano:   fakeCardano{},
 		Metrics:   m,
+		Logger:    logger,
 	}), m
 }
 
@@ -211,6 +263,71 @@ func TestSignOpCert_CounterWarnMode_ConcurrentCommitRegression(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(m.watermarkConflicts); got != 1 {
 		t.Fatalf("watermark_conflicts_total = %v, want 1 (exactly once, detected at commit)", got)
+	}
+}
+
+// TestSignOpCert_CounterWarnMode_ConcurrentCommitRegression_AuditFields covers
+// the same commit-time-only regression as
+// TestSignOpCert_CounterWarnMode_ConcurrentCommitRegression, but asserts on
+// the audit record's fields directly: the commit-time warn log must include
+// the stored counter that won the race, so the record can be correlated to
+// it, matching the fields the pre-sign warn path records.
+func TestSignOpCert_CounterWarnMode_ConcurrentCommitRegression_AuditFields(t *testing.T) {
+	k := newFakeKey(t)
+	pw := &pausingCounterWatermark{
+		Watermark: watermark.NewMemWatermark(),
+		counter:   watermark.NewMemWatermark(),
+		paused:    make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+	h := &capturingHandler{}
+	c, _ := newOpCertCoordinatorWithLogger(t, k, pw, watermark.ModeWarn, slog.New(h))
+	ctx := context.Background()
+	kes := make([]byte, kesVkeySize)
+
+	var (
+		wg       sync.WaitGroup
+		loserRes *OpCertResult
+		loserErr error
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		loserRes, _, loserErr = c.SignOpCert(ctx, kes, 7, 2, k.hash.String())
+	}()
+
+	<-pw.paused
+	if _, code, err := c.SignOpCert(ctx, kes, 7, 1, k.hash.String()); err != nil {
+		t.Fatalf("winner: unexpected error %v (code=%s)", err, code)
+	}
+	close(pw.release)
+	wg.Wait()
+
+	if loserErr != nil || loserRes == nil || loserRes.SignatureHex == "" {
+		t.Fatalf("loser: want successful warn-mode signature, got (res=%v, err=%v)", loserRes, loserErr)
+	}
+
+	rec, ok := h.findByReason("issue counter regression detected at commit (concurrent signer; warn mode)")
+	if !ok {
+		t.Fatalf("commit-time warn audit record not found")
+	}
+	var (
+		hasStored bool
+		stored    uint64
+	)
+	rec.Attrs(func(a slog.Attr) bool {
+		if a.Key == "stored-counter" {
+			hasStored = true
+			stored = a.Value.Uint64()
+			return false
+		}
+		return true
+	})
+	if !hasStored {
+		t.Fatalf("commit-time warn audit record is missing the stored-counter field")
+	}
+	if stored != 7 {
+		t.Fatalf("stored-counter = %d, want 7 (the counter that won the race)", stored)
 	}
 }
 

--- a/internal/signer/coordinator_opcert_watermark_test.go
+++ b/internal/signer/coordinator_opcert_watermark_test.go
@@ -16,6 +16,8 @@ package signer
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/blinklabs-io/bursa/internal/signer/backend"
@@ -23,6 +25,40 @@ import (
 	"github.com/blinklabs-io/bursa/internal/signer/watermark"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
+
+// pausingCounterWatermark wraps a CounterWatermark and, on the first call to
+// CounterFor, blocks the caller until released. Tests use it to force a
+// specific interleaving between two concurrent SignOpCert calls: the paused
+// goroutine's pre-sign lookup completes (and sees no conflict) before the
+// other goroutine commits, so any regression can only be detected later, at
+// commit time.
+//
+// The "first call" gate uses an atomic CompareAndSwap rather than sync.Once:
+// a second, concurrent Once.Do call blocks on Once's internal mutex until the
+// first call's function returns, which here would deadlock (the first call's
+// function only returns once the test observes the second call completing).
+// CompareAndSwap lets the second caller proceed immediately instead.
+type pausingCounterWatermark struct {
+	watermark.Watermark
+	counter watermark.CounterWatermark
+
+	paused   chan struct{} // closed once the pausing call's lookup has returned
+	release  chan struct{} // closed by the test to let the paused call continue
+	didPause atomic.Bool
+}
+
+func (p *pausingCounterWatermark) CounterFor(ctx context.Context, key backend.KeyHash, scope string) (uint64, bool, error) {
+	v, ok, err := p.counter.CounterFor(ctx, key, scope)
+	if p.didPause.CompareAndSwap(false, true) {
+		close(p.paused)
+		<-p.release
+	}
+	return v, ok, err
+}
+
+func (p *pausingCounterWatermark) CheckAndCommitCounter(ctx context.Context, key backend.KeyHash, scope string, counter uint64) error {
+	return p.counter.CheckAndCommitCounter(ctx, key, scope, counter)
+}
 
 func newOpCertCoordinator(t *testing.T, k *fakeKey, wm watermark.Watermark, mode watermark.Mode) (*Coordinator, *Metrics) {
 	t.Helper()
@@ -125,6 +161,56 @@ func TestSignOpCert_CounterWarnMode(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(m.watermarkConflicts); got != 1 {
 		t.Fatalf("watermark_conflicts_total = %v, want 1", got)
+	}
+}
+
+// TestSignOpCert_CounterWarnMode_ConcurrentCommitRegression covers a
+// regression that is only detectable at commit time: two requests for the
+// same counter both pass the pre-sign lookup (neither sees the other's
+// counter yet), one commits first, and the other's commit then loses the
+// race. In warn mode, that losing request must still return a signature and
+// must emit exactly one conflict metric (not zero, and not double-counted
+// against the pre-sign path).
+func TestSignOpCert_CounterWarnMode_ConcurrentCommitRegression(t *testing.T) {
+	k := newFakeKey(t)
+	pw := &pausingCounterWatermark{
+		Watermark: watermark.NewMemWatermark(),
+		counter:   watermark.NewMemWatermark(),
+		paused:    make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+	c, m := newOpCertCoordinator(t, k, pw, watermark.ModeWarn)
+	ctx := context.Background()
+	kes := make([]byte, kesVkeySize)
+
+	var (
+		wg       sync.WaitGroup
+		loserRes *OpCertResult
+		loserErr error
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// This call's CounterFor is the one that pauses (via pw.once): it
+		// sees no stored counter, then blocks before the winner commits.
+		loserRes, _, loserErr = c.SignOpCert(ctx, kes, 7, 2, k.hash.String())
+	}()
+
+	// Wait for the losing request's pre-sign lookup to complete before
+	// letting the winner run to completion (sign + commit) for the same
+	// counter.
+	<-pw.paused
+	if _, code, err := c.SignOpCert(ctx, kes, 7, 1, k.hash.String()); err != nil {
+		t.Fatalf("winner: unexpected error %v (code=%s)", err, code)
+	}
+	close(pw.release)
+	wg.Wait()
+
+	if loserErr != nil || loserRes == nil || loserRes.SignatureHex == "" {
+		t.Fatalf("loser: want successful warn-mode signature, got (res=%v, err=%v)", loserRes, loserErr)
+	}
+	if got := testutil.ToFloat64(m.watermarkConflicts); got != 1 {
+		t.Fatalf("watermark_conflicts_total = %v, want 1 (exactly once, detected at commit)", got)
 	}
 }
 

--- a/internal/signer/watermark/counter_test.go
+++ b/internal/signer/watermark/counter_test.go
@@ -1,0 +1,223 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watermark
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/blinklabs-io/bursa/internal/signer/backend"
+)
+
+// counterStore is the subset of CounterWatermark exercised by the shared tests.
+type counterStore interface {
+	CounterWatermark
+}
+
+func runCounterMonotonicity(t *testing.T, wm counterStore) {
+	t.Helper()
+	ctx := context.Background()
+	var key backend.KeyHash
+	key[0] = 0xAA
+	scope := "opcert-counter"
+
+	// No record yet.
+	if _, ok, err := wm.CounterFor(ctx, key, scope); err != nil || ok {
+		t.Fatalf("CounterFor on empty: got (ok=%v, err=%v)", ok, err)
+	}
+
+	// First counter N stores N.
+	if err := wm.CheckAndCommitCounter(ctx, key, scope, 5); err != nil {
+		t.Fatalf("first commit at 5: %v", err)
+	}
+	if v, ok, err := wm.CounterFor(ctx, key, scope); err != nil || !ok || v != 5 {
+		t.Fatalf("after first commit: got (v=%d, ok=%v, err=%v), want 5", v, ok, err)
+	}
+
+	// Same counter N -> regression.
+	if err := wm.CheckAndCommitCounter(ctx, key, scope, 5); !errors.Is(err, ErrCounterRegression) {
+		t.Fatalf("re-commit at 5: expected ErrCounterRegression, got %v", err)
+	}
+	// N-1 -> regression.
+	if err := wm.CheckAndCommitCounter(ctx, key, scope, 4); !errors.Is(err, ErrCounterRegression) {
+		t.Fatalf("commit at 4: expected ErrCounterRegression, got %v", err)
+	}
+	// Stored value unchanged after rejected commits.
+	if v, _, _ := wm.CounterFor(ctx, key, scope); v != 5 {
+		t.Fatalf("stored counter regressed to %d after rejected commits, want 5", v)
+	}
+	// N+1 -> advances.
+	if err := wm.CheckAndCommitCounter(ctx, key, scope, 6); err != nil {
+		t.Fatalf("commit at 6: %v", err)
+	}
+	if v, _, _ := wm.CounterFor(ctx, key, scope); v != 6 {
+		t.Fatalf("after advance: got %d, want 6", v)
+	}
+	// A large jump advances too.
+	if err := wm.CheckAndCommitCounter(ctx, key, scope, 1000); err != nil {
+		t.Fatalf("commit at 1000: %v", err)
+	}
+	if v, _, _ := wm.CounterFor(ctx, key, scope); v != 1000 {
+		t.Fatalf("after jump: got %d, want 1000", v)
+	}
+}
+
+func runCounterPerKeyIsolation(t *testing.T, wm counterStore) {
+	t.Helper()
+	ctx := context.Background()
+	var keyA, keyB backend.KeyHash
+	keyA[0] = 1
+	keyB[0] = 2
+	scope := "opcert-counter"
+
+	if err := wm.CheckAndCommitCounter(ctx, keyA, scope, 10); err != nil {
+		t.Fatalf("keyA commit: %v", err)
+	}
+	// keyB is independent: a low counter must still be accepted.
+	if err := wm.CheckAndCommitCounter(ctx, keyB, scope, 1); err != nil {
+		t.Fatalf("keyB commit at 1 should be independent of keyA: %v", err)
+	}
+	if v, _, _ := wm.CounterFor(ctx, keyA, scope); v != 10 {
+		t.Fatalf("keyA stored counter changed to %d, want 10", v)
+	}
+	if v, _, _ := wm.CounterFor(ctx, keyB, scope); v != 1 {
+		t.Fatalf("keyB stored counter %d, want 1", v)
+	}
+}
+
+func TestMemWatermark_CounterMonotonicity(t *testing.T) {
+	runCounterMonotonicity(t, NewMemWatermark())
+}
+
+func TestMemWatermark_CounterPerKeyIsolation(t *testing.T) {
+	runCounterPerKeyIsolation(t, NewMemWatermark())
+}
+
+func TestSqliteWatermark_CounterMonotonicity(t *testing.T) {
+	wm, err := NewSqliteWatermark(filepath.Join(t.TempDir(), "wm.db"))
+	if err != nil {
+		t.Fatalf("NewSqliteWatermark: %v", err)
+	}
+	defer wm.Close()
+	runCounterMonotonicity(t, wm)
+}
+
+func TestSqliteWatermark_CounterPerKeyIsolation(t *testing.T) {
+	wm, err := NewSqliteWatermark(filepath.Join(t.TempDir(), "wm.db"))
+	if err != nil {
+		t.Fatalf("NewSqliteWatermark: %v", err)
+	}
+	defer wm.Close()
+	runCounterPerKeyIsolation(t, wm)
+}
+
+// TestSqliteWatermark_CounterPersistsAcrossReopen verifies durability: a counter
+// committed before close is still enforced after the store is reopened.
+func TestSqliteWatermark_CounterPersistsAcrossReopen(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "wm.db")
+	ctx := context.Background()
+	var key backend.KeyHash
+	key[3] = 9
+	scope := "opcert-counter"
+
+	wm, err := NewSqliteWatermark(dbPath)
+	if err != nil {
+		t.Fatalf("NewSqliteWatermark (first open): %v", err)
+	}
+	if err := wm.CheckAndCommitCounter(ctx, key, scope, 42); err != nil {
+		t.Fatalf("commit 42: %v", err)
+	}
+	if err := wm.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	wm2, err := NewSqliteWatermark(dbPath)
+	if err != nil {
+		t.Fatalf("NewSqliteWatermark (second open): %v", err)
+	}
+	defer wm2.Close()
+
+	if v, ok, err := wm2.CounterFor(ctx, key, scope); err != nil || !ok || v != 42 {
+		t.Fatalf("after reopen: got (v=%d, ok=%v, err=%v), want 42", v, ok, err)
+	}
+	// A repeat of the persisted counter must still be rejected.
+	if err := wm2.CheckAndCommitCounter(ctx, key, scope, 42); !errors.Is(err, ErrCounterRegression) {
+		t.Fatalf("re-commit 42 after reopen: expected ErrCounterRegression, got %v", err)
+	}
+	// A higher counter still advances after reopen.
+	if err := wm2.CheckAndCommitCounter(ctx, key, scope, 43); err != nil {
+		t.Fatalf("commit 43 after reopen: %v", err)
+	}
+}
+
+// runCounterConcurrency asserts that when many goroutines race to commit the
+// same counter for the same key, exactly one succeeds.
+func runCounterConcurrency(t *testing.T, wm counterStore) {
+	t.Helper()
+	ctx := context.Background()
+	var key backend.KeyHash
+	key[0] = 0x5A
+	scope := "opcert-counter"
+
+	const goroutines = 16
+	var (
+		wg        sync.WaitGroup
+		mu        sync.Mutex
+		successes int
+	)
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			err := wm.CheckAndCommitCounter(ctx, key, scope, 7)
+			if err == nil {
+				mu.Lock()
+				successes++
+				mu.Unlock()
+				return
+			}
+			if !errors.Is(err, ErrCounterRegression) {
+				t.Errorf("unexpected error: %v", err)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if successes != 1 {
+		t.Fatalf("expected exactly 1 successful commit, got %d", successes)
+	}
+	if v, _, _ := wm.CounterFor(ctx, key, scope); v != 7 {
+		t.Fatalf("stored counter %d, want 7", v)
+	}
+}
+
+func TestMemWatermark_CounterConcurrency(t *testing.T) {
+	runCounterConcurrency(t, NewMemWatermark())
+}
+
+func TestSqliteWatermark_CounterConcurrency(t *testing.T) {
+	wm, err := NewSqliteWatermark(filepath.Join(t.TempDir(), "wm.db"))
+	if err != nil {
+		t.Fatalf("NewSqliteWatermark: %v", err)
+	}
+	defer wm.Close()
+	runCounterConcurrency(t, wm)
+}

--- a/internal/signer/watermark/sqlite.go
+++ b/internal/signer/watermark/sqlite.go
@@ -17,6 +17,7 @@ package watermark
 import (
 	"context"
 	"database/sql"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -47,6 +48,17 @@ func NewSqliteWatermark(path string) (*SqliteWatermark, error) {
 	)`); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("create watermark table: %w", err)
+	}
+	// counter_watermark stores the highest monotonic counter (e.g. opcert issue
+	// counter) per (key, scope). counter is a big-endian, fixed-width hex string
+	// so that a lexicographic (default TEXT) comparison equals numeric ordering.
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS counter_watermark (
+		record_key TEXT PRIMARY KEY,
+		counter TEXT NOT NULL,
+		updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+	)`); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("create counter_watermark table: %w", err)
 	}
 	return &SqliteWatermark{db: db}, nil
 }
@@ -101,6 +113,50 @@ func (s *SqliteWatermark) Commit(ctx context.Context, key backend.KeyHash, scope
 		recordKey(key, scope), hex.EncodeToString(d[:]))
 	if err != nil {
 		return fmt.Errorf("watermark commit: %w", err)
+	}
+	return nil
+}
+
+func (s *SqliteWatermark) CounterFor(ctx context.Context, key backend.KeyHash, scope string) (uint64, bool, error) {
+	var have string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT counter FROM counter_watermark WHERE record_key = ?`,
+		recordKey(key, scope)).Scan(&have)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("counter watermark lookup: %w", err)
+	}
+	raw, err := hex.DecodeString(have)
+	if err != nil || len(raw) != 8 {
+		return 0, false, fmt.Errorf("counter watermark: corrupt stored counter %q", have)
+	}
+	return binary.BigEndian.Uint64(raw), true, nil
+}
+
+func (s *SqliteWatermark) CheckAndCommitCounter(ctx context.Context, key backend.KeyHash, scope string, counter uint64) error {
+	// Single atomic upsert: insert when no row exists, else update only when the
+	// new counter is strictly greater. When the guard fails the DO UPDATE is a
+	// no-op and RETURNING yields no row (sql.ErrNoRows) -> regression. This is the
+	// same pattern the payload watermark uses, so two concurrent callers with the
+	// same counter cannot both commit.
+	want := counterEncode(counter)
+	var have string
+	err := s.db.QueryRowContext(ctx,
+		`INSERT INTO counter_watermark (record_key, counter) VALUES (?, ?)
+		 ON CONFLICT(record_key) DO UPDATE SET counter = excluded.counter, updated_at = strftime('%s','now')
+		 WHERE excluded.counter > counter_watermark.counter
+		 RETURNING counter`,
+		recordKey(key, scope), want).Scan(&have)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrCounterRegression
+	}
+	if err != nil {
+		return fmt.Errorf("counter watermark check and commit: %w", err)
+	}
+	if have != want {
+		return ErrCounterRegression
 	}
 	return nil
 }

--- a/internal/signer/watermark/watermark.go
+++ b/internal/signer/watermark/watermark.go
@@ -17,6 +17,8 @@ package watermark
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"sync"
 
@@ -25,6 +27,11 @@ import (
 
 // ErrConflict indicates a different payload was already signed for (key, scope).
 var ErrConflict = errors.New("watermark conflict: divergent payload for the same key and scope")
+
+// ErrCounterRegression indicates a monotonic counter was not strictly greater
+// than the highest already recorded for (key, scope). It is the anti-double-sign
+// guard for operational-certificate issue counters.
+var ErrCounterRegression = errors.New("watermark conflict: counter is not strictly greater than the highest already signed")
 
 // Mode controls how the coordinator applies the watermark.
 type Mode string
@@ -49,6 +56,33 @@ type Watermark interface {
 	Commit(ctx context.Context, key backend.KeyHash, scope string, payload []byte) error
 }
 
+// CounterWatermark guards a strictly-increasing per-(key, scope) counter, such
+// as an operational-certificate issue counter. It is a distinct guard from the
+// divergent-payload Watermark: here the invariant is monotonicity (each recorded
+// value must exceed the previous), not payload equality. The Sqlite and Mem
+// stores implement both interfaces on the same backing store.
+type CounterWatermark interface {
+	// CounterFor returns the highest counter recorded for (key, scope) and
+	// whether any record exists. It performs no mutation.
+	CounterFor(ctx context.Context, key backend.KeyHash, scope string) (uint64, bool, error)
+	// CheckAndCommitCounter atomically records counter as the new highest for
+	// (key, scope) if and only if it is strictly greater than the highest already
+	// recorded (or none exists). It returns ErrCounterRegression, recording
+	// nothing, when counter is not strictly greater. The check and commit are a
+	// single atomic operation so that two concurrent callers with the same
+	// counter cannot both succeed.
+	CheckAndCommitCounter(ctx context.Context, key backend.KeyHash, scope string, counter uint64) error
+}
+
+// counterEncode renders a uint64 as a fixed-width, big-endian hex string so that
+// lexicographic string comparison (used by the sqlite store) matches numeric
+// comparison, and no lossy uint64->int64 conversion is needed.
+func counterEncode(counter uint64) string {
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], counter)
+	return hex.EncodeToString(b[:])
+}
+
 func recordKey(key backend.KeyHash, scope string) string { return key.String() + "|" + scope }
 
 func digest(payload []byte) [32]byte { return sha256.Sum256(payload) }
@@ -58,12 +92,15 @@ func digest(payload []byte) [32]byte { return sha256.Sum256(payload) }
 // (key, scope) pair, never evicted). It is suitable for testing and short-lived
 // single-process use only.
 type MemWatermark struct {
-	mu      sync.Mutex
-	records map[string][32]byte
+	mu       sync.Mutex
+	records  map[string][32]byte
+	counters map[string]uint64
 }
 
 // NewMemWatermark builds an empty in-memory watermark.
-func NewMemWatermark() *MemWatermark { return &MemWatermark{records: map[string][32]byte{}} }
+func NewMemWatermark() *MemWatermark {
+	return &MemWatermark{records: map[string][32]byte{}, counters: map[string]uint64{}}
+}
 
 func (m *MemWatermark) Check(_ context.Context, key backend.KeyHash, scope string, payload []byte) error {
 	m.mu.Lock()
@@ -96,5 +133,23 @@ func (m *MemWatermark) Commit(_ context.Context, key backend.KeyHash, scope stri
 	if _, ok := m.records[k]; !ok {
 		m.records[k] = digest(payload)
 	}
+	return nil
+}
+
+func (m *MemWatermark) CounterFor(_ context.Context, key backend.KeyHash, scope string) (uint64, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	v, ok := m.counters[recordKey(key, scope)]
+	return v, ok, nil
+}
+
+func (m *MemWatermark) CheckAndCommitCounter(_ context.Context, key backend.KeyHash, scope string, counter uint64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k := recordKey(key, scope)
+	if prev, ok := m.counters[k]; ok && counter <= prev {
+		return ErrCounterRegression
+	}
+	m.counters[k] = counter
 	return nil
 }


### PR DESCRIPTION
Enforces operational-certificate issue-counter monotonicity in the remote signer's `SignOpCert` path (anti-double-sign guard).

## Enforcement
- Tracks the highest `issue_counter` per cold-key hash, scoped `opcert-counter` (record key embeds the cold-key hash; per-cold-key isolation).
- On `SignOpCert`: rejects any `issue_counter` that is not strictly greater than the highest already signed for that cold key. A strictly-greater counter signs, and the new highest is persisted only after a verified signature via an atomic advance-if-greater upsert (never regresses).
- Concurrency-safe: the check+commit is a single atomic operation, so two concurrent signs for the same cold key and counter cannot both succeed.
- Reject `ErrorCode`: `conflict` (consistent with the tx watermark path).

## Modes
Reuses the coordinator's watermark mode plumbing:
- `off`: no counter check.
- `warn`: logs + increments the conflict metric on a regression, but still signs.
- `enforce`: rejects a regression with `conflict`.

## Durability
Persisted in the pure-Go (`modernc`) sqlite store in a new `counter_watermark` table; counters stored as big-endian fixed-width hex so lexicographic comparison equals numeric ordering (no lossy uint64->int64 conversion). The mem store mirrors the behavior for tests. Existing `tx`/`cip8` payload-watermark behavior is unchanged.

## Metrics / audit
- Reuses `bursa_signer_watermark_conflicts_total` for counter regressions (plus `bursa_signer_deny_total{reason="conflict"}` and `bursa_signer_requests_total{type="opcert",result="conflict"}`).
- Each decision is logged via the existing structured audit (cold key, requested counter, stored counter, outcome); no key material is logged.

## Files
- `internal/signer/watermark/watermark.go` - `CounterWatermark` interface, `ErrCounterRegression`, mem-store counter methods.
- `internal/signer/watermark/sqlite.go` - `counter_watermark` table + `CounterFor` / `CheckAndCommitCounter`.
- `internal/signer/coordinator_opcert.go` - pre-sign check, post-sign atomic commit, mode handling, metrics, audit.
- `internal/signer/watermark/counter_test.go` - store-level monotonicity, per-key isolation, sqlite durability across reopen, concurrency (exactly-one-succeeds).
- `internal/signer/coordinator_opcert_watermark_test.go` - `SignOpCert` enforce/warn/off and per-cold-key isolation.

## Verify
`CGO_ENABLED=0 go build ./...`, `go vet ./...`, `go test ./...` (incl. `-race` on the counter tests), `golangci-lint run ./...` (0 issues) all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces strictly increasing operational-certificate issue counters in the remote signer to prevent double-signing. Supports `off`/`warn`/`enforce` modes with metrics, audit logs, and durable per-key storage.

- **New Features**
  - `SignOpCert` rejects non-increasing `issue_counter` per cold key (`conflict` in enforce, warn in warn).
  - Atomic advance-if-greater commit after signature verification; drops the signature if a concurrent commit wins in enforce.
  - Per-key isolation via `opcert-counter`; durable sqlite `counter_watermark` (big-endian fixed-width hex), with in-memory mirror.
  - Tests for monotonicity, per-key isolation, concurrency, modes, and sqlite durability.

- **Bug Fixes**
  - In warn mode, if a regression is detected only at commit time (due to a concurrent signer), emit a single warning and increment the conflict metric; the audit log now also includes the stored counter that won the race.

<sup>Written for commit 238afab2b34660c6b6d079d813587cecfdcbd67b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protection against duplicate or out-of-order operational certificate signing.
  * Signing counters now advance monotonically and are tracked independently for each signing key.
  * Configurable enforcement modes support strict rejection, warning-only behavior, or disabled checks.
  * Counter state can persist across restarts for reliable protection.

* **Bug Fixes**
  * Prevented concurrent signing requests from incorrectly reusing an older counter.

* **Tests**
  * Added coverage for counter validation, persistence, concurrency, and enforcement modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->