### PR TITLE
feat(signer): PKCS#11 (Ed25519) HSM custody backend

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/gowebpki/jcs v1.0.1
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/miekg/pkcs11 v1.1.2
 	github.com/prometheus/client_golang v1.24.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -356,6 +356,8 @@ github.com/mattn/go-colorable v0.1.15/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stg
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.23 h1:cYwCQTQf3HB6xUC+BtyCLZNr7IzbOmoZbmssVNzSyiQ=
 github.com/mattn/go-isatty v0.0.23/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
+github.com/miekg/pkcs11 v1.1.2 h1:/VxmeAX5qU6Q3EwafypogwWbYryHFmF2RpkJmw3m4MQ=
+github.com/miekg/pkcs11 v1.1.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
 github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=

--- a/go.sum
+++ b/go.sum
@@ -350,6 +350,8 @@ github.com/mattn/go-colorable v0.1.15/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stg
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsReI=
 github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
+github.com/miekg/pkcs11 v1.1.2 h1:/VxmeAX5qU6Q3EwafypogwWbYryHFmF2RpkJmw3m4MQ=
+github.com/miekg/pkcs11 v1.1.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
 github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,17 +67,22 @@ type SignerWatermarkConfig struct {
 // SignerBackendConfig configures a key-custody backend.
 type SignerBackendConfig struct {
 	Name          string                   `yaml:"name"`
-	Type          string                   `yaml:"type"`           // "software" | "sops" | "vault"
+	Type          string                   `yaml:"type"`           // "software" | "sops" | "vault" | "pkcs11"
 	Path          string                   `yaml:"path"`           // software: key dir
 	PassphraseEnv string                   `yaml:"passphrase_env"` // software: env var holding the key-file passphrase
 	SecretPrefix  string                   `yaml:"secret_prefix"`  // sops: secret short-name prefix within google.project
 	Address       string                   `yaml:"address"`        // vault
 	TransitMount  string                   `yaml:"transit_mount"`  // vault
 	TokenEnv      string                   `yaml:"token_env"`      // vault: env var holding the token (default VAULT_TOKEN)
-	Keys          []SignerBackendKeyConfig `yaml:"keys"`           // vault: explicit transit key list
+	Module        string                   `yaml:"module"`         // pkcs11: path to the PKCS#11 module (.so)
+	TokenLabel    string                   `yaml:"token_label"`    // pkcs11: token label used to select the slot
+	Slot          *uint                    `yaml:"slot"`           // pkcs11: explicit slot id (alternative to token_label)
+	PINEnv        string                   `yaml:"pin_env"`        // pkcs11: env var holding the user PIN (never stored in config)
+	Keys          []SignerBackendKeyConfig `yaml:"keys"`           // vault: explicit transit key list; pkcs11: optional CKA_LABEL filter + key type
 }
 
-// SignerBackendKeyConfig names a remote key and its Cardano key type.
+// SignerBackendKeyConfig names a remote key and its Cardano key type. For vault
+// Name is the transit key name; for pkcs11 Name is the object's CKA_LABEL.
 type SignerBackendKeyConfig struct {
 	Name string `yaml:"name"`
 	Type string `yaml:"type"` // payment|stake|drep|cc-hot|cc-cold|pool|policy

--- a/internal/signer/backend/pkcs11.go
+++ b/internal/signer/backend/pkcs11.go
@@ -1,0 +1,349 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build pkcs11
+
+// Package backend, PKCS#11 driver. Compiled only with -tags pkcs11 (requires
+// CGO). Keys never leave the HSM: the token holds the private key and performs
+// the Ed25519 signature. Because no in-process private key is available, this
+// backend deliberately does NOT implement LoadedKeyProvider, so the CIP-8 path
+// (which needs a *bursa.LoadedKey) correctly rejects pkcs11 keys — the same
+// posture as the Vault backend.
+package backend
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/miekg/pkcs11"
+)
+
+// PKCS#11 v3.0 constants for Edwards-curve keys and PureEdDSA. miekg/pkcs11
+// v1.1.2 does not define these, so we declare the standard spec values.
+const (
+	ckkECEdwards = 0x00000040 // CKK_EC_EDWARDS
+	ckmEDDSA     = 0x00001057 // CKM_EDDSA (PureEdDSA over the raw message)
+)
+
+// pkcs11Key is a KeyRef whose private key lives in the HSM. Sign delegates to
+// the token over the shared session.
+type pkcs11Key struct {
+	label       string
+	pub         ed25519.PublicKey
+	hash        KeyHash
+	typ         KeyType
+	backendName string
+	priv        pkcs11.ObjectHandle
+	sign        func(priv pkcs11.ObjectHandle, msg []byte) ([]byte, error)
+}
+
+func (k *pkcs11Key) Hash() KeyHash                { return k.hash }
+func (k *pkcs11Key) PublicKey() ed25519.PublicKey { return k.pub }
+func (k *pkcs11Key) Type() KeyType                { return k.typ }
+func (k *pkcs11Key) Extended() bool               { return false }
+func (k *pkcs11Key) Backend() string              { return k.backendName }
+
+// Sign asks the HSM to produce a 64-byte Ed25519 signature over digest.
+// CKM_EDDSA with no parameter is PureEdDSA, so the token signs digest as the
+// message exactly like ed25519.Sign — byte-for-byte identical to the software
+// and Vault backends for the same key and message (Ed25519 is deterministic).
+func (k *pkcs11Key) Sign(_ context.Context, digest []byte) ([]byte, error) {
+	sig, err := k.sign(k.priv, digest)
+	if err != nil {
+		return nil, fmt.Errorf("pkcs11 sign: %w", err)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return nil, fmt.Errorf("pkcs11 sign: expected %d-byte signature, got %d", ed25519.SignatureSize, len(sig))
+	}
+	return sig, nil
+}
+
+// PKCS11Backend signs standard Ed25519 keys held in a PKCS#11 token (HSM).
+type PKCS11Backend struct {
+	name    string
+	ctx     *pkcs11.Ctx
+	session pkcs11.SessionHandle
+	// mu serializes token operations: a PKCS#11 session is single-threaded and
+	// SignInit/Sign form one non-reentrant operation.
+	mu   sync.Mutex
+	keys map[KeyHash]*pkcs11Key
+}
+
+// NewPKCS11Backend loads the module, selects the token, logs in with the PIN,
+// and enumerates its Ed25519 signing keys. The returned backend keeps the
+// session open for the process lifetime; call Close to release it.
+func NewPKCS11Backend(cfg PKCS11Config) (Backend, error) {
+	if cfg.Module == "" {
+		return nil, errors.New("pkcs11 backend requires a module path")
+	}
+	if cfg.TokenLabel == "" && cfg.Slot == nil {
+		return nil, errors.New("pkcs11 backend requires a token label or slot")
+	}
+	for _, k := range cfg.Keys {
+		if !k.Type.Valid() {
+			return nil, fmt.Errorf("pkcs11 key %q: invalid key type %q", k.Label, k.Type)
+		}
+	}
+
+	p := pkcs11.New(cfg.Module)
+	if p == nil {
+		return nil, fmt.Errorf("pkcs11: failed to load module %q", cfg.Module)
+	}
+	if err := p.Initialize(); err != nil {
+		p.Destroy()
+		return nil, fmt.Errorf("pkcs11 initialize: %w", err)
+	}
+
+	b := &PKCS11Backend{name: cfg.Name, ctx: p, keys: map[KeyHash]*pkcs11Key{}}
+
+	slot, err := selectSlot(p, cfg)
+	if err != nil {
+		_ = b.teardown(false, false)
+		return nil, err
+	}
+	session, err := p.OpenSession(slot, pkcs11.CKF_SERIAL_SESSION)
+	if err != nil {
+		_ = b.teardown(false, false)
+		return nil, fmt.Errorf("pkcs11 open session: %w", err)
+	}
+	b.session = session
+	if err := p.Login(session, pkcs11.CKU_USER, cfg.PIN); err != nil {
+		_ = b.teardown(true, false)
+		return nil, fmt.Errorf("pkcs11 login: %w", err)
+	}
+
+	if err := b.loadKeys(cfg); err != nil {
+		_ = b.teardown(true, true)
+		return nil, err
+	}
+	if len(b.keys) == 0 {
+		_ = b.teardown(true, true)
+		return nil, fmt.Errorf("pkcs11 backend %q: no Ed25519 signing keys found on the token", cfg.Name)
+	}
+	return b, nil
+}
+
+// signWithSession runs one SignInit+Sign under the session mutex.
+func (b *PKCS11Backend) signWithSession(priv pkcs11.ObjectHandle, msg []byte) ([]byte, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	mech := []*pkcs11.Mechanism{pkcs11.NewMechanism(ckmEDDSA, nil)}
+	if err := b.ctx.SignInit(b.session, mech, priv); err != nil {
+		return nil, fmt.Errorf("sign init: %w", err)
+	}
+	sig, err := b.ctx.Sign(b.session, msg)
+	if err != nil {
+		return nil, fmt.Errorf("sign: %w", err)
+	}
+	return sig, nil
+}
+
+func (b *PKCS11Backend) loadKeys(cfg PKCS11Config) error {
+	var filter map[string]KeyType
+	if len(cfg.Keys) > 0 {
+		filter = make(map[string]KeyType, len(cfg.Keys))
+		for _, k := range cfg.Keys {
+			filter[k.Label] = k.Type
+		}
+	}
+
+	privs, err := findEdwardsObjects(b.ctx, b.session, pkcs11.CKO_PRIVATE_KEY)
+	if err != nil {
+		return fmt.Errorf("pkcs11 enumerate private keys: %w", err)
+	}
+	for _, priv := range privs {
+		attrs, err := b.ctx.GetAttributeValue(b.session, priv, []*pkcs11.Attribute{
+			pkcs11.NewAttribute(pkcs11.CKA_ID, nil),
+			pkcs11.NewAttribute(pkcs11.CKA_LABEL, nil),
+		})
+		if err != nil {
+			return fmt.Errorf("pkcs11 read private key attributes: %w", err)
+		}
+		id, label := attrs[0].Value, string(attrs[1].Value)
+
+		typ := KeyTypePayment
+		if filter != nil {
+			t, ok := filter[label]
+			if !ok {
+				continue // not in the configured allowlist
+			}
+			typ = t
+		}
+
+		pub, err := publicKeyForID(b.ctx, b.session, id)
+		if err != nil {
+			// A signing key with no readable public counterpart cannot be
+			// addressed by key hash; skip it rather than fail the whole load.
+			continue
+		}
+		hash := HashPublicKey(pub)
+		b.keys[hash] = &pkcs11Key{
+			label:       label,
+			pub:         ed25519.PublicKey(pub),
+			hash:        hash,
+			typ:         typ,
+			backendName: b.name,
+			priv:        priv,
+			sign:        b.signWithSession,
+		}
+	}
+	return nil
+}
+
+// selectSlot resolves the configured slot id or token label to a slot with a
+// present token.
+func selectSlot(p *pkcs11.Ctx, cfg PKCS11Config) (uint, error) {
+	slots, err := p.GetSlotList(true)
+	if err != nil {
+		return 0, fmt.Errorf("pkcs11 get slot list: %w", err)
+	}
+	if cfg.Slot != nil {
+		for _, s := range slots {
+			if s == *cfg.Slot {
+				return s, nil
+			}
+		}
+		return 0, fmt.Errorf("pkcs11: slot %d not found or has no token", *cfg.Slot)
+	}
+	for _, s := range slots {
+		ti, err := p.GetTokenInfo(s)
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(ti.Label) == cfg.TokenLabel {
+			return s, nil
+		}
+	}
+	return 0, fmt.Errorf("pkcs11: no token with label %q", cfg.TokenLabel)
+}
+
+// findEdwardsObjects returns all CKK_EC_EDWARDS objects of the given class.
+func findEdwardsObjects(p *pkcs11.Ctx, session pkcs11.SessionHandle, class uint) ([]pkcs11.ObjectHandle, error) {
+	tmpl := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, class),
+		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, uint(ckkECEdwards)),
+	}
+	if err := p.FindObjectsInit(session, tmpl); err != nil {
+		return nil, err
+	}
+	var out []pkcs11.ObjectHandle
+	for {
+		objs, _, err := p.FindObjects(session, 128)
+		if err != nil {
+			_ = p.FindObjectsFinal(session)
+			return nil, err
+		}
+		if len(objs) == 0 {
+			break
+		}
+		out = append(out, objs...)
+	}
+	if err := p.FindObjectsFinal(session); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// publicKeyForID finds the Edwards public key object with the given CKA_ID and
+// returns its raw 32-byte Ed25519 public key.
+func publicKeyForID(p *pkcs11.Ctx, session pkcs11.SessionHandle, id []byte) ([]byte, error) {
+	tmpl := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PUBLIC_KEY),
+		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, uint(ckkECEdwards)),
+		pkcs11.NewAttribute(pkcs11.CKA_ID, id),
+	}
+	if err := p.FindObjectsInit(session, tmpl); err != nil {
+		return nil, err
+	}
+	objs, _, err := p.FindObjects(session, 1)
+	if err != nil {
+		_ = p.FindObjectsFinal(session)
+		return nil, err
+	}
+	if err := p.FindObjectsFinal(session); err != nil {
+		return nil, err
+	}
+	if len(objs) == 0 {
+		return nil, errors.New("no matching public key object")
+	}
+	attrs, err := p.GetAttributeValue(session, objs[0], []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_EC_POINT, nil),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return edwardsPublicKey(attrs[0].Value)
+}
+
+// edwardsPublicKey extracts the 32-byte Ed25519 public key from a CKA_EC_POINT
+// value. Per PKCS#11 v3.0 the point is a DER-encoded OCTET STRING wrapping the
+// raw key (0x04 0x20 || key); some tokens return the raw 32 bytes.
+func edwardsPublicKey(ecPoint []byte) ([]byte, error) {
+	var raw []byte
+	if _, err := asn1.Unmarshal(ecPoint, &raw); err == nil && len(raw) == ed25519.PublicKeySize {
+		return raw, nil
+	}
+	if len(ecPoint) == ed25519.PublicKeySize {
+		return ecPoint, nil
+	}
+	return nil, fmt.Errorf("unexpected EC_POINT encoding (%d bytes)", len(ecPoint))
+}
+
+func (b *PKCS11Backend) Name() string { return b.name }
+
+func (b *PKCS11Backend) GetKey(_ context.Context, hash KeyHash) (KeyRef, error) {
+	k, ok := b.keys[hash]
+	if !ok {
+		return nil, ErrKeyNotFound
+	}
+	return k, nil
+}
+
+func (b *PKCS11Backend) ListKeys(_ context.Context) ([]KeyRef, error) {
+	out := make([]KeyRef, 0, len(b.keys))
+	for _, k := range b.keys {
+		out = append(out, k)
+	}
+	return out, nil
+}
+
+// Close logs out and finalizes the module, releasing the session.
+func (b *PKCS11Backend) Close() error {
+	return b.teardown(true, true)
+}
+
+// teardown releases resources in reverse order of acquisition. loggedIn and
+// sessionOpen let partially-constructed backends clean up on the error path.
+func (b *PKCS11Backend) teardown(sessionOpen, loggedIn bool) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.ctx == nil {
+		return nil
+	}
+	if loggedIn {
+		_ = b.ctx.Logout(b.session)
+	}
+	if sessionOpen {
+		_ = b.ctx.CloseSession(b.session)
+	}
+	err := b.ctx.Finalize()
+	b.ctx.Destroy()
+	b.ctx = nil
+	return err
+}

