### PR TITLE
fix(ci): repair webview wallet builds on macOS and Linux

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -88,6 +88,51 @@ jobs:
       - name: go build
         run: cd ui && go build ./cmd/bursa-wallet
 
+  # Compile the `-tags webview` desktop variant. Every other Go job builds only
+  # the default pure-Go wallet, so nothing on a pull request ever exercised the
+  # CGO webview path or the per-platform window_*.go / window_darwin.m sources.
+  # Two breakages reached main that way — a duplicate Objective-C symbol on
+  # macOS and webview_go's hardcoded webkit2gtk-4.0 dependency on Ubuntu 24.04 —
+  # and were only caught by the release workflow. This builds the same variant
+  # the release does, through the same Makefile target.
+  #
+  # Windows is intentionally absent: its webview build needs a bespoke MSYS2
+  # toolchain and explicit CC/CXX wiring (see the publish workflow), which
+  # remains that platform's guard.
+  ui-webview:
+    name: ui-webview (${{ matrix.os }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            os: linux
+          - runner: macos-15
+            os: darwin
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0 https://github.com/actions/setup-node/releases/tag/v7.0.0
+        with:
+          node-version: 22
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
+        with:
+          go-version: 1.26.x
+      # Mirrors the release job's dependency set. Ubuntu 24.04 ships only
+      # webkit2gtk-4.1; the Makefile's webkit-shim target bridges webview_go's
+      # hardcoded 4.0 pkg-config request onto it.
+      - name: Install Linux webview dependencies
+        if: matrix.os == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev
+      # The webview binary embeds the SPA, so the //go:embed dist target must be
+      # populated before the Go build.
+      - name: Build web bundle
+        run: cd ui/web && npm ci && npm run build
+      - name: Build webview binary
+        run: make wallet-binary-webview
+
   ui-lint:
     name: ui-lint
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ stake.skey
 stake.vkey
 .worktrees/
 .superpowers/
+
+# Generated webkit2gtk-4.0 pkg-config shim for the Linux webview build
+.pkgconfig/

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ mod-tidy:
 
 clean:
 	rm -f $(BINARIES)
+	rm -rf $(WEBVIEW_PKG_CONFIG_DIR)
 
 format: mod-tidy
 	go fmt ./...

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,12 @@ UI_GO_LDFLAGS=-ldflags "$(UI_LDFLAGS_CONTENT)"
 # GOOS=windows, so it is appended conditionally.
 UI_WEBVIEW_LDFLAGS=-ldflags "$(UI_LDFLAGS_CONTENT)$(if $(filter windows,$(GOOS)), -H=windowsgui,)"
 
-.PHONY: build wallet wallet-binary wallet-webview wallet-binary-webview bundle-macos pkg-macos pkg-macos-adhoc mod-tidy clean test
+# Holds the generated webkit2gtk-4.0 pkg-config shim (see webkit-shim below).
+# Prepended to PKG_CONFIG_PATH for webview builds; harmless when it does not
+# exist, which is the case on every target that needs no shim.
+WEBVIEW_PKG_CONFIG_DIR=$(ROOT_DIR)/.pkgconfig
+
+.PHONY: build wallet wallet-binary wallet-webview wallet-binary-webview webkit-shim bundle-macos pkg-macos pkg-macos-adhoc mod-tidy clean test
 
 # Alias for building program binary
 build: $(BINARIES)
@@ -62,12 +67,38 @@ wallet-webview:
 
 # Compile only the webview bursa-wallet binary, assuming the web bundle has
 # already been built into the //go:embed dist target. Honors GOOS/GOARCH.
-wallet-binary-webview:
-	cd ui && CGO_ENABLED=1 go build \
+wallet-binary-webview: webkit-shim
+	cd ui && CGO_ENABLED=1 \
+		PKG_CONFIG_PATH="$(WEBVIEW_PKG_CONFIG_DIR)$(if $(PKG_CONFIG_PATH),:$(PKG_CONFIG_PATH),)" \
+		go build \
 		$(UI_WEBVIEW_LDFLAGS) \
 		-tags webview \
 		-o bursa-wallet$(if $(filter windows,$(GOOS)),.exe,) \
 		./cmd/bursa-wallet
+
+# github.com/webview/webview_go hardcodes `pkg-config: gtk+-3.0 webkit2gtk-4.0`
+# and offers no 4.1 build tag; the pinned commit is also upstream's latest, so
+# there is no newer version to bump to. Ubuntu 24.04+ (and every distro that
+# dropped EOL libsoup2) ships only webkit2gtk-4.1, where the build fails with
+# "Package webkit2gtk-4.0 was not found in the pkg-config search path".
+#
+# When 4.0 is genuinely absent but 4.1 is present, generate a forwarding .pc so
+# pkg-config resolves the 4.0 request to the 4.1 headers and libs. webview_go
+# only uses WebKitGTK APIs that are identical across the two; they differ in
+# libsoup2 vs libsoup3, which webview_go does not touch. The stale shim is
+# removed first so the probe sees the true system state — a host with a real
+# 4.0 installed gets no shim and links against it directly.
+webkit-shim:
+ifeq ($(GOOS),linux)
+	@rm -f $(WEBVIEW_PKG_CONFIG_DIR)/webkit2gtk-4.0.pc
+	@if ! pkg-config --exists webkit2gtk-4.0 && pkg-config --exists webkit2gtk-4.1; then \
+		mkdir -p $(WEBVIEW_PKG_CONFIG_DIR); \
+		printf 'Name: webkit2gtk-4.0\nDescription: Shim forwarding to webkit2gtk-4.1\nVersion: %s\nRequires: webkit2gtk-4.1\n' \
+			"$$(pkg-config --modversion webkit2gtk-4.1)" \
+			> $(WEBVIEW_PKG_CONFIG_DIR)/webkit2gtk-4.0.pc; \
+		echo "webkit2gtk-4.0 absent; generated 4.1 forwarding shim in $(WEBVIEW_PKG_CONFIG_DIR)"; \
+	fi
+endif
 
 # Build an ad-hoc-signed macOS Bursa.app + .pkg for LOCAL testing (no Developer
 # ID needed). The pkg itself is unsigned; install with

--- a/ui/internal/desktoptray/window_darwin.go
+++ b/ui/internal/desktoptray/window_darwin.go
@@ -17,72 +17,22 @@
 package desktoptray
 
 /*
-#cgo CFLAGS: -x objective-c
 #cgo LDFLAGS: -framework Cocoa
-#import <Cocoa/Cocoa.h>
 
-// desktopTrayCloseRequested is implemented in Go (see the //export below).
-extern void desktopTrayCloseRequested(void);
-
-// BursaWindowDelegate intercepts the window's red close button and its yellow
-// minimize button. Returning NO from windowShouldClose: keeps the NSWindow (and
-// the embedded node) alive; the Go side hides it to the tray. AppKit has no
-// cancelable "should miniaturize" hook, so minimize is caught in
-// windowDidMiniaturize: — by then the window has already miniaturized, so the Go
-// hide path (desktop_tray_hide) deminiaturizes before ordering it out, leaving
-// no Dock tile behind. Both routes funnel through the one hide-to-tray path.
-// This replaces any delegate the webview set, which is intended: we want close
-// and minimize to hide, not terminate or sit in the Dock.
-@interface BursaWindowDelegate : NSObject <NSWindowDelegate>
-@end
-
-@implementation BursaWindowDelegate
-- (BOOL)windowShouldClose:(NSWindow *)sender {
-	(void)sender;
-	desktopTrayCloseRequested();
-	return NO; // keep the window; Go orders it out to the tray
-}
-- (void)windowDidMiniaturize:(NSNotification *)notification {
-	(void)notification;
-	desktopTrayCloseRequested(); // Go hides to the tray (and deminiaturizes)
-}
-@end
-
-static BursaWindowDelegate *g_desktop_tray_delegate = nil;
-
-// desktop_tray_install_close sets our close-intercepting delegate. Must run on
-// the AppKit main thread; the desktop shell calls this on the main goroutine
-// (runtime.LockOSThread) before [NSApp run].
-static void desktop_tray_install_close(void *window) {
-	NSWindow *win = (NSWindow *)window;
-	if (g_desktop_tray_delegate == nil) {
-		g_desktop_tray_delegate = [[BursaWindowDelegate alloc] init];
-	}
-	[win setDelegate:g_desktop_tray_delegate];
-}
-
-// desktop_tray_hide orders the window out and drops the app to accessory
-// activation so only the tray item remains (no Dock icon / menu bar). If the
-// window arrived here via a minimize (windowDidMiniaturize:), it is still
-// miniaturized; deminiaturize first so ordering it out leaves no minimized Dock
-// tile and the next show restores a normal window.
-static void desktop_tray_hide(void *window) {
-	NSWindow *win = (NSWindow *)window;
-	if ([win isMiniaturized]) {
-		[win deminiaturize:nil];
-	}
-	[win orderOut:nil];
-	[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
-}
-
-// desktop_tray_show restores regular activation, brings the app forward and
-// makes the window key + front.
-static void desktop_tray_show(void *window) {
-	NSWindow *win = (NSWindow *)window;
-	[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-	[NSApp activateIgnoringOtherApps:YES];
-	[win makeKeyAndOrderFront:nil];
-}
+// Declarations only. The Objective-C definitions live in window_darwin.m, which
+// cgo compiles exactly once.
+//
+// They cannot live in this preamble: the package exports a function to C (see
+// the //export below), so cgo copies the preamble into the generated
+// _cgo_export translation unit as well as this file's own. Duplicating a
+// `static` C function is harmless — that is why the Linux and Windows variants
+// keep their callbacks inline — but an Objective-C @implementation always emits
+// external symbols (`static` is meaningless for it), so the class would be
+// defined in two objects and the link fails with
+// "duplicate symbol '_OBJC_CLASS_$_BursaWindowDelegate'".
+void desktop_tray_install_close(void *window);
+void desktop_tray_hide(void *window);
+void desktop_tray_show(void *window);
 */
 import "C"
 

--- a/ui/internal/desktoptray/window_darwin.m
+++ b/ui/internal/desktoptray/window_darwin.m
@@ -1,0 +1,81 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build webview && darwin
+
+#import <Cocoa/Cocoa.h>
+
+// desktopTrayCloseRequested is implemented in Go and exported to C by cgo (see
+// the //export in window_darwin.go).
+extern void desktopTrayCloseRequested(void);
+
+// BursaWindowDelegate intercepts the window's red close button and its yellow
+// minimize button. Returning NO from windowShouldClose: keeps the NSWindow (and
+// the embedded node) alive; the Go side hides it to the tray. AppKit has no
+// cancelable "should miniaturize" hook, so minimize is caught in
+// windowDidMiniaturize: — by then the window has already miniaturized, so the Go
+// hide path (desktop_tray_hide) deminiaturizes before ordering it out, leaving
+// no Dock tile behind. Both routes funnel through the one hide-to-tray path.
+// This replaces any delegate the webview set, which is intended: we want close
+// and minimize to hide, not terminate or sit in the Dock.
+@interface BursaWindowDelegate : NSObject <NSWindowDelegate>
+@end
+
+@implementation BursaWindowDelegate
+- (BOOL)windowShouldClose:(NSWindow *)sender {
+	(void)sender;
+	desktopTrayCloseRequested();
+	return NO; // keep the window; Go orders it out to the tray
+}
+- (void)windowDidMiniaturize:(NSNotification *)notification {
+	(void)notification;
+	desktopTrayCloseRequested(); // Go hides to the tray (and deminiaturizes)
+}
+@end
+
+static BursaWindowDelegate *g_desktop_tray_delegate = nil;
+
+// desktop_tray_install_close sets our close-intercepting delegate. Must run on
+// the AppKit main thread; the desktop shell calls this on the main goroutine
+// (runtime.LockOSThread) before [NSApp run].
+void desktop_tray_install_close(void *window) {
+	NSWindow *win = (NSWindow *)window;
+	if (g_desktop_tray_delegate == nil) {
+		g_desktop_tray_delegate = [[BursaWindowDelegate alloc] init];
+	}
+	[win setDelegate:g_desktop_tray_delegate];
+}
+
+// desktop_tray_hide orders the window out and drops the app to accessory
+// activation so only the tray item remains (no Dock icon / menu bar). If the
+// window arrived here via a minimize (windowDidMiniaturize:), it is still
+// miniaturized; deminiaturize first so ordering it out leaves no minimized Dock
+// tile and the next show restores a normal window.
+void desktop_tray_hide(void *window) {
+	NSWindow *win = (NSWindow *)window;
+	if ([win isMiniaturized]) {
+		[win deminiaturize:nil];
+	}
+	[win orderOut:nil];
+	[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+}
+
+// desktop_tray_show restores regular activation, brings the app forward and
+// makes the window key + front.
+void desktop_tray_show(void *window) {
+	NSWindow *win = (NSWindow *)window;
+	[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+	[NSApp activateIgnoringOtherApps:YES];
+	[win makeKeyAndOrderFront:nil];
+}


### PR DESCRIPTION
The release workflow's wallet builds are failing on `main`: four of the eight `build-wallet-binaries` jobs are red (macOS arm64 + amd64, Linux amd64 + arm64). Tagging today would produce a draft release missing those artifacts, and `finalize-release` would never run.

Two independent causes.

## macOS: duplicate Objective-C symbol

```
duplicate symbol '_OBJC_CLASS_$_BursaWindowDelegate' in:
    .../000000.o
    .../000001.o
ld: 2 duplicate symbols
```

`desktoptray` exports a function to C (`//export desktopTrayCloseRequested`), which makes cgo copy the file's preamble into the generated `_cgo_export` translation unit in addition to the file's own. Duplicating a `static` C function is harmless — that is exactly why the Linux and Windows variants, whose callbacks are all `static`, are unaffected — but an Objective-C `@implementation` always emits external symbols (`static` is meaningless for it), so `BursaWindowDelegate` ended up defined in two objects.

The Objective-C definitions move to `window_darwin.m`, which cgo compiles exactly once. The preamble keeps only declarations, and `-x objective-c` is dropped from `CFLAGS` since the `.m` extension carries that now.

## Linux: webkit2gtk-4.0 not found

```
Package webkit2gtk-4.0 was not found in the pkg-config search path.
```

`webview_go` hardcodes `pkg-config: gtk+-3.0 webkit2gtk-4.0` and offers no 4.1 build tag. The pinned commit is also upstream's latest, so there is no newer version to move to. Ubuntu 24.04 — and every distro that dropped EOL libsoup2 — ships only webkit2gtk-4.1.

A new `webkit-shim` make target generates a forwarding `.pc` when 4.0 is absent and 4.1 is present, so the 4.0 request resolves against the 4.1 headers and libs. `webview_go` only uses WebKitGTK APIs that are identical across the two; the difference between them is libsoup2 vs libsoup3, which `webview_go` does not touch. The shim is skipped entirely when a real 4.0 is installed, and it fixes local builds on Ubuntu 24.04+ as well as CI.

## Why no pull request caught either

`ui-go` builds only the default pure-Go wallet, so the `-tags webview` sources — every `window_*.go`, and now the `.m` — were never compiled on a pull request. The release workflow was the first thing to build them, after merge.

The new `ui-webview` job builds the webview variant on Linux and macOS through the same Makefile target the release uses. Windows is intentionally left to the release workflow: its webview build needs a bespoke MSYS2 toolchain plus explicit `CC`/`CXX` wiring, which would be duplicated logic here.

## Verification

On a host with only webkit2gtk-4.1 installed — the exact condition that fails in CI:

- `make wallet-webview` succeeds. The shim is generated, and the resulting binary links `libwebkit2gtk-4.1.so.0` and `libsoup-3.0.so.0`, confirming it resolved through the shim rather than bypassing it.
- The default pure-Go build (`CGO_ENABLED=0 go build ./cmd/bursa-wallet`) still succeeds, so the added `.m` cannot trip "C source files not allowed when not using cgo".
- `go list` confirms file selection in all three configurations: `window_darwin.m` is compiled for darwin + webview, and excluded both for darwin without the tag and for linux + webview.
- The cgo duplicate-preamble mechanism and this fix pattern were each confirmed against a minimal standalone reproduction.

macOS cannot be compiled on a Linux host, so the `ui-webview` job in this PR is what proves that half.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes webview wallet release builds on macOS and Linux. Adds a CI job to build the webview variant on PRs so issues are caught before release.

- **Bug Fixes**
  - macOS: Moved the Objective‑C delegate from the `cgo` preamble to `window_darwin.m` to stop duplicate `_OBJC_CLASS_$_BursaWindowDelegate` symbols. `window_darwin.go` now holds declarations only.
  - Linux: Added a `Makefile` `webkit-shim` that creates a local `pkg-config` `webkit2gtk-4.0.pc` which forwards to `webkit2gtk-4.1` when 4.0 is missing. `.pkgconfig` is prepended to `PKG_CONFIG_PATH` in `wallet-binary-webview`.

- **Refactors**
  - CI: Added `ui-webview` for Linux and macOS to build the SPA and run `make wallet-binary-webview`, matching the release build. Windows remains covered by the release workflow.
  - Build hygiene: `make clean` now removes the generated `.pkgconfig` shim; `.pkgconfig/` is ignored in Git.

<sup>Written for commit 3276ca071304cb7d775e9cd2f41315608bd89a47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