--- a/internal/signer/backend/pkcs11.go
+++ b/internal/signer/backend/pkcs11.go
@@ -188,6 +188,11 @@ func (b *PKCS11Backend) loadKeys(cfg PKCS11Config) error {
 
 		pub, err := publicKeyForID(b.ctx, b.session, id)
 		if err != nil {
+			if errors.Is(err, errAmbiguousPublicKey) {
+				// A duplicate CKA_ID could bind this private key to an
+				// arbitrary public key object; refuse to guess.
+				return fmt.Errorf("pkcs11 load key %q: %w", label, err)
+			}
 			// A signing key with no readable public counterpart cannot be
 			// addressed by key hash; skip it rather than fail the whole load.
 			continue
@@ -260,8 +265,18 @@ func findEdwardsObjects(p *pkcs11.Ctx, session pkcs11.SessionHandle, class uint)
 	return out, nil
 }
 
+// errAmbiguousPublicKey is returned by publicKeyForID when a CKA_ID matches
+// more than one public key object. A token should never expose two public
+// key objects sharing a CKA_ID with a signing private key, but PKCS#11 does
+// not enforce uniqueness, so treat it as ambiguous rather than guessing which
+// one is the private key's real counterpart.
+var errAmbiguousPublicKey = errors.New("ambiguous public key match for CKA_ID")
+
 // publicKeyForID finds the Edwards public key object with the given CKA_ID and
-// returns its raw 32-byte Ed25519 public key.
+// returns its raw 32-byte Ed25519 public key. It returns errAmbiguousPublicKey
+// if more than one public key object shares the CKA_ID: silently picking one
+// could bind the private key to the wrong public key, corrupting KeyHash
+// registration and producing signatures that fail verification.
 func publicKeyForID(p *pkcs11.Ctx, session pkcs11.SessionHandle, id []byte) ([]byte, error) {
 	tmpl := []*pkcs11.Attribute{
 		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PUBLIC_KEY),
@@ -271,7 +286,9 @@ func publicKeyForID(p *pkcs11.Ctx, session pkcs11.SessionHandle, id []byte) ([]b
 	if err := p.FindObjectsInit(session, tmpl); err != nil {
 		return nil, err
 	}
-	objs, _, err := p.FindObjects(session, 1)
+	// Ask for one more than we accept so a second match is detected here
+	// instead of silently truncated away by the token/driver.
+	objs, _, err := p.FindObjects(session, 2)
 	if err != nil {
 		_ = p.FindObjectsFinal(session)
 		return nil, err
@@ -281,6 +298,9 @@ func publicKeyForID(p *pkcs11.Ctx, session pkcs11.SessionHandle, id []byte) ([]b
 	}
 	if len(objs) == 0 {
 		return nil, errors.New("no matching public key object")
+	}
+	if len(objs) > 1 {
+		return nil, fmt.Errorf("%w %x: %d matching objects", errAmbiguousPublicKey, id, len(objs))
 	}
 	attrs, err := p.GetAttributeValue(session, objs[0], []*pkcs11.Attribute{
 		pkcs11.NewAttribute(pkcs11.CKA_EC_POINT, nil),

--- a/internal/signer/backend/pkcs11.go
+++ b/internal/signer/backend/pkcs11.go
@@ -1,0 +1,378 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build pkcs11
+
+// Package backend, PKCS#11 driver. Compiled only with -tags pkcs11 (requires
+// CGO). Keys never leave the HSM: the token holds the private key and performs
+// the Ed25519 signature. Because no in-process private key is available, this
+// backend deliberately does NOT implement LoadedKeyProvider, so the CIP-8 path
+// (which needs a *bursa.LoadedKey) correctly rejects pkcs11 keys — the same
+// posture as the Vault backend.
+package backend
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/miekg/pkcs11"
+)
+
+// PKCS#11 v3.0 constants for Edwards-curve keys and PureEdDSA. miekg/pkcs11
+// v1.1.2 does not define these, so we declare the standard spec values.
+const (
+	ckkECEdwards = 0x00000040 // CKK_EC_EDWARDS
+	ckmEDDSA     = 0x00001057 // CKM_EDDSA (PureEdDSA over the raw message)
+)
+
+// pkcs11Key is a KeyRef whose private key lives in the HSM. Sign delegates to
+// the token over the shared session.
+type pkcs11Key struct {
+	label       string
+	pub         ed25519.PublicKey
+	hash        KeyHash
+	typ         KeyType
+	backendName string
+	priv        pkcs11.ObjectHandle
+	sign        func(priv pkcs11.ObjectHandle, msg []byte) ([]byte, error)
+}
+
+func (k *pkcs11Key) Hash() KeyHash                { return k.hash }
+func (k *pkcs11Key) PublicKey() ed25519.PublicKey { return k.pub }
+func (k *pkcs11Key) Type() KeyType                { return k.typ }
+func (k *pkcs11Key) Extended() bool               { return false }
+func (k *pkcs11Key) Backend() string              { return k.backendName }
+
+// Sign asks the HSM to produce a 64-byte Ed25519 signature over digest.
+// CKM_EDDSA with no parameter is PureEdDSA, so the token signs digest as the
+// message exactly like ed25519.Sign — byte-for-byte identical to the software
+// and Vault backends for the same key and message (Ed25519 is deterministic).
+func (k *pkcs11Key) Sign(_ context.Context, digest []byte) ([]byte, error) {
+	sig, err := k.sign(k.priv, digest)
+	if err != nil {
+		return nil, fmt.Errorf("pkcs11 sign: %w", err)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return nil, fmt.Errorf("pkcs11 sign: expected %d-byte signature, got %d", ed25519.SignatureSize, len(sig))
+	}
+	return sig, nil
+}
+
+// PKCS11Backend signs standard Ed25519 keys held in a PKCS#11 token (HSM).
+type PKCS11Backend struct {
+	name    string
+	ctx     *pkcs11.Ctx
+	session pkcs11.SessionHandle
+	// mu serializes token operations: a PKCS#11 session is single-threaded and
+	// SignInit/Sign form one non-reentrant operation.
+	mu   sync.Mutex
+	keys map[KeyHash]*pkcs11Key
+}
+
+// NewPKCS11Backend loads the module, selects the token, logs in with the PIN,
+// and enumerates its Ed25519 signing keys. The returned backend keeps the
+// session open for the process lifetime; call Close to release it.
+func NewPKCS11Backend(cfg PKCS11Config) (Backend, error) {
+	if cfg.Module == "" {
+		return nil, errors.New("pkcs11 backend requires a module path")
+	}
+	if cfg.TokenLabel == "" && cfg.Slot == nil {
+		return nil, errors.New("pkcs11 backend requires a token label or slot")
+	}
+	for _, k := range cfg.Keys {
+		if !k.Type.Valid() {
+			return nil, fmt.Errorf("pkcs11 key %q: invalid key type %q", k.Label, k.Type)
+		}
+	}
+
+	p := pkcs11.New(cfg.Module)
+	if p == nil {
+		return nil, fmt.Errorf("pkcs11: failed to load module %q", cfg.Module)
+	}
+	if err := p.Initialize(); err != nil {
+		p.Destroy()
+		return nil, fmt.Errorf("pkcs11 initialize: %w", err)
+	}
+
+	b := &PKCS11Backend{name: cfg.Name, ctx: p, keys: map[KeyHash]*pkcs11Key{}}
+
+	slot, err := selectSlot(p, cfg)
+	if err != nil {
+		_ = b.teardown(false, false)
+		return nil, err
+	}
+	session, err := p.OpenSession(slot, pkcs11.CKF_SERIAL_SESSION)
+	if err != nil {
+		_ = b.teardown(false, false)
+		return nil, fmt.Errorf("pkcs11 open session: %w", err)
+	}
+	b.session = session
+	if err := p.Login(session, pkcs11.CKU_USER, cfg.PIN); err != nil {
+		_ = b.teardown(true, false)
+		return nil, fmt.Errorf("pkcs11 login: %w", err)
+	}
+
+	if err := b.loadKeys(cfg); err != nil {
+		_ = b.teardown(true, true)
+		return nil, err
+	}
+	if len(b.keys) == 0 {
+		_ = b.teardown(true, true)
+		return nil, fmt.Errorf("pkcs11 backend %q: no Ed25519 signing keys found on the token", cfg.Name)
+	}
+	return b, nil
+}
+
+// signWithSession runs one SignInit+Sign under the session mutex.
+func (b *PKCS11Backend) signWithSession(priv pkcs11.ObjectHandle, msg []byte) ([]byte, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	mech := []*pkcs11.Mechanism{pkcs11.NewMechanism(ckmEDDSA, nil)}
+	if err := b.ctx.SignInit(b.session, mech, priv); err != nil {
+		return nil, fmt.Errorf("sign init: %w", err)
+	}
+	sig, err := b.ctx.Sign(b.session, msg)
+	if err != nil {
+		return nil, fmt.Errorf("sign: %w", err)
+	}
+	return sig, nil
+}
+
+func (b *PKCS11Backend) loadKeys(cfg PKCS11Config) error {
+	var filter map[string]KeyType
+	if len(cfg.Keys) > 0 {
+		filter = make(map[string]KeyType, len(cfg.Keys))
+		for _, k := range cfg.Keys {
+			filter[k.Label] = k.Type
+		}
+	}
+
+	privs, err := findEdwardsObjects(b.ctx, b.session, pkcs11.CKO_PRIVATE_KEY)
+	if err != nil {
+		return fmt.Errorf("pkcs11 enumerate private keys: %w", err)
+	}
+	for _, priv := range privs {
+		attrs, err := b.ctx.GetAttributeValue(b.session, priv, []*pkcs11.Attribute{
+			pkcs11.NewAttribute(pkcs11.CKA_ID, nil),
+			pkcs11.NewAttribute(pkcs11.CKA_LABEL, nil),
+		})
+		if err != nil {
+			return fmt.Errorf("pkcs11 read private key attributes: %w", err)
+		}
+		id, label := attrs[0].Value, string(attrs[1].Value)
+
+		typ := KeyTypePayment
+		if filter != nil {
+			t, ok := filter[label]
+			if !ok {
+				continue // not in the configured allowlist
+			}
+			typ = t
+		}
+
+		pub, err := publicKeyForID(b.ctx, b.session, id)
+		if err != nil {
+			if errors.Is(err, errAmbiguousPublicKey) {
+				// A duplicate CKA_ID could bind this private key to an
+				// arbitrary public key object; refuse to guess.
+				return fmt.Errorf("pkcs11 load key %q: %w", label, err)
+			}
+			// A signing key with no readable public counterpart cannot be
+			// addressed by key hash; skip it rather than fail the whole load.
+			continue
+		}
+		hash := HashPublicKey(pub)
+		b.keys[hash] = &pkcs11Key{
+			label:       label,
+			pub:         ed25519.PublicKey(pub),
+			hash:        hash,
+			typ:         typ,
+			backendName: b.name,
+			priv:        priv,
+			sign:        b.signWithSession,
+		}
+	}
+	return nil
+}
+
+// selectSlot resolves the configured slot id or token label to a slot with a
+// present token.
+func selectSlot(p *pkcs11.Ctx, cfg PKCS11Config) (uint, error) {
+	slots, err := p.GetSlotList(true)
+	if err != nil {
+		return 0, fmt.Errorf("pkcs11 get slot list: %w", err)
+	}
+	if cfg.Slot != nil {
+		for _, s := range slots {
+			if s == *cfg.Slot {
+				return s, nil
+			}
+		}
+		return 0, fmt.Errorf("pkcs11: slot %d not found or has no token", *cfg.Slot)
+	}
+	for _, s := range slots {
+		ti, err := p.GetTokenInfo(s)
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(ti.Label) == cfg.TokenLabel {
+			return s, nil
+		}
+	}
+	return 0, fmt.Errorf("pkcs11: no token with label %q", cfg.TokenLabel)
+}
+
+// findEdwardsObjects returns all CKK_EC_EDWARDS objects of the given class.
+func findEdwardsObjects(p *pkcs11.Ctx, session pkcs11.SessionHandle, class uint) ([]pkcs11.ObjectHandle, error) {
+	tmpl := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, class),
+		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, uint(ckkECEdwards)),
+	}
+	if err := p.FindObjectsInit(session, tmpl); err != nil {
+		return nil, err
+	}
+	var out []pkcs11.ObjectHandle
+	for {
+		objs, _, err := p.FindObjects(session, 128)
+		if err != nil {
+			_ = p.FindObjectsFinal(session)
+			return nil, err
+		}
+		if len(objs) == 0 {
+			break
+		}
+		out = append(out, objs...)
+	}
+	if err := p.FindObjectsFinal(session); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// errAmbiguousPublicKey is returned by publicKeyForID when a CKA_ID matches
+// more than one public key object. A token should never expose two public
+// key objects sharing a CKA_ID with a signing private key, but PKCS#11 does
+// not enforce uniqueness, so treat it as ambiguous rather than guessing which
+// one is the private key's real counterpart.
+var errAmbiguousPublicKey = errors.New("ambiguous public key match for CKA_ID")
+
+// publicKeyForID finds the Edwards public key object with the given CKA_ID and
+// returns its raw 32-byte Ed25519 public key. It returns errAmbiguousPublicKey
+// if more than one public key object shares the CKA_ID: silently picking one
+// could bind the private key to the wrong public key, corrupting KeyHash
+// registration and producing signatures that fail verification.
+func publicKeyForID(p *pkcs11.Ctx, session pkcs11.SessionHandle, id []byte) ([]byte, error) {
+	tmpl := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PUBLIC_KEY),
+		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, uint(ckkECEdwards)),
+		pkcs11.NewAttribute(pkcs11.CKA_ID, id),
+	}
+	if err := p.FindObjectsInit(session, tmpl); err != nil {
+		return nil, err
+	}
+	// Loop until FindObjects returns zero objects: PKCS#11 permits a token to
+	// return fewer objects than requested in a single call even when more
+	// matches exist, so a single bounded call could silently miss a second
+	// match sharing the CKA_ID.
+	var objs []pkcs11.ObjectHandle
+	for {
+		batch, _, err := p.FindObjects(session, 128)
+		if err != nil {
+			_ = p.FindObjectsFinal(session)
+			return nil, err
+		}
+		if len(batch) == 0 {
+			break
+		}
+		objs = append(objs, batch...)
+	}
+	if err := p.FindObjectsFinal(session); err != nil {
+		return nil, err
+	}
+	if len(objs) == 0 {
+		return nil, errors.New("no matching public key object")
+	}
+	if len(objs) > 1 {
+		return nil, fmt.Errorf("%w %x: %d matching objects", errAmbiguousPublicKey, id, len(objs))
+	}
+	attrs, err := p.GetAttributeValue(session, objs[0], []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_EC_POINT, nil),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return edwardsPublicKey(attrs[0].Value)
+}
+
+// edwardsPublicKey extracts the 32-byte Ed25519 public key from a CKA_EC_POINT
+// value. Per PKCS#11 v3.0 the point is a DER-encoded OCTET STRING wrapping the
+// raw key (0x04 0x20 || key); some tokens return the raw 32 bytes.
+func edwardsPublicKey(ecPoint []byte) ([]byte, error) {
+	var raw []byte
+	if _, err := asn1.Unmarshal(ecPoint, &raw); err == nil && len(raw) == ed25519.PublicKeySize {
+		return raw, nil
+	}
+	if len(ecPoint) == ed25519.PublicKeySize {
+		return ecPoint, nil
+	}
+	return nil, fmt.Errorf("unexpected EC_POINT encoding (%d bytes)", len(ecPoint))
+}
+
+func (b *PKCS11Backend) Name() string { return b.name }
+
+func (b *PKCS11Backend) GetKey(_ context.Context, hash KeyHash) (KeyRef, error) {
+	k, ok := b.keys[hash]
+	if !ok {
+		return nil, ErrKeyNotFound
+	}
+	return k, nil
+}
+
+func (b *PKCS11Backend) ListKeys(_ context.Context) ([]KeyRef, error) {
+	out := make([]KeyRef, 0, len(b.keys))
+	for _, k := range b.keys {
+		out = append(out, k)
+	}
+	return out, nil
+}
+
+// Close logs out and finalizes the module, releasing the session.
+func (b *PKCS11Backend) Close() error {
+	return b.teardown(true, true)
+}
+
+// teardown releases resources in reverse order of acquisition. loggedIn and
+// sessionOpen let partially-constructed backends clean up on the error path.
+func (b *PKCS11Backend) teardown(sessionOpen, loggedIn bool) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.ctx == nil {
+		return nil
+	}
+	if loggedIn {
+		_ = b.ctx.Logout(b.session)
+	}
+	if sessionOpen {
+		_ = b.ctx.CloseSession(b.session)
+	}
+	err := b.ctx.Finalize()
+	b.ctx.Destroy()
+	b.ctx = nil
+	return err
+}

--- a/internal/signer/backend/pkcs11_config.go
+++ b/internal/signer/backend/pkcs11_config.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+// PKCS11Config is the resolved input to NewPKCS11Backend. It is shared by the
+// tagged (CGO) implementation and the pure-Go stub so setup wiring compiles in
+// both build configurations. The PIN is resolved from an env var by the wiring
+// layer and never read from plaintext config.
+type PKCS11Config struct {
+	Name       string
+	Module     string // filesystem path to the PKCS#11 module (.so)
+	TokenLabel string // token label used to select the slot
+	Slot       *uint  // explicit slot id (alternative to TokenLabel)
+	PIN        string // user PIN (resolved from an env var by the caller)
+	// Keys is an optional allowlist: when non-empty, only objects whose
+	// CKA_LABEL is listed are loaded, each with the given Cardano key type.
+	// When empty, every Ed25519 signing key on the token is loaded as payment.
+	Keys []PKCS11KeyConfig
+}
+
+// PKCS11KeyConfig maps a PKCS#11 object label to a Cardano key type.
+type PKCS11KeyConfig struct {
+	Label string
+	Type  KeyType
+}

--- a/internal/signer/backend/pkcs11_softhsm_test.go
+++ b/internal/signer/backend/pkcs11_softhsm_test.go
@@ -1,0 +1,352 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build pkcs11
+
+package backend
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/asn1"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/miekg/pkcs11"
+)
+
+// CKM_EC_EDWARDS_KEY_PAIR_GEN, only used when provisioning the test token.
+const ckmECEdwardsKeyPairGen = 0x00001055
+
+// ed25519OID is the DER-encoded CKA_EC_PARAMS for edwards25519 (OID 1.3.101.112).
+func ed25519OID(t *testing.T) []byte {
+	t.Helper()
+	b, err := asn1.Marshal(asn1.ObjectIdentifier{1, 3, 101, 112})
+	if err != nil {
+		t.Fatalf("marshal ed25519 OID: %v", err)
+	}
+	return b
+}
+
+// findSoftHSMModule locates libsofthsm2.so, or returns "" to signal a skip.
+func findSoftHSMModule() string {
+	if m := os.Getenv("SOFTHSM2_MODULE"); m != "" {
+		if _, err := os.Stat(m); err == nil {
+			return m
+		}
+	}
+	candidates := []string{
+		"/usr/lib/softhsm/libsofthsm2.so",
+		"/usr/lib/aarch64-linux-gnu/softhsm/libsofthsm2.so",
+		"/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so",
+		"/usr/local/lib/softhsm/libsofthsm2.so",
+		"/opt/homebrew/lib/softhsm/libsofthsm2.so",
+	}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			return c
+		}
+	}
+	return ""
+}
+
+// setupSoftHSMToken initializes a fresh SoftHSM token in a temp dir and returns
+// the module path, token label, and PIN. The token is isolated via
+// SOFTHSM2_CONF so it never touches the host's real token store.
+func setupSoftHSMToken(t *testing.T) (module, label, pin string) {
+	t.Helper()
+	module = findSoftHSMModule()
+	if module == "" {
+		t.Skip("SoftHSM2 module not found; skipping PKCS#11 runtime test")
+	}
+	util, err := exec.LookPath("softhsm2-util")
+	if err != nil {
+		t.Skip("softhsm2-util not found; skipping PKCS#11 runtime test")
+	}
+
+	dir := t.TempDir()
+	tokenDir := filepath.Join(dir, "tokens")
+	if err := os.MkdirAll(tokenDir, 0o700); err != nil {
+		t.Fatalf("mkdir tokens: %v", err)
+	}
+	conf := filepath.Join(dir, "softhsm2.conf")
+	cfg := "directories.tokendir = " + tokenDir + "\n" +
+		"objectstore.backend = file\n" +
+		"log.level = ERROR\n"
+	if err := os.WriteFile(conf, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write softhsm2.conf: %v", err)
+	}
+	t.Setenv("SOFTHSM2_CONF", conf)
+
+	label, pin = "bursa-test", "1234"
+	out, err := exec.Command(util,
+		"--init-token", "--free",
+		"--label", label,
+		"--pin", pin,
+		"--so-pin", "5678",
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("softhsm2-util init-token: %v\n%s", err, out)
+	}
+	return module, label, pin
+}
+
+// importEd25519Key writes a known Ed25519 key pair into the token (matching
+// CKA_ID on both objects) so the backend can enumerate it and so the signature
+// can be checked byte-for-byte against the software implementation.
+func importEd25519Key(t *testing.T, module, label, pin string, pub ed25519.PublicKey, priv ed25519.PrivateKey) {
+	t.Helper()
+	p := pkcs11.New(module)
+	if p == nil {
+		t.Fatalf("load module %q", module)
+	}
+	if err := p.Initialize(); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	defer func() {
+		_ = p.Finalize()
+		p.Destroy()
+	}()
+
+	slot, err := findSlotByLabel(p, label)
+	if err != nil {
+		t.Fatalf("find slot: %v", err)
+	}
+	session, err := p.OpenSession(slot, pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION)
+	if err != nil {
+		t.Fatalf("open session: %v", err)
+	}
+	defer func() { _ = p.CloseSession(session) }()
+	if err := p.Login(session, pkcs11.CKU_USER, pin); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	defer func() { _ = p.Logout(session) }()
+
+	oid := ed25519OID(t)
+	id := []byte{0x01}
+	ecPoint, err := asn1.Marshal([]byte(pub)) // DER OCTET STRING wrapping the 32-byte key
+	if err != nil {
+		t.Fatalf("marshal EC_POINT: %v", err)
+	}
+
+	pubTmpl := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PUBLIC_KEY),
+		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, uint(ckkECEdwards)),
+		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+		pkcs11.NewAttribute(pkcs11.CKA_VERIFY, true),
+		pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, oid),
+		pkcs11.NewAttribute(pkcs11.CKA_EC_POINT, ecPoint),
+		pkcs11.NewAttribute(pkcs11.CKA_ID, id),
+		pkcs11.NewAttribute(pkcs11.CKA_LABEL, "bursa-key"),
+	}
+	if _, err := p.CreateObject(session, pubTmpl); err != nil {
+		t.Fatalf("create public key object: %v", err)
+	}
+
+	privTmpl := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PRIVATE_KEY),
+		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, uint(ckkECEdwards)),
+		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+		pkcs11.NewAttribute(pkcs11.CKA_PRIVATE, true),
+		pkcs11.NewAttribute(pkcs11.CKA_SIGN, true),
+		pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, oid),
+		pkcs11.NewAttribute(pkcs11.CKA_VALUE, priv.Seed()), // 32-byte Ed25519 seed
+		pkcs11.NewAttribute(pkcs11.CKA_ID, id),
+		pkcs11.NewAttribute(pkcs11.CKA_LABEL, "bursa-key"),
+	}
+	if _, err := p.CreateObject(session, privTmpl); err != nil {
+		t.Fatalf("create private key object: %v", err)
+	}
+}
+
+func findSlotByLabel(p *pkcs11.Ctx, label string) (uint, error) {
+	cfg := PKCS11Config{TokenLabel: label}
+	return selectSlot(p, cfg)
+}
+
+// TestPKCS11Backend_SoftHSM imports a known Ed25519 key, then asserts that the
+// backend derives the correct KeyHash, produces a valid signature, and that the
+// signature is byte-for-byte identical to the software (ed25519.Sign) output.
+func TestPKCS11Backend_SoftHSM(t *testing.T) {
+	module, label, pin := setupSoftHSMToken(t)
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	importEd25519Key(t, module, label, pin, pub, priv)
+
+	b, err := NewPKCS11Backend(PKCS11Config{
+		Name:       "hsm",
+		Module:     module,
+		TokenLabel: label,
+		PIN:        pin,
+	})
+	if err != nil {
+		t.Fatalf("NewPKCS11Backend: %v", err)
+	}
+	defer func() {
+		if c, ok := b.(*PKCS11Backend); ok {
+			_ = c.Close()
+		}
+	}()
+
+	ctx := context.Background()
+	want := HashPublicKey(pub)
+	ref, err := b.GetKey(ctx, want)
+	if err != nil {
+		t.Fatalf("GetKey: %v", err)
+	}
+	if ref.Hash() != want {
+		t.Fatalf("hash mismatch: got %s want %s", ref.Hash(), want)
+	}
+	if !bytes.Equal(ref.PublicKey(), pub) {
+		t.Fatalf("public key mismatch")
+	}
+	if ref.Extended() {
+		t.Fatal("pkcs11 key must not report as extended")
+	}
+	if _, ok := ref.(LoadedKeyProvider); ok {
+		t.Fatal("pkcs11 key must not expose an in-process LoadedKey")
+	}
+
+	digest := make([]byte, 32)
+	for i := range digest {
+		digest[i] = byte(i)
+	}
+	sig, err := ref.Sign(ctx, digest)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if !ed25519.Verify(pub, digest, sig) {
+		t.Fatal("HSM signature failed ed25519 verification")
+	}
+
+	// Byte-for-byte parity with the software backend: CKM_EDDSA PureEdDSA over
+	// the same message is deterministic and must match ed25519.Sign exactly.
+	soft := ed25519.Sign(priv, digest)
+	if !bytes.Equal(sig, soft) {
+		t.Fatalf("HSM signature != software signature\n hsm:  %x\n soft: %x", sig, soft)
+	}
+}
+
+// TestPKCS11Backend_SoftHSM_AmbiguousPublicKey verifies that a token exposing
+// two public key objects under the same CKA_ID as a signing private key
+// causes the backend to reject loading that key, rather than silently
+// pairing the private key with an arbitrary one of the ambiguous public
+// key objects (which would corrupt KeyHash registration).
+func TestPKCS11Backend_SoftHSM_AmbiguousPublicKey(t *testing.T) {
+	module, label, pin := setupSoftHSMToken(t)
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pubA, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pubB, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	// Provision the ambiguous objects with a fully torn-down provisioning
+	// session (Logout/CloseSession/Finalize all complete) before opening the
+	// backend's own session below — SoftHSM rejects a second C_Initialize
+	// while another is still live in the process.
+	func() {
+		p := pkcs11.New(module)
+		if p == nil {
+			t.Fatalf("load module %q", module)
+		}
+		if err := p.Initialize(); err != nil {
+			t.Fatalf("initialize: %v", err)
+		}
+		defer func() {
+			_ = p.Finalize()
+			p.Destroy()
+		}()
+
+		slot, err := findSlotByLabel(p, label)
+		if err != nil {
+			t.Fatalf("find slot: %v", err)
+		}
+		session, err := p.OpenSession(slot, pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION)
+		if err != nil {
+			t.Fatalf("open session: %v", err)
+		}
+		defer func() { _ = p.CloseSession(session) }()
+		if err := p.Login(session, pkcs11.CKU_USER, pin); err != nil {
+			t.Fatalf("login: %v", err)
+		}
+		defer func() { _ = p.Logout(session) }()
+
+		oid := ed25519OID(t)
+		id := []byte{0x02}
+
+		for _, pub := range []ed25519.PublicKey{pubA, pubB} {
+			ecPoint, err := asn1.Marshal([]byte(pub))
+			if err != nil {
+				t.Fatalf("marshal EC_POINT: %v", err)
+			}
+			pubTmpl := []*pkcs11.Attribute{
+				pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PUBLIC_KEY),
+				pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, uint(ckkECEdwards)),
+				pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+				pkcs11.NewAttribute(pkcs11.CKA_VERIFY, true),
+				pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, oid),
+				pkcs11.NewAttribute(pkcs11.CKA_EC_POINT, ecPoint),
+				pkcs11.NewAttribute(pkcs11.CKA_ID, id),
+				pkcs11.NewAttribute(pkcs11.CKA_LABEL, "bursa-ambiguous"),
+			}
+			if _, err := p.CreateObject(session, pubTmpl); err != nil {
+				t.Fatalf("create public key object: %v", err)
+			}
+		}
+
+		privTmpl := []*pkcs11.Attribute{
+			pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PRIVATE_KEY),
+			pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, uint(ckkECEdwards)),
+			pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+			pkcs11.NewAttribute(pkcs11.CKA_PRIVATE, true),
+			pkcs11.NewAttribute(pkcs11.CKA_SIGN, true),
+			pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, oid),
+			pkcs11.NewAttribute(pkcs11.CKA_VALUE, priv.Seed()),
+			pkcs11.NewAttribute(pkcs11.CKA_ID, id),
+			pkcs11.NewAttribute(pkcs11.CKA_LABEL, "bursa-ambiguous"),
+		}
+		if _, err := p.CreateObject(session, privTmpl); err != nil {
+			t.Fatalf("create private key object: %v", err)
+		}
+	}()
+
+	_, err = NewPKCS11Backend(PKCS11Config{
+		Name:       "hsm",
+		Module:     module,
+		TokenLabel: label,
+		PIN:        pin,
+	})
+	if err == nil {
+		t.Fatal("expected NewPKCS11Backend to fail on ambiguous CKA_ID, got nil error")
+	}
+	if !errors.Is(err, errAmbiguousPublicKey) {
+		t.Fatalf("expected errAmbiguousPublicKey, got: %v", err)
+	}
+}

--- a/internal/signer/backend/pkcs11_softhsm_test.go
+++ b/internal/signer/backend/pkcs11_softhsm_test.go
@@ -1,0 +1,246 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build pkcs11
+
+package backend
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/asn1"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/miekg/pkcs11"
+)
+
+// CKM_EC_EDWARDS_KEY_PAIR_GEN, only used when provisioning the test token.
+const ckmECEdwardsKeyPairGen = 0x00001055
+
+// ed25519OID is the DER-encoded CKA_EC_PARAMS for edwards25519 (OID 1.3.101.112).
+func ed25519OID(t *testing.T) []byte {
+	t.Helper()
+	b, err := asn1.Marshal(asn1.ObjectIdentifier{1, 3, 101, 112})
+	if err != nil {
+		t.Fatalf("marshal ed25519 OID: %v", err)
+	}
+	return b
+}
+
+// findSoftHSMModule locates libsofthsm2.so, or returns "" to signal a skip.
+func findSoftHSMModule() string {
+	if m := os.Getenv("SOFTHSM2_MODULE"); m != "" {
+		if _, err := os.Stat(m); err == nil {
+			return m
+		}
+	}
+	candidates := []string{
+		"/usr/lib/softhsm/libsofthsm2.so",
+		"/usr/lib/aarch64-linux-gnu/softhsm/libsofthsm2.so",
+		"/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so",
+		"/usr/local/lib/softhsm/libsofthsm2.so",
+		"/opt/homebrew/lib/softhsm/libsofthsm2.so",
+	}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			return c
+		}
+	}
+	return ""
+}
+
+// setupSoftHSMToken initializes a fresh SoftHSM token in a temp dir and returns
+// the module path, token label, and PIN. The token is isolated via
+// SOFTHSM2_CONF so it never touches the host's real token store.
+func setupSoftHSMToken(t *testing.T) (module, label, pin string) {
+	t.Helper()
+	module = findSoftHSMModule()
+	if module == "" {
+		t.Skip("SoftHSM2 module not found; skipping PKCS#11 runtime test")
+	}
+	util, err := exec.LookPath("softhsm2-util")
+	if err != nil {
+		t.Skip("softhsm2-util not found; skipping PKCS#11 runtime test")
+	}
+
+	dir := t.TempDir()
+	tokenDir := filepath.Join(dir, "tokens")
+	if err := os.MkdirAll(tokenDir, 0o700); err != nil {
+		t.Fatalf("mkdir tokens: %v", err)
+	}
+	conf := filepath.Join(dir, "softhsm2.conf")
+	cfg := "directories.tokendir = " + tokenDir + "\n" +
+		"objectstore.backend = file\n" +
+		"log.level = ERROR\n"
+	if err := os.WriteFile(conf, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write softhsm2.conf: %v", err)
+	}
+	t.Setenv("SOFTHSM2_CONF", conf)
+
+	label, pin = "bursa-test", "1234"
+	out, err := exec.Command(util,
+		"--init-token", "--free",
+		"--label", label,
+		"--pin", pin,
+		"--so-pin", "5678",
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("softhsm2-util init-token: %v\n%s", err, out)
+	}
+	return module, label, pin
+}
+
+// importEd25519Key writes a known Ed25519 key pair into the token (matching
+// CKA_ID on both objects) so the backend can enumerate it and so the signature
+// can be checked byte-for-byte against the software implementation.
+func importEd25519Key(t *testing.T, module, label, pin string, pub ed25519.PublicKey, priv ed25519.PrivateKey) {
+	t.Helper()
+	p := pkcs11.New(module)
+	if p == nil {
+		t.Fatalf("load module %q", module)
+	}
+	if err := p.Initialize(); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	defer func() {
+		_ = p.Finalize()
+		p.Destroy()
+	}()
+
+	slot, err := findSlotByLabel(p, label)
+	if err != nil {
+		t.Fatalf("find slot: %v", err)
+	}
+	session, err := p.OpenSession(slot, pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION)
+	if err != nil {
+		t.Fatalf("open session: %v", err)
+	}
+	defer func() { _ = p.CloseSession(session) }()
+	if err := p.Login(session, pkcs11.CKU_USER, pin); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	defer func() { _ = p.Logout(session) }()
+
+	oid := ed25519OID(t)
+	id := []byte{0x01}
+	ecPoint, err := asn1.Marshal([]byte(pub)) // DER OCTET STRING wrapping the 32-byte key
+	if err != nil {
+		t.Fatalf("marshal EC_POINT: %v", err)
+	}
+
+	pubTmpl := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PUBLIC_KEY),
+		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, uint(ckkECEdwards)),
+		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+		pkcs11.NewAttribute(pkcs11.CKA_VERIFY, true),
+		pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, oid),
+		pkcs11.NewAttribute(pkcs11.CKA_EC_POINT, ecPoint),
+		pkcs11.NewAttribute(pkcs11.CKA_ID, id),
+		pkcs11.NewAttribute(pkcs11.CKA_LABEL, "bursa-key"),
+	}
+	if _, err := p.CreateObject(session, pubTmpl); err != nil {
+		t.Fatalf("create public key object: %v", err)
+	}
+
+	privTmpl := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PRIVATE_KEY),
+		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, uint(ckkECEdwards)),
+		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+		pkcs11.NewAttribute(pkcs11.CKA_PRIVATE, true),
+		pkcs11.NewAttribute(pkcs11.CKA_SIGN, true),
+		pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, oid),
+		pkcs11.NewAttribute(pkcs11.CKA_VALUE, priv.Seed()), // 32-byte Ed25519 seed
+		pkcs11.NewAttribute(pkcs11.CKA_ID, id),
+		pkcs11.NewAttribute(pkcs11.CKA_LABEL, "bursa-key"),
+	}
+	if _, err := p.CreateObject(session, privTmpl); err != nil {
+		t.Fatalf("create private key object: %v", err)
+	}
+}
+
+func findSlotByLabel(p *pkcs11.Ctx, label string) (uint, error) {
+	cfg := PKCS11Config{TokenLabel: label}
+	return selectSlot(p, cfg)
+}
+
+// TestPKCS11Backend_SoftHSM imports a known Ed25519 key, then asserts that the
+// backend derives the correct KeyHash, produces a valid signature, and that the
+// signature is byte-for-byte identical to the software (ed25519.Sign) output.
+func TestPKCS11Backend_SoftHSM(t *testing.T) {
+	module, label, pin := setupSoftHSMToken(t)
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	importEd25519Key(t, module, label, pin, pub, priv)
+
+	b, err := NewPKCS11Backend(PKCS11Config{
+		Name:       "hsm",
+		Module:     module,
+		TokenLabel: label,
+		PIN:        pin,
+	})
+	if err != nil {
+		t.Fatalf("NewPKCS11Backend: %v", err)
+	}
+	defer func() {
+		if c, ok := b.(*PKCS11Backend); ok {
+			_ = c.Close()
+		}
+	}()
+
+	ctx := context.Background()
+	want := HashPublicKey(pub)
+	ref, err := b.GetKey(ctx, want)
+	if err != nil {
+		t.Fatalf("GetKey: %v", err)
+	}
+	if ref.Hash() != want {
+		t.Fatalf("hash mismatch: got %s want %s", ref.Hash(), want)
+	}
+	if !bytes.Equal(ref.PublicKey(), pub) {
+		t.Fatalf("public key mismatch")
+	}
+	if ref.Extended() {
+		t.Fatal("pkcs11 key must not report as extended")
+	}
+	if _, ok := ref.(LoadedKeyProvider); ok {
+		t.Fatal("pkcs11 key must not expose an in-process LoadedKey")
+	}
+
+	digest := make([]byte, 32)
+	for i := range digest {
+		digest[i] = byte(i)
+	}
+	sig, err := ref.Sign(ctx, digest)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if !ed25519.Verify(pub, digest, sig) {
+		t.Fatal("HSM signature failed ed25519 verification")
+	}
+
+	// Byte-for-byte parity with the software backend: CKM_EDDSA PureEdDSA over
+	// the same message is deterministic and must match ed25519.Sign exactly.
+	soft := ed25519.Sign(priv, digest)
+	if !bytes.Equal(sig, soft) {
+		t.Fatalf("HSM signature != software signature\n hsm:  %x\n soft: %x", sig, soft)
+	}
+}

--- a/internal/signer/backend/pkcs11_softhsm_test.go
+++ b/internal/signer/backend/pkcs11_softhsm_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/asn1"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -242,5 +243,110 @@ func TestPKCS11Backend_SoftHSM(t *testing.T) {
 	soft := ed25519.Sign(priv, digest)
 	if !bytes.Equal(sig, soft) {
 		t.Fatalf("HSM signature != software signature\n hsm:  %x\n soft: %x", sig, soft)
+	}
+}
+
+// TestPKCS11Backend_SoftHSM_AmbiguousPublicKey verifies that a token exposing
+// two public key objects under the same CKA_ID as a signing private key
+// causes the backend to reject loading that key, rather than silently
+// pairing the private key with an arbitrary one of the ambiguous public
+// key objects (which would corrupt KeyHash registration).
+func TestPKCS11Backend_SoftHSM_AmbiguousPublicKey(t *testing.T) {
+	module, label, pin := setupSoftHSMToken(t)
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pubA, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pubB, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	// Provision the ambiguous objects with a fully torn-down provisioning
+	// session (Logout/CloseSession/Finalize all complete) before opening the
+	// backend's own session below — SoftHSM rejects a second C_Initialize
+	// while another is still live in the process.
+	func() {
+		p := pkcs11.New(module)
+		if p == nil {
+			t.Fatalf("load module %q", module)
+		}
+		if err := p.Initialize(); err != nil {
+			t.Fatalf("initialize: %v", err)
+		}
+		defer func() {
+			_ = p.Finalize()
+			p.Destroy()
+		}()
+
+		slot, err := findSlotByLabel(p, label)
+		if err != nil {
+			t.Fatalf("find slot: %v", err)
+		}
+		session, err := p.OpenSession(slot, pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION)
+		if err != nil {
+			t.Fatalf("open session: %v", err)
+		}
+		defer func() { _ = p.CloseSession(session) }()
+		if err := p.Login(session, pkcs11.CKU_USER, pin); err != nil {
+			t.Fatalf("login: %v", err)
+		}
+		defer func() { _ = p.Logout(session) }()
+
+		oid := ed25519OID(t)
+		id := []byte{0x02}
+
+		for _, pub := range []ed25519.PublicKey{pubA, pubB} {
+			ecPoint, err := asn1.Marshal([]byte(pub))
+			if err != nil {
+				t.Fatalf("marshal EC_POINT: %v", err)
+			}
+			pubTmpl := []*pkcs11.Attribute{
+				pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PUBLIC_KEY),
+				pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, uint(ckkECEdwards)),
+				pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+				pkcs11.NewAttribute(pkcs11.CKA_VERIFY, true),
+				pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, oid),
+				pkcs11.NewAttribute(pkcs11.CKA_EC_POINT, ecPoint),
+				pkcs11.NewAttribute(pkcs11.CKA_ID, id),
+				pkcs11.NewAttribute(pkcs11.CKA_LABEL, "bursa-ambiguous"),
+			}
+			if _, err := p.CreateObject(session, pubTmpl); err != nil {
+				t.Fatalf("create public key object: %v", err)
+			}
+		}
+
+		privTmpl := []*pkcs11.Attribute{
+			pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PRIVATE_KEY),
+			pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, uint(ckkECEdwards)),
+			pkcs11.NewAttribute(pkcs11.CKA_TOKEN, true),
+			pkcs11.NewAttribute(pkcs11.CKA_PRIVATE, true),
+			pkcs11.NewAttribute(pkcs11.CKA_SIGN, true),
+			pkcs11.NewAttribute(pkcs11.CKA_EC_PARAMS, oid),
+			pkcs11.NewAttribute(pkcs11.CKA_VALUE, priv.Seed()),
+			pkcs11.NewAttribute(pkcs11.CKA_ID, id),
+			pkcs11.NewAttribute(pkcs11.CKA_LABEL, "bursa-ambiguous"),
+		}
+		if _, err := p.CreateObject(session, privTmpl); err != nil {
+			t.Fatalf("create private key object: %v", err)
+		}
+	}()
+
+	_, err = NewPKCS11Backend(PKCS11Config{
+		Name:       "hsm",
+		Module:     module,
+		TokenLabel: label,
+		PIN:        pin,
+	})
+	if err == nil {
+		t.Fatal("expected NewPKCS11Backend to fail on ambiguous CKA_ID, got nil error")
+	}
+	if !errors.Is(err, errAmbiguousPublicKey) {
+		t.Fatalf("expected errAmbiguousPublicKey, got: %v", err)
 	}
 }

--- a/internal/signer/backend/pkcs11_stub.go
+++ b/internal/signer/backend/pkcs11_stub.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !pkcs11
+
+package backend
+
+import "errors"
+
+// ErrPKCS11NotCompiled is returned by the pure-Go build, where the PKCS#11
+// backend (which requires CGO) is not compiled in. Build with -tags pkcs11 and
+// CGO_ENABLED=1 to enable it.
+var ErrPKCS11NotCompiled = errors.New("pkcs11 backend not compiled in (build with -tags pkcs11)")
+
+// NewPKCS11Backend is the pure-Go stub. It matches the tagged constructor's
+// signature so setup wiring compiles under CGO_ENABLED=0, and always fails.
+func NewPKCS11Backend(_ PKCS11Config) (Backend, error) {
+	return nil, ErrPKCS11NotCompiled
+}

--- a/internal/signer/backend/pkcs11_stub_test.go
+++ b/internal/signer/backend/pkcs11_stub_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !pkcs11
+
+package backend
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestNewPKCS11Backend_StubNotCompiled verifies the pure-Go build returns a
+// clear not-compiled-in error instead of silently doing nothing.
+func TestNewPKCS11Backend_StubNotCompiled(t *testing.T) {
+	b, err := NewPKCS11Backend(PKCS11Config{
+		Name:       "hsm",
+		Module:     "/usr/lib/softhsm/libsofthsm2.so",
+		TokenLabel: "bursa",
+		PIN:        "1234",
+	})
+	if b != nil {
+		t.Fatalf("expected nil backend from stub, got %#v", b)
+	}
+	if !errors.Is(err, ErrPKCS11NotCompiled) {
+		t.Fatalf("expected ErrPKCS11NotCompiled, got %v", err)
+	}
+}

--- a/internal/signer/pkcs11.go
+++ b/internal/signer/pkcs11.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signer
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/blinklabs-io/bursa/internal/config"
+	"github.com/blinklabs-io/bursa/internal/signer/backend"
+)
+
+// buildPKCS11Backend validates config and constructs a PKCS#11 HSM backend. It
+// is pure Go and compiles in both build configurations: the actual driver is
+// backend.NewPKCS11Backend, which is the real CGO implementation under
+// -tags pkcs11 and a not-compiled-in stub otherwise. The user PIN is read from
+// the configured env var and never taken from plaintext config.
+func buildPKCS11Backend(c config.SignerBackendConfig) (backend.Backend, error) {
+	if c.Module == "" {
+		return nil, errors.New("pkcs11 backend requires module (path to the PKCS#11 .so)")
+	}
+	if c.TokenLabel == "" && c.Slot == nil {
+		return nil, errors.New("pkcs11 backend requires token_label or slot")
+	}
+	if c.PINEnv == "" {
+		return nil, errors.New("pkcs11 backend requires pin_env (env var holding the user PIN)")
+	}
+	pin := os.Getenv(c.PINEnv)
+	if pin == "" {
+		return nil, fmt.Errorf("pkcs11 pin env var %s is empty", c.PINEnv)
+	}
+	keys := make([]backend.PKCS11KeyConfig, 0, len(c.Keys))
+	for _, k := range c.Keys {
+		kt := backend.KeyType(k.Type)
+		if !kt.Valid() {
+			return nil, fmt.Errorf("pkcs11 key %q: invalid key type %q", k.Name, k.Type)
+		}
+		keys = append(keys, backend.PKCS11KeyConfig{Label: k.Name, Type: kt})
+	}
+	return backend.NewPKCS11Backend(backend.PKCS11Config{
+		Name:       c.Name,
+		Module:     c.Module,
+		TokenLabel: c.TokenLabel,
+		Slot:       c.Slot,
+		PIN:        pin,
+		Keys:       keys,
+	})
+}

--- a/internal/signer/pkcs11_test.go
+++ b/internal/signer/pkcs11_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/bursa/internal/config"
+)
+
+// The following tests exercise buildPKCS11Backend's config validation, which is
+// pure Go and runs in both build configurations (it fails before reaching the
+// tag-gated driver). See internal/signer/backend/pkcs11_softhsm_test.go for the
+// -tags pkcs11 runtime test against SoftHSM.
+
+func TestBuildPKCS11Backend_RequiresModule(t *testing.T) {
+	_, err := buildPKCS11Backend(config.SignerBackendConfig{
+		Name: "hsm", Type: "pkcs11", TokenLabel: "bursa", PINEnv: "PKCS11_PIN",
+	})
+	if err == nil || !strings.Contains(err.Error(), "module") {
+		t.Fatalf("expected module error, got %v", err)
+	}
+}
+
+func TestBuildPKCS11Backend_RequiresTokenOrSlot(t *testing.T) {
+	_, err := buildPKCS11Backend(config.SignerBackendConfig{
+		Name: "hsm", Type: "pkcs11", Module: "/lib/softhsm.so", PINEnv: "PKCS11_PIN",
+	})
+	if err == nil || !strings.Contains(err.Error(), "token_label or slot") {
+		t.Fatalf("expected token_label/slot error, got %v", err)
+	}
+}
+
+func TestBuildPKCS11Backend_RequiresPinEnv(t *testing.T) {
+	_, err := buildPKCS11Backend(config.SignerBackendConfig{
+		Name: "hsm", Type: "pkcs11", Module: "/lib/softhsm.so", TokenLabel: "bursa",
+	})
+	if err == nil || !strings.Contains(err.Error(), "pin_env") {
+		t.Fatalf("expected pin_env error, got %v", err)
+	}
+}
+
+func TestBuildPKCS11Backend_EmptyPin(t *testing.T) {
+	t.Setenv("PKCS11_PIN", "")
+	_, err := buildPKCS11Backend(config.SignerBackendConfig{
+		Name: "hsm", Type: "pkcs11", Module: "/lib/softhsm.so",
+		TokenLabel: "bursa", PINEnv: "PKCS11_PIN",
+	})
+	if err == nil || !strings.Contains(err.Error(), "is empty") {
+		t.Fatalf("expected empty PIN error, got %v", err)
+	}
+}
+
+func TestBuildPKCS11Backend_InvalidKeyType(t *testing.T) {
+	t.Setenv("PKCS11_PIN", "1234")
+	_, err := buildPKCS11Backend(config.SignerBackendConfig{
+		Name: "hsm", Type: "pkcs11", Module: "/lib/softhsm.so",
+		TokenLabel: "bursa", PINEnv: "PKCS11_PIN",
+		Keys: []config.SignerBackendKeyConfig{{Name: "k", Type: "bogus"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid key type") {
+		t.Fatalf("expected invalid key type error, got %v", err)
+	}
+}

--- a/internal/signer/setup.go
+++ b/internal/signer/setup.go
@@ -87,8 +87,10 @@ var sopsDecrypt = sops.Decrypt
 
 // BuildBackends constructs configured backends. Software backends load only
 // *.skey files from their configured directory; other files (.vkey, README,
-// etc.) are skipped silently. All three backend types (software, sops, vault)
-// are fully wired.
+// etc.) are skipped silently. All backend types (software, sops, vault, pkcs11)
+// are wired here; the pkcs11 driver is CGO-only and requires the pkcs11 build
+// tag (the default build wires a stub that returns a clear not-compiled-in
+// error).
 func BuildBackends(ctx context.Context, cfgs []config.SignerBackendConfig) ([]backend.Backend, error) {
 	// Non-nil slice so callers (and nilaway) can rely on a non-nil result on the
 	// success path; an empty config yields an empty, not nil, slice.
@@ -164,6 +166,12 @@ func BuildBackends(ctx context.Context, cfgs []config.SignerBackendConfig) ([]ba
 			b, err := buildVaultBackend(ctx, c)
 			if err != nil {
 				return nil, fmt.Errorf("vault backend %q: %w", c.Name, err)
+			}
+			backends = append(backends, b)
+		case "pkcs11":
+			b, err := buildPKCS11Backend(c)
+			if err != nil {
+				return nil, fmt.Errorf("pkcs11 backend %q: %w", c.Name, err)
 			}
 			backends = append(backends, b)
 		default:


### PR DESCRIPTION
Adds a PKCS#11 HSM custody backend to the bursa remote signer — the first true HSM backend (YubiHSM2 / SoftHSM / AWS CloudHSM), where the Ed25519 private key never leaves the token.

## Backend
- New `pkcs11` backend type in the signer. The token holds the private key and performs the Ed25519 signature over the digest; keys are enumerated by their public key and identified by `KeyHash` (blake2b-224) like every other backend. Standard Ed25519 only (no extended BIP32-Ed25519).
- Like the Vault backend, it does not implement `LoadedKeyProvider` (no in-process private key), so the CIP-8 path correctly rejects pkcs11 keys.
- Keys register by `KeyHash` through the resolver; the startup ambiguity check applies unchanged.

## Build-tag gating
- `internal/signer/backend/pkcs11.go` (`//go:build pkcs11`, CGO): real driver using `github.com/miekg/pkcs11`.
- `internal/signer/backend/pkcs11_stub.go` (`//go:build !pkcs11`): same `NewPKCS11Backend` signature, returns `"pkcs11 backend not compiled in (build with -tags pkcs11)"`.
- Shared `PKCS11Config` in an untagged file; wiring (`internal/signer/pkcs11.go`, `setup.go`) is pure Go and compiles in both configurations.
- Default build = pure-Go stub (`CGO_ENABLED=0`). Real backend = `CGO_ENABLED=1 go build -tags pkcs11`. The `miekg/pkcs11` dependency is only compiled under the tag; the default `CGO_ENABLED=0` build does not pull it in.

## EdDSA mechanism
- Signing uses `CKM_EDDSA` with no parameter = PureEdDSA over the raw message. Cardano signs the 32-byte blake2b tx-id as the Ed25519 message, so the token signs exactly those bytes. Ed25519 is deterministic, so the output is byte-for-byte identical to the software and Vault backends for the same key and message. `CKM_EDDSA` (0x1057) and `CKK_EC_EDWARDS` (0x40) are declared as spec constants (miekg/pkcs11 v1.1.2 does not export them).

## Config shape
```yaml
signer:
  backends:
    - name: hsm
      type: pkcs11
      module: /usr/lib/softhsm/libsofthsm2.so
      token_label: bursa          # or: slot: 0
      pin_env: PKCS11_PIN         # PIN read from env, never plaintext config
      keys:                       # optional: CKA_LABEL allowlist + key type
        - name: payment-1
          type: payment
```
When `keys` is omitted, every Ed25519 signing key on the token is loaded as `payment`.

## Tests
- Pure-Go (default build): config validation (module/token/slot/pin_env/empty-PIN/key-type); stub returns the not-compiled-in error; setup wiring compiles under `CGO_ENABLED=0`.
- `-tags pkcs11`: initializes an isolated temp SoftHSM2 token, imports a known Ed25519 key, and asserts the derived `KeyHash` matches the pubkey, the signature verifies against the pubkey, and the signature is byte-for-byte equal to `ed25519.Sign` for the same key/message. Skips with a clear message if SoftHSM2 is absent.

## Verification
- `CGO_ENABLED=0 go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run ./...` — pass, 0 lint issues.
- `CGO_ENABLED=1 go build -tags pkcs11 ./...` compiles; `go test -tags pkcs11 ./internal/signer/backend/...` ran with SoftHSM2 present — the runtime + byte-parity test passed. Tagged lint (`--build-tags pkcs11`) 0 issues.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PKCS#11 HSM custody backend for Ed25519 so the signer can use real HSMs while keeping private keys on-token. Default builds remain pure Go; enable the backend with CGO and the `pkcs11` tag.

- **Key details**
  - New `pkcs11` backend: Ed25519 only; PureEdDSA (`CKM_EDDSA`) signatures match software/Vault outputs; no extended/BIP32; CIP‑8 path rejects pkcs11 keys.
  - Keys are discovered by public key, identified by blake2b‑224 `KeyHash`, and exposed via the existing resolver.
  - Ambiguous `CKA_ID` public key matches are rejected, and the search loops `C_FindObjects` to detect all matches.
  - Config adds `module`, `token_label` or `slot`, and `pin_env`; optional `keys` maps PKCS#11 `CKA_LABEL` to the Cardano key type. If `keys` is omitted, all Ed25519 signing keys load as `payment`.
  - Session access is serialized; constants for `CKM_EDDSA` and `CKK_EC_EDWARDS` are defined locally; public keys are read from `CKA_EC_POINT`.

- **Migration**
  - Build with `CGO_ENABLED=1` and `-tags pkcs11`; default build uses a stub that returns a clear “not compiled in” error. The `github.com/miekg/pkcs11` dependency is gated by this tag.
  - Configure a backend with `type: pkcs11`, set `module`, `token_label` or `slot`, and `pin_env` (set the PIN via that env var, not in config).

<sup>Written for commit 21901ec6291a79b5fd9ac6f4addbc5a682f5b2e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for PKCS#11 hardware security modules as signing backends.
  * Added configuration for module paths, token labels or slots, PIN environment variables, and optional key filters.
  * Added Ed25519 key discovery, lookup, listing, and signing through supported hardware tokens.
  * Added clear errors when PKCS#11 support is unavailable or configuration is invalid.

* **Tests**
  * Added coverage for hardware-backed key discovery, signing, configuration validation, and unavailable PKCS#11 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->