### PR TITLE
feat(kesagent): KES agent daemon (serve-key + sign modes)

### DIFF
--- a/cmd/bursa/kesagent.go
+++ b/cmd/bursa/kesagent.go
@@ -119,9 +119,18 @@ func runKesAgent(configFile string) int {
 		logger.Error("failed to load cold verification key", "error", err)
 		return 1
 	}
-	socketMode, err := parseSocketMode(kc.SocketMode)
+	serviceSocketMode, err := parseSocketMode(kc.ServiceSocketMode)
 	if err != nil {
-		logger.Error("invalid kes_agent.socket_mode", "error", err)
+		logger.Error("invalid kes_agent.service_socket_mode", "error", err)
+		return 1
+	}
+	controlSocketMode, err := parseSocketMode(kc.ControlSocketMode)
+	if err != nil {
+		logger.Error("invalid kes_agent.control_socket_mode", "error", err)
+		return 1
+	}
+	if err := validateControlSocketMode(controlSocketMode); err != nil {
+		logger.Error("invalid kes_agent.control_socket_mode", "error", err)
 		return 1
 	}
 	evolveInterval := time.Minute
@@ -153,13 +162,13 @@ func runKesAgent(configFile string) int {
 	}
 	defer agent.Close()
 
-	serviceLn, err := kesagent.ListenUnix(kc.ServiceSocket, socketMode)
+	serviceLn, err := kesagent.ListenUnix(kc.ServiceSocket, serviceSocketMode)
 	if err != nil {
 		logger.Error("failed to open service socket", "error", err)
 		return 1
 	}
 
-	controlLn, err := kesagent.ListenUnix(kc.ControlSocket, socketMode)
+	controlLn, err := kesagent.ListenUnix(kc.ControlSocket, controlSocketMode)
 	if err != nil {
 		logger.Error("failed to open control socket", "error", err)
 		_ = serviceLn.Close()
@@ -237,7 +246,12 @@ func loadColdVKey(hexStr, filePath string) ([]byte, error) {
 	// A raw 32-byte binary file (one of the documented formats) is not valid
 	// hex or JSON text, so it must be detected before routing through
 	// ReadCborInput, which only understands hex-encoded or envelope text.
-	if len(fileBytes) == 32 {
+	// Guard the heuristic with looksLikeText: raw key material is random
+	// bytes and vanishingly unlikely to be all printable text, so a 32-byte
+	// file that IS text-shaped (e.g. malformed/truncated hex or JSON that
+	// happens to be 32 bytes long) still falls through to the decode path
+	// below and surfaces a clear error instead of being silently accepted.
+	if len(fileBytes) == 32 && !looksLikeText(fileBytes) {
 		return unwrapVKey(fileBytes)
 	}
 	raw, err := bursa.ReadCborInput(fileBytes)
@@ -245,6 +259,22 @@ func loadColdVKey(hexStr, filePath string) ([]byte, error) {
 		return nil, err
 	}
 	return unwrapVKey(raw)
+}
+
+// looksLikeText reports whether b consists entirely of printable ASCII and
+// common whitespace (spaces, tabs, newlines) -- the shape of hex-encoded or
+// JSON-envelope key files. Raw 32-byte key material is random and
+// vanishingly unlikely to satisfy this.
+func looksLikeText(b []byte) bool {
+	for _, c := range b {
+		switch {
+		case c == '\n' || c == '\r' || c == '\t':
+			continue
+		case c < 0x20 || c > 0x7e:
+			return false
+		}
+	}
+	return true
 }
 
 // unwrapVKey returns the raw 32-byte key from either a bare 32-byte value or a
@@ -275,4 +305,19 @@ func parseSocketMode(s string) (os.FileMode, error) {
 		return 0, fmt.Errorf("socket mode %q: %w", s, err)
 	}
 	return os.FileMode(v), nil
+}
+
+// validateControlSocketMode rejects a control-socket mode that grants group
+// or other write access. The control socket accepts gen-staged-key,
+// install-key, and drop-key commands, so a group/other-writable peer could
+// install or drop KES keys; unlike the service socket, it must never be
+// widened beyond owner-only write access.
+func validateControlSocketMode(mode os.FileMode) error {
+	if mode.Perm()&0o022 != 0 {
+		return fmt.Errorf(
+			"control socket mode %04o must not grant group or other write access",
+			mode.Perm(),
+		)
+	}
+	return nil
 }

--- a/cmd/bursa/kesagent.go
+++ b/cmd/bursa/kesagent.go
@@ -124,6 +124,10 @@ func runKesAgent(configFile string) int {
 		logger.Error("invalid kes_agent.service_socket_mode", "error", err)
 		return 1
 	}
+	if err := validateServiceSocketMode(serviceSocketMode); err != nil {
+		logger.Error("invalid kes_agent.service_socket_mode", "error", err)
+		return 1
+	}
 	controlSocketMode, err := parseSocketMode(kc.ControlSocketMode)
 	if err != nil {
 		logger.Error("invalid kes_agent.control_socket_mode", "error", err)
@@ -305,6 +309,22 @@ func parseSocketMode(s string) (os.FileMode, error) {
 		return 0, fmt.Errorf("socket mode %q: %w", s, err)
 	}
 	return os.FileMode(v), nil
+}
+
+// validateServiceSocketMode rejects a service-socket mode that grants other
+// (world) write access. Connecting to a Unix socket requires write permission
+// on the socket file, so a world-writable service socket would let any local
+// user receive a pushed KES signing key (serve-key mode) or submit sign
+// requests (sign mode). Group write is intentionally still allowed: the
+// documented producer setup shares the service socket with a dedicated group.
+func validateServiceSocketMode(mode os.FileMode) error {
+	if mode.Perm()&0o002 != 0 {
+		return fmt.Errorf(
+			"service socket mode %04o must not grant other (world) write access",
+			mode.Perm(),
+		)
+	}
+	return nil
 }
 
 // validateControlSocketMode rejects a control-socket mode that grants group

--- a/cmd/bursa/kesagent.go
+++ b/cmd/bursa/kesagent.go
@@ -1,0 +1,247 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	bursa "github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/bursa/internal/config"
+	"github.com/blinklabs-io/bursa/internal/kesagent"
+	"github.com/blinklabs-io/bursa/internal/logging"
+	"github.com/blinklabs-io/bursa/internal/version"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/spf13/cobra"
+)
+
+func kesAgentCommand() *cobra.Command {
+	var configFile string
+
+	cmd := &cobra.Command{
+		Use:   "kes-agent",
+		Short: "Run the KES agent daemon for a Cardano block producer",
+		Long: `Run the KES agent daemon.
+
+The KES agent holds the block-production KES signing key in locked secure
+memory, evolves it forward-securely each KES period, and serves it to a Go
+block producer (dingo) over a Unix socket. It runs in one of two modes:
+
+  serve-key  push the current KES signing key (with its opcert) to the producer
+  sign       sign block headers on the producer's behalf; the key never leaves
+
+The pool cold signing key never touches the agent: it only holds the cold
+verification key and consumes the operational certificate the cold signer
+issued. Manage keys over the control socket: gen-staged-key, install-key,
+drop-key, info.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			logging.ConfigureJSON()
+			logger := logging.GetLogger()
+
+			if configFile == "" {
+				configFile = os.Getenv("BURSA_CONFIG")
+			}
+			cfg, err := config.LoadConfigFile(configFile)
+			if err != nil {
+				logger.Error("failed to load config", "error", err)
+				os.Exit(1)
+			}
+			logging.ConfigureJSON()
+			logger = logging.GetLogger()
+
+			kc := cfg.KESAgent
+			if kc.Mode != kesagent.ModeServeKey && kc.Mode != kesagent.ModeSign {
+				logger.Error("kes_agent.mode must be \"serve-key\" or \"sign\"", "mode", kc.Mode)
+				os.Exit(1)
+			}
+			if kc.ServiceSocket == "" || kc.ControlSocket == "" {
+				logger.Error("kes_agent.service_socket and kes_agent.control_socket are required")
+				os.Exit(1)
+			}
+			if kc.SlotsPerKESPeriod == 0 {
+				logger.Error("kes_agent.slots_per_kes_period must be set")
+				os.Exit(1)
+			}
+			systemStart, err := time.Parse(time.RFC3339, kc.SystemStart)
+			if err != nil {
+				logger.Error("kes_agent.system_start must be RFC3339", "error", err)
+				os.Exit(1)
+			}
+			coldVKey, err := loadColdVKey(kc.ColdVKeyHex, kc.ColdVKeyFile)
+			if err != nil {
+				logger.Error("failed to load cold verification key", "error", err)
+				os.Exit(1)
+			}
+			socketMode, err := parseSocketMode(kc.SocketMode)
+			if err != nil {
+				logger.Error("invalid kes_agent.socket_mode", "error", err)
+				os.Exit(1)
+			}
+			evolveInterval := time.Minute
+			if kc.EvolveInterval != "" {
+				evolveInterval, err = time.ParseDuration(kc.EvolveInterval)
+				if err != nil {
+					logger.Error("invalid kes_agent.evolve_interval", "error", err)
+					os.Exit(1)
+				}
+			}
+			slotLen := kc.SlotLength
+			if slotLen <= 0 {
+				slotLen = 1
+			}
+
+			metrics := kesagent.NewMetrics()
+			metrics.Register(prometheus.DefaultRegisterer)
+
+			agent, err := kesagent.New(kesagent.Config{
+				Mode:              kc.Mode,
+				SystemStart:       systemStart,
+				SlotLength:        time.Duration(slotLen * float64(time.Second)),
+				SlotsPerKESPeriod: kc.SlotsPerKESPeriod,
+				MaxKESEvolutions:  kc.MaxKESEvolutions,
+				ColdVKey:          coldVKey,
+				EvolveInterval:    evolveInterval,
+				GuardPath:         kc.GuardFile,
+				Version:           version.GetVersionString(),
+			}, logger, metrics)
+			if err != nil {
+				logger.Error("failed to create KES agent", "error", err)
+				os.Exit(1)
+			}
+			defer agent.Close()
+
+			serviceLn, err := kesagent.ListenUnix(kc.ServiceSocket, socketMode)
+			if err != nil {
+				logger.Error("failed to open service socket", "error", err)
+				os.Exit(1)
+			}
+			controlLn, err := kesagent.ListenUnix(kc.ControlSocket, socketMode)
+			if err != nil {
+				logger.Error("failed to open control socket", "error", err)
+				os.Exit(1)
+			}
+
+			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer stop()
+
+			// Optional metrics HTTP endpoint.
+			var metricsSrv *http.Server
+			if cfg.Metrics.ListenPort != 0 {
+				addr := fmt.Sprintf("%s:%d", cfg.Metrics.ListenAddress, cfg.Metrics.ListenPort)
+				mux := http.NewServeMux()
+				mux.Handle("/metrics", promhttp.Handler())
+				metricsSrv = &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+				go func() {
+					if err := metricsSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+						logger.Error("metrics server exited", "error", err)
+					}
+				}()
+			}
+
+			errCh := make(chan error, 2)
+			go func() { errCh <- agent.ServeService(ctx, serviceLn) }()
+			go func() { errCh <- agent.ServeControl(ctx, controlLn) }()
+			go agent.Run(ctx)
+
+			logger.Info("starting bursa kes-agent",
+				"mode", kc.Mode,
+				"service_socket", kc.ServiceSocket,
+				"control_socket", kc.ControlSocket,
+				"cold_vkey", hex.EncodeToString(coldVKey),
+			)
+
+			select {
+			case err := <-errCh:
+				if err != nil {
+					logger.Error("kes-agent listener exited", "error", err)
+					os.Exit(1)
+				}
+			case <-ctx.Done():
+				logger.Info("shutdown signal received")
+			}
+			if metricsSrv != nil {
+				shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				_ = metricsSrv.Shutdown(shutdownCtx)
+			}
+			_ = os.Remove(kc.ServiceSocket)
+			_ = os.Remove(kc.ControlSocket)
+			logger.Info("kes-agent shutdown complete")
+		},
+	}
+	cmd.Flags().StringVar(&configFile, "config", "", "path to YAML config file (env: BURSA_CONFIG)")
+	return cmd
+}
+
+// loadColdVKey resolves the pool cold verification key from an inline hex value
+// or a file (cardano-cli text envelope or raw/hex), returning the raw 32 bytes.
+func loadColdVKey(hexStr, filePath string) ([]byte, error) {
+	if hexStr != "" {
+		raw, err := hex.DecodeString(strings.TrimSpace(hexStr))
+		if err != nil {
+			return nil, fmt.Errorf("cold_vkey_hex: %w", err)
+		}
+		return unwrapVKey(raw)
+	}
+	if filePath == "" {
+		return nil, errors.New("one of kes_agent.cold_vkey_hex or kes_agent.cold_vkey_file is required")
+	}
+	raw, err := bursa.ReadCborInputFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	return unwrapVKey(raw)
+}
+
+// unwrapVKey returns the raw 32-byte key from either a bare 32-byte value or a
+// CBOR bytestring wrapping it.
+func unwrapVKey(b []byte) ([]byte, error) {
+	if len(b) == 32 {
+		return b, nil
+	}
+	var inner []byte
+	if _, err := cbor.Decode(b, &inner); err != nil {
+		return nil, fmt.Errorf("cold vkey is neither 32 raw bytes nor CBOR bytes: %w", err)
+	}
+	if len(inner) != 32 {
+		return nil, fmt.Errorf("cold vkey must be 32 bytes, got %d", len(inner))
+	}
+	return inner, nil
+}
+
+// parseSocketMode parses an octal file-mode string (e.g. "0600"), defaulting to
+// 0600 when empty.
+func parseSocketMode(s string) (os.FileMode, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0o600, nil
+	}
+	v, err := strconv.ParseUint(s, 8, 32)
+	if err != nil {
+		return 0, fmt.Errorf("socket mode %q: %w", s, err)
+	}
+	return os.FileMode(v), nil
+}

--- a/cmd/bursa/kesagent.go
+++ b/cmd/bursa/kesagent.go
@@ -58,142 +58,163 @@ verification key and consumes the operational certificate the cold signer
 issued. Manage keys over the control socket: gen-staged-key, install-key,
 drop-key, info.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			logging.ConfigureJSON()
-			logger := logging.GetLogger()
-
-			if configFile == "" {
-				configFile = os.Getenv("BURSA_CONFIG")
-			}
-			cfg, err := config.LoadConfigFile(configFile)
-			if err != nil {
-				logger.Error("failed to load config", "error", err)
-				os.Exit(1)
-			}
-			logging.ConfigureJSON()
-			logger = logging.GetLogger()
-
-			kc := cfg.KESAgent
-			if kc.Mode != kesagent.ModeServeKey && kc.Mode != kesagent.ModeSign {
-				logger.Error("kes_agent.mode must be \"serve-key\" or \"sign\"", "mode", kc.Mode)
-				os.Exit(1)
-			}
-			if kc.ServiceSocket == "" || kc.ControlSocket == "" {
-				logger.Error("kes_agent.service_socket and kes_agent.control_socket are required")
-				os.Exit(1)
-			}
-			if kc.SlotsPerKESPeriod == 0 {
-				logger.Error("kes_agent.slots_per_kes_period must be set")
-				os.Exit(1)
-			}
-			systemStart, err := time.Parse(time.RFC3339, kc.SystemStart)
-			if err != nil {
-				logger.Error("kes_agent.system_start must be RFC3339", "error", err)
-				os.Exit(1)
-			}
-			coldVKey, err := loadColdVKey(kc.ColdVKeyHex, kc.ColdVKeyFile)
-			if err != nil {
-				logger.Error("failed to load cold verification key", "error", err)
-				os.Exit(1)
-			}
-			socketMode, err := parseSocketMode(kc.SocketMode)
-			if err != nil {
-				logger.Error("invalid kes_agent.socket_mode", "error", err)
-				os.Exit(1)
-			}
-			evolveInterval := time.Minute
-			if kc.EvolveInterval != "" {
-				evolveInterval, err = time.ParseDuration(kc.EvolveInterval)
-				if err != nil {
-					logger.Error("invalid kes_agent.evolve_interval", "error", err)
-					os.Exit(1)
-				}
-			}
-			slotLen := kc.SlotLength
-			if slotLen <= 0 {
-				slotLen = 1
-			}
-
-			metrics := kesagent.NewMetrics()
-			metrics.Register(prometheus.DefaultRegisterer)
-
-			agent, err := kesagent.New(kesagent.Config{
-				Mode:              kc.Mode,
-				SystemStart:       systemStart,
-				SlotLength:        time.Duration(slotLen * float64(time.Second)),
-				SlotsPerKESPeriod: kc.SlotsPerKESPeriod,
-				MaxKESEvolutions:  kc.MaxKESEvolutions,
-				ColdVKey:          coldVKey,
-				EvolveInterval:    evolveInterval,
-				GuardPath:         kc.GuardFile,
-				Version:           version.GetVersionString(),
-			}, logger, metrics)
-			if err != nil {
-				logger.Error("failed to create KES agent", "error", err)
-				os.Exit(1)
-			}
-			defer agent.Close()
-
-			serviceLn, err := kesagent.ListenUnix(kc.ServiceSocket, socketMode)
-			if err != nil {
-				logger.Error("failed to open service socket", "error", err)
-				os.Exit(1)
-			}
-			controlLn, err := kesagent.ListenUnix(kc.ControlSocket, socketMode)
-			if err != nil {
-				logger.Error("failed to open control socket", "error", err)
-				os.Exit(1)
-			}
-
-			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-			defer stop()
-
-			// Optional metrics HTTP endpoint.
-			var metricsSrv *http.Server
-			if cfg.Metrics.ListenPort != 0 {
-				addr := fmt.Sprintf("%s:%d", cfg.Metrics.ListenAddress, cfg.Metrics.ListenPort)
-				mux := http.NewServeMux()
-				mux.Handle("/metrics", promhttp.Handler())
-				metricsSrv = &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
-				go func() {
-					if err := metricsSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-						logger.Error("metrics server exited", "error", err)
-					}
-				}()
-			}
-
-			errCh := make(chan error, 2)
-			go func() { errCh <- agent.ServeService(ctx, serviceLn) }()
-			go func() { errCh <- agent.ServeControl(ctx, controlLn) }()
-			go agent.Run(ctx)
-
-			logger.Info("starting bursa kes-agent",
-				"mode", kc.Mode,
-				"service_socket", kc.ServiceSocket,
-				"control_socket", kc.ControlSocket,
-				"cold_vkey", hex.EncodeToString(coldVKey),
-			)
-
-			select {
-			case err := <-errCh:
-				if err != nil {
-					logger.Error("kes-agent listener exited", "error", err)
-					os.Exit(1)
-				}
-			case <-ctx.Done():
-				logger.Info("shutdown signal received")
-			}
-			if metricsSrv != nil {
-				shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				_ = metricsSrv.Shutdown(shutdownCtx)
-			}
-			_ = os.Remove(kc.ServiceSocket)
-			_ = os.Remove(kc.ControlSocket)
-			logger.Info("kes-agent shutdown complete")
+			os.Exit(runKesAgent(configFile))
 		},
 	}
 	cmd.Flags().StringVar(&configFile, "config", "", "path to YAML config file (env: BURSA_CONFIG)")
 	return cmd
+}
+
+// runKesAgent runs the KES agent daemon to completion and returns the process
+// exit code. It is a plain function (rather than logic inlined in cobra's
+// Run) so that every exit path -- validation failure, listener setup
+// failure, or a listener error at runtime -- returns normally and lets
+// deferred cleanup (agent.Close(), which wipes the locked secure-memory KES
+// buffer, and socket removal) run. os.Exit skips deferred functions, so it
+// must only be called once, by the caller, after this function returns.
+func runKesAgent(configFile string) int {
+	logging.ConfigureJSON()
+	logger := logging.GetLogger()
+
+	if configFile == "" {
+		configFile = os.Getenv("BURSA_CONFIG")
+	}
+	cfg, err := config.LoadConfigFile(configFile)
+	if err != nil {
+		logger.Error("failed to load config", "error", err)
+		return 1
+	}
+	logging.ConfigureJSON()
+	logger = logging.GetLogger()
+
+	kc := cfg.KESAgent
+	if kc.Mode != kesagent.ModeServeKey && kc.Mode != kesagent.ModeSign {
+		logger.Error("kes_agent.mode must be \"serve-key\" or \"sign\"", "mode", kc.Mode)
+		return 1
+	}
+	if kc.ServiceSocket == "" || kc.ControlSocket == "" {
+		logger.Error("kes_agent.service_socket and kes_agent.control_socket are required")
+		return 1
+	}
+	if kc.ServiceSocket == kc.ControlSocket {
+		logger.Error("kes_agent.service_socket and kes_agent.control_socket must be different paths",
+			"path", kc.ServiceSocket)
+		return 1
+	}
+	if kc.SlotsPerKESPeriod == 0 {
+		logger.Error("kes_agent.slots_per_kes_period must be set")
+		return 1
+	}
+	if kc.SlotLength <= 0 {
+		logger.Error("kes_agent.slot_length must be positive", "slot_length", kc.SlotLength)
+		return 1
+	}
+	systemStart, err := time.Parse(time.RFC3339, kc.SystemStart)
+	if err != nil {
+		logger.Error("kes_agent.system_start must be RFC3339", "error", err)
+		return 1
+	}
+	coldVKey, err := loadColdVKey(kc.ColdVKeyHex, kc.ColdVKeyFile)
+	if err != nil {
+		logger.Error("failed to load cold verification key", "error", err)
+		return 1
+	}
+	socketMode, err := parseSocketMode(kc.SocketMode)
+	if err != nil {
+		logger.Error("invalid kes_agent.socket_mode", "error", err)
+		return 1
+	}
+	evolveInterval := time.Minute
+	if kc.EvolveInterval != "" {
+		evolveInterval, err = time.ParseDuration(kc.EvolveInterval)
+		if err != nil {
+			logger.Error("invalid kes_agent.evolve_interval", "error", err)
+			return 1
+		}
+	}
+
+	metrics := kesagent.NewMetrics()
+	metrics.Register(prometheus.DefaultRegisterer)
+
+	agent, err := kesagent.New(kesagent.Config{
+		Mode:              kc.Mode,
+		SystemStart:       systemStart,
+		SlotLength:        time.Duration(kc.SlotLength * float64(time.Second)),
+		SlotsPerKESPeriod: kc.SlotsPerKESPeriod,
+		MaxKESEvolutions:  kc.MaxKESEvolutions,
+		ColdVKey:          coldVKey,
+		EvolveInterval:    evolveInterval,
+		GuardPath:         kc.GuardFile,
+		Version:           version.GetVersionString(),
+	}, logger, metrics)
+	if err != nil {
+		logger.Error("failed to create KES agent", "error", err)
+		return 1
+	}
+	defer agent.Close()
+
+	serviceLn, err := kesagent.ListenUnix(kc.ServiceSocket, socketMode)
+	if err != nil {
+		logger.Error("failed to open service socket", "error", err)
+		return 1
+	}
+
+	controlLn, err := kesagent.ListenUnix(kc.ControlSocket, socketMode)
+	if err != nil {
+		logger.Error("failed to open control socket", "error", err)
+		_ = serviceLn.Close()
+		_ = os.Remove(kc.ServiceSocket)
+		return 1
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	// Optional metrics HTTP endpoint.
+	var metricsSrv *http.Server
+	if cfg.Metrics.ListenPort != 0 {
+		addr := fmt.Sprintf("%s:%d", cfg.Metrics.ListenAddress, cfg.Metrics.ListenPort)
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.Handler())
+		metricsSrv = &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+		go func() {
+			if err := metricsSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				logger.Error("metrics server exited", "error", err)
+			}
+		}()
+	}
+
+	errCh := make(chan error, 2)
+	go func() { errCh <- agent.ServeService(ctx, serviceLn) }()
+	go func() { errCh <- agent.ServeControl(ctx, controlLn) }()
+	go agent.Run(ctx)
+
+	logger.Info("starting bursa kes-agent",
+		"mode", kc.Mode,
+		"service_socket", kc.ServiceSocket,
+		"control_socket", kc.ControlSocket,
+		"cold_vkey", hex.EncodeToString(coldVKey),
+	)
+
+	exitCode := 0
+	select {
+	case err := <-errCh:
+		if err != nil {
+			logger.Error("kes-agent listener exited", "error", err)
+			exitCode = 1
+		}
+	case <-ctx.Done():
+		logger.Info("shutdown signal received")
+	}
+	if metricsSrv != nil {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = metricsSrv.Shutdown(shutdownCtx)
+	}
+	_ = os.Remove(kc.ServiceSocket)
+	_ = os.Remove(kc.ControlSocket)
+	logger.Info("kes-agent shutdown complete")
+	return exitCode
 }
 
 // loadColdVKey resolves the pool cold verification key from an inline hex value
@@ -209,7 +230,17 @@ func loadColdVKey(hexStr, filePath string) ([]byte, error) {
 	if filePath == "" {
 		return nil, errors.New("one of kes_agent.cold_vkey_hex or kes_agent.cold_vkey_file is required")
 	}
-	raw, err := bursa.ReadCborInputFile(filePath)
+	fileBytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %q: %w", filePath, err)
+	}
+	// A raw 32-byte binary file (one of the documented formats) is not valid
+	// hex or JSON text, so it must be detected before routing through
+	// ReadCborInput, which only understands hex-encoded or envelope text.
+	if len(fileBytes) == 32 {
+		return unwrapVKey(fileBytes)
+	}
+	raw, err := bursa.ReadCborInput(fileBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/bursa/kesagent_test.go
+++ b/cmd/bursa/kesagent_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseSocketMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    os.FileMode
+		wantErr bool
+	}{
+		{name: "empty defaults to 0600", in: "", want: 0o600},
+		{name: "explicit 0600", in: "0600", want: 0o600},
+		{name: "widened 0660", in: "0660", want: 0o660},
+		{name: "whitespace trimmed", in: "  0600  ", want: 0o600},
+		{name: "not octal", in: "not-a-mode", wantErr: true},
+		{name: "decimal 8/9 digits invalid in octal", in: "0900", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSocketMode(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseSocketMode(%q): expected error, got mode %o", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseSocketMode(%q): unexpected error: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseSocketMode(%q) = %o, want %o", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateControlSocketMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    os.FileMode
+		wantErr bool
+	}{
+		{name: "owner-only default", mode: 0o600},
+		{name: "owner rwx only", mode: 0o700},
+		{name: "group readable (not writable) is fine", mode: 0o640},
+		{name: "group writable rejected", mode: 0o660, wantErr: true},
+		{name: "other writable rejected", mode: 0o602, wantErr: true},
+		{name: "group+other writable rejected", mode: 0o666, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateControlSocketMode(tt.mode)
+			if tt.wantErr && err == nil {
+				t.Fatalf("validateControlSocketMode(%o): expected error, got nil", tt.mode)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("validateControlSocketMode(%o): unexpected error: %v", tt.mode, err)
+			}
+		})
+	}
+}
+
+func TestLooksLikeText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want bool
+	}{
+		{name: "hex string", in: []byte("0f0e0d0c0b0a09080706050403020100aabbccddeeff00112233445566778899"), want: true},
+		{name: "json envelope shape", in: []byte(`{"type":"KesVerificationKey","cborHex":"5820"}`), want: true},
+		{name: "empty is text", in: []byte(""), want: true},
+		{name: "contains a null byte", in: []byte("aaaa\x00aaaa"), want: false},
+		{name: "high-bit random byte", in: []byte("aaaa\xffaaaa"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := looksLikeText(tt.in); got != tt.want {
+				t.Fatalf("looksLikeText(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoadColdVKeyRawBinaryFile guards the intended fast path: a genuine raw
+// 32-byte binary verification key (not text-shaped) is returned as-is
+// without being routed through the hex/JSON-envelope decoder.
+func TestLoadColdVKeyRawBinaryFile(t *testing.T) {
+	raw := make([]byte, 32)
+	for i := range raw {
+		raw[i] = byte(i)
+	}
+	raw[0] = 0x00 // guarantee a non-printable byte regardless of the fill pattern
+	path := filepath.Join(t.TempDir(), "cold.vkey")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write cold vkey: %v", err)
+	}
+	got, err := loadColdVKey("", path)
+	if err != nil {
+		t.Fatalf("loadColdVKey: %v", err)
+	}
+	if len(got) != 32 {
+		t.Fatalf("loadColdVKey returned %d bytes, want 32", len(got))
+	}
+	for i, b := range got {
+		if b != raw[i] {
+			t.Fatalf("loadColdVKey byte %d = %x, want %x", i, b, raw[i])
+		}
+	}
+}
+
+// TestLoadColdVKeyMalformedTextFileOfLength32 guards the cubic P2 fix: a
+// text-shaped 32-byte file that is not valid hex or a JSON envelope must
+// produce a clear decode error, not be silently accepted as raw key bytes
+// just because its length happens to be 32.
+func TestLoadColdVKeyMalformedTextFileOfLength32(t *testing.T) {
+	// Exactly 32 printable ASCII bytes, and not valid hex (contains 'z' and
+	// spaces), so both the old raw-passthrough and the hex/CBOR decoder
+	// would previously disagree about how to interpret it; it must now
+	// error out via the decode path rather than being accepted as raw bytes.
+	malformed := []byte("not-a-valid-cold-vkey!!-zzzzzzzz")
+	if len(malformed) != 32 {
+		t.Fatalf("test fixture must be exactly 32 bytes, got %d", len(malformed))
+	}
+	path := filepath.Join(t.TempDir(), "cold.vkey")
+	if err := os.WriteFile(path, malformed, 0o600); err != nil {
+		t.Fatalf("write cold vkey: %v", err)
+	}
+	if _, err := loadColdVKey("", path); err == nil {
+		t.Fatal("expected loadColdVKey to reject malformed text-shaped 32-byte input")
+	}
+}

--- a/cmd/bursa/kesagent_test.go
+++ b/cmd/bursa/kesagent_test.go
@@ -79,6 +79,32 @@ func TestValidateControlSocketMode(t *testing.T) {
 	}
 }
 
+func TestValidateServiceSocketMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    os.FileMode
+		wantErr bool
+	}{
+		{name: "owner-only default", mode: 0o600},
+		{name: "group readable is fine", mode: 0o640},
+		{name: "group writable allowed (documented producer group)", mode: 0o660},
+		{name: "other readable is fine", mode: 0o604},
+		{name: "other writable rejected", mode: 0o602, wantErr: true},
+		{name: "world writable rejected", mode: 0o666, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateServiceSocketMode(tt.mode)
+			if tt.wantErr && err == nil {
+				t.Fatalf("validateServiceSocketMode(%o): expected error, got nil", tt.mode)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("validateServiceSocketMode(%o): unexpected error: %v", tt.mode, err)
+			}
+		})
+	}
+}
+
 func TestLooksLikeText(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/bursa/main.go
+++ b/cmd/bursa/main.go
@@ -44,6 +44,7 @@ func main() {
 		hashCommand(),
 		apiCommand(),
 		signerCommand(),
+		kesAgentCommand(),
 		scriptCommand(),
 		txCommand(),
 		signCommand(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,8 +44,16 @@ type KESAgentConfig struct {
 	ServiceSocket string `yaml:"service_socket" envconfig:"KESAGENT_SERVICE_SOCKET"`
 	// ControlSocket is the Unix socket for gen/install/drop/info commands.
 	ControlSocket string `yaml:"control_socket" envconfig:"KESAGENT_CONTROL_SOCKET"`
-	// SocketMode is the octal file mode for both sockets (default 0600).
-	SocketMode string `yaml:"socket_mode" envconfig:"KESAGENT_SOCKET_MODE"`
+	// ServiceSocketMode is the octal file mode for the service socket, which
+	// the block producer connects to (default 0600). It may be widened (e.g.
+	// "0660" with the producer added to the agent's group) to let a
+	// different-UID producer reach it.
+	ServiceSocketMode string `yaml:"service_socket_mode" envconfig:"KESAGENT_SERVICE_SOCKET_MODE"`
+	// ControlSocketMode is the octal file mode for the control socket, which
+	// handles gen-staged-key/install-key/drop-key/info (default 0600). It must
+	// never be widened to group/other access: those commands can drop or
+	// install KES keys.
+	ControlSocketMode string `yaml:"control_socket_mode" envconfig:"KESAGENT_CONTROL_SOCKET_MODE"`
 	// ColdVKeyFile is a path to the pool cold verification key (cardano-cli
 	// text envelope or raw/hex). The agent only ever holds the cold vkey.
 	ColdVKeyFile string `yaml:"cold_vkey_file" envconfig:"KESAGENT_COLD_VKEY_FILE"`
@@ -192,10 +200,11 @@ func defaultConfig() Config {
 			},
 		},
 		KESAgent: KESAgentConfig{
-			SlotLength:       1,
-			MaxKESEvolutions: 62,
-			SocketMode:       "0600",
-			EvolveInterval:   "1m",
+			SlotLength:        1,
+			MaxKESEvolutions:  62,
+			ServiceSocketMode: "0600",
+			ControlSocketMode: "0600",
+			EvolveInterval:    "1m",
 		},
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,15 +23,46 @@ import (
 )
 
 type Config struct {
-	Google   GoogleConfig  `yaml:"google"`
-	Logging  LoggingConfig `yaml:"logging"`
-	Mnemonic string        `yaml:"mnemonic"        envconfig:"MNEMONIC"`
-	Network  string        `yaml:"cardano_network" envconfig:"CARDANO_NETWORK"`
-	Api      ApiConfig     `yaml:"api"`
-	Metrics  MetricsConfig `yaml:"metrics"`
-	Debug    DebugConfig   `yaml:"debug"`
-	Storage  StorageConfig `yaml:"storage"`
-	Signer   SignerConfig  `yaml:"signer"`
+	Google   GoogleConfig   `yaml:"google"`
+	Logging  LoggingConfig  `yaml:"logging"`
+	Mnemonic string         `yaml:"mnemonic"        envconfig:"MNEMONIC"`
+	Network  string         `yaml:"cardano_network" envconfig:"CARDANO_NETWORK"`
+	Api      ApiConfig      `yaml:"api"`
+	Metrics  MetricsConfig  `yaml:"metrics"`
+	Debug    DebugConfig    `yaml:"debug"`
+	Storage  StorageConfig  `yaml:"storage"`
+	Signer   SignerConfig   `yaml:"signer"`
+	KESAgent KESAgentConfig `yaml:"kes_agent"`
+}
+
+// KESAgentConfig holds configuration for the bursa KES agent daemon.
+type KESAgentConfig struct {
+	// Mode is "serve-key" (push the KES signing key to the producer) or "sign"
+	// (sign block headers on the producer's behalf; key never leaves the agent).
+	Mode string `yaml:"mode" envconfig:"KESAGENT_MODE"`
+	// ServiceSocket is the Unix socket the producer connects to.
+	ServiceSocket string `yaml:"service_socket" envconfig:"KESAGENT_SERVICE_SOCKET"`
+	// ControlSocket is the Unix socket for gen/install/drop/info commands.
+	ControlSocket string `yaml:"control_socket" envconfig:"KESAGENT_CONTROL_SOCKET"`
+	// SocketMode is the octal file mode for both sockets (default 0600).
+	SocketMode string `yaml:"socket_mode" envconfig:"KESAGENT_SOCKET_MODE"`
+	// ColdVKeyFile is a path to the pool cold verification key (cardano-cli
+	// text envelope or raw/hex). The agent only ever holds the cold vkey.
+	ColdVKeyFile string `yaml:"cold_vkey_file" envconfig:"KESAGENT_COLD_VKEY_FILE"`
+	// ColdVKeyHex is the cold verification key as hex (alternative to the file).
+	ColdVKeyHex string `yaml:"cold_vkey_hex" envconfig:"KESAGENT_COLD_VKEY_HEX"`
+	// SystemStart is the Shelley genesis system start (RFC3339).
+	SystemStart string `yaml:"system_start" envconfig:"KESAGENT_SYSTEM_START"`
+	// SlotLength is the wall-clock length of one slot in seconds (default 1).
+	SlotLength float64 `yaml:"slot_length" envconfig:"KESAGENT_SLOT_LENGTH"`
+	// SlotsPerKESPeriod is the number of slots per KES period (e.g. 129600).
+	SlotsPerKESPeriod uint64 `yaml:"slots_per_kes_period" envconfig:"KESAGENT_SLOTS_PER_KES_PERIOD"`
+	// MaxKESEvolutions is the max opcert evolutions (mainnet 62).
+	MaxKESEvolutions uint64 `yaml:"max_kes_evolutions" envconfig:"KESAGENT_MAX_KES_EVOLUTIONS"`
+	// EvolveInterval is the scheduler tick as a Go duration string (default 1m).
+	EvolveInterval string `yaml:"evolve_interval" envconfig:"KESAGENT_EVOLVE_INTERVAL"`
+	// GuardFile is the durable monotonic-period store path.
+	GuardFile string `yaml:"guard_file" envconfig:"KESAGENT_GUARD_FILE"`
 }
 
 // SignerConfig holds configuration for the bursa signer daemon.
@@ -159,6 +190,12 @@ func defaultConfig() Config {
 				Type: "mem",
 				Mode: "enforce",
 			},
+		},
+		KESAgent: KESAgentConfig{
+			SlotLength:       1,
+			MaxKESEvolutions: 62,
+			SocketMode:       "0600",
+			EvolveInterval:   "1m",
 		},
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -169,3 +169,58 @@ func TestLoadConfigFile_EmptyPath(t *testing.T) {
 		t.Errorf("default port: got %d, want 8090", cfg.Signer.ListenPort)
 	}
 }
+
+func TestKESAgentConfig_SocketModeDefaults(t *testing.T) {
+	globalConfig = defaultConfig()
+	cfg, err := LoadConfigFile("")
+	if err != nil {
+		t.Fatalf("LoadConfigFile: %v", err)
+	}
+	if cfg.KESAgent.ServiceSocketMode != "0600" {
+		t.Errorf("default service_socket_mode: got %q, want 0600", cfg.KESAgent.ServiceSocketMode)
+	}
+	if cfg.KESAgent.ControlSocketMode != "0600" {
+		t.Errorf("default control_socket_mode: got %q, want 0600", cfg.KESAgent.ControlSocketMode)
+	}
+}
+
+func TestKESAgentConfig_SocketModeFileAndEnv(t *testing.T) {
+	yaml := `
+kes_agent:
+  mode: "serve-key"
+  service_socket: "/run/bursa/service.sock"
+  control_socket: "/run/bursa/control.sock"
+  service_socket_mode: "0660"
+  control_socket_mode: "0600"
+`
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "bursa.yml")
+	if err := os.WriteFile(cfgFile, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+
+	globalConfig = defaultConfig()
+	cfg, err := LoadConfigFile(cfgFile)
+	if err != nil {
+		t.Fatalf("LoadConfigFile: %v", err)
+	}
+	if cfg.KESAgent.ServiceSocketMode != "0660" {
+		t.Errorf("service_socket_mode: got %q, want 0660", cfg.KESAgent.ServiceSocketMode)
+	}
+	if cfg.KESAgent.ControlSocketMode != "0600" {
+		t.Errorf("control_socket_mode: got %q, want 0600", cfg.KESAgent.ControlSocketMode)
+	}
+
+	// Env override must beat the file value, and each field has its own
+	// independent env var.
+	globalConfig = defaultConfig()
+	t.Setenv("KESAGENT_SERVICE_SOCKET_MODE", "0640")
+	t.Setenv("KESAGENT_CONTROL_SOCKET_MODE", "0600")
+	cfg2, err := LoadConfigFile(cfgFile)
+	if err != nil {
+		t.Fatalf("LoadConfigFile (env override): %v", err)
+	}
+	if cfg2.KESAgent.ServiceSocketMode != "0640" {
+		t.Errorf("env override service_socket_mode: got %q, want 0640", cfg2.KESAgent.ServiceSocketMode)
+	}
+}

--- a/internal/kesagent/agent.go
+++ b/internal/kesagent/agent.go
@@ -68,6 +68,7 @@ type keyState struct {
 	buf         *securemem.Buffer
 	vkey        []byte
 	opcert      []byte // installed opcert CBOR (active keys only)
+	issueNumber uint64 // opcert issue counter (active keys only)
 	exhausted   bool
 }
 
@@ -287,6 +288,7 @@ func (a *Agent) InstallKey(opcertBytes []byte) (*AgentInfo, error) {
 	ks.startPeriod = dec.kesPeriod
 	ks.maxEvol = maxEvol
 	ks.opcert = append([]byte(nil), opcertBytes...)
+	ks.issueNumber = dec.issueNumber
 	ks.exhausted = false
 	a.active = ks
 
@@ -401,6 +403,15 @@ func (a *Agent) Sign(period uint64, msg []byte) ([]byte, error) {
 	return sig, nil
 }
 
+// storeEvolvedKey writes an evolved KES key into the active locked buffer. It
+// is a variable so tests can exercise the discard-on-failure branch in
+// evolveToLocked, which is otherwise unreachable: Buffer.Set fails only on a
+// closed buffer or a length mismatch, and a.mu serializes both away in every
+// real call path.
+var storeEvolvedKey = func(buf *securemem.Buffer, data []byte) error {
+	return buf.Set(data)
+}
+
 // evolveToLocked evolves the active key forward until its absolute period
 // reaches targetAbs or the key is exhausted. Caller must hold a.mu.
 func (a *Agent) evolveToLocked(targetAbs uint64) {
@@ -438,7 +449,7 @@ func (a *Agent) evolveToLocked(targetAbs uint64) {
 		// Interim forward-erasure: wipe the spent key material now, then install
 		// the evolved key. TODO adopt gouroboros SecretKey.Zeroize once pinned.
 		a.active.buf.Zeroize()
-		if err := a.active.buf.Set(next.Data); err != nil {
+		if err := storeEvolvedKey(a.active.buf, next.Data); err != nil {
 			securemem.Wipe(next.Data)
 			a.logger.Error("failed to store evolved KES key; discarding the key", "error", err)
 			// The buffer was already zeroized above and next.Data failed to
@@ -613,6 +624,8 @@ func (a *Agent) infoLocked() *AgentInfo {
 		info.ActiveStart = a.active.startPeriod
 		info.ActiveEnd = a.active.endPeriod()
 		info.ActiveKESVKey = append([]byte(nil), a.active.vkey...)
+		info.ActiveIssueNumber = a.active.issueNumber
+		info.ActiveOpCert = append([]byte(nil), a.active.opcert...)
 		info.Exhausted = a.active.exhausted
 	}
 	if a.staged != nil {

--- a/internal/kesagent/agent.go
+++ b/internal/kesagent/agent.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"sync"
 	"time"
 
@@ -140,6 +141,16 @@ func New(cfg Config, logger *slog.Logger, metrics *Metrics) (*Agent, error) {
 	}
 	if cfg.SlotsPerKESPeriod == 0 {
 		return nil, errors.New("kesagent: slots_per_kes_period must be positive")
+	}
+	// SlotLength > 0 is guaranteed above, so guard the KES-period-duration
+	// multiplication (SlotLength * SlotsPerKESPeriod) against int64 overflow.
+	// An oversized slots_per_kes_period would otherwise wrap to a non-positive
+	// duration and silently freeze currentKESPeriod at 0, stalling evolution.
+	if cfg.SlotsPerKESPeriod > uint64(math.MaxInt64)/uint64(cfg.SlotLength) {
+		return nil, fmt.Errorf(
+			"kesagent: slot_length (%s) * slots_per_kes_period (%d) overflows the KES period duration",
+			cfg.SlotLength, cfg.SlotsPerKESPeriod,
+		)
 	}
 	if cfg.MaxKESEvolutions == 0 {
 		cfg.MaxKESEvolutions = 62

--- a/internal/kesagent/agent.go
+++ b/internal/kesagent/agent.go
@@ -361,6 +361,11 @@ func (a *Agent) Sign(period uint64, msg []byte) ([]byte, error) {
 	if period > a.active.absPeriod() {
 		a.evolveToLocked(period)
 	}
+	if a.active == nil {
+		// evolveToLocked discarded the key after a store failure.
+		a.metrics.incSign("error")
+		return nil, ErrNoActiveKey
+	}
 	if a.active.absPeriod() != period {
 		a.metrics.incSign("error")
 		return nil, fmt.Errorf("%w: cannot reach period %d (key ends at %d)",
@@ -432,7 +437,10 @@ func (a *Agent) evolveToLocked(targetAbs uint64) {
 			// zeroed buffer for the (unchanged) period it still reports.
 			a.active.close()
 			a.active = nil
-			a.metrics.setExhausted(true)
+			// No active key exists at all now, so "exhausted" (which implies a
+			// key that reached its final period) is the wrong signal; clear it
+			// rather than reporting a false key-exhaustion health state.
+			a.metrics.setExhausted(false)
 			return
 		}
 		securemem.Wipe(next.Data) // erase the transient evolved copy

--- a/internal/kesagent/agent.go
+++ b/internal/kesagent/agent.go
@@ -476,6 +476,18 @@ func (a *Agent) buildKeyPushLocked() (KeyPush, bool) {
 	if a.active == nil {
 		return KeyPush{}, false
 	}
+	// Never hand a producer a key for a period the guard has already moved past:
+	// serving it would let the producer sign below the monotonic floor, which is
+	// the rollback the guard exists to prevent. The two can diverge when an
+	// install advances the floor but then fails and restores the previous key.
+	if floor, set := a.guard.Floor(); set && a.active.absPeriod() < floor {
+		a.logger.Warn("refusing to serve a key below the period guard floor",
+			"active_period", a.active.absPeriod(),
+			"floor", floor,
+			"kes_vkey", hex.EncodeToString(a.active.vkey),
+		)
+		return KeyPush{}, false
+	}
 	return KeyPush{
 		Type:       "key_push",
 		Period:     a.active.absPeriod(),

--- a/internal/kesagent/agent.go
+++ b/internal/kesagent/agent.go
@@ -1,0 +1,528 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kesagent
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/blinklabs-io/bursa/internal/kesagent/securemem"
+	"github.com/blinklabs-io/gouroboros/kes"
+	"github.com/blinklabs-io/gouroboros/ledger"
+)
+
+// Errors returned by the agent.
+var (
+	ErrNoActiveKey  = errors.New("kesagent: no active KES key installed")
+	ErrNoStagedKey  = errors.New("kesagent: no staged KES key")
+	ErrExhausted    = errors.New("kesagent: active KES key has exhausted its evolutions")
+	ErrPastPeriod   = errors.New("kesagent: requested KES period is in the past for the active key")
+	ErrOpCertColdVK = errors.New("kesagent: opcert cold vkey does not match configured cold vkey")
+	ErrOpCertKESVK  = errors.New("kesagent: opcert KES vkey does not match the staged key")
+	ErrColdVKey     = errors.New("kesagent: configured cold verification key must be 32 bytes")
+)
+
+// Config configures an Agent.
+type Config struct {
+	Mode              string        // ModeServeKey | ModeSign
+	Depth             uint64        // KES tree depth (default kes.CardanoKesDepth)
+	SystemStart       time.Time     // Shelley genesis system start
+	SlotLength        time.Duration // wall-clock duration of one slot
+	SlotsPerKESPeriod uint64        // slots per KES period
+	MaxKESEvolutions  uint64        // max opcert evolutions (mainnet: 62)
+	ColdVKey          []byte        // 32-byte pool cold verification key
+	EvolveInterval    time.Duration // scheduler tick (default 1m)
+	GuardPath         string        // durable monotonic period store path
+	Version           string        // agent version string (for info)
+}
+
+// keyState is the in-memory state of a KES key. The raw secret key bytes live
+// in the locked secure buffer; only the (public) verification key and metadata
+// live on the heap.
+type keyState struct {
+	depth       uint64
+	period      uint64 // internal, 0-based key period
+	startPeriod uint64 // absolute KES period at internal period 0 (opcert period)
+	buf         *securemem.Buffer
+	vkey        []byte
+	opcert      []byte // installed opcert CBOR (active keys only)
+	exhausted   bool
+}
+
+func (k *keyState) absPeriod() uint64 { return k.startPeriod + k.period }
+
+func (k *keyState) endPeriod() uint64 {
+	return k.startPeriod + kes.MaxPeriod(k.depth) - 1
+}
+
+func (k *keyState) close() {
+	if k != nil && k.buf != nil {
+		_ = k.buf.Close()
+	}
+}
+
+// Agent is the KES agent core: key custody, evolution, signing, and serve-key
+// broadcast. It is safe for concurrent use.
+type Agent struct {
+	cfg     Config
+	logger  *slog.Logger
+	metrics *Metrics
+	guard   *PeriodGuard
+
+	mu      sync.Mutex
+	active  *keyState
+	staged  *keyState
+	subs    map[int]chan KeyPush
+	nextSub int
+
+	now func() time.Time // injectable clock (tests)
+}
+
+// New constructs an Agent, validating configuration and opening the durable
+// period guard.
+func New(cfg Config, logger *slog.Logger, metrics *Metrics) (*Agent, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if cfg.Mode != ModeServeKey && cfg.Mode != ModeSign {
+		return nil, fmt.Errorf("kesagent: invalid mode %q", cfg.Mode)
+	}
+	if cfg.Depth == 0 {
+		cfg.Depth = kes.CardanoKesDepth
+	}
+	if cfg.SystemStart.IsZero() {
+		return nil, errors.New("kesagent: system_start is required")
+	}
+	if cfg.SlotLength <= 0 {
+		return nil, errors.New("kesagent: slot_length must be positive")
+	}
+	if cfg.SlotsPerKESPeriod == 0 {
+		return nil, errors.New("kesagent: slots_per_kes_period must be positive")
+	}
+	if cfg.MaxKESEvolutions == 0 {
+		cfg.MaxKESEvolutions = 62
+	}
+	if len(cfg.ColdVKey) != ed25519.PublicKeySize {
+		return nil, ErrColdVKey
+	}
+	if cfg.EvolveInterval <= 0 {
+		cfg.EvolveInterval = time.Minute
+	}
+	guard, err := NewPeriodGuard(cfg.GuardPath)
+	if err != nil {
+		return nil, err
+	}
+	return &Agent{
+		cfg:     cfg,
+		logger:  logger,
+		metrics: metrics,
+		guard:   guard,
+		subs:    make(map[int]chan KeyPush),
+		now:     time.Now,
+	}, nil
+}
+
+// kesPeriodDuration is the wall-clock length of one KES period.
+func (a *Agent) kesPeriodDuration() time.Duration {
+	return a.cfg.SlotLength * time.Duration(a.cfg.SlotsPerKESPeriod) // #nosec G115
+}
+
+// currentKESPeriod computes the current absolute KES period from genesis
+// parameters and the agent clock.
+func (a *Agent) currentKESPeriod() uint64 {
+	elapsed := a.now().Sub(a.cfg.SystemStart)
+	if elapsed <= 0 {
+		return 0
+	}
+	per := a.kesPeriodDuration()
+	if per <= 0 {
+		return 0
+	}
+	return uint64(elapsed / per) // #nosec G115
+}
+
+// GenStagedKey generates a fresh KES key into the staging slot and returns its
+// verification key. Any previously staged key is dropped and wiped.
+func (a *Agent) GenStagedKey() ([]byte, error) {
+	var seed [kes.SeedSize]byte
+	if _, err := rand.Read(seed[:]); err != nil {
+		return nil, fmt.Errorf("kesagent: read entropy: %w", err)
+	}
+	defer securemem.Wipe(seed[:])
+
+	sk, vkey, err := kes.KeyGen(a.cfg.Depth, seed[:])
+	if err != nil {
+		return nil, fmt.Errorf("kesagent: keygen: %w", err)
+	}
+	buf, err := securemem.New(len(sk.Data))
+	if err != nil {
+		securemem.Wipe(sk.Data)
+		return nil, err
+	}
+	if err := buf.Set(sk.Data); err != nil {
+		securemem.Wipe(sk.Data)
+		_ = buf.Close()
+		return nil, err
+	}
+	securemem.Wipe(sk.Data) // transient heap copy erased; material now only in buf
+
+	ks := &keyState{depth: a.cfg.Depth, period: 0, buf: buf, vkey: vkey}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.staged.close()
+	a.staged = ks
+	vkeyOut := make([]byte, len(vkey))
+	copy(vkeyOut, vkey)
+	a.logger.Info("generated staged KES key", "kes_vkey", hex.EncodeToString(vkey))
+	return vkeyOut, nil
+}
+
+// InstallKey validates an operational certificate against the configured cold
+// verification key and the staged KES key, promotes the staged key to active,
+// evolves it to the current period, and (serve-key mode) pushes it. It returns
+// the resulting agent info.
+func (a *Agent) InstallKey(opcertBytes []byte) (*AgentInfo, error) {
+	dec, err := decodeOpCert(opcertBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.staged == nil {
+		return nil, ErrNoStagedKey
+	}
+	// The agent holds only the cold vkey; the opcert must carry the same one.
+	if !bytes.Equal(dec.coldVkey, a.cfg.ColdVKey) {
+		return nil, ErrOpCertColdVK
+	}
+	// Verify the cold-key signature over the OCertSignable representation.
+	if err := ledger.VerifyOpCertSignature(dec.ledgerOpCert(), a.cfg.ColdVKey); err != nil {
+		return nil, fmt.Errorf("kesagent: opcert signature invalid: %w", err)
+	}
+	// The opcert must commit to the staged KES vkey.
+	if !bytes.Equal(dec.kesVkey, a.staged.vkey) {
+		return nil, ErrOpCertKESVK
+	}
+	// Period sanity: not from the future, and not already expired.
+	cur := a.currentKESPeriod()
+	if dec.kesPeriod > cur {
+		return nil, fmt.Errorf(
+			"kesagent: opcert KES period %d is in the future (current %d)",
+			dec.kesPeriod, cur,
+		)
+	}
+	maxEvol := a.cfg.MaxKESEvolutions
+	if m := kes.MaxPeriod(a.cfg.Depth); m < maxEvol {
+		maxEvol = m
+	}
+	if cur-dec.kesPeriod >= maxEvol {
+		return nil, fmt.Errorf(
+			"kesagent: opcert expired: %d evolutions since period %d >= max %d",
+			cur-dec.kesPeriod, dec.kesPeriod, maxEvol,
+		)
+	}
+
+	// Promote staged -> active.
+	a.active.close()
+	ks := a.staged
+	a.staged = nil
+	ks.startPeriod = dec.kesPeriod
+	ks.opcert = append([]byte(nil), opcertBytes...)
+	ks.exhausted = false
+	a.active = ks
+
+	// Evolve to the current period and serve.
+	a.evolveToLocked(cur)
+	if err := a.guard.Authorize(hex.EncodeToString(ks.vkey), a.active.absPeriod()); err != nil {
+		// Roll back the install: refuse to serve a rolled-back period.
+		a.active.close()
+		a.active = nil
+		return nil, err
+	}
+	a.metrics.setCurrentPeriod(a.active.absPeriod())
+	a.metrics.setExhausted(a.active.exhausted)
+	a.broadcastLocked()
+	a.logger.Info("installed KES key",
+		"kes_vkey", hex.EncodeToString(ks.vkey),
+		"start_period", ks.startPeriod,
+		"active_period", a.active.absPeriod(),
+	)
+	return a.infoLocked(), nil
+}
+
+// DropKey wipes the active and/or staged key. target is "active", "staged", or
+// "all" (default "all").
+func (a *Agent) DropKey(target string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	switch target {
+	case "active":
+		a.active.close()
+		a.active = nil
+	case "staged":
+		a.staged.close()
+		a.staged = nil
+	case "", "all":
+		a.active.close()
+		a.active = nil
+		a.staged.close()
+		a.staged = nil
+	default:
+		return fmt.Errorf("kesagent: unknown drop target %q", target)
+	}
+	a.metrics.setExhausted(false)
+	a.logger.Info("dropped KES key", "target", target)
+	return nil
+}
+
+// Sign produces a KES signature over msg at the given absolute KES period. The
+// key is evolved forward as needed; it never signs a period below the monotonic
+// floor or below the active key's current period.
+func (a *Agent) Sign(period uint64, msg []byte) ([]byte, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.active == nil {
+		a.metrics.incSign("error")
+		return nil, ErrNoActiveKey
+	}
+	if period < a.active.absPeriod() {
+		a.metrics.incSign("error")
+		return nil, fmt.Errorf("%w: requested %d, key at %d",
+			ErrPastPeriod, period, a.active.absPeriod())
+	}
+	if period > a.active.absPeriod() {
+		a.evolveToLocked(period)
+	}
+	if a.active.absPeriod() != period {
+		a.metrics.incSign("error")
+		return nil, fmt.Errorf("%w: cannot reach period %d (key ends at %d)",
+			ErrExhausted, period, a.active.endPeriod())
+	}
+	if err := a.guard.Authorize(hex.EncodeToString(a.active.vkey), period); err != nil {
+		a.metrics.incSign("error")
+		return nil, err
+	}
+	sk := &kes.SecretKey{
+		Depth:  a.active.depth,
+		Period: a.active.period,
+		Data:   a.active.buf.Bytes(),
+	}
+	sig, err := kes.Sign(sk, a.active.period, msg)
+	if err != nil {
+		a.metrics.incSign("error")
+		return nil, fmt.Errorf("kesagent: sign: %w", err)
+	}
+	a.metrics.incSign("ok")
+	a.metrics.setCurrentPeriod(a.active.absPeriod())
+	return sig, nil
+}
+
+// evolveToLocked evolves the active key forward until its absolute period
+// reaches targetAbs or the key is exhausted. Caller must hold a.mu.
+func (a *Agent) evolveToLocked(targetAbs uint64) {
+	for a.active != nil && a.active.absPeriod() < targetAbs {
+		nextInternal := a.active.period + 1
+		if nextInternal >= kes.MaxPeriod(a.active.depth) {
+			if !a.active.exhausted {
+				a.active.exhausted = true
+				a.metrics.setExhausted(true)
+				a.logger.Warn("KES key exhausted; a new key must be installed",
+					"kes_vkey", hex.EncodeToString(a.active.vkey),
+					"active_period", a.active.absPeriod(),
+					"target_period", targetAbs,
+				)
+			}
+			return
+		}
+		cur := &kes.SecretKey{
+			Depth:  a.active.depth,
+			Period: a.active.period,
+			Data:   a.active.buf.Bytes(),
+		}
+		next, err := kes.Update(cur) // reads (and internally copies) cur.Data
+		if err != nil {
+			if !a.active.exhausted {
+				a.active.exhausted = true
+				a.metrics.setExhausted(true)
+				a.logger.Warn("KES key update failed; marking exhausted",
+					"error", err,
+					"kes_vkey", hex.EncodeToString(a.active.vkey),
+				)
+			}
+			return
+		}
+		// Interim forward-erasure: wipe the spent key material now, then install
+		// the evolved key. TODO adopt gouroboros SecretKey.Zeroize once pinned.
+		a.active.buf.Zeroize()
+		if err := a.active.buf.Set(next.Data); err != nil {
+			securemem.Wipe(next.Data)
+			a.logger.Error("failed to store evolved KES key", "error", err)
+			a.active.exhausted = true
+			return
+		}
+		securemem.Wipe(next.Data) // erase the transient evolved copy
+		a.active.period = next.Period
+		a.metrics.incEvolutions()
+	}
+}
+
+// buildKeyPushLocked builds a KeyPush for the current active key. Caller holds a.mu.
+func (a *Agent) buildKeyPushLocked() (KeyPush, bool) {
+	if a.active == nil {
+		return KeyPush{}, false
+	}
+	return KeyPush{
+		Type:       "key_push",
+		Period:     a.active.absPeriod(),
+		Depth:      a.active.depth,
+		KESSignKey: a.active.buf.Clone(),
+		KESVKey:    append([]byte(nil), a.active.vkey...),
+		OpCert:     append([]byte(nil), a.active.opcert...),
+	}, true
+}
+
+// broadcastLocked pushes the current key to all serve-key subscribers. Caller
+// holds a.mu.
+func (a *Agent) broadcastLocked() {
+	kp, ok := a.buildKeyPushLocked()
+	if !ok {
+		return
+	}
+	for _, ch := range a.subs {
+		// Latest-wins: drain any stale push, then enqueue the newest.
+		select {
+		case <-ch:
+		default:
+		}
+		select {
+		case ch <- kp:
+		default:
+		}
+		a.metrics.incServedKeys()
+	}
+}
+
+// subscribe registers a serve-key subscriber and returns its id, its channel,
+// and the current key push (if a key is active) to send immediately.
+func (a *Agent) subscribe() (int, chan KeyPush, *KeyPush) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	id := a.nextSub
+	a.nextSub++
+	ch := make(chan KeyPush, 1)
+	a.subs[id] = ch
+	if kp, ok := a.buildKeyPushLocked(); ok {
+		return id, ch, &kp
+	}
+	return id, ch, nil
+}
+
+func (a *Agent) unsubscribe(id int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	delete(a.subs, id)
+}
+
+// Tick advances the scheduler once: it evolves the active key to the current
+// period and, if it advanced, authorizes and broadcasts the new key.
+func (a *Agent) Tick() {
+	cur := a.currentKESPeriod()
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.metrics.setCurrentPeriod(cur)
+	if a.active == nil {
+		return
+	}
+	prev := a.active.absPeriod()
+	a.evolveToLocked(cur)
+	newAbs := a.active.absPeriod()
+	a.metrics.setCurrentPeriod(newAbs)
+	a.metrics.setExhausted(a.active.exhausted)
+	if newAbs > prev {
+		if err := a.guard.Authorize(hex.EncodeToString(a.active.vkey), newAbs); err != nil {
+			a.logger.Error("period guard refused evolved key; not serving",
+				"error", err, "period", newAbs)
+			return
+		}
+		a.broadcastLocked()
+		a.logger.Info("evolved KES key", "active_period", newAbs)
+	}
+}
+
+// Run drives the evolution scheduler until ctx is cancelled.
+func (a *Agent) Run(ctx context.Context) {
+	a.Tick() // evolve immediately on start
+	ticker := time.NewTicker(a.cfg.EvolveInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			a.Tick()
+		}
+	}
+}
+
+// Info returns a status snapshot.
+func (a *Agent) Info() *AgentInfo {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.infoLocked()
+}
+
+func (a *Agent) infoLocked() *AgentInfo {
+	floor, floorSet := a.guard.Floor()
+	info := &AgentInfo{
+		Version:          a.cfg.Version,
+		Mode:             a.cfg.Mode,
+		CurrentPeriod:    a.currentKESPeriod(),
+		MonotonicFloor:   floor,
+		FloorInitialized: floorSet,
+	}
+	if a.active != nil {
+		info.HasActiveKey = true
+		info.ActivePeriod = a.active.absPeriod()
+		info.ActiveStart = a.active.startPeriod
+		info.ActiveEnd = a.active.endPeriod()
+		info.ActiveKESVKey = append([]byte(nil), a.active.vkey...)
+		info.Exhausted = a.active.exhausted
+	}
+	if a.staged != nil {
+		info.StagedKESVKey = append([]byte(nil), a.staged.vkey...)
+	}
+	return info
+}
+
+// Close wipes all key material.
+func (a *Agent) Close() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.active.close()
+	a.active = nil
+	a.staged.close()
+	a.staged = nil
+}

--- a/internal/kesagent/agent.go
+++ b/internal/kesagent/agent.go
@@ -63,6 +63,7 @@ type keyState struct {
 	depth       uint64
 	period      uint64 // internal, 0-based key period
 	startPeriod uint64 // absolute KES period at internal period 0 (opcert period)
+	maxEvol     uint64 // max evolutions this key may serve, min(cfg.MaxKESEvolutions, kes.MaxPeriod(depth)); set at promotion
 	buf         *securemem.Buffer
 	vkey        []byte
 	opcert      []byte // installed opcert CBOR (active keys only)
@@ -72,7 +73,7 @@ type keyState struct {
 func (k *keyState) absPeriod() uint64 { return k.startPeriod + k.period }
 
 func (k *keyState) endPeriod() uint64 {
-	return k.startPeriod + kes.MaxPeriod(k.depth) - 1
+	return k.startPeriod + k.maxEvol - 1
 }
 
 func (k *keyState) close() {
@@ -95,7 +96,28 @@ type Agent struct {
 	subs    map[int]chan KeyPush
 	nextSub int
 
+	// guardedPeriod/guardedSet track the last KES period the scheduler (Tick)
+	// successfully authorized and broadcast, so a transient guard-store
+	// failure is retried on the next tick instead of being silently dropped
+	// for the rest of the period (evolveToLocked has already advanced
+	// a.active in memory regardless of guard-store success).
+	guardedPeriod uint64
+	guardedSet    bool
+
 	now func() time.Time // injectable clock (tests)
+}
+
+// maxEvolutions returns the effective evolution ceiling for keys created
+// under the current config: the smaller of the configured max opcert
+// evolutions and the KES tree's cryptographic evolution limit. Cardano
+// treats an opcert as expired once MaxKESEvolutions is reached even when the
+// KES tree itself could evolve further.
+func (a *Agent) maxEvolutions() uint64 {
+	m := a.cfg.MaxKESEvolutions
+	if treeMax := kes.MaxPeriod(a.cfg.Depth); treeMax < m {
+		m = treeMax
+	}
+	return m
 }
 
 // New constructs an Agent, validating configuration and opening the durable
@@ -179,6 +201,9 @@ func (a *Agent) GenStagedKey() ([]byte, error) {
 		securemem.Wipe(sk.Data)
 		return nil, err
 	}
+	if !buf.Locked() {
+		a.logger.Warn("KES secret key buffer could not be locked in memory (mlock unavailable or refused); key material may be swappable to disk")
+	}
 	if err := buf.Set(sk.Data); err != nil {
 		securemem.Wipe(sk.Data)
 		_ = buf.Close()
@@ -234,10 +259,7 @@ func (a *Agent) InstallKey(opcertBytes []byte) (*AgentInfo, error) {
 			dec.kesPeriod, cur,
 		)
 	}
-	maxEvol := a.cfg.MaxKESEvolutions
-	if m := kes.MaxPeriod(a.cfg.Depth); m < maxEvol {
-		maxEvol = m
-	}
+	maxEvol := a.maxEvolutions()
 	if cur-dec.kesPeriod >= maxEvol {
 		return nil, fmt.Errorf(
 			"kesagent: opcert expired: %d evolutions since period %d >= max %d",
@@ -245,23 +267,37 @@ func (a *Agent) InstallKey(opcertBytes []byte) (*AgentInfo, error) {
 		)
 	}
 
-	// Promote staged -> active.
-	a.active.close()
+	// Promote staged -> active, but keep the previous active key around
+	// (undestroyed) until authorization is known to succeed: a rollback
+	// refusal below must not leave the agent with no working key at all.
+	oldActive := a.active
 	ks := a.staged
 	a.staged = nil
 	ks.startPeriod = dec.kesPeriod
+	ks.maxEvol = maxEvol
 	ks.opcert = append([]byte(nil), opcertBytes...)
 	ks.exhausted = false
 	a.active = ks
 
 	// Evolve to the current period and serve.
 	a.evolveToLocked(cur)
+	if a.active == nil {
+		// evolveToLocked can only clear a.active on an internal key-store
+		// failure (see the buf.Set failure path); treat it the same as a
+		// guard refusal and restore the previous key.
+		a.active = oldActive
+		return nil, errors.New("kesagent: failed to evolve newly installed key to the current period")
+	}
 	if err := a.guard.Authorize(hex.EncodeToString(ks.vkey), a.active.absPeriod()); err != nil {
-		// Roll back the install: refuse to serve a rolled-back period.
+		// Roll back the install: keep serving the previous active key
+		// rather than discarding a working key on a rollback refusal.
 		a.active.close()
-		a.active = nil
+		a.active = oldActive
 		return nil, err
 	}
+	oldActive.close()
+	a.guardedPeriod = a.active.absPeriod()
+	a.guardedSet = true
 	a.metrics.setCurrentPeriod(a.active.absPeriod())
 	a.metrics.setExhausted(a.active.exhausted)
 	a.broadcastLocked()
@@ -282,6 +318,7 @@ func (a *Agent) DropKey(target string) error {
 	case "active":
 		a.active.close()
 		a.active = nil
+		a.guardedSet = false
 	case "staged":
 		a.staged.close()
 		a.staged = nil
@@ -290,10 +327,18 @@ func (a *Agent) DropKey(target string) error {
 		a.active = nil
 		a.staged.close()
 		a.staged = nil
+		a.guardedSet = false
 	default:
 		return fmt.Errorf("kesagent: unknown drop target %q", target)
 	}
-	a.metrics.setExhausted(false)
+	// Dropping only the staged key leaves the active key (and its exhaustion
+	// state) untouched; derive the gauge from whatever remains active rather
+	// than always clearing it.
+	if a.active != nil {
+		a.metrics.setExhausted(a.active.exhausted)
+	} else {
+		a.metrics.setExhausted(false)
+	}
 	a.logger.Info("dropped KES key", "target", target)
 	return nil
 }
@@ -345,7 +390,7 @@ func (a *Agent) Sign(period uint64, msg []byte) ([]byte, error) {
 func (a *Agent) evolveToLocked(targetAbs uint64) {
 	for a.active != nil && a.active.absPeriod() < targetAbs {
 		nextInternal := a.active.period + 1
-		if nextInternal >= kes.MaxPeriod(a.active.depth) {
+		if nextInternal >= a.active.maxEvol {
 			if !a.active.exhausted {
 				a.active.exhausted = true
 				a.metrics.setExhausted(true)
@@ -379,8 +424,15 @@ func (a *Agent) evolveToLocked(targetAbs uint64) {
 		a.active.buf.Zeroize()
 		if err := a.active.buf.Set(next.Data); err != nil {
 			securemem.Wipe(next.Data)
-			a.logger.Error("failed to store evolved KES key", "error", err)
-			a.active.exhausted = true
+			a.logger.Error("failed to store evolved KES key; discarding the key", "error", err)
+			// The buffer was already zeroized above and next.Data failed to
+			// land, so a.active.period is stale relative to its now-zeroed
+			// buffer contents. Discard the key entirely rather than leaving
+			// it installed: Sign() would otherwise happily sign over the
+			// zeroed buffer for the (unchanged) period it still reports.
+			a.active.close()
+			a.active = nil
+			a.metrics.setExhausted(true)
 			return
 		}
 		securemem.Wipe(next.Data) // erase the transient evolved copy
@@ -419,9 +471,12 @@ func (a *Agent) broadcastLocked() {
 		}
 		select {
 		case ch <- kp:
+			a.metrics.incServedKeys()
 		default:
+			// Subscriber channel is still full (shouldn't happen since we
+			// just drained it above, but be defensive): don't count a push
+			// that was dropped as served.
 		}
-		a.metrics.incServedKeys()
 	}
 }
 
@@ -456,20 +511,31 @@ func (a *Agent) Tick() {
 	if a.active == nil {
 		return
 	}
-	prev := a.active.absPeriod()
 	a.evolveToLocked(cur)
+	if a.active == nil {
+		// evolveToLocked discarded the key after a store failure.
+		return
+	}
 	newAbs := a.active.absPeriod()
 	a.metrics.setCurrentPeriod(newAbs)
 	a.metrics.setExhausted(a.active.exhausted)
-	if newAbs > prev {
-		if err := a.guard.Authorize(hex.EncodeToString(a.active.vkey), newAbs); err != nil {
-			a.logger.Error("period guard refused evolved key; not serving",
-				"error", err, "period", newAbs)
-			return
-		}
-		a.broadcastLocked()
-		a.logger.Info("evolved KES key", "active_period", newAbs)
+	// Authorize (and broadcast) whenever the current period hasn't already
+	// been successfully authorized: gating only on "did the in-memory key
+	// just evolve" would mean a transient guard-store failure (e.g. a full
+	// disk) is never retried, since evolveToLocked has already advanced
+	// a.active in memory and won't advance it again for the same period.
+	if a.guardedSet && a.guardedPeriod == newAbs {
+		return
 	}
+	if err := a.guard.Authorize(hex.EncodeToString(a.active.vkey), newAbs); err != nil {
+		a.logger.Error("period guard refused evolved key; not serving",
+			"error", err, "period", newAbs)
+		return
+	}
+	a.guardedPeriod = newAbs
+	a.guardedSet = true
+	a.broadcastLocked()
+	a.logger.Info("evolved KES key", "active_period", newAbs)
 }
 
 // Run drives the evolution scheduler until ctx is cancelled.

--- a/internal/kesagent/agent.go
+++ b/internal/kesagent/agent.go
@@ -478,23 +478,33 @@ func (a *Agent) buildKeyPushLocked() (KeyPush, bool) {
 // broadcastLocked pushes the current key to all serve-key subscribers. Caller
 // holds a.mu.
 func (a *Agent) broadcastLocked() {
-	kp, ok := a.buildKeyPushLocked()
+	base, ok := a.buildKeyPushLocked()
 	if !ok {
 		return
 	}
+	// base.KESSignKey is a plaintext clone of the locked signing key. Hand each
+	// subscriber its OWN copy (so one handler wiping its copy after writing
+	// cannot corrupt another's) and wipe every copy the moment it is no longer
+	// needed, so superseded key material does not linger on the swappable heap
+	// and defeat the forward-erasure done on evolution.
+	defer securemem.Wipe(base.KESSignKey)
 	for _, ch := range a.subs {
-		// Latest-wins: drain any stale push, then enqueue the newest.
+		kp := base
+		kp.KESSignKey = append([]byte(nil), base.KESSignKey...)
+		// Latest-wins: drain and wipe any stale push, then enqueue the newest.
 		select {
-		case <-ch:
+		case stale := <-ch:
+			securemem.Wipe(stale.KESSignKey)
 		default:
 		}
 		select {
 		case ch <- kp:
 			a.metrics.incServedKeys()
 		default:
-			// Subscriber channel is still full (shouldn't happen since we
-			// just drained it above, but be defensive): don't count a push
-			// that was dropped as served.
+			// Subscriber channel is still full (shouldn't happen since we just
+			// drained it above, but be defensive): wipe the copy we could not
+			// deliver rather than dropping it un-erased, and don't count it.
+			securemem.Wipe(kp.KESSignKey)
 		}
 	}
 }
@@ -517,6 +527,15 @@ func (a *Agent) subscribe() (int, chan KeyPush, *KeyPush) {
 func (a *Agent) unsubscribe(id int) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	// Drain and wipe any key push still queued for this subscriber so its
+	// plaintext signing-key copy does not outlive the subscription on the heap.
+	if ch, ok := a.subs[id]; ok {
+		select {
+		case kp := <-ch:
+			securemem.Wipe(kp.KESSignKey)
+		default:
+		}
+	}
 	delete(a.subs, id)
 }
 

--- a/internal/kesagent/agent.go
+++ b/internal/kesagent/agent.go
@@ -306,6 +306,12 @@ func (a *Agent) InstallKey(opcertBytes []byte) (*AgentInfo, error) {
 		// rather than discarding a working key on a rollback refusal.
 		a.active.close()
 		a.active = oldActive
+		// The floor may have advanced anyway (a rename that committed before a
+		// later step failed), which would leave the restored key below it.
+		// buildKeyPushLocked refuses to build such a push, but a push built
+		// before this call can still be sitting in a subscriber's channel;
+		// drain those so a producer cannot sign below the committed floor.
+		a.dropQueuedPushesBelowFloorLocked()
 		return nil, err
 	}
 	oldActive.close()
@@ -528,6 +534,41 @@ func (a *Agent) broadcastLocked() {
 			// drained it above, but be defensive): wipe the copy we could not
 			// deliver rather than dropping it un-erased, and don't count it.
 			securemem.Wipe(kp.KESSignKey)
+		}
+	}
+}
+
+// dropQueuedPushesBelowFloorLocked drains and wipes any queued key push whose
+// period is below the guard floor. Caller holds a.mu.
+//
+// buildKeyPushLocked refuses to build a below-floor push, but that only covers
+// pushes not yet built: a push enqueued while the key and the floor still
+// agreed stays in its subscriber's buffered channel, and a serve-key client
+// reading it would be handed a key for a period the floor has since passed.
+func (a *Agent) dropQueuedPushesBelowFloorLocked() {
+	floor, set := a.guard.Floor()
+	if !set {
+		return
+	}
+	for id, ch := range a.subs {
+		select {
+		case kp := <-ch:
+			if kp.Period < floor {
+				a.logger.Warn("dropping queued KES key push below the guard floor",
+					"subscriber", id,
+					"push_period", kp.Period,
+					"floor", floor,
+				)
+				securemem.Wipe(kp.KESSignKey)
+				continue
+			}
+			// Above the floor: put it back rather than dropping a valid push.
+			select {
+			case ch <- kp:
+			default:
+				securemem.Wipe(kp.KESSignKey)
+			}
+		default:
 		}
 	}
 }

--- a/internal/kesagent/agent_test.go
+++ b/internal/kesagent/agent_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/gouroboros/kes"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestCurrentKESPeriodMath(t *testing.T) {
@@ -213,6 +214,48 @@ func TestEvolveExhaustion(t *testing.T) {
 	// It reached its last servable period (start 0 + MaxPeriod-1 = 3).
 	if info.ActivePeriod != 3 {
 		t.Fatalf("ActivePeriod = %d, want 3 (last evolution)", info.ActivePeriod)
+	}
+}
+
+// TestEvolveToLockedDiscardClearsExhaustedGauge exercises the no-active-key
+// discard path evolveToLocked takes on a buf.Set failure directly (bypassing
+// the crypto evolution itself, which requires a correctly-sized, open
+// buffer and so can't be made to fail buf.Set in isolation -- Set only
+// errors on a length mismatch, which kes.Update never produces, or on
+// ErrClosed, which requires a concurrent Close() that a.mu serializes away
+// in every real call path). It manufactures the discard by calling the same
+// close+nil+metrics sequence evolveToLocked runs on that failure, then
+// asserts the invariants Sign/Tick/InstallKey all depend on afterward: no
+// active key, and the exhausted gauge cleared rather than left reporting a
+// (nonexistent) exhausted key.
+func TestEvolveToLockedDiscardClearsExhaustedGauge(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(1))
+	metrics := NewMetrics()
+	a.metrics = metrics
+	vkey, _ := a.GenStagedKey()
+	if _, err := a.InstallKey(makeOpCert(t, vkey, 1, 1, cold)); err != nil {
+		t.Fatalf("InstallKey: %v", err)
+	}
+	metrics.setExhausted(true) // simulate a stale "exhausted" reading
+
+	// Run evolveToLocked's discard-on-failure sequence directly.
+	a.mu.Lock()
+	a.active.close()
+	a.active = nil
+	a.metrics.setExhausted(false)
+	a.mu.Unlock()
+
+	if got := testutil.ToFloat64(metrics.exhausted); got != 0 {
+		t.Fatalf("exhausted gauge = %v, want 0 (no active key, not an exhausted one)", got)
+	}
+
+	// Sign must observe the discarded key and return ErrNoActiveKey, not
+	// dereference it (this is the guard added in Sign to match Tick and
+	// InstallKey, for whichever path -- present or future -- leaves
+	// a.active nil after evolveToLocked runs).
+	if _, err := a.Sign(2, []byte("msg")); !errors.Is(err, ErrNoActiveKey) {
+		t.Fatalf("Sign after key discard: want ErrNoActiveKey, got %v", err)
 	}
 }
 

--- a/internal/kesagent/agent_test.go
+++ b/internal/kesagent/agent_test.go
@@ -335,3 +335,42 @@ func TestInfoReportsActiveIssueNumberAndOpCert(t *testing.T) {
 			dropped.ActiveIssueNumber, dropped.ActiveOpCert)
 	}
 }
+
+// TestSubscribeRefusesKeyBelowGuardFloor covers the case where the active key
+// and the guard floor have diverged: an install advances the floor, then fails
+// and restores the previous (lower-period) key. Serving that key would let a
+// producer sign below the monotonic floor, which is the rollback the guard
+// exists to prevent — so neither a new subscriber nor a broadcast may receive
+// it.
+func TestSubscribeRefusesKeyBelowGuardFloor(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeServeKey, cold, kes.CardanoKesDepth, atPeriod(1))
+	vkey, _ := a.GenStagedKey()
+	if _, err := a.InstallKey(makeOpCert(t, vkey, 1, 1, cold)); err != nil {
+		t.Fatalf("InstallKey: %v", err)
+	}
+
+	// Sanity: with the floor at the active period, a subscriber gets the key.
+	id, _, current := a.subscribe()
+	if current == nil {
+		t.Fatal("subscribe returned no key push while the key is at the floor")
+	}
+	securemem.Wipe(current.KESSignKey)
+	a.unsubscribe(id)
+
+	// Advance the floor past the active key, as a failed install would.
+	a.mu.Lock()
+	active := a.active.absPeriod()
+	a.mu.Unlock()
+	if err := a.guard.Authorize("newer-key", active+1); err != nil {
+		t.Fatalf("advance guard floor: %v", err)
+	}
+
+	id, _, current = a.subscribe()
+	defer a.unsubscribe(id)
+	if current != nil {
+		securemem.Wipe(current.KESSignKey)
+		t.Fatalf("subscribe served a key at period %d below guard floor %d",
+			active, active+1)
+	}
+}

--- a/internal/kesagent/agent_test.go
+++ b/internal/kesagent/agent_test.go
@@ -374,3 +374,47 @@ func TestSubscribeRefusesKeyBelowGuardFloor(t *testing.T) {
 			active, active+1)
 	}
 }
+
+// TestQueuedPushBelowFloorIsDroppedOnRollback covers the gap between the guard
+// floor and an already-enqueued push: buildKeyPushLocked refuses to build a
+// below-floor push, but one enqueued while the key and floor still agreed sits
+// in the subscriber's channel, and a serve-key client reading it would be
+// handed a key for a period the floor has since passed.
+func TestQueuedPushBelowFloorIsDroppedOnRollback(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeServeKey, cold, kes.CardanoKesDepth, atPeriod(1))
+	vkey, _ := a.GenStagedKey()
+	if _, err := a.InstallKey(makeOpCert(t, vkey, 1, 1, cold)); err != nil {
+		t.Fatalf("InstallKey: %v", err)
+	}
+
+	// A subscriber with a push queued at the current (soon to be stale) period.
+	id, ch, current := a.subscribe()
+	defer a.unsubscribe(id)
+	if current == nil {
+		t.Fatal("subscribe returned no key push")
+	}
+	securemem.Wipe(current.KESSignKey)
+	a.mu.Lock()
+	a.broadcastLocked()
+	active := a.active.absPeriod()
+	a.mu.Unlock()
+	if len(ch) != 1 {
+		t.Fatalf("queued pushes = %d, want 1 before the floor advances", len(ch))
+	}
+
+	// Advance the floor past the queued push, as a committed-but-failed
+	// install would, then run the drain.
+	if err := a.guard.Authorize("newer-key", active+1); err != nil {
+		t.Fatalf("advance floor: %v", err)
+	}
+	a.mu.Lock()
+	a.dropQueuedPushesBelowFloorLocked()
+	a.mu.Unlock()
+
+	if len(ch) != 0 {
+		kp := <-ch
+		t.Fatalf("a push for period %d survived a floor advance to %d",
+			kp.Period, active+1)
+	}
+}

--- a/internal/kesagent/agent_test.go
+++ b/internal/kesagent/agent_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/bursa/internal/kesagent/securemem"
 	"github.com/blinklabs-io/gouroboros/kes"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
@@ -217,18 +218,14 @@ func TestEvolveExhaustion(t *testing.T) {
 	}
 }
 
-// TestEvolveToLockedDiscardClearsExhaustedGauge exercises the no-active-key
-// discard path evolveToLocked takes on a buf.Set failure directly (bypassing
-// the crypto evolution itself, which requires a correctly-sized, open
-// buffer and so can't be made to fail buf.Set in isolation -- Set only
-// errors on a length mismatch, which kes.Update never produces, or on
-// ErrClosed, which requires a concurrent Close() that a.mu serializes away
-// in every real call path). It manufactures the discard by calling the same
-// close+nil+metrics sequence evolveToLocked runs on that failure, then
-// asserts the invariants Sign/Tick/InstallKey all depend on afterward: no
-// active key, and the exhausted gauge cleared rather than left reporting a
-// (nonexistent) exhausted key.
-func TestEvolveToLockedDiscardClearsExhaustedGauge(t *testing.T) {
+// TestEvolveToLockedDiscardsKeyWhenStoreFails drives evolveToLocked's real
+// discard-on-failure branch by making the locked-buffer store fail, rather than
+// hand-replicating the close+nil+metrics sequence (which would assert only what
+// the test itself just did). The branch matters because the buffer has already
+// been zeroized by the time the store runs: leaving the key installed would let
+// Sign produce a signature over zeroed key material for the period the key
+// still claims.
+func TestEvolveToLockedDiscardsKeyWhenStoreFails(t *testing.T) {
 	cold := newColdKey(t)
 	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(1))
 	metrics := NewMetrics()
@@ -237,23 +234,27 @@ func TestEvolveToLockedDiscardClearsExhaustedGauge(t *testing.T) {
 	if _, err := a.InstallKey(makeOpCert(t, vkey, 1, 1, cold)); err != nil {
 		t.Fatalf("InstallKey: %v", err)
 	}
-	metrics.setExhausted(true) // simulate a stale "exhausted" reading
+	metrics.setExhausted(true) // stale reading that the discard must clear
 
-	// Run evolveToLocked's discard-on-failure sequence directly.
+	orig := storeEvolvedKey
+	storeEvolvedKey = func(*securemem.Buffer, []byte) error {
+		return errors.New("simulated locked-buffer store failure")
+	}
+	t.Cleanup(func() { storeEvolvedKey = orig })
+
+	// Ask for a later period so evolveToLocked actually iterates and reaches
+	// the store step.
 	a.mu.Lock()
-	a.active.close()
-	a.active = nil
-	a.metrics.setExhausted(false)
+	a.evolveToLocked(a.active.absPeriod() + 1)
+	active := a.active
 	a.mu.Unlock()
 
+	if active != nil {
+		t.Fatal("active key retained after a failed store; it holds a zeroized buffer")
+	}
 	if got := testutil.ToFloat64(metrics.exhausted); got != 0 {
 		t.Fatalf("exhausted gauge = %v, want 0 (no active key, not an exhausted one)", got)
 	}
-
-	// Sign must observe the discarded key and return ErrNoActiveKey, not
-	// dereference it (this is the guard added in Sign to match Tick and
-	// InstallKey, for whichever path -- present or future -- leaves
-	// a.active nil after evolveToLocked runs).
 	if _, err := a.Sign(2, []byte("msg")); !errors.Is(err, ErrNoActiveKey) {
 		t.Fatalf("Sign after key discard: want ErrNoActiveKey, got %v", err)
 	}
@@ -295,5 +296,42 @@ func TestInstallRefusedByGuardFloor(t *testing.T) {
 	}
 	if a.Info().HasActiveKey {
 		t.Fatal("no active key should remain after refused install")
+	}
+}
+
+// TestInfoReportsActiveIssueNumberAndOpCert covers the two fields an operator
+// needs to confirm a KES rotation took effect: the issue counter the network
+// uses to accept the pool's blocks, and the opcert bytes themselves, which in
+// sign mode are otherwise unobtainable from the agent.
+func TestInfoReportsActiveIssueNumberAndOpCert(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(1))
+	vkey, _ := a.GenStagedKey()
+	const issueNumber = 7
+	opcert := makeOpCert(t, vkey, issueNumber, 1, cold)
+	info, err := a.InstallKey(opcert)
+	if err != nil {
+		t.Fatalf("InstallKey: %v", err)
+	}
+	if info.ActiveIssueNumber != issueNumber {
+		t.Fatalf("ActiveIssueNumber = %d, want %d", info.ActiveIssueNumber, issueNumber)
+	}
+	if !bytes.Equal(info.ActiveOpCert, opcert) {
+		t.Fatalf("ActiveOpCert = %x, want the installed opcert %x", info.ActiveOpCert, opcert)
+	}
+	// Info() must report the same thing as the InstallKey response.
+	later := a.Info()
+	if later.ActiveIssueNumber != issueNumber || !bytes.Equal(later.ActiveOpCert, opcert) {
+		t.Fatalf("Info() = (issue %d, opcert %x), want (%d, %x)",
+			later.ActiveIssueNumber, later.ActiveOpCert, issueNumber, opcert)
+	}
+	// With no active key the fields must not report a stale certificate.
+	if err := a.DropKey("all"); err != nil {
+		t.Fatalf("DropKey: %v", err)
+	}
+	dropped := a.Info()
+	if dropped.ActiveIssueNumber != 0 || dropped.ActiveOpCert != nil {
+		t.Fatalf("after DropKey: issue %d opcert %x, want zero/nil",
+			dropped.ActiveIssueNumber, dropped.ActiveOpCert)
 	}
 }

--- a/internal/kesagent/agent_test.go
+++ b/internal/kesagent/agent_test.go
@@ -1,0 +1,256 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kesagent
+
+import (
+	"bytes"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/kes"
+)
+
+func TestCurrentKESPeriodMath(t *testing.T) {
+	cold := newColdKey(t)
+	// now = period 5 start + 5s (still in period 5), 10s per period.
+	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(5).Add(5*time.Second))
+	if got := a.currentKESPeriod(); got != 5 {
+		t.Fatalf("currentKESPeriod = %d, want 5", got)
+	}
+	// Before genesis -> 0.
+	a.now = func() time.Time { return epoch.Add(-time.Hour) }
+	if got := a.currentKESPeriod(); got != 0 {
+		t.Fatalf("pre-genesis currentKESPeriod = %d, want 0", got)
+	}
+}
+
+func TestGenStagedKey(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(0))
+	vkey, err := a.GenStagedKey()
+	if err != nil {
+		t.Fatalf("GenStagedKey: %v", err)
+	}
+	if len(vkey) != kes.PublicKeySize {
+		t.Fatalf("vkey len = %d, want %d", len(vkey), kes.PublicKeySize)
+	}
+	info := a.Info()
+	if !bytes.Equal(info.StagedKESVKey, vkey) {
+		t.Fatal("info staged vkey mismatch")
+	}
+	if info.HasActiveKey {
+		t.Fatal("no active key expected before install")
+	}
+}
+
+func TestInstallAndSign(t *testing.T) {
+	cold := newColdKey(t)
+	// Current period 5; opcert issued at period 3.
+	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(5))
+	vkey, err := a.GenStagedKey()
+	if err != nil {
+		t.Fatalf("GenStagedKey: %v", err)
+	}
+	opcert := makeOpCert(t, vkey, 1, 3, cold)
+	info, err := a.InstallKey(opcert)
+	if err != nil {
+		t.Fatalf("InstallKey: %v", err)
+	}
+	if !info.HasActiveKey {
+		t.Fatal("expected active key after install")
+	}
+	if info.ActiveStart != 3 {
+		t.Fatalf("ActiveStart = %d, want 3", info.ActiveStart)
+	}
+	if info.ActivePeriod != 5 {
+		t.Fatalf("ActivePeriod = %d, want 5 (evolved to current)", info.ActivePeriod)
+	}
+
+	// Sign at the current period; verify with the internal evolution period.
+	msg := []byte("block-header-body")
+	sig, err := a.Sign(5, msg)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	internal := uint64(5 - 3)
+	if !kes.VerifySignedKES(vkey, internal, msg, sig) {
+		t.Fatal("KES signature failed to verify at evolution period 2")
+	}
+	// It must NOT verify at the wrong evolution period.
+	if kes.VerifySignedKES(vkey, internal+1, msg, sig) {
+		t.Fatal("signature verified at wrong period")
+	}
+}
+
+func TestSignPastPeriodRejected(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(5))
+	vkey, _ := a.GenStagedKey()
+	if _, err := a.InstallKey(makeOpCert(t, vkey, 1, 3, cold)); err != nil {
+		t.Fatalf("InstallKey: %v", err)
+	}
+	// Active key is at absolute period 5; signing period 4 is in the past.
+	if _, err := a.Sign(4, []byte("x")); !errors.Is(err, ErrPastPeriod) {
+		t.Fatalf("Sign past period: want ErrPastPeriod, got %v", err)
+	}
+}
+
+func TestSignForwardEvolves(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(3))
+	vkey, _ := a.GenStagedKey()
+	if _, err := a.InstallKey(makeOpCert(t, vkey, 1, 3, cold)); err != nil {
+		t.Fatalf("InstallKey: %v", err)
+	}
+	// Sign at a future period: the key must evolve forward to reach it.
+	msg := []byte("future")
+	sig, err := a.Sign(7, msg)
+	if err != nil {
+		t.Fatalf("Sign future: %v", err)
+	}
+	if !kes.VerifySignedKES(vkey, 7-3, msg, sig) {
+		t.Fatal("forward-evolved signature failed to verify")
+	}
+}
+
+func TestInstallOpCertMismatches(t *testing.T) {
+	cold := newColdKey(t)
+	other := newColdKey(t)
+	a := testAgent(t, ModeServeKey, cold, kes.CardanoKesDepth, atPeriod(2))
+	vkey, _ := a.GenStagedKey()
+
+	// Opcert signed and stamped by a DIFFERENT cold key.
+	if _, err := a.InstallKey(makeOpCert(t, vkey, 1, 2, other)); !errors.Is(err, ErrOpCertColdVK) {
+		t.Fatalf("wrong cold vkey: want ErrOpCertColdVK, got %v", err)
+	}
+
+	// Opcert carrying the correct cold vkey but a bad signature (tamper).
+	bad := makeOpCert(t, vkey, 1, 2, cold)
+	// Flip a byte inside the signature region by rebuilding with a mismatched
+	// KES vkey but correct cold vkey stamp: signature won't cover this vkey.
+	otherVkey := make([]byte, len(vkey))
+	copy(otherVkey, vkey)
+	otherVkey[0] ^= 0xff
+	badSig := tamperOpCertKESVkey(t, bad, otherVkey)
+	if _, err := a.InstallKey(badSig); err == nil {
+		t.Fatal("tampered opcert signature: expected error")
+	}
+
+	// Opcert for a different KES key (validly signed) -> ErrOpCertKESVK.
+	wrongKey := make([]byte, len(vkey))
+	copy(wrongKey, vkey)
+	wrongKey[1] ^= 0xff
+	if _, err := a.InstallKey(makeOpCert(t, wrongKey, 1, 2, cold)); !errors.Is(err, ErrOpCertKESVK) {
+		t.Fatalf("wrong kes vkey: want ErrOpCertKESVK, got %v", err)
+	}
+}
+
+func TestInstallNoStagedKey(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(2))
+	if _, err := a.InstallKey(makeOpCert(t, make([]byte, 32), 1, 2, cold)); !errors.Is(err, ErrNoStagedKey) {
+		t.Fatalf("install without staged: want ErrNoStagedKey, got %v", err)
+	}
+}
+
+func TestInstallFuturePeriodRejected(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(2))
+	vkey, _ := a.GenStagedKey()
+	// Opcert period 9 while current period is 2 -> future.
+	if _, err := a.InstallKey(makeOpCert(t, vkey, 1, 9, cold)); err == nil {
+		t.Fatal("expected error for future opcert period")
+	}
+}
+
+func TestDropKey(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(2))
+	vkey, _ := a.GenStagedKey()
+	if _, err := a.InstallKey(makeOpCert(t, vkey, 1, 2, cold)); err != nil {
+		t.Fatalf("InstallKey: %v", err)
+	}
+	if err := a.DropKey("active"); err != nil {
+		t.Fatalf("DropKey: %v", err)
+	}
+	if a.Info().HasActiveKey {
+		t.Fatal("active key should be gone after drop")
+	}
+	if _, err := a.Sign(2, []byte("x")); !errors.Is(err, ErrNoActiveKey) {
+		t.Fatalf("sign after drop: want ErrNoActiveKey, got %v", err)
+	}
+}
+
+func TestEvolveExhaustion(t *testing.T) {
+	cold := newColdKey(t)
+	// depth 2 -> MaxPeriod 4 (internal periods 0..3).
+	a := testAgent(t, ModeServeKey, cold, 2, atPeriod(0))
+	vkey, _ := a.GenStagedKey()
+	if _, err := a.InstallKey(makeOpCert(t, vkey, 1, 0, cold)); err != nil {
+		t.Fatalf("InstallKey: %v", err)
+	}
+	// Advance the clock well past the key's reach and tick the scheduler.
+	a.now = func() time.Time { return atPeriod(10) }
+	a.Tick()
+	info := a.Info()
+	if !info.Exhausted {
+		t.Fatal("expected key to be exhausted")
+	}
+	// It reached its last servable period (start 0 + MaxPeriod-1 = 3).
+	if info.ActivePeriod != 3 {
+		t.Fatalf("ActivePeriod = %d, want 3 (last evolution)", info.ActivePeriod)
+	}
+}
+
+func TestInstallRefusedByGuardFloor(t *testing.T) {
+	cold := newColdKey(t)
+	path := filepath.Join(t.TempDir(), "guard.json")
+	// Pre-seed the durable guard with a high floor.
+	g, err := NewPeriodGuard(path)
+	if err != nil {
+		t.Fatalf("NewPeriodGuard: %v", err)
+	}
+	if err := g.Authorize("prev", 100); err != nil {
+		t.Fatalf("seed guard: %v", err)
+	}
+
+	cfg := Config{
+		Mode:              ModeServeKey,
+		Depth:             kes.CardanoKesDepth,
+		SystemStart:       epoch,
+		SlotLength:        time.Second,
+		SlotsPerKESPeriod: 10,
+		ColdVKey:          cold.pub,
+		EvolveInterval:    time.Hour,
+		GuardPath:         path,
+	}
+	a, err := New(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(a.Close)
+	a.now = func() time.Time { return atPeriod(5) }
+
+	vkey, _ := a.GenStagedKey()
+	// Install at period 5, but the floor is 100 -> rollback refused.
+	if _, err := a.InstallKey(makeOpCert(t, vkey, 1, 5, cold)); !errors.Is(err, ErrPeriodRollback) {
+		t.Fatalf("install below floor: want ErrPeriodRollback, got %v", err)
+	}
+	if a.Info().HasActiveKey {
+		t.Fatal("no active key should remain after refused install")
+	}
+}

--- a/internal/kesagent/connset.go
+++ b/internal/kesagent/connset.go
@@ -19,12 +19,21 @@ import (
 	"sync"
 )
 
+// maxTrackedConns caps the number of simultaneously tracked (accepted)
+// connections per listener. A peer with socket access could otherwise open
+// unbounded connections -- each advertising a large frame it never completes --
+// to exhaust the agent's goroutines and memory. The service socket serves a
+// pool's handful of block producers and the control socket is used
+// interactively, so this ceiling is far above any legitimate use.
+const maxTrackedConns = 256
+
 // connSet tracks live accepted connections so an accept loop can close them
 // on shutdown. Closing only the listener (as net.Listener.Close does) does
 // not unblock a handler already parked in a blocking read on a connection
 // that was accepted before shutdown; that leaves ServeService/ServeControl's
 // wg.Wait() unable to complete. connSet lets the accept loop reach into
-// those already-accepted connections and close them too.
+// those already-accepted connections and close them too. It also bounds the
+// number of concurrent connections (see maxTrackedConns).
 type connSet struct {
 	mu     sync.Mutex
 	m      map[net.Conn]struct{}
@@ -35,20 +44,23 @@ func newConnSet() *connSet {
 	return &connSet{m: make(map[net.Conn]struct{})}
 }
 
-// add registers c for tracking. If closeAll has already run, the accept loop
-// is shutting down and c was accepted in the shutdown race (after closeAll's
-// pass but before the caller could register it); rather than track a
-// connection closeAll will never see again, close it immediately so its
-// handler goroutine unblocks right away instead of hanging in a blocking
-// read.
-func (s *connSet) add(c net.Conn) {
+// add registers c for tracking and reports whether it was accepted. It returns
+// false (and does not track c) when the set is already shutting down (closeAll
+// has run) or when tracking c would exceed maxTrackedConns; in either case the
+// caller must close c. Refusing the connection here (rather than tracking it)
+// keeps a just-accepted connection from either escaping shutdown closure or
+// pushing concurrent connections past the ceiling.
+func (s *connSet) add(c net.Conn) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
-		_ = c.Close()
-		return
+		return false
+	}
+	if len(s.m) >= maxTrackedConns {
+		return false
 	}
 	s.m[c] = struct{}{}
+	return true
 }
 
 func (s *connSet) remove(c net.Conn) {

--- a/internal/kesagent/connset.go
+++ b/internal/kesagent/connset.go
@@ -26,17 +26,28 @@ import (
 // wg.Wait() unable to complete. connSet lets the accept loop reach into
 // those already-accepted connections and close them too.
 type connSet struct {
-	mu sync.Mutex
-	m  map[net.Conn]struct{}
+	mu     sync.Mutex
+	m      map[net.Conn]struct{}
+	closed bool
 }
 
 func newConnSet() *connSet {
 	return &connSet{m: make(map[net.Conn]struct{})}
 }
 
+// add registers c for tracking. If closeAll has already run, the accept loop
+// is shutting down and c was accepted in the shutdown race (after closeAll's
+// pass but before the caller could register it); rather than track a
+// connection closeAll will never see again, close it immediately so its
+// handler goroutine unblocks right away instead of hanging in a blocking
+// read.
 func (s *connSet) add(c net.Conn) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.closed {
+		_ = c.Close()
+		return
+	}
 	s.m[c] = struct{}{}
 }
 
@@ -46,13 +57,17 @@ func (s *connSet) remove(c net.Conn) {
 	delete(s.m, c)
 }
 
-// closeAll closes every tracked connection. Safe to call concurrently with
-// add/remove; a connection removed just before closeAll iterates it is
-// simply skipped.
+// closeAll closes every tracked connection and marks the set closed: any
+// connection registered via add afterward is closed immediately instead of
+// being tracked (see add), guaranteeing that no connection accepted
+// concurrently with shutdown can escape closure. Safe to call concurrently
+// with add/remove, and safe to call more than once.
 func (s *connSet) closeAll() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.closed = true
 	for c := range s.m {
 		_ = c.Close()
+		delete(s.m, c)
 	}
 }

--- a/internal/kesagent/connset.go
+++ b/internal/kesagent/connset.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kesagent
+
+import (
+	"net"
+	"sync"
+)
+
+// connSet tracks live accepted connections so an accept loop can close them
+// on shutdown. Closing only the listener (as net.Listener.Close does) does
+// not unblock a handler already parked in a blocking read on a connection
+// that was accepted before shutdown; that leaves ServeService/ServeControl's
+// wg.Wait() unable to complete. connSet lets the accept loop reach into
+// those already-accepted connections and close them too.
+type connSet struct {
+	mu sync.Mutex
+	m  map[net.Conn]struct{}
+}
+
+func newConnSet() *connSet {
+	return &connSet{m: make(map[net.Conn]struct{})}
+}
+
+func (s *connSet) add(c net.Conn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[c] = struct{}{}
+}
+
+func (s *connSet) remove(c net.Conn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, c)
+}
+
+// closeAll closes every tracked connection. Safe to call concurrently with
+// add/remove; a connection removed just before closeAll iterates it is
+// simply skipped.
+func (s *connSet) closeAll() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for c := range s.m {
+		_ = c.Close()
+	}
+}

--- a/internal/kesagent/connset_test.go
+++ b/internal/kesagent/connset_test.go
@@ -37,24 +37,51 @@ func TestConnSetCloseAllClosesTrackedConns(t *testing.T) {
 	}
 }
 
-// TestConnSetAddAfterCloseAllClosesImmediately guards against the shutdown
-// race this connSet exists to close: a connection accepted concurrently with
-// shutdown (after closeAll's pass has already run, but before the accept
-// loop could register it) must not be tracked and left open -- add must
-// close it immediately so its handler goroutine unblocks right away instead
-// of hanging in a blocking read forever.
-func TestConnSetAddAfterCloseAllClosesImmediately(t *testing.T) {
+// TestConnSetAddAfterCloseAllIsRefused guards against the shutdown race this
+// connSet exists to handle: a connection accepted concurrently with shutdown
+// (after closeAll's pass has already run, but before the accept loop could
+// register it) must not be tracked. add reports false so the accept loop
+// closes the connection itself, keeping its handler goroutine from hanging in
+// a blocking read forever.
+func TestConnSetAddAfterCloseAllIsRefused(t *testing.T) {
 	s := newConnSet()
 	s.closeAll() // simulate shutdown having already completed a pass
 
 	server, client := net.Pipe()
 	t.Cleanup(func() { _ = client.Close() })
-	s.add(server)
+	t.Cleanup(func() { _ = server.Close() })
+	if s.add(server) {
+		t.Fatal("add after closeAll must be refused so the caller closes the connection")
+	}
+}
 
-	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
-	buf := make([]byte, 1)
-	if _, err := client.Read(buf); err == nil {
-		t.Fatal("expected a connection added after closeAll to be closed immediately")
+// TestConnSetEnforcesMaxTrackedConns verifies the concurrent-connection ceiling:
+// add refuses connections beyond maxTrackedConns and accepts again once a slot
+// is freed via remove.
+func TestConnSetEnforcesMaxTrackedConns(t *testing.T) {
+	s := newConnSet()
+	tracked := make([]net.Conn, 0, maxTrackedConns)
+	for i := 0; i < maxTrackedConns; i++ {
+		server, client := net.Pipe()
+		t.Cleanup(func() { _ = server.Close() })
+		t.Cleanup(func() { _ = client.Close() })
+		if !s.add(server) {
+			t.Fatalf("add %d within the cap should succeed", i)
+		}
+		tracked = append(tracked, server)
+	}
+
+	over, overClient := net.Pipe()
+	t.Cleanup(func() { _ = over.Close() })
+	t.Cleanup(func() { _ = overClient.Close() })
+	if s.add(over) {
+		t.Fatal("add beyond maxTrackedConns must be refused")
+	}
+
+	// Freeing a slot lets a new connection be tracked again.
+	s.remove(tracked[0])
+	if !s.add(over) {
+		t.Fatal("add after freeing a slot should succeed")
 	}
 }
 

--- a/internal/kesagent/connset_test.go
+++ b/internal/kesagent/connset_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kesagent
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestConnSetCloseAllClosesTrackedConns(t *testing.T) {
+	s := newConnSet()
+	server, client := net.Pipe()
+	t.Cleanup(func() { _ = client.Close() })
+	s.add(server)
+
+	s.closeAll()
+
+	// server was closed by closeAll; a read on the client side must now
+	// observe EOF/closed-pipe rather than blocking.
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 1)
+	if _, err := client.Read(buf); err == nil {
+		t.Fatal("expected the client side to observe the server conn closed")
+	}
+}
+
+// TestConnSetAddAfterCloseAllClosesImmediately guards against the shutdown
+// race this connSet exists to close: a connection accepted concurrently with
+// shutdown (after closeAll's pass has already run, but before the accept
+// loop could register it) must not be tracked and left open -- add must
+// close it immediately so its handler goroutine unblocks right away instead
+// of hanging in a blocking read forever.
+func TestConnSetAddAfterCloseAllClosesImmediately(t *testing.T) {
+	s := newConnSet()
+	s.closeAll() // simulate shutdown having already completed a pass
+
+	server, client := net.Pipe()
+	t.Cleanup(func() { _ = client.Close() })
+	s.add(server)
+
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 1)
+	if _, err := client.Read(buf); err == nil {
+		t.Fatal("expected a connection added after closeAll to be closed immediately")
+	}
+}
+
+func TestConnSetRemoveThenCloseAllSkipsRemoved(t *testing.T) {
+	s := newConnSet()
+	server, client := net.Pipe()
+	t.Cleanup(func() { _ = server.Close() })
+	t.Cleanup(func() { _ = client.Close() })
+	s.add(server)
+	s.remove(server)
+
+	s.closeAll()
+
+	// server was never closed by closeAll (it was removed first), so a read
+	// with a short deadline should time out rather than observe a close.
+	_ = client.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+	buf := make([]byte, 1)
+	_, err := client.Read(buf)
+	if netErr, ok := err.(net.Error); !ok || !netErr.Timeout() {
+		t.Fatalf("expected a read timeout (conn not closed), got %v", err)
+	}
+}

--- a/internal/kesagent/control.go
+++ b/internal/kesagent/control.go
@@ -34,25 +34,31 @@ const (
 // ServeControl accepts connections on ln and processes control commands until
 // ctx is cancelled or ln is closed.
 func (a *Agent) ServeControl(ctx context.Context, ln net.Listener) error {
+	conns := newConnSet()
 	go func() {
 		<-ctx.Done()
 		_ = ln.Close()
+		// Unblock any handler already parked in a read on a connection
+		// accepted before shutdown, so wg.Wait() below can complete.
+		conns.closeAll()
 	}()
 	var wg sync.WaitGroup
+	defer wg.Wait()
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
 			select {
 			case <-ctx.Done():
-				wg.Wait()
 				return nil
 			default:
 				return fmt.Errorf("kesagent: control accept: %w", err)
 			}
 		}
+		conns.add(conn)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			defer conns.remove(conn)
 			a.handleControlConn(conn)
 		}()
 	}
@@ -60,6 +66,12 @@ func (a *Agent) ServeControl(ctx context.Context, ln net.Listener) error {
 
 func (a *Agent) handleControlConn(conn net.Conn) {
 	defer func() { _ = conn.Close() }()
+	// Send the handshake Hello frame (matches the service socket; see the
+	// package doc comment in protocol.go).
+	if err := writeFrame(conn, Hello{Protocol: ProtocolID, Mode: a.cfg.Mode}); err != nil {
+		a.logger.Debug("control hello write failed", "error", err)
+		return
+	}
 	for {
 		var cmd Command
 		if err := readFrame(conn, &cmd); err != nil {

--- a/internal/kesagent/control.go
+++ b/internal/kesagent/control.go
@@ -35,8 +35,14 @@ const (
 // ctx is cancelled or ln is closed.
 func (a *Agent) ServeControl(ctx context.Context, ln net.Listener) error {
 	conns := newConnSet()
+	// srvCtx is cancelled on every return path so the watchdog goroutine always
+	// exits; otherwise it stays parked forever when ServeControl returns via a
+	// closed listener or an Accept error (permanently so under
+	// context.Background(), whose Done() is a nil channel).
+	srvCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	go func() {
-		<-ctx.Done()
+		<-srvCtx.Done()
 		_ = ln.Close()
 		// Unblock any handler already parked in a read on a connection
 		// accepted before shutdown, so wg.Wait() below can complete.

--- a/internal/kesagent/control.go
+++ b/internal/kesagent/control.go
@@ -43,7 +43,14 @@ func (a *Agent) ServeControl(ctx context.Context, ln net.Listener) error {
 		conns.closeAll()
 	}()
 	var wg sync.WaitGroup
-	defer wg.Wait()
+	// Close every tracked connection before waiting on every return path, not
+	// just the ctx-cancellation goroutine above: a listener closed externally
+	// (or any non-context Accept error) must also unblock handlers already
+	// parked in a blocking read, or wg.Wait() below hangs forever.
+	defer func() {
+		conns.closeAll()
+		wg.Wait()
+	}()
 	for {
 		conn, err := ln.Accept()
 		if err != nil {

--- a/internal/kesagent/control.go
+++ b/internal/kesagent/control.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kesagent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+)
+
+// Control command names.
+const (
+	CmdGenStagedKey = "gen-staged-key"
+	CmdInstallKey   = "install-key"
+	CmdDropKey      = "drop-key"
+	CmdInfo         = "info"
+)
+
+// ServeControl accepts connections on ln and processes control commands until
+// ctx is cancelled or ln is closed.
+func (a *Agent) ServeControl(ctx context.Context, ln net.Listener) error {
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+	var wg sync.WaitGroup
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				wg.Wait()
+				return nil
+			default:
+				return fmt.Errorf("kesagent: control accept: %w", err)
+			}
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			a.handleControlConn(conn)
+		}()
+	}
+}
+
+func (a *Agent) handleControlConn(conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+	for {
+		var cmd Command
+		if err := readFrame(conn, &cmd); err != nil {
+			if !errors.Is(err, io.EOF) {
+				a.logger.Debug("control read failed", "error", err)
+			}
+			return
+		}
+		reply := a.dispatch(cmd)
+		if err := writeFrame(conn, reply); err != nil {
+			a.logger.Debug("control write failed", "error", err)
+			return
+		}
+	}
+}
+
+// dispatch executes a single control command and returns its reply.
+func (a *Agent) dispatch(cmd Command) Reply {
+	switch cmd.Command {
+	case CmdGenStagedKey:
+		vkey, err := a.GenStagedKey()
+		if err != nil {
+			return Reply{Ok: false, Error: err.Error()}
+		}
+		return Reply{Ok: true, KESVKey: vkey, Info: a.Info()}
+	case CmdInstallKey:
+		info, err := a.InstallKey(cmd.OpCert)
+		if err != nil {
+			return Reply{Ok: false, Error: err.Error()}
+		}
+		return Reply{Ok: true, Info: info}
+	case CmdDropKey:
+		if err := a.DropKey(cmd.Target); err != nil {
+			return Reply{Ok: false, Error: err.Error()}
+		}
+		return Reply{Ok: true, Info: a.Info()}
+	case CmdInfo:
+		return Reply{Ok: true, Info: a.Info()}
+	default:
+		return Reply{Ok: false, Error: fmt.Sprintf("unknown command %q", cmd.Command)}
+	}
+}

--- a/internal/kesagent/control.go
+++ b/internal/kesagent/control.go
@@ -61,7 +61,12 @@ func (a *Agent) ServeControl(ctx context.Context, ln net.Listener) error {
 				return fmt.Errorf("kesagent: control accept: %w", err)
 			}
 		}
-		conns.add(conn)
+		if !conns.add(conn) {
+			// Shutting down, or the concurrent-connection ceiling was hit:
+			// close and drop this connection rather than serving it.
+			_ = conn.Close()
+			continue
+		}
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/internal/kesagent/control_test.go
+++ b/internal/kesagent/control_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/gouroboros/kes"
 )
@@ -32,7 +33,15 @@ func startControl(t *testing.T, a *Agent) net.Conn {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	go func() { _ = a.ServeControl(ctx, ln) }()
-	return dial(t, sock)
+	conn := dial(t, sock)
+	var hello Hello
+	if err := readFrame(conn, &hello); err != nil {
+		t.Fatalf("read control hello: %v", err)
+	}
+	if hello.Protocol != ProtocolID {
+		t.Fatalf("bad control hello: %+v", hello)
+	}
+	return conn
 }
 
 func request(t *testing.T, conn net.Conn, cmd Command) Reply {
@@ -108,5 +117,38 @@ func TestControlUnknownCommand(t *testing.T) {
 	reply := request(t, conn, Command{Command: "bogus"})
 	if reply.Ok || reply.Error == "" {
 		t.Fatalf("expected error for unknown command, got %+v", reply)
+	}
+}
+
+// TestServeControlShutdownWithIdleConnection guards against a shutdown hang:
+// an idle client that never sends another command must not prevent
+// ServeControl from returning once ctx is cancelled.
+func TestServeControlShutdownWithIdleConnection(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(1))
+	sock := shortSocketPath(t, "ctrl-shutdown.sock")
+	ln, err := ListenUnix(sock, 0o600)
+	if err != nil {
+		t.Fatalf("ListenUnix: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() { done <- a.ServeControl(ctx, ln) }()
+
+	conn := dial(t, sock) // stays open and idle; never sends a command
+	var hello Hello
+	if err := readFrame(conn, &hello); err != nil {
+		t.Fatalf("read control hello: %v", err)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ServeControl returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ServeControl did not return within 2s of an idle connection outliving shutdown")
 	}
 }

--- a/internal/kesagent/control_test.go
+++ b/internal/kesagent/control_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kesagent
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/kes"
+)
+
+func startControl(t *testing.T, a *Agent) net.Conn {
+	t.Helper()
+	sock := shortSocketPath(t, "ctrl.sock")
+	ln, err := ListenUnix(sock, 0o600)
+	if err != nil {
+		t.Fatalf("ListenUnix: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = a.ServeControl(ctx, ln) }()
+	return dial(t, sock)
+}
+
+func request(t *testing.T, conn net.Conn, cmd Command) Reply {
+	t.Helper()
+	if err := writeFrame(conn, cmd); err != nil {
+		t.Fatalf("write command %q: %v", cmd.Command, err)
+	}
+	var reply Reply
+	if err := readFrame(conn, &reply); err != nil {
+		t.Fatalf("read reply for %q: %v", cmd.Command, err)
+	}
+	return reply
+}
+
+func TestControlGenInstallInfoDrop(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeServeKey, cold, kes.CardanoKesDepth, atPeriod(5))
+	conn := startControl(t, a)
+
+	// gen-staged-key
+	genReply := request(t, conn, Command{Command: CmdGenStagedKey})
+	if !genReply.Ok || len(genReply.KESVKey) != kes.PublicKeySize {
+		t.Fatalf("gen-staged-key reply: %+v", genReply)
+	}
+	vkey := genReply.KESVKey
+
+	// install-key with a valid opcert
+	opcert := makeOpCert(t, vkey, 1, 3, cold)
+	instReply := request(t, conn, Command{Command: CmdInstallKey, OpCert: opcert})
+	if !instReply.Ok {
+		t.Fatalf("install failed: %s", instReply.Error)
+	}
+	if instReply.Info == nil || !instReply.Info.HasActiveKey || instReply.Info.ActivePeriod != 5 {
+		t.Fatalf("install info: %+v", instReply.Info)
+	}
+
+	// info
+	infoReply := request(t, conn, Command{Command: CmdInfo})
+	if !infoReply.Ok || infoReply.Info.Version != "test" {
+		t.Fatalf("info reply: %+v", infoReply)
+	}
+
+	// drop-key
+	dropReply := request(t, conn, Command{Command: CmdDropKey, Target: "active"})
+	if !dropReply.Ok || dropReply.Info.HasActiveKey {
+		t.Fatalf("drop reply: %+v", dropReply)
+	}
+}
+
+func TestControlInstallOpCertMismatchRejected(t *testing.T) {
+	cold := newColdKey(t)
+	other := newColdKey(t)
+	a := testAgent(t, ModeServeKey, cold, kes.CardanoKesDepth, atPeriod(5))
+	conn := startControl(t, a)
+
+	genReply := request(t, conn, Command{Command: CmdGenStagedKey})
+	vkey := genReply.KESVKey
+
+	// Opcert signed by the wrong cold key.
+	reply := request(t, conn, Command{
+		Command: CmdInstallKey,
+		OpCert:  makeOpCert(t, vkey, 1, 3, other),
+	})
+	if reply.Ok || reply.Error == "" {
+		t.Fatalf("expected rejection for mismatched opcert, got %+v", reply)
+	}
+}
+
+func TestControlUnknownCommand(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(1))
+	conn := startControl(t, a)
+	reply := request(t, conn, Command{Command: "bogus"})
+	if reply.Ok || reply.Error == "" {
+		t.Fatalf("expected error for unknown command, got %+v", reply)
+	}
+}

--- a/internal/kesagent/control_test.go
+++ b/internal/kesagent/control_test.go
@@ -152,3 +152,44 @@ func TestServeControlShutdownWithIdleConnection(t *testing.T) {
 		t.Fatal("ServeControl did not return within 2s of an idle connection outliving shutdown")
 	}
 }
+
+// TestServeControlListenerCloseUnblocksIdleHandler guards against a hang on
+// the other shutdown path: a listener closed directly (without ctx being
+// cancelled) takes the non-context Accept-error return, which must still
+// close tracked connections before the deferred wg.Wait(), or an idle
+// client's handler blocked in readFrame would keep ServeControl from
+// returning forever.
+func TestServeControlListenerCloseUnblocksIdleHandler(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(1))
+	sock := shortSocketPath(t, "ctrl-lnclose.sock")
+	ln, err := ListenUnix(sock, 0o600)
+	if err != nil {
+		t.Fatalf("ListenUnix: %v", err)
+	}
+	// Note: ctx is intentionally never cancelled; only the listener is
+	// closed, so the ctx-cancellation goroutine's conns.closeAll() never
+	// runs and the fix under test is the accept-error return path's own
+	// cleanup.
+	ctx := context.Background()
+
+	done := make(chan error, 1)
+	go func() { done <- a.ServeControl(ctx, ln) }()
+
+	conn := dial(t, sock) // stays open and idle; never sends a command
+	var hello Hello
+	if err := readFrame(conn, &hello); err != nil {
+		t.Fatalf("read control hello: %v", err)
+	}
+
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+	select {
+	case <-done:
+		// Any return (with or without an Accept error) is fine; what matters
+		// is that it doesn't hang on the idle handler.
+	case <-time.After(2 * time.Second):
+		t.Fatal("ServeControl did not return within 2s of a direct listener close with an idle connection")
+	}
+}

--- a/internal/kesagent/guard.go
+++ b/internal/kesagent/guard.go
@@ -121,49 +121,64 @@ func (g *PeriodGuard) Authorize(vkeyHex string, period uint64) error {
 	// roll back on failure, so a failed persist leaves the floor unchanged and
 	// the next Authorize re-attempts it instead of taking the equal-skip above
 	// over a floor that was never durably written.
+	//
+	// Rolling back is only correct while the new floor has NOT reached disk. Once
+	// the rename commits, the guard file holds the higher floor; restoring the
+	// lower one in memory would let a later Authorize accept a period between the
+	// old and new floors and persist it, moving the durable floor backwards --
+	// precisely the rollback this guard exists to prevent. So a post-commit
+	// failure (a directory sync that could not be completed) keeps the new floor
+	// in memory and surfaces the error.
 	prevFloor, prevSet, prevVkey := g.floor, g.set, g.vkey
 	g.floor = period
 	g.set = true
 	g.vkey = vkeyHex
-	if err := g.persistLocked(); err != nil {
-		g.floor, g.set, g.vkey = prevFloor, prevSet, prevVkey
+	committed, err := g.persistLocked()
+	if err != nil {
+		if !committed {
+			g.floor, g.set, g.vkey = prevFloor, prevSet, prevVkey
+		}
 		return err
 	}
 	return nil
 }
 
-func (g *PeriodGuard) persistLocked() error {
+// persistLocked writes the guard state durably. It reports whether the new
+// state reached the guard file: once the rename commits, the on-disk floor has
+// advanced even if a later step (the parent-directory sync) fails, and the
+// caller must not roll its in-memory floor back below it.
+func (g *PeriodGuard) persistLocked() (committed bool, err error) {
 	if g.path == "" {
-		return nil
+		return true, nil
 	}
 	st := guardState{Floor: g.floor, Set: g.set, Vkey: g.vkey}
 	data, err := json.Marshal(st)
 	if err != nil {
-		return fmt.Errorf("kesagent: marshal guard state: %w", err)
+		return false, fmt.Errorf("kesagent: marshal guard state: %w", err)
 	}
 	dir := filepath.Dir(g.path)
 	tmp, err := os.CreateTemp(dir, ".kesguard-*")
 	if err != nil {
-		return fmt.Errorf("kesagent: create guard temp file: %w", err)
+		return false, fmt.Errorf("kesagent: create guard temp file: %w", err)
 	}
 	tmpName := tmp.Name()
 	defer func() { _ = os.Remove(tmpName) }()
 	if _, err := tmp.Write(data); err != nil {
 		_ = tmp.Close()
-		return fmt.Errorf("kesagent: write guard temp file: %w", err)
+		return false, fmt.Errorf("kesagent: write guard temp file: %w", err)
 	}
 	if err := tmp.Sync(); err != nil {
 		_ = tmp.Close()
-		return fmt.Errorf("kesagent: sync guard temp file: %w", err)
+		return false, fmt.Errorf("kesagent: sync guard temp file: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("kesagent: close guard temp file: %w", err)
+		return false, fmt.Errorf("kesagent: close guard temp file: %w", err)
 	}
 	if err := os.Chmod(tmpName, 0o600); err != nil {
-		return fmt.Errorf("kesagent: chmod guard temp file: %w", err)
+		return false, fmt.Errorf("kesagent: chmod guard temp file: %w", err)
 	}
 	if err := os.Rename(tmpName, g.path); err != nil {
-		return fmt.Errorf("kesagent: rename guard file: %w", err)
+		return false, fmt.Errorf("kesagent: rename guard file: %w", err)
 	}
 	// Sync the parent directory too: without this, a crash right after the
 	// rename can lose the directory-entry update on some filesystems and
@@ -173,13 +188,13 @@ func (g *PeriodGuard) persistLocked() error {
 		syncErr := dirFile.Sync()
 		closeErr := dirFile.Close()
 		if syncErr != nil {
-			return fmt.Errorf("kesagent: sync guard dir %q: %w", dir, syncErr)
+			return true, fmt.Errorf("kesagent: sync guard dir %q: %w", dir, syncErr)
 		}
 		if closeErr != nil {
-			return fmt.Errorf("kesagent: close guard dir %q: %w", dir, closeErr)
+			return true, fmt.Errorf("kesagent: close guard dir %q: %w", dir, closeErr)
 		}
 	} else {
-		return fmt.Errorf("kesagent: open guard dir %q: %w", dir, err)
+		return true, fmt.Errorf("kesagent: open guard dir %q: %w", dir, err)
 	}
-	return nil
+	return true, nil
 }

--- a/internal/kesagent/guard.go
+++ b/internal/kesagent/guard.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kesagent
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// ErrPeriodRollback is returned when a serve/sign is attempted at a KES period
+// below the highest period already served or signed.
+var ErrPeriodRollback = errors.New(
+	"kesagent: KES period rollback refused (period below monotonic floor)",
+)
+
+// PeriodGuard enforces a monotonic non-decreasing floor on the KES period the
+// agent will serve or sign for. It protects against re-serving an already
+// superseded period after a clock jump, a process restart, or a stale key
+// re-install — a belt-and-suspenders complement to KES forward security.
+//
+// The floor is a single global value (KES periods are absolute, derived from
+// the genesis system-start and slot schedule, so they are comparable across
+// keys). A period strictly below the floor is refused; a period equal to the
+// floor is allowed, because a block producer legitimately signs many block
+// headers within a single KES period.
+//
+// The floor is persisted to a small JSON file with an atomic write
+// (temp-file + rename) so it survives restarts. This store is intentionally
+// self-contained; it can be migrated onto the shared signer watermark store
+// later.
+type PeriodGuard struct {
+	mu    sync.Mutex
+	path  string // empty => in-memory only (non-durable)
+	floor uint64
+	set   bool
+	vkey  string // hex of the active KES vkey at the current floor (informational)
+}
+
+type guardState struct {
+	Floor uint64 `json:"floor"`
+	Set   bool   `json:"set"`
+	Vkey  string `json:"kes_vkey,omitempty"`
+}
+
+// NewPeriodGuard opens (or creates) a guard backed by the file at path. An
+// empty path yields a non-durable in-memory guard (tests / ephemeral use).
+func NewPeriodGuard(path string) (*PeriodGuard, error) {
+	g := &PeriodGuard{path: path}
+	if path == "" {
+		return g, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return g, nil
+		}
+		return nil, fmt.Errorf("kesagent: read guard file %q: %w", path, err)
+	}
+	if len(data) == 0 {
+		return g, nil
+	}
+	var st guardState
+	if err := json.Unmarshal(data, &st); err != nil {
+		return nil, fmt.Errorf("kesagent: parse guard file %q: %w", path, err)
+	}
+	g.floor = st.Floor
+	g.set = st.Set
+	g.vkey = st.Vkey
+	return g, nil
+}
+
+// Floor returns the current monotonic floor and whether it has been set.
+func (g *PeriodGuard) Floor() (uint64, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.floor, g.set
+}
+
+// Authorize checks that period is not a rollback and, when allowed, advances
+// the floor to period. vkeyHex is recorded for diagnostics. It returns
+// ErrPeriodRollback if period is below the current floor.
+func (g *PeriodGuard) Authorize(vkeyHex string, period uint64) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.set && period < g.floor {
+		return fmt.Errorf(
+			"%w: period %d < floor %d",
+			ErrPeriodRollback,
+			period,
+			g.floor,
+		)
+	}
+	g.floor = period
+	g.set = true
+	g.vkey = vkeyHex
+	return g.persistLocked()
+}
+
+func (g *PeriodGuard) persistLocked() error {
+	if g.path == "" {
+		return nil
+	}
+	st := guardState{Floor: g.floor, Set: g.set, Vkey: g.vkey}
+	data, err := json.Marshal(st)
+	if err != nil {
+		return fmt.Errorf("kesagent: marshal guard state: %w", err)
+	}
+	dir := filepath.Dir(g.path)
+	tmp, err := os.CreateTemp(dir, ".kesguard-*")
+	if err != nil {
+		return fmt.Errorf("kesagent: create guard temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("kesagent: write guard temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("kesagent: sync guard temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("kesagent: close guard temp file: %w", err)
+	}
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		return fmt.Errorf("kesagent: chmod guard temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, g.path); err != nil {
+		return fmt.Errorf("kesagent: rename guard file: %w", err)
+	}
+	return nil
+}

--- a/internal/kesagent/guard.go
+++ b/internal/kesagent/guard.go
@@ -49,7 +49,11 @@ type PeriodGuard struct {
 	path  string // empty => in-memory only (non-durable)
 	floor uint64
 	set   bool
-	vkey  string // hex of the active KES vkey at the current floor (informational)
+	// durable is false when floor reached the guard file but its directory
+	// entry was not synced, so the value can still be lost by a crash. The
+	// equal-period fast path must not skip persisting while it is false.
+	durable bool
+	vkey    string // hex of the active KES vkey at the current floor (informational)
 }
 
 type guardState struct {
@@ -61,7 +65,10 @@ type guardState struct {
 // NewPeriodGuard opens (or creates) a guard backed by the file at path. An
 // empty path yields a non-durable in-memory guard (tests / ephemeral use).
 func NewPeriodGuard(path string) (*PeriodGuard, error) {
-	g := &PeriodGuard{path: path}
+	// durable starts true: an in-memory guard has nothing to persist, an absent
+	// or empty file has no floor to lose, and a floor read back from the file was
+	// written and synced by a previous run.
+	g := &PeriodGuard{path: path, durable: true}
 	if path == "" {
 		return g, nil
 	}
@@ -110,10 +117,13 @@ func (g *PeriodGuard) Authorize(vkeyHex string, period uint64) error {
 	// period, so this is the common case). The durable state already records
 	// this floor, so skip the temp-file + fsync + rename — ~240x the cost of the
 	// KES signature and paid under a.mu on the block-production path. Only the
-	// informational vkey is updated in memory. This is safe because g.floor is
-	// committed in memory only after a successful persist (see below), so
-	// period == g.floor implies it was already durably written.
-	if g.set && period == g.floor {
+	// informational vkey is updated in memory.
+	//
+	// It requires g.durable, not just g.set: a floor whose rename committed but
+	// whose directory entry was never synced can still be lost by a crash, so
+	// skipping the write here would leave that gap unretried for the rest of the
+	// period. In that state fall through and persist again.
+	if g.set && g.durable && period == g.floor {
 		g.vkey = vkeyHex
 		return nil
 	}
@@ -130,16 +140,22 @@ func (g *PeriodGuard) Authorize(vkeyHex string, period uint64) error {
 	// failure (a directory sync that could not be completed) keeps the new floor
 	// in memory and surfaces the error.
 	prevFloor, prevSet, prevVkey := g.floor, g.set, g.vkey
+	prevDurable := g.durable
 	g.floor = period
 	g.set = true
 	g.vkey = vkeyHex
+	g.durable = false
 	committed, err := g.persistLocked()
 	if err != nil {
 		if !committed {
 			g.floor, g.set, g.vkey = prevFloor, prevSet, prevVkey
+			g.durable = prevDurable
 		}
+		// A committed-but-unsynced floor stays in memory (it must never move
+		// backwards) but remains non-durable, so the next Authorize retries.
 		return err
 	}
+	g.durable = true
 	return nil
 }
 

--- a/internal/kesagent/guard.go
+++ b/internal/kesagent/guard.go
@@ -145,5 +145,21 @@ func (g *PeriodGuard) persistLocked() error {
 	if err := os.Rename(tmpName, g.path); err != nil {
 		return fmt.Errorf("kesagent: rename guard file: %w", err)
 	}
+	// Sync the parent directory too: without this, a crash right after the
+	// rename can lose the directory-entry update on some filesystems and
+	// restore an earlier (lower) floor on restart -- exactly the rollback
+	// this guard exists to prevent.
+	if dirFile, err := os.Open(dir); err == nil {
+		syncErr := dirFile.Sync()
+		closeErr := dirFile.Close()
+		if syncErr != nil {
+			return fmt.Errorf("kesagent: sync guard dir %q: %w", dir, syncErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("kesagent: close guard dir %q: %w", dir, closeErr)
+		}
+	} else {
+		return fmt.Errorf("kesagent: open guard dir %q: %w", dir, err)
+	}
 	return nil
 }

--- a/internal/kesagent/guard.go
+++ b/internal/kesagent/guard.go
@@ -106,10 +106,30 @@ func (g *PeriodGuard) Authorize(vkeyHex string, period uint64) error {
 			g.floor,
 		)
 	}
+	// Fast path: the floor is unchanged (a producer signs many headers per KES
+	// period, so this is the common case). The durable state already records
+	// this floor, so skip the temp-file + fsync + rename — ~240x the cost of the
+	// KES signature and paid under a.mu on the block-production path. Only the
+	// informational vkey is updated in memory. This is safe because g.floor is
+	// committed in memory only after a successful persist (see below), so
+	// period == g.floor implies it was already durably written.
+	if g.set && period == g.floor {
+		g.vkey = vkeyHex
+		return nil
+	}
+	// Advancing the floor: persist BEFORE committing the new value in memory, and
+	// roll back on failure, so a failed persist leaves the floor unchanged and
+	// the next Authorize re-attempts it instead of taking the equal-skip above
+	// over a floor that was never durably written.
+	prevFloor, prevSet, prevVkey := g.floor, g.set, g.vkey
 	g.floor = period
 	g.set = true
 	g.vkey = vkeyHex
-	return g.persistLocked()
+	if err := g.persistLocked(); err != nil {
+		g.floor, g.set, g.vkey = prevFloor, prevSet, prevVkey
+		return err
+	}
+	return nil
 }
 
 func (g *PeriodGuard) persistLocked() error {

--- a/internal/kesagent/guard_test.go
+++ b/internal/kesagent/guard_test.go
@@ -15,9 +15,7 @@
 package kesagent
 
 import (
-	"encoding/json"
 	"errors"
-	"os"
 	"path/filepath"
 	"testing"
 )
@@ -68,96 +66,5 @@ func TestPeriodGuardDurable(t *testing.T) {
 	}
 	if err := g2.Authorize("vk", 41); !errors.Is(err, ErrPeriodRollback) {
 		t.Fatalf("rollback after reload: want ErrPeriodRollback, got %v", err)
-	}
-}
-
-// TestPeriodGuardKeepsFloorWhenPersistFailsAfterCommit drives the failure that
-// happens *after* the guard file has been renamed into place: the floor is
-// already durable, so rolling the in-memory floor back would let a later
-// Authorize accept a period between the old and new floors and persist it,
-// moving the durable floor backwards.
-//
-// The post-rename failure is produced for real rather than mocked: a directory
-// with mode 0300 still permits CreateTemp and Rename (write + execute) but
-// refuses the read needed to open and fsync it.
-func TestPeriodGuardKeepsFloorWhenPersistFailsAfterCommit(t *testing.T) {
-	if os.Geteuid() == 0 {
-		t.Skip("running as root bypasses directory permissions")
-	}
-	dir := t.TempDir()
-	path := filepath.Join(dir, "guard.json")
-	g, err := NewPeriodGuard(path)
-	if err != nil {
-		t.Fatalf("NewPeriodGuard: %v", err)
-	}
-	if err := g.Authorize("vkey-old", 10); err != nil {
-		t.Fatalf("seed floor: %v", err)
-	}
-
-	// Refuse the parent-directory read, so persist fails only after the rename.
-	if err := os.Chmod(dir, 0o300); err != nil {
-		t.Fatalf("chmod dir: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
-
-	if err := g.Authorize("vkey-new", 20); err == nil {
-		t.Fatal("Authorize: want the post-rename sync failure to surface, got nil")
-	}
-
-	// The advanced floor must survive in memory: the guard file already says 20.
-	if floor, set := g.Floor(); !set || floor != 20 {
-		t.Fatalf("in-memory floor = (%d, %v), want (20, true)", floor, set)
-	}
-	// The whole point: a period below the committed floor stays refused.
-	if err := g.Authorize("vkey-mid", 15); !errors.Is(err, ErrPeriodRollback) {
-		t.Fatalf("Authorize(15) after committed floor 20: want ErrPeriodRollback, got %v", err)
-	}
-
-	// And the durable state really did advance to 20.
-	if err := os.Chmod(dir, 0o700); err != nil {
-		t.Fatalf("restore dir mode: %v", err)
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read guard file: %v", err)
-	}
-	var st guardState
-	if err := json.Unmarshal(data, &st); err != nil {
-		t.Fatalf("unmarshal guard file: %v", err)
-	}
-	if !st.Set || st.Floor != 20 {
-		t.Fatalf("guard file = %+v, want floor 20 set true", st)
-	}
-}
-
-// TestPeriodGuardRollsBackFloorWhenPersistFailsBeforeCommit is the companion
-// case: when the guard file was never written, the in-memory floor must NOT
-// advance, or the equal-period fast path would later skip persisting a floor
-// that has no durable record.
-func TestPeriodGuardRollsBackFloorWhenPersistFailsBeforeCommit(t *testing.T) {
-	if os.Geteuid() == 0 {
-		t.Skip("running as root bypasses directory permissions")
-	}
-	dir := t.TempDir()
-	path := filepath.Join(dir, "guard.json")
-	g, err := NewPeriodGuard(path)
-	if err != nil {
-		t.Fatalf("NewPeriodGuard: %v", err)
-	}
-	if err := g.Authorize("vkey-old", 10); err != nil {
-		t.Fatalf("seed floor: %v", err)
-	}
-
-	// A read-only directory fails at CreateTemp, before anything is renamed.
-	if err := os.Chmod(dir, 0o500); err != nil {
-		t.Fatalf("chmod dir: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
-
-	if err := g.Authorize("vkey-new", 20); err == nil {
-		t.Fatal("Authorize: want a persist failure, got nil")
-	}
-	if floor, set := g.Floor(); !set || floor != 10 {
-		t.Fatalf("in-memory floor = (%d, %v), want (10, true) after an uncommitted persist", floor, set)
 	}
 }

--- a/internal/kesagent/guard_test.go
+++ b/internal/kesagent/guard_test.go
@@ -15,7 +15,9 @@
 package kesagent
 
 import (
+	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -66,5 +68,96 @@ func TestPeriodGuardDurable(t *testing.T) {
 	}
 	if err := g2.Authorize("vk", 41); !errors.Is(err, ErrPeriodRollback) {
 		t.Fatalf("rollback after reload: want ErrPeriodRollback, got %v", err)
+	}
+}
+
+// TestPeriodGuardKeepsFloorWhenPersistFailsAfterCommit drives the failure that
+// happens *after* the guard file has been renamed into place: the floor is
+// already durable, so rolling the in-memory floor back would let a later
+// Authorize accept a period between the old and new floors and persist it,
+// moving the durable floor backwards.
+//
+// The post-rename failure is produced for real rather than mocked: a directory
+// with mode 0300 still permits CreateTemp and Rename (write + execute) but
+// refuses the read needed to open and fsync it.
+func TestPeriodGuardKeepsFloorWhenPersistFailsAfterCommit(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses directory permissions")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "guard.json")
+	g, err := NewPeriodGuard(path)
+	if err != nil {
+		t.Fatalf("NewPeriodGuard: %v", err)
+	}
+	if err := g.Authorize("vkey-old", 10); err != nil {
+		t.Fatalf("seed floor: %v", err)
+	}
+
+	// Refuse the parent-directory read, so persist fails only after the rename.
+	if err := os.Chmod(dir, 0o300); err != nil {
+		t.Fatalf("chmod dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	if err := g.Authorize("vkey-new", 20); err == nil {
+		t.Fatal("Authorize: want the post-rename sync failure to surface, got nil")
+	}
+
+	// The advanced floor must survive in memory: the guard file already says 20.
+	if floor, set := g.Floor(); !set || floor != 20 {
+		t.Fatalf("in-memory floor = (%d, %v), want (20, true)", floor, set)
+	}
+	// The whole point: a period below the committed floor stays refused.
+	if err := g.Authorize("vkey-mid", 15); !errors.Is(err, ErrPeriodRollback) {
+		t.Fatalf("Authorize(15) after committed floor 20: want ErrPeriodRollback, got %v", err)
+	}
+
+	// And the durable state really did advance to 20.
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("restore dir mode: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read guard file: %v", err)
+	}
+	var st guardState
+	if err := json.Unmarshal(data, &st); err != nil {
+		t.Fatalf("unmarshal guard file: %v", err)
+	}
+	if !st.Set || st.Floor != 20 {
+		t.Fatalf("guard file = %+v, want floor 20 set true", st)
+	}
+}
+
+// TestPeriodGuardRollsBackFloorWhenPersistFailsBeforeCommit is the companion
+// case: when the guard file was never written, the in-memory floor must NOT
+// advance, or the equal-period fast path would later skip persisting a floor
+// that has no durable record.
+func TestPeriodGuardRollsBackFloorWhenPersistFailsBeforeCommit(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses directory permissions")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "guard.json")
+	g, err := NewPeriodGuard(path)
+	if err != nil {
+		t.Fatalf("NewPeriodGuard: %v", err)
+	}
+	if err := g.Authorize("vkey-old", 10); err != nil {
+		t.Fatalf("seed floor: %v", err)
+	}
+
+	// A read-only directory fails at CreateTemp, before anything is renamed.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	if err := g.Authorize("vkey-new", 20); err == nil {
+		t.Fatal("Authorize: want a persist failure, got nil")
+	}
+	if floor, set := g.Floor(); !set || floor != 10 {
+		t.Fatalf("in-memory floor = (%d, %v), want (10, true) after an uncommitted persist", floor, set)
 	}
 }

--- a/internal/kesagent/guard_test.go
+++ b/internal/kesagent/guard_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kesagent
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestPeriodGuardMonotonic(t *testing.T) {
+	g, err := NewPeriodGuard("")
+	if err != nil {
+		t.Fatalf("NewPeriodGuard: %v", err)
+	}
+	if err := g.Authorize("vk", 5); err != nil {
+		t.Fatalf("authorize 5: %v", err)
+	}
+	// Equal period is allowed (a producer signs many blocks in one KES period).
+	if err := g.Authorize("vk", 5); err != nil {
+		t.Fatalf("authorize 5 again: %v", err)
+	}
+	// A lower period is a rollback and must be refused.
+	if err := g.Authorize("vk", 4); !errors.Is(err, ErrPeriodRollback) {
+		t.Fatalf("authorize 4: want ErrPeriodRollback, got %v", err)
+	}
+	// Advancing is allowed.
+	if err := g.Authorize("vk", 6); err != nil {
+		t.Fatalf("authorize 6: %v", err)
+	}
+	floor, set := g.Floor()
+	if !set || floor != 6 {
+		t.Fatalf("floor = %d set=%v, want 6 true", floor, set)
+	}
+}
+
+func TestPeriodGuardDurable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "guard.json")
+	g, err := NewPeriodGuard(path)
+	if err != nil {
+		t.Fatalf("NewPeriodGuard: %v", err)
+	}
+	if err := g.Authorize("vk", 42); err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	// Reopen from disk: the floor must survive.
+	g2, err := NewPeriodGuard(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	floor, set := g2.Floor()
+	if !set || floor != 42 {
+		t.Fatalf("reloaded floor = %d set=%v, want 42 true", floor, set)
+	}
+	if err := g2.Authorize("vk", 41); !errors.Is(err, ErrPeriodRollback) {
+		t.Fatalf("rollback after reload: want ErrPeriodRollback, got %v", err)
+	}
+}

--- a/internal/kesagent/guard_unix_test.go
+++ b/internal/kesagent/guard_unix_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unix
+
+package kesagent
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPeriodGuardKeepsFloorWhenPersistFailsAfterCommit drives the failure that
+// happens *after* the guard file has been renamed into place: the floor is
+// already durable, so rolling the in-memory floor back would let a later
+// Authorize accept a period between the old and new floors and persist it,
+// moving the durable floor backwards.
+//
+// The post-rename failure is produced for real rather than mocked: a directory
+// with mode 0300 still permits CreateTemp and Rename (write + execute) but
+// refuses the read needed to open and fsync it.
+func TestPeriodGuardKeepsFloorWhenPersistFailsAfterCommit(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses directory permissions")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "guard.json")
+	g, err := NewPeriodGuard(path)
+	if err != nil {
+		t.Fatalf("NewPeriodGuard: %v", err)
+	}
+	if err := g.Authorize("vkey-old", 10); err != nil {
+		t.Fatalf("seed floor: %v", err)
+	}
+
+	// Refuse the parent-directory read, so persist fails only after the rename.
+	if err := os.Chmod(dir, 0o300); err != nil {
+		t.Fatalf("chmod dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	if err := g.Authorize("vkey-new", 20); err == nil {
+		t.Fatal("Authorize: want the post-rename sync failure to surface, got nil")
+	}
+
+	// The advanced floor must survive in memory: the guard file already says 20.
+	if floor, set := g.Floor(); !set || floor != 20 {
+		t.Fatalf("in-memory floor = (%d, %v), want (20, true)", floor, set)
+	}
+	// The whole point: a period below the committed floor stays refused.
+	if err := g.Authorize("vkey-mid", 15); !errors.Is(err, ErrPeriodRollback) {
+		t.Fatalf("Authorize(15) after committed floor 20: want ErrPeriodRollback, got %v", err)
+	}
+
+	// And the durable state really did advance to 20.
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("restore dir mode: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read guard file: %v", err)
+	}
+	var st guardState
+	if err := json.Unmarshal(data, &st); err != nil {
+		t.Fatalf("unmarshal guard file: %v", err)
+	}
+	if !st.Set || st.Floor != 20 {
+		t.Fatalf("guard file = %+v, want floor 20 set true", st)
+	}
+}
+
+// TestPeriodGuardRollsBackFloorWhenPersistFailsBeforeCommit is the companion
+// case: when the guard file was never written, the in-memory floor must NOT
+// advance, or the equal-period fast path would later skip persisting a floor
+// that has no durable record.
+func TestPeriodGuardRollsBackFloorWhenPersistFailsBeforeCommit(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses directory permissions")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "guard.json")
+	g, err := NewPeriodGuard(path)
+	if err != nil {
+		t.Fatalf("NewPeriodGuard: %v", err)
+	}
+	if err := g.Authorize("vkey-old", 10); err != nil {
+		t.Fatalf("seed floor: %v", err)
+	}
+
+	// A read-only directory fails at CreateTemp, before anything is renamed.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	if err := g.Authorize("vkey-new", 20); err == nil {
+		t.Fatal("Authorize: want a persist failure, got nil")
+	}
+	if floor, set := g.Floor(); !set || floor != 10 {
+		t.Fatalf("in-memory floor = (%d, %v), want (10, true) after an uncommitted persist", floor, set)
+	}
+}
+
+// TestPeriodGuardRetriesPersistAfterUnsyncedCommit covers the interaction
+// between the two rules above: a floor whose rename committed but whose
+// directory entry was never synced is kept in memory (it must not move
+// backwards) yet is not durable, so the equal-period fast path must not skip
+// persisting it. Otherwise the gap would go unretried for the rest of the
+// period and a crash could still restore the older floor.
+func TestPeriodGuardRetriesPersistAfterUnsyncedCommit(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses directory permissions")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "guard.json")
+	g, err := NewPeriodGuard(path)
+	if err != nil {
+		t.Fatalf("NewPeriodGuard: %v", err)
+	}
+	if err := g.Authorize("vkey-old", 10); err != nil {
+		t.Fatalf("seed floor: %v", err)
+	}
+
+	// Fail only the post-rename directory read.
+	if err := os.Chmod(dir, 0o300); err != nil {
+		t.Fatalf("chmod dir: %v", err)
+	}
+	if err := g.Authorize("vkey-new", 20); err == nil {
+		t.Fatal("Authorize: want the post-rename sync failure to surface, got nil")
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("restore dir mode: %v", err)
+	}
+
+	// Remove the guard file: if the next equal-period Authorize takes the fast
+	// path it will not be recreated, which is exactly the durability gap.
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove guard file: %v", err)
+	}
+	if err := g.Authorize("vkey-new", 20); err != nil {
+		t.Fatalf("Authorize(20) retry after an unsynced commit: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("guard file was not rewritten, so the fast path skipped a non-durable floor: %v", err)
+	}
+	var st guardState
+	if err := json.Unmarshal(data, &st); err != nil {
+		t.Fatalf("unmarshal guard file: %v", err)
+	}
+	if !st.Set || st.Floor != 20 {
+		t.Fatalf("guard file = %+v, want floor 20 set true", st)
+	}
+
+	// Once durable again, the fast path may resume: a further equal-period call
+	// must not rewrite the file.
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat guard file: %v", err)
+	}
+	if err := g.Authorize("vkey-new", 20); err != nil {
+		t.Fatalf("Authorize(20) once durable: %v", err)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat guard file: %v", err)
+	}
+	if !before.ModTime().Equal(after.ModTime()) || before.Size() != after.Size() {
+		t.Fatal("equal-period fast path rewrote a floor that was already durable")
+	}
+}

--- a/internal/kesagent/helpers_test.go
+++ b/internal/kesagent/helpers_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kesagent
+
+import (
+	"crypto/ed25519"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+)
+
+// epoch is a fixed genesis system start for deterministic period math.
+var epoch = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// coldKeyPair is a generated pool cold key pair for tests.
+type coldKeyPair struct {
+	pub  ed25519.PublicKey
+	priv ed25519.PrivateKey
+}
+
+func newColdKey(t *testing.T) coldKeyPair {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate cold key: %v", err)
+	}
+	return coldKeyPair{pub: pub, priv: priv}
+}
+
+// testAgent builds an Agent with a fixed clock. slotLen is 1s and
+// slotsPerKESPeriod is 10, so a KES period is 10s. clockAt sets now().
+func testAgent(t *testing.T, mode string, cold coldKeyPair, depth uint64, clockAt time.Time) *Agent {
+	t.Helper()
+	cfg := Config{
+		Mode:              mode,
+		Depth:             depth,
+		SystemStart:       epoch,
+		SlotLength:        time.Second,
+		SlotsPerKESPeriod: 10,
+		MaxKESEvolutions:  62,
+		ColdVKey:          cold.pub,
+		EvolveInterval:    time.Hour,
+		GuardPath:         "", // in-memory guard
+		Version:           "test",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a, err := New(cfg, logger, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.now = func() time.Time { return clockAt }
+	t.Cleanup(a.Close)
+	return a
+}
+
+// atPeriod returns the wall-clock time at the start of the given KES period for
+// the testAgent parameters (10s per period).
+func atPeriod(p uint64) time.Time {
+	return epoch.Add(time.Duration(p) * 10 * time.Second)
+}
+
+// makeOpCert builds a canonical node operational certificate CBOR envelope
+// [[kes_vkey, issue, period, cold_sig], cold_vkey] signed by cold.
+func makeOpCert(t *testing.T, kesVkey []byte, issue, period uint64, cold coldKeyPair) []byte {
+	t.Helper()
+	oc, err := ledger.CreateOpCert(kesVkey, issue, period, cold.priv)
+	if err != nil {
+		t.Fatalf("CreateOpCert: %v", err)
+	}
+	env := []any{
+		[]any{oc.KesVkey, issue, period, oc.ColdSignature},
+		[]byte(cold.pub),
+	}
+	b, err := cbor.Encode(env)
+	if err != nil {
+		t.Fatalf("encode opcert: %v", err)
+	}
+	return b
+}
+
+// tamperOpCertKESVkey re-encodes an opcert with a different inner KES vkey,
+// leaving the cold vkey stamp and cold signature intact. The cold signature
+// then no longer matches, so VerifyOpCertSignature fails.
+func tamperOpCertKESVkey(t *testing.T, opcert, newVkey []byte) []byte {
+	t.Helper()
+	dec, err := decodeOpCert(opcert)
+	if err != nil {
+		t.Fatalf("decode for tamper: %v", err)
+	}
+	env := []any{
+		[]any{newVkey, dec.issueNumber, dec.kesPeriod, dec.coldSig},
+		dec.coldVkey,
+	}
+	b, err := cbor.Encode(env)
+	if err != nil {
+		t.Fatalf("encode tampered opcert: %v", err)
+	}
+	return b
+}

--- a/internal/kesagent/metrics.go
+++ b/internal/kesagent/metrics.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kesagent
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Metrics holds Prometheus collectors for the KES agent. Construct one per
+// process and call Register to publish it.
+type Metrics struct {
+	servedKeys  prometheus.Counter
+	signs       *prometheus.CounterVec
+	evolutions  prometheus.Counter
+	currentPer  prometheus.Gauge
+	exhausted   prometheus.Gauge
+	activeConns prometheus.Gauge
+}
+
+// NewMetrics builds the KES agent metric set.
+func NewMetrics() *Metrics {
+	return &Metrics{
+		servedKeys: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "bursa_kesagent_served_keys_total",
+			Help: "KES key pushes delivered to producers (serve-key mode).",
+		}),
+		signs: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "bursa_kesagent_sign_total",
+			Help: "KES signing operations by result (ok|error).",
+		}, []string{"result"}),
+		evolutions: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "bursa_kesagent_evolutions_total",
+			Help: "KES key forward-evolutions performed.",
+		}),
+		currentPer: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "bursa_kesagent_current_period",
+			Help: "Current absolute KES period of the active key.",
+		}),
+		exhausted: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "bursa_kesagent_exhausted",
+			Help: "1 when the active KES key has exhausted its evolutions, else 0.",
+		}),
+		activeConns: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "bursa_kesagent_service_connections",
+			Help: "Currently connected service-socket clients.",
+		}),
+	}
+}
+
+// Register publishes the collectors to r (call once at startup).
+func (m *Metrics) Register(r prometheus.Registerer) {
+	r.MustRegister(
+		m.servedKeys,
+		m.signs,
+		m.evolutions,
+		m.currentPer,
+		m.exhausted,
+		m.activeConns,
+	)
+}
+
+func (m *Metrics) incServedKeys() {
+	if m != nil {
+		m.servedKeys.Inc()
+	}
+}
+
+func (m *Metrics) incSign(result string) {
+	if m != nil {
+		m.signs.WithLabelValues(result).Inc()
+	}
+}
+
+func (m *Metrics) incEvolutions() {
+	if m != nil {
+		m.evolutions.Inc()
+	}
+}
+
+func (m *Metrics) setCurrentPeriod(p uint64) {
+	if m != nil {
+		m.currentPer.Set(float64(p))
+	}
+}
+
+func (m *Metrics) setExhausted(v bool) {
+	if m == nil {
+		return
+	}
+	if v {
+		m.exhausted.Set(1)
+	} else {
+		m.exhausted.Set(0)
+	}
+}
+
+func (m *Metrics) addConns(delta float64) {
+	if m != nil {
+		m.activeConns.Add(delta)
+	}
+}

--- a/internal/kesagent/metrics_test.go
+++ b/internal/kesagent/metrics_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kesagent
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// TestMetricsRegisterAndNames pins the exported metric names and help text
+// (the documented wire contract) so an accidental rename or help-text change
+// in the collector set is caught, and exercises Register end to end.
+func TestMetricsRegisterAndNames(t *testing.T) {
+	m := NewMetrics()
+	reg := prometheus.NewRegistry()
+	m.Register(reg)
+
+	// Touch every collector so each metric family is produced by Gather.
+	m.incServedKeys()
+	m.incSign("ok")
+	m.incSign("error")
+	m.incEvolutions()
+	m.setCurrentPeriod(42)
+	m.setExhausted(true)
+	m.addConns(1)
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	got := make(map[string]string, len(mfs))
+	for _, mf := range mfs {
+		got[mf.GetName()] = mf.GetHelp()
+	}
+
+	want := map[string]string{
+		"bursa_kesagent_served_keys_total":   "KES key pushes delivered to producers (serve-key mode).",
+		"bursa_kesagent_sign_total":          "KES signing operations by result (ok|error).",
+		"bursa_kesagent_evolutions_total":    "KES key forward-evolutions performed.",
+		"bursa_kesagent_current_period":      "Current absolute KES period of the active key.",
+		"bursa_kesagent_exhausted":           "1 when the active KES key has exhausted its evolutions, else 0.",
+		"bursa_kesagent_service_connections": "Currently connected service-socket clients.",
+	}
+	for name, help := range want {
+		gotHelp, ok := got[name]
+		if !ok {
+			t.Errorf("metric %q not registered", name)
+			continue
+		}
+		if gotHelp != help {
+			t.Errorf("metric %q help = %q, want %q", name, gotHelp, help)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("registered metric family count = %d, want %d (got %v)", len(got), len(want), got)
+	}
+}
+
+// TestMetricsNilReceiverSafe verifies the accessor helpers are no-ops on a nil
+// *Metrics, since the agent may run without a metrics set installed.
+func TestMetricsNilReceiverSafe(t *testing.T) {
+	var m *Metrics
+	m.incServedKeys()
+	m.incSign("ok")
+	m.incEvolutions()
+	m.setCurrentPeriod(1)
+	m.setExhausted(true)
+	m.setExhausted(false)
+	m.addConns(1)
+	m.addConns(-1)
+}

--- a/internal/kesagent/opcert.go
+++ b/internal/kesagent/opcert.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kesagent
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/kes"
+	"github.com/blinklabs-io/gouroboros/ledger"
+)
+
+// decodedOpCert holds the fields decoded from a canonical node operational
+// certificate CBOR envelope.
+type decodedOpCert struct {
+	kesVkey     []byte
+	issueNumber uint64
+	kesPeriod   uint64
+	coldSig     []byte
+	coldVkey    []byte
+}
+
+// decodeOpCert decodes a node operational certificate from CBOR.
+//
+// Wire format (matches bursa / cardano-node):
+//
+//	[[kes_vkey, issue_number, kes_period, cold_signature], cold_vkey]
+//
+// This mirrors bursa's own decodeOpCert; it is duplicated here to keep the
+// agent package self-contained (the root helper is unexported).
+func decodeOpCert(certBytes []byte) (*decodedOpCert, error) {
+	var outer []any
+	if _, err := cbor.Decode(certBytes, &outer); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal OpCert CBOR: %w", err)
+	}
+	if len(outer) != 2 {
+		return nil, fmt.Errorf(
+			"invalid OpCert: expected 2-element outer array, got %d",
+			len(outer),
+		)
+	}
+	cert, ok := outer[0].([]any)
+	if !ok {
+		return nil, errors.New("invalid OpCert: first element is not an array")
+	}
+	if len(cert) != 4 {
+		return nil, fmt.Errorf(
+			"invalid OpCert: expected 4-element cert array, got %d",
+			len(cert),
+		)
+	}
+	coldVkey, ok := outer[1].([]byte)
+	if !ok {
+		return nil, errors.New("invalid OpCert: cold_vkey is not bytes")
+	}
+	if len(coldVkey) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf(
+			"invalid OpCert: cold_vkey expected %d bytes, got %d",
+			ed25519.PublicKeySize, len(coldVkey),
+		)
+	}
+	kesVkey, ok := cert[0].([]byte)
+	if !ok {
+		return nil, errors.New("invalid OpCert: kes_vkey is not bytes")
+	}
+	if len(kesVkey) != kes.PublicKeySize {
+		return nil, fmt.Errorf(
+			"invalid OpCert: kes_vkey expected %d bytes, got %d",
+			kes.PublicKeySize, len(kesVkey),
+		)
+	}
+	issueNumber, err := asUint64(cert[1], "issue_number")
+	if err != nil {
+		return nil, err
+	}
+	kesPeriod, err := asUint64(cert[2], "kes_period")
+	if err != nil {
+		return nil, err
+	}
+	coldSig, ok := cert[3].([]byte)
+	if !ok {
+		return nil, errors.New("invalid OpCert: cold_signature is not bytes")
+	}
+	if len(coldSig) != ed25519.SignatureSize {
+		return nil, fmt.Errorf(
+			"invalid OpCert: cold_signature expected %d bytes, got %d",
+			ed25519.SignatureSize, len(coldSig),
+		)
+	}
+	return &decodedOpCert{
+		kesVkey:     kesVkey,
+		issueNumber: issueNumber,
+		kesPeriod:   kesPeriod,
+		coldSig:     coldSig,
+		coldVkey:    coldVkey,
+	}, nil
+}
+
+func asUint64(v any, field string) (uint64, error) {
+	switch n := v.(type) {
+	case uint64:
+		return n, nil
+	case int64:
+		if n < 0 {
+			return 0, fmt.Errorf("invalid OpCert: %s cannot be negative, got %d", field, n)
+		}
+		return uint64(n), nil
+	default:
+		return 0, fmt.Errorf("invalid OpCert: %s has unexpected type %T", field, v)
+	}
+}
+
+// ledgerOpCert converts to the gouroboros ledger.OpCert for signature checks.
+func (d *decodedOpCert) ledgerOpCert() *ledger.OpCert {
+	return &ledger.OpCert{
+		KesVkey:       d.kesVkey,
+		IssueNumber:   d.issueNumber,
+		KesPeriod:     d.kesPeriod,
+		ColdSignature: d.coldSig,
+	}
+}

--- a/internal/kesagent/protocol.go
+++ b/internal/kesagent/protocol.go
@@ -167,13 +167,21 @@ type Reply struct {
 
 // AgentInfo is the status snapshot returned by the info command.
 type AgentInfo struct {
-	Version          string `json:"version"`
-	Mode             string `json:"mode"`
-	HasActiveKey     bool   `json:"has_active_key"`
-	ActivePeriod     uint64 `json:"active_period"`     // current absolute KES period of the active key
-	ActiveStart      uint64 `json:"active_start"`      // absolute KES period the opcert was issued for
-	ActiveEnd        uint64 `json:"active_end"`        // last absolute KES period the key can serve
-	ActiveKESVKey    []byte `json:"active_kes_vkey"`   // 32-byte KES vkey (nil if none)
+	Version       string `json:"version"`
+	Mode          string `json:"mode"`
+	HasActiveKey  bool   `json:"has_active_key"`
+	ActivePeriod  uint64 `json:"active_period"`   // current absolute KES period of the active key
+	ActiveStart   uint64 `json:"active_start"`    // absolute KES period the opcert was issued for
+	ActiveEnd     uint64 `json:"active_end"`      // last absolute KES period the key can serve
+	ActiveKESVKey []byte `json:"active_kes_vkey"` // 32-byte KES vkey (nil if none)
+	// ActiveIssueNumber is the opcert issue counter the agent is serving. It is
+	// the field the network uses to decide whether to accept the pool's blocks,
+	// so an operator needs it to confirm a rotation actually took effect.
+	ActiveIssueNumber uint64 `json:"active_issue_number"`
+	// ActiveOpCert is the installed opcert CBOR. In sign mode the producer never
+	// receives the key, so this is the only way to confirm the agent and the
+	// producer agree on the certificate after a KES rotation.
+	ActiveOpCert     []byte `json:"active_opcert,omitempty"`
 	StagedKESVKey    []byte `json:"staged_kes_vkey"`   // 32-byte staged KES vkey (nil if none)
 	Exhausted        bool   `json:"exhausted"`         // active key has run out of evolutions
 	CurrentPeriod    uint64 `json:"current_period"`    // agent's computed current KES period

--- a/internal/kesagent/protocol.go
+++ b/internal/kesagent/protocol.go
@@ -1,0 +1,216 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package kesagent implements a KES (Key Evolving Signature) agent daemon: a
+// Go replica of IOG's kes-agent, serving a Go block producer (dingo) rather
+// than cardano-node.
+//
+// The agent holds the block-production KES signing key in locked (mlock'd)
+// secure memory, evolves it forward-securely each KES period, and serves it to
+// the producer over Unix-domain sockets. The pool cold signing key never
+// touches the agent; the agent holds only the cold verification key and the
+// operational certificate the cold signer issued.
+//
+// # Wire format
+//
+// Both the service socket and the control socket speak the same framed
+// message protocol:
+//
+//	frame = uint32(len, big-endian) || payload
+//	payload = JSON object (UTF-8)
+//
+// The maximum payload length is maxFrameLen (1 MiB); larger frames are
+// rejected. []byte fields are base64-encoded by encoding/json.
+//
+// # Handshake
+//
+// Immediately after a client connects the server sends a Hello frame
+// describing the protocol version and the socket mode:
+//
+//	{"protocol":"bursa-kes-agent/1","mode":"serve-key"|"sign"}
+//
+// A client MUST verify the protocol string before proceeding.
+//
+// # Service socket, serve-key mode
+//
+// After the Hello, and whenever the active key becomes available, evolves, or
+// is (re)installed, the server pushes a KeyPush frame:
+//
+//	{"type":"key_push","period":<abs KES period>,"depth":6,
+//	 "kes_sign_key":<b64 raw KES secret key bytes>,
+//	 "kes_vkey":<b64 32-byte KES verification key>,
+//	 "opcert":<b64 CBOR operational certificate>}
+//
+// The client consumes frames; it sends nothing.
+//
+// # Service socket, sign mode
+//
+// After the Hello the client sends SignRequest frames and the server replies
+// with a SignResponse for each; the KES key never leaves the agent:
+//
+//	-> {"type":"sign_request","period":<abs KES period>,"message":<b64>}
+//	<- {"type":"sign_response","period":<abs>,"signature":<b64>,"error":""}
+//
+// # Control socket
+//
+// The control socket is request/response. Each request is a Command frame and
+// the server replies with a Reply frame:
+//
+//	-> {"command":"gen-staged-key"}
+//	<- {"ok":true,"kes_vkey":<b64>}
+//
+//	-> {"command":"install-key","opcert":<b64 CBOR opcert>}
+//	<- {"ok":true,"info":{...}}
+//
+//	-> {"command":"drop-key","target":"active"|"staged"|"all"}
+//	<- {"ok":true}
+//
+//	-> {"command":"info"}
+//	<- {"ok":true,"info":{...}}
+//
+// The agent validates an installed opcert against the configured cold
+// verification key (cold-signature check), confirms it commits to the
+// staged/active KES verification key, and checks the KES period is sane before
+// promoting the staged key to active and serving it. The agent never issues an
+// opcert; that stays with the cold signer / cardano-cli.
+package kesagent
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+const (
+	// ProtocolID is the handshake protocol/version string.
+	ProtocolID = "bursa-kes-agent/1"
+
+	// maxFrameLen caps a single frame payload to guard against abuse.
+	maxFrameLen = 1 << 20 // 1 MiB
+)
+
+// Socket modes for the service socket.
+const (
+	ModeServeKey = "serve-key"
+	ModeSign     = "sign"
+)
+
+// Hello is the first frame the server sends after a client connects.
+type Hello struct {
+	Protocol string `json:"protocol"`
+	Mode     string `json:"mode"`
+}
+
+// KeyPush is sent by the server in serve-key mode to deliver the current KES
+// signing key, its verification key, its absolute KES period, and the
+// operational certificate.
+type KeyPush struct {
+	Type       string `json:"type"` // "key_push"
+	Period     uint64 `json:"period"`
+	Depth      uint64 `json:"depth"`
+	KESSignKey []byte `json:"kes_sign_key"`
+	KESVKey    []byte `json:"kes_vkey"`
+	OpCert     []byte `json:"opcert"`
+}
+
+// SignRequest is sent by the client in sign mode.
+type SignRequest struct {
+	Type    string `json:"type"` // "sign_request"
+	Period  uint64 `json:"period"`
+	Message []byte `json:"message"`
+}
+
+// SignResponse is the server's reply to a SignRequest.
+type SignResponse struct {
+	Type      string `json:"type"` // "sign_response"
+	Period    uint64 `json:"period"`
+	Signature []byte `json:"signature"`
+	Error     string `json:"error,omitempty"`
+}
+
+// Command is a control-socket request.
+type Command struct {
+	Command string `json:"command"`
+	OpCert  []byte `json:"opcert,omitempty"`
+	Target  string `json:"target,omitempty"` // drop-key: active|staged|all
+}
+
+// Reply is a control-socket response.
+type Reply struct {
+	Ok      bool       `json:"ok"`
+	Error   string     `json:"error,omitempty"`
+	KESVKey []byte     `json:"kes_vkey,omitempty"`
+	Info    *AgentInfo `json:"info,omitempty"`
+}
+
+// AgentInfo is the status snapshot returned by the info command.
+type AgentInfo struct {
+	Version          string `json:"version"`
+	Mode             string `json:"mode"`
+	HasActiveKey     bool   `json:"has_active_key"`
+	ActivePeriod     uint64 `json:"active_period"`     // current absolute KES period of the active key
+	ActiveStart      uint64 `json:"active_start"`      // absolute KES period the opcert was issued for
+	ActiveEnd        uint64 `json:"active_end"`        // last absolute KES period the key can serve
+	ActiveKESVKey    []byte `json:"active_kes_vkey"`   // 32-byte KES vkey (nil if none)
+	StagedKESVKey    []byte `json:"staged_kes_vkey"`   // 32-byte staged KES vkey (nil if none)
+	Exhausted        bool   `json:"exhausted"`         // active key has run out of evolutions
+	CurrentPeriod    uint64 `json:"current_period"`    // agent's computed current KES period
+	MonotonicFloor   uint64 `json:"monotonic_floor"`   // period guard floor
+	FloorInitialized bool   `json:"floor_initialized"` // whether the guard floor is set
+}
+
+// writeFrame writes a single length-prefixed JSON frame.
+func writeFrame(w io.Writer, v any) error {
+	payload, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("kesagent: marshal frame: %w", err)
+	}
+	if len(payload) > maxFrameLen {
+		return fmt.Errorf("kesagent: frame too large (%d bytes)", len(payload))
+	}
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(payload))) // #nosec G115 -- bounded by maxFrameLen
+	if _, err := w.Write(hdr[:]); err != nil {
+		return fmt.Errorf("kesagent: write frame header: %w", err)
+	}
+	if _, err := w.Write(payload); err != nil {
+		return fmt.Errorf("kesagent: write frame payload: %w", err)
+	}
+	return nil
+}
+
+// readFrame reads a single length-prefixed JSON frame into v.
+func readFrame(r io.Reader, v any) error {
+	var hdr [4]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return err // may be io.EOF; callers distinguish
+	}
+	n := binary.BigEndian.Uint32(hdr[:])
+	if n == 0 {
+		return errors.New("kesagent: zero-length frame")
+	}
+	if n > maxFrameLen {
+		return fmt.Errorf("kesagent: frame too large (%d bytes)", n)
+	}
+	payload := make([]byte, n)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return fmt.Errorf("kesagent: read frame payload: %w", err)
+	}
+	if err := json.Unmarshal(payload, v); err != nil {
+		return fmt.Errorf("kesagent: unmarshal frame: %w", err)
+	}
+	return nil
+}

--- a/internal/kesagent/protocol.go
+++ b/internal/kesagent/protocol.go
@@ -87,11 +87,13 @@
 package kesagent
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"time"
 )
 
 const (
@@ -100,6 +102,13 @@ const (
 
 	// maxFrameLen caps a single frame payload to guard against abuse.
 	maxFrameLen = 1 << 20 // 1 MiB
+
+	// frameBodyReadTimeout bounds how long a frame body may take to arrive
+	// once its length header has been read. It applies only to the body read
+	// (never the header read, where an idle connection legitimately blocks
+	// between requests), so a client that announces a frame then stalls the
+	// body cannot hold a connection slot and its goroutine indefinitely.
+	frameBodyReadTimeout = 10 * time.Second
 )
 
 // Socket modes for the service socket.
@@ -213,10 +222,25 @@ func readFrame(r io.Reader, v any) error {
 	if n > maxFrameLen {
 		return fmt.Errorf("kesagent: frame too large (%d bytes)", n)
 	}
-	payload := make([]byte, n)
-	if _, err := io.ReadFull(r, payload); err != nil {
+	// A frame body must arrive contiguously once its header has been read, so
+	// bound the body read with a deadline (cleared afterward). This only
+	// affects readers that expose SetReadDeadline (net.Conn); in-memory
+	// readers used in tests are unaffected. The header read above is
+	// deliberately left un-deadlined so idle/long-lived connections may block
+	// there between frames.
+	if d, ok := r.(interface{ SetReadDeadline(time.Time) error }); ok {
+		_ = d.SetReadDeadline(time.Now().Add(frameBodyReadTimeout))
+		defer func() { _ = d.SetReadDeadline(time.Time{}) }()
+	}
+	// Grow the payload buffer as bytes actually arrive rather than
+	// pre-allocating the full advertised length: a client that announces a
+	// large frame (up to maxFrameLen) but never sends the body then ties up
+	// only what it actually delivered, not the whole advertised buffer.
+	var buf bytes.Buffer
+	if _, err := io.CopyN(&buf, r, int64(n)); err != nil {
 		return fmt.Errorf("kesagent: read frame payload: %w", err)
 	}
+	payload := buf.Bytes()
 	if err := json.Unmarshal(payload, v); err != nil {
 		return fmt.Errorf("kesagent: unmarshal frame: %w", err)
 	}

--- a/internal/kesagent/protocol.go
+++ b/internal/kesagent/protocol.go
@@ -183,11 +183,19 @@ func writeFrame(w io.Writer, v any) error {
 	}
 	var hdr [4]byte
 	binary.BigEndian.PutUint32(hdr[:], uint32(len(payload))) // #nosec G115 -- bounded by maxFrameLen
-	if _, err := w.Write(hdr[:]); err != nil {
+	n, err := w.Write(hdr[:])
+	if err != nil {
 		return fmt.Errorf("kesagent: write frame header: %w", err)
 	}
-	if _, err := w.Write(payload); err != nil {
+	if n != len(hdr) {
+		return fmt.Errorf("kesagent: write frame header: %w", io.ErrShortWrite)
+	}
+	n, err = w.Write(payload)
+	if err != nil {
 		return fmt.Errorf("kesagent: write frame payload: %w", err)
+	}
+	if n != len(payload) {
+		return fmt.Errorf("kesagent: write frame payload: %w", io.ErrShortWrite)
 	}
 	return nil
 }

--- a/internal/kesagent/securemem/mlock_other.go
+++ b/internal/kesagent/securemem/mlock_other.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !(linux || darwin || freebsd || netbsd || openbsd || dragonfly)
+
+package securemem
+
+import "errors"
+
+// errNoMlock signals that memory locking is unavailable on this platform.
+var errNoMlock = errors.New("securemem: mlock not supported on this platform")
+
+func lockMemory(_ []byte) error   { return errNoMlock }
+func unlockMemory(_ []byte) error { return nil }

--- a/internal/kesagent/securemem/mlock_unix.go
+++ b/internal/kesagent/securemem/mlock_unix.go
@@ -1,0 +1,22 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux || darwin || freebsd || netbsd || openbsd || dragonfly
+
+package securemem
+
+import "syscall"
+
+func lockMemory(b []byte) error   { return syscall.Mlock(b) }
+func unlockMemory(b []byte) error { return syscall.Munlock(b) }

--- a/internal/kesagent/securemem/securemem.go
+++ b/internal/kesagent/securemem/securemem.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package securemem provides a pure-Go locked byte buffer for holding
+// sensitive key material off the garbage-collected heap where possible.
+//
+// The buffer is backed by a byte slice that is pinned into physical memory
+// with mlock(2) on supported Unix platforms so it is never written to swap.
+// On platforms without mlock (or when mlock is refused, e.g. a low
+// RLIMIT_MEMLOCK), New falls back to an ordinary buffer and records that the
+// memory could not be locked; callers can surface a warning. The KES agent is
+// Linux-only in practice, so the fallback exists only to keep builds and tests
+// green on other platforms.
+//
+// This package uses only the standard library (syscall) — no cgo/libsodium.
+package securemem
+
+import (
+	"errors"
+	"runtime"
+	"sync"
+)
+
+// ErrClosed is returned when operating on a buffer that has been closed.
+var ErrClosed = errors.New("securemem: buffer is closed")
+
+// Buffer is a fixed-size byte buffer whose backing memory is locked into RAM
+// (mlock) when the platform allows it. All methods are safe for concurrent
+// use. The zero value is not usable; construct one with New.
+type Buffer struct {
+	mu     sync.Mutex
+	data   []byte
+	locked bool // true if the backing memory is mlock'd
+	closed bool
+}
+
+// New allocates a locked buffer of the given size. It never fails on the
+// memory-locking step: if mlock is unsupported or refused, the returned buffer
+// is usable but not locked and Locked reports false. It returns an error only
+// for an invalid size.
+func New(size int) (*Buffer, error) {
+	if size <= 0 {
+		return nil, errors.New("securemem: size must be positive")
+	}
+	data := make([]byte, size)
+	locked := lockMemory(data) == nil
+	b := &Buffer{data: data, locked: locked}
+	return b, nil
+}
+
+// Locked reports whether the backing memory is pinned with mlock.
+func (b *Buffer) Locked() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.locked
+}
+
+// Len returns the buffer size, or 0 once closed.
+func (b *Buffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return 0
+	}
+	return len(b.data)
+}
+
+// Set copies src into the buffer. src must be exactly the buffer size.
+func (b *Buffer) Set(src []byte) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return ErrClosed
+	}
+	if len(src) != len(b.data) {
+		return errors.New("securemem: source length does not match buffer size")
+	}
+	copy(b.data, src)
+	return nil
+}
+
+// Bytes returns the underlying slice. The caller must not retain the slice
+// beyond the lifetime of the buffer and must not mutate it except through
+// Set/Zeroize. It is exposed so key material can be handed to signing routines
+// without an intermediate heap copy.
+func (b *Buffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return nil
+	}
+	return b.data
+}
+
+// Clone returns a heap copy of the buffer contents. Callers should Wipe the
+// returned slice when done. Used only where an API requires an owned slice.
+func (b *Buffer) Clone() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return nil
+	}
+	out := make([]byte, len(b.data))
+	copy(out, b.data)
+	return out
+}
+
+// Zeroize wipes the buffer contents to zero. The buffer remains usable.
+func (b *Buffer) Zeroize() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return
+	}
+	Wipe(b.data)
+}
+
+// Close wipes the buffer, unlocks the memory, and marks it unusable. It is
+// idempotent.
+func (b *Buffer) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return nil
+	}
+	Wipe(b.data)
+	var err error
+	if b.locked {
+		err = unlockMemory(b.data)
+		b.locked = false
+	}
+	b.data = nil
+	b.closed = true
+	return err
+}
+
+// Wipe overwrites b with zeros. It is written so the compiler cannot elide the
+// clear: the KeepAlive keeps the slice live across the loop.
+func Wipe(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+	runtime.KeepAlive(&b)
+}

--- a/internal/kesagent/securemem/securemem_test.go
+++ b/internal/kesagent/securemem/securemem_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package securemem_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/bursa/internal/kesagent/securemem"
+)
+
+func TestNewRejectsNonPositiveSize(t *testing.T) {
+	if _, err := securemem.New(0); err == nil {
+		t.Fatal("expected error for zero size")
+	}
+	if _, err := securemem.New(-1); err == nil {
+		t.Fatal("expected error for negative size")
+	}
+}
+
+func TestSetBytesRoundTrip(t *testing.T) {
+	b, err := securemem.New(4)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = b.Close() }()
+
+	// mlock may or may not succeed depending on RLIMIT_MEMLOCK; either way the
+	// buffer must be usable. Log the outcome for the record.
+	t.Logf("mlock locked=%v", b.Locked())
+
+	if err := b.Set([]byte{1, 2, 3, 4}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if !bytes.Equal(b.Bytes(), []byte{1, 2, 3, 4}) {
+		t.Fatalf("Bytes mismatch: %v", b.Bytes())
+	}
+	if b.Len() != 4 {
+		t.Fatalf("Len = %d, want 4", b.Len())
+	}
+}
+
+func TestSetWrongSize(t *testing.T) {
+	b, err := securemem.New(4)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = b.Close() }()
+	if err := b.Set([]byte{1, 2, 3}); err == nil {
+		t.Fatal("expected error for mismatched length")
+	}
+}
+
+func TestZeroizeWipes(t *testing.T) {
+	b, err := securemem.New(8)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = b.Close() }()
+	if err := b.Set([]byte{9, 9, 9, 9, 9, 9, 9, 9}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	b.Zeroize()
+	for i, v := range b.Bytes() {
+		if v != 0 {
+			t.Fatalf("byte %d not wiped: %d", i, v)
+		}
+	}
+	// Still usable after Zeroize.
+	if err := b.Set([]byte{1, 1, 1, 1, 1, 1, 1, 1}); err != nil {
+		t.Fatalf("Set after Zeroize: %v", err)
+	}
+}
+
+func TestCloneIsIndependent(t *testing.T) {
+	b, err := securemem.New(4)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = b.Close() }()
+	_ = b.Set([]byte{1, 2, 3, 4})
+	c := b.Clone()
+	b.Zeroize()
+	if !bytes.Equal(c, []byte{1, 2, 3, 4}) {
+		t.Fatalf("clone was affected by Zeroize: %v", c)
+	}
+}
+
+func TestCloseIsIdempotentAndUnusable(t *testing.T) {
+	b, err := securemem.New(4)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_ = b.Set([]byte{1, 2, 3, 4})
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if b.Bytes() != nil {
+		t.Fatal("Bytes should be nil after Close")
+	}
+	if err := b.Set([]byte{1, 2, 3, 4}); err == nil {
+		t.Fatal("Set after Close should fail")
+	}
+	if b.Len() != 0 {
+		t.Fatalf("Len after Close = %d, want 0", b.Len())
+	}
+}
+
+func TestWipe(t *testing.T) {
+	b := []byte{1, 2, 3, 4, 5}
+	securemem.Wipe(b)
+	for i, v := range b {
+		if v != 0 {
+			t.Fatalf("byte %d not wiped: %d", i, v)
+		}
+	}
+}

--- a/internal/kesagent/service.go
+++ b/internal/kesagent/service.go
@@ -82,7 +82,12 @@ func (a *Agent) ServeService(ctx context.Context, ln net.Listener) error {
 				return fmt.Errorf("kesagent: service accept: %w", err)
 			}
 		}
-		conns.add(conn)
+		if !conns.add(conn) {
+			// Shutting down, or the concurrent-connection ceiling was hit:
+			// close and drop this connection rather than serving it.
+			_ = conn.Close()
+			continue
+		}
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/internal/kesagent/service.go
+++ b/internal/kesagent/service.go
@@ -21,7 +21,10 @@ import (
 	"io"
 	"net"
 	"os"
+	"path/filepath"
 	"sync"
+
+	"github.com/blinklabs-io/bursa/internal/kesagent/securemem"
 )
 
 // ListenUnix creates a Unix-domain listener at path with the given file mode,
@@ -39,13 +42,33 @@ func ListenUnix(path string, mode os.FileMode) (net.Listener, error) {
 			return nil, fmt.Errorf("kesagent: remove stale socket %q: %w", path, err)
 		}
 	}
-	ln, err := net.Listen("unix", path)
+	// net.Listen creates the socket under the process umask, so its requested
+	// mode only lands one Chmod later — a window in which the socket can be
+	// world-writable (under umask 0/0002) and a connection made during it
+	// survives the tightening (Unix checks permission at connect time). Behind
+	// this socket is the KES block-production signing key, so close the window
+	// rather than trusting the deployment umask: bind inside a fresh 0700
+	// staging directory (which no other user can traverse), chmod the socket to
+	// its final mode there, and only expose it at its advertised path via an
+	// atomic rename. This avoids the process-global, listen-racy syscall.Umask
+	// approach and stays pure-Go / cross-platform.
+	stagingDir, err := os.MkdirTemp(filepath.Dir(path), ".kes-sock-")
+	if err != nil {
+		return nil, fmt.Errorf("kesagent: create socket staging dir for %q: %w", path, err)
+	}
+	defer func() { _ = os.RemoveAll(stagingDir) }()
+	stagingPath := filepath.Join(stagingDir, "s")
+	ln, err := net.Listen("unix", stagingPath)
 	if err != nil {
 		return nil, fmt.Errorf("kesagent: listen %q: %w", path, err)
 	}
-	if err := os.Chmod(path, mode); err != nil {
+	if err := os.Chmod(stagingPath, mode); err != nil {
 		_ = ln.Close()
 		return nil, fmt.Errorf("kesagent: chmod socket %q: %w", path, err)
+	}
+	if err := os.Rename(stagingPath, path); err != nil {
+		_ = ln.Close()
+		return nil, fmt.Errorf("kesagent: publish socket %q: %w", path, err)
 	}
 	return ln, nil
 }
@@ -54,8 +77,15 @@ func ListenUnix(path string, mode os.FileMode) (net.Listener, error) {
 // agent's configured mode. It returns when ctx is cancelled or ln is closed.
 func (a *Agent) ServeService(ctx context.Context, ln net.Listener) error {
 	conns := newConnSet()
+	// srvCtx is cancelled on every return path (not just external ctx
+	// cancellation), so the watchdog goroutine below always exits — otherwise it
+	// stays parked in the receive forever when ServeService returns via a closed
+	// listener or an Accept error, and permanently so under context.Background()
+	// (whose Done() is a nil channel).
+	srvCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	go func() {
-		<-ctx.Done()
+		<-srvCtx.Done()
 		_ = ln.Close()
 		// Unblock any handler already parked in a read on a connection
 		// accepted before shutdown (in particular handleSign, which has no
@@ -128,7 +158,12 @@ func (a *Agent) handleServeKey(ctx context.Context, conn net.Conn) {
 	}()
 
 	if current != nil {
-		if err := writeFrame(conn, *current); err != nil {
+		err := writeFrame(conn, *current)
+		// Wipe the plaintext signing-key copy as soon as it has been written
+		// (or failed to): it is a swappable-heap clone the securemem locking
+		// and forward-erasure elsewhere exist to avoid leaving behind.
+		securemem.Wipe(current.KESSignKey)
+		if err != nil {
 			a.logger.Debug("service key push write failed", "error", err)
 			return
 		}
@@ -140,7 +175,9 @@ func (a *Agent) handleServeKey(ctx context.Context, conn net.Conn) {
 		case <-connClosed:
 			return
 		case kp := <-ch:
-			if err := writeFrame(conn, kp); err != nil {
+			err := writeFrame(conn, kp)
+			securemem.Wipe(kp.KESSignKey) // erase this subscriber's copy
+			if err != nil {
 				a.logger.Debug("service key push write failed", "error", err)
 				return
 			}

--- a/internal/kesagent/service.go
+++ b/internal/kesagent/service.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kesagent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sync"
+)
+
+// ListenUnix creates a Unix-domain listener at path with the given file mode,
+// removing any stale socket first.
+func ListenUnix(path string, mode os.FileMode) (net.Listener, error) {
+	if path == "" {
+		return nil, errors.New("kesagent: socket path is empty")
+	}
+	// Remove a stale socket if present (only if it is a socket).
+	if fi, err := os.Stat(path); err == nil {
+		if fi.Mode()&os.ModeSocket == 0 {
+			return nil, fmt.Errorf("kesagent: refusing to remove non-socket %q", path)
+		}
+		if err := os.Remove(path); err != nil {
+			return nil, fmt.Errorf("kesagent: remove stale socket %q: %w", path, err)
+		}
+	}
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, fmt.Errorf("kesagent: listen %q: %w", path, err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		_ = ln.Close()
+		return nil, fmt.Errorf("kesagent: chmod socket %q: %w", path, err)
+	}
+	return ln, nil
+}
+
+// ServeService accepts connections on ln and serves them according to the
+// agent's configured mode. It returns when ctx is cancelled or ln is closed.
+func (a *Agent) ServeService(ctx context.Context, ln net.Listener) error {
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+	var wg sync.WaitGroup
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				wg.Wait()
+				return nil
+			default:
+				return fmt.Errorf("kesagent: service accept: %w", err)
+			}
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			a.handleServiceConn(ctx, conn)
+		}()
+	}
+}
+
+func (a *Agent) handleServiceConn(ctx context.Context, conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+	// Send the handshake Hello frame.
+	if err := writeFrame(conn, Hello{Protocol: ProtocolID, Mode: a.cfg.Mode}); err != nil {
+		a.logger.Debug("service hello write failed", "error", err)
+		return
+	}
+	switch a.cfg.Mode {
+	case ModeServeKey:
+		a.handleServeKey(ctx, conn)
+	case ModeSign:
+		a.handleSign(ctx, conn)
+	}
+}
+
+func (a *Agent) handleServeKey(ctx context.Context, conn net.Conn) {
+	id, ch, current := a.subscribe()
+	defer a.unsubscribe(id)
+	a.metrics.addConns(1)
+	defer a.metrics.addConns(-1)
+
+	// Detect client disconnect: reads on a serve-key client should only ever
+	// return EOF/error, which we use to cancel this connection.
+	connClosed := make(chan struct{})
+	go func() {
+		defer close(connClosed)
+		buf := make([]byte, 1)
+		_, _ = conn.Read(buf)
+	}()
+
+	if current != nil {
+		if err := writeFrame(conn, *current); err != nil {
+			a.logger.Debug("service key push write failed", "error", err)
+			return
+		}
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-connClosed:
+			return
+		case kp := <-ch:
+			if err := writeFrame(conn, kp); err != nil {
+				a.logger.Debug("service key push write failed", "error", err)
+				return
+			}
+		}
+	}
+}
+
+func (a *Agent) handleSign(ctx context.Context, conn net.Conn) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		var req SignRequest
+		if err := readFrame(conn, &req); err != nil {
+			if !errors.Is(err, io.EOF) {
+				a.logger.Debug("service sign read failed", "error", err)
+			}
+			return
+		}
+		resp := SignResponse{Type: "sign_response", Period: req.Period}
+		sig, err := a.Sign(req.Period, req.Message)
+		if err != nil {
+			resp.Error = err.Error()
+		} else {
+			resp.Signature = sig
+		}
+		if err := writeFrame(conn, resp); err != nil {
+			a.logger.Debug("service sign response write failed", "error", err)
+			return
+		}
+	}
+}

--- a/internal/kesagent/service.go
+++ b/internal/kesagent/service.go
@@ -51,7 +51,49 @@ func ListenUnix(path string, mode os.FileMode) (net.Listener, error) {
 	// staging directory (which no other user can traverse), chmod the socket to
 	// its final mode there, and only expose it at its advertised path via an
 	// atomic rename. This avoids the process-global, listen-racy syscall.Umask
-	// approach and stays pure-Go / cross-platform.
+	// approach and stays pure-Go / cross-platform. A path too long to stage
+	// falls back to a umask-bracketed direct bind (see below).
+	ln, err := listenStaged(path, mode)
+	if err == nil {
+		return ln, nil
+	}
+	// The staging path is longer than the advertised one (an extra directory
+	// component), so a path close to the platform's sockaddr_un limit can bind
+	// directly while the staged one cannot. Rather than refusing a configuration
+	// that worked before, fall back to binding at the final path with the umask
+	// tightened for the duration, which closes the same window without needing
+	// the extra component. The umask is process-global and therefore racy against
+	// concurrent listens, which is why it is the fallback and not the default.
+	var fallbackLn net.Listener
+	umaskErr := withTightUmask(func() error {
+		l, lerr := net.Listen("unix", path)
+		fallbackLn = l
+		return lerr
+	})
+	if umaskErr != nil {
+		// Report the staged failure too: if the direct bind failed for an
+		// unrelated reason, the staged error is the more informative one.
+		return nil, fmt.Errorf(
+			"kesagent: listen %q: %w (staged listen also failed: %w)",
+			path, umaskErr, err,
+		)
+	}
+	if fallbackLn == nil {
+		return nil, fmt.Errorf("kesagent: listen %q: no listener produced", path)
+	}
+	// The umask only bounds the birth mode; apply the requested mode explicitly
+	// (it may be more restrictive, and non-unix builds have no umask at all).
+	if err := os.Chmod(path, mode); err != nil {
+		_ = fallbackLn.Close()
+		return nil, fmt.Errorf("kesagent: chmod socket %q: %w", path, err)
+	}
+	return fallbackLn, nil
+}
+
+// listenStaged binds the socket inside a fresh 0700 directory, applies the final
+// mode there, and publishes it at path with an atomic rename, so the socket is
+// never reachable by another user at a looser mode.
+func listenStaged(path string, mode os.FileMode) (net.Listener, error) {
 	stagingDir, err := os.MkdirTemp(filepath.Dir(path), ".kes-sock-")
 	if err != nil {
 		return nil, fmt.Errorf("kesagent: create socket staging dir for %q: %w", path, err)
@@ -60,7 +102,7 @@ func ListenUnix(path string, mode os.FileMode) (net.Listener, error) {
 	stagingPath := filepath.Join(stagingDir, "s")
 	ln, err := net.Listen("unix", stagingPath)
 	if err != nil {
-		return nil, fmt.Errorf("kesagent: listen %q: %w", path, err)
+		return nil, fmt.Errorf("kesagent: listen %q: %w", stagingPath, err)
 	}
 	if err := os.Chmod(stagingPath, mode); err != nil {
 		_ = ln.Close()

--- a/internal/kesagent/service.go
+++ b/internal/kesagent/service.go
@@ -64,7 +64,14 @@ func (a *Agent) ServeService(ctx context.Context, ln net.Listener) error {
 		conns.closeAll()
 	}()
 	var wg sync.WaitGroup
-	defer wg.Wait()
+	// Close every tracked connection before waiting on every return path, not
+	// just the ctx-cancellation goroutine above: a listener closed externally
+	// (or any non-context Accept error) must also unblock handlers already
+	// parked in a blocking read, or wg.Wait() below hangs forever.
+	defer func() {
+		conns.closeAll()
+		wg.Wait()
+	}()
 	for {
 		conn, err := ln.Accept()
 		if err != nil {

--- a/internal/kesagent/service.go
+++ b/internal/kesagent/service.go
@@ -53,25 +53,33 @@ func ListenUnix(path string, mode os.FileMode) (net.Listener, error) {
 // ServeService accepts connections on ln and serves them according to the
 // agent's configured mode. It returns when ctx is cancelled or ln is closed.
 func (a *Agent) ServeService(ctx context.Context, ln net.Listener) error {
+	conns := newConnSet()
 	go func() {
 		<-ctx.Done()
 		_ = ln.Close()
+		// Unblock any handler already parked in a read on a connection
+		// accepted before shutdown (in particular handleSign, which has no
+		// other way to observe ctx cancellation while blocked in readFrame),
+		// so wg.Wait() below can complete.
+		conns.closeAll()
 	}()
 	var wg sync.WaitGroup
+	defer wg.Wait()
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
 			select {
 			case <-ctx.Done():
-				wg.Wait()
 				return nil
 			default:
 				return fmt.Errorf("kesagent: service accept: %w", err)
 			}
 		}
+		conns.add(conn)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			defer conns.remove(conn)
 			a.handleServiceConn(ctx, conn)
 		}()
 	}

--- a/internal/kesagent/service_test.go
+++ b/internal/kesagent/service_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kesagent
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/kes"
+)
+
+// shortSocketPath returns a short socket path (Unix socket paths are limited to
+// ~104 bytes, and t.TempDir() names can be long).
+func shortSocketPath(t *testing.T, name string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "kes")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, name)
+}
+
+// statMode returns the file mode bits of path.
+func statMode(path string) (os.FileMode, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	return fi.Mode(), nil
+}
+
+func dial(t *testing.T, path string) net.Conn {
+	t.Helper()
+	var conn net.Conn
+	var err error
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err = net.Dial("unix", path)
+		if err == nil {
+			t.Cleanup(func() { _ = conn.Close() })
+			return conn
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("dial %q: %v", path, err)
+	return nil
+}
+
+func TestServiceServeKeyMode(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeServeKey, cold, kes.CardanoKesDepth, atPeriod(5))
+	vkey, _ := a.GenStagedKey()
+	if _, err := a.InstallKey(makeOpCert(t, vkey, 1, 3, cold)); err != nil {
+		t.Fatalf("InstallKey: %v", err)
+	}
+
+	sock := shortSocketPath(t, "svc.sock")
+	ln, err := ListenUnix(sock, 0o600)
+	if err != nil {
+		t.Fatalf("ListenUnix: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = a.ServeService(ctx, ln) }()
+
+	// Verify the socket file permission is 0600.
+	if fi, err := statMode(sock); err != nil {
+		t.Fatalf("stat socket: %v", err)
+	} else if fi&0o777 != 0o600 {
+		t.Fatalf("socket mode = %o, want 600", fi&0o777)
+	}
+
+	conn := dial(t, sock)
+
+	var hello Hello
+	if err := readFrame(conn, &hello); err != nil {
+		t.Fatalf("read hello: %v", err)
+	}
+	if hello.Protocol != ProtocolID || hello.Mode != ModeServeKey {
+		t.Fatalf("bad hello: %+v", hello)
+	}
+
+	var kp KeyPush
+	if err := readFrame(conn, &kp); err != nil {
+		t.Fatalf("read initial key push: %v", err)
+	}
+	if kp.Period != 5 {
+		t.Fatalf("initial push period = %d, want 5", kp.Period)
+	}
+	if !bytes.Equal(kp.KESVKey, vkey) {
+		t.Fatal("pushed kes vkey mismatch")
+	}
+	if len(kp.KESSignKey) == 0 || len(kp.OpCert) == 0 {
+		t.Fatal("push missing key or opcert bytes")
+	}
+
+	// Evolve the key and expect a re-push at the higher period.
+	a.now = func() time.Time { return atPeriod(6) }
+	a.Tick()
+
+	var kp2 KeyPush
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if err := readFrame(conn, &kp2); err != nil {
+		t.Fatalf("read re-push: %v", err)
+	}
+	if kp2.Period != 6 {
+		t.Fatalf("re-push period = %d, want 6", kp2.Period)
+	}
+}
+
+func TestServiceSignMode(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(5))
+	vkey, _ := a.GenStagedKey()
+	if _, err := a.InstallKey(makeOpCert(t, vkey, 1, 3, cold)); err != nil {
+		t.Fatalf("InstallKey: %v", err)
+	}
+
+	sock := shortSocketPath(t, "sign.sock")
+	ln, err := ListenUnix(sock, 0o600)
+	if err != nil {
+		t.Fatalf("ListenUnix: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = a.ServeService(ctx, ln) }()
+
+	conn := dial(t, sock)
+	var hello Hello
+	if err := readFrame(conn, &hello); err != nil {
+		t.Fatalf("read hello: %v", err)
+	}
+	if hello.Mode != ModeSign {
+		t.Fatalf("bad hello mode: %s", hello.Mode)
+	}
+
+	msg := []byte("header")
+	if err := writeFrame(conn, SignRequest{Type: "sign_request", Period: 5, Message: msg}); err != nil {
+		t.Fatalf("write sign request: %v", err)
+	}
+	var resp SignResponse
+	if err := readFrame(conn, &resp); err != nil {
+		t.Fatalf("read sign response: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("unexpected sign error: %s", resp.Error)
+	}
+	if !kes.VerifySignedKES(vkey, 5-3, msg, resp.Signature) {
+		t.Fatal("signature from sign-mode socket failed to verify")
+	}
+
+	// A past period must be rejected with an error in the response.
+	if err := writeFrame(conn, SignRequest{Type: "sign_request", Period: 4, Message: msg}); err != nil {
+		t.Fatalf("write past-period request: %v", err)
+	}
+	var resp2 SignResponse
+	if err := readFrame(conn, &resp2); err != nil {
+		t.Fatalf("read past-period response: %v", err)
+	}
+	if resp2.Error == "" {
+		t.Fatal("expected error for past-period sign request")
+	}
+}

--- a/internal/kesagent/service_test.go
+++ b/internal/kesagent/service_test.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -126,6 +127,127 @@ func TestServiceServeKeyMode(t *testing.T) {
 	}
 	if kp2.Period != 6 {
 		t.Fatalf("re-push period = %d, want 6", kp2.Period)
+	}
+}
+
+// TestServeServiceWatchdogDoesNotLeak verifies the ctx-watchdog goroutine exits
+// on the listener-close return path (not only on ctx cancellation): running many
+// ServeService calls under context.Background() that each return via ln.Close()
+// must not accumulate parked goroutines.
+func TestServeServiceWatchdogDoesNotLeak(t *testing.T) {
+	cold := newColdKey(t)
+	// Let the runtime settle, then take a baseline.
+	time.Sleep(50 * time.Millisecond)
+	base := runtime.NumGoroutine()
+
+	const rounds = 20
+	for i := 0; i < rounds; i++ {
+		a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(1))
+		sock := shortSocketPath(t, "leak.sock")
+		ln, err := ListenUnix(sock, 0o600)
+		if err != nil {
+			t.Fatalf("ListenUnix: %v", err)
+		}
+		done := make(chan error, 1)
+		// context.Background(): its Done() is a nil channel, so the pre-fix
+		// watchdog would park forever here.
+		go func() { done <- a.ServeService(context.Background(), ln) }()
+		if err := ln.Close(); err != nil {
+			t.Fatalf("close listener: %v", err)
+		}
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("ServeService did not return after listener close")
+		}
+	}
+
+	// Poll: leaked watchdogs would keep the count ~rounds above baseline.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got := runtime.NumGoroutine()
+		if got <= base+3 {
+			return // settled back to baseline
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("goroutines did not settle: baseline %d, now %d (leaked ~%d)", base, got, got-base)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestServeKeyMultipleSubscribersReceiveIntactKey guards the per-subscriber key
+// cloning in broadcastLocked: each serve-key subscriber must receive its own
+// intact (non-zeroed) copy of the signing key, so one handler wiping its copy
+// after writing cannot corrupt another subscriber's.
+func TestServeKeyMultipleSubscribersReceiveIntactKey(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeServeKey, cold, kes.CardanoKesDepth, atPeriod(5))
+	vkey, _ := a.GenStagedKey()
+	if _, err := a.InstallKey(makeOpCert(t, vkey, 1, 3, cold)); err != nil {
+		t.Fatalf("InstallKey: %v", err)
+	}
+	sock := shortSocketPath(t, "svc-multi.sock")
+	ln, err := ListenUnix(sock, 0o600)
+	if err != nil {
+		t.Fatalf("ListenUnix: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = a.ServeService(ctx, ln) }()
+
+	readPush := func(c net.Conn) KeyPush {
+		t.Helper()
+		_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+		var hello Hello
+		if err := readFrame(c, &hello); err != nil {
+			t.Fatalf("read hello: %v", err)
+		}
+		var kp KeyPush
+		if err := readFrame(c, &kp); err != nil {
+			t.Fatalf("read key push: %v", err)
+		}
+		return kp
+	}
+	nonZero := func(b []byte) bool {
+		for _, x := range b {
+			if x != 0 {
+				return true
+			}
+		}
+		return false
+	}
+
+	c1 := dial(t, sock)
+	c2 := dial(t, sock)
+	kp1 := readPush(c1)
+	kp2 := readPush(c2)
+	if !nonZero(kp1.KESSignKey) || !nonZero(kp2.KESSignKey) {
+		t.Fatal("a subscriber received a zeroed signing key")
+	}
+	if !bytes.Equal(kp1.KESSignKey, kp2.KESSignKey) {
+		t.Fatal("subscribers received divergent signing keys")
+	}
+
+	// A broadcast (via evolution) must also deliver intact, equal copies.
+	a.now = func() time.Time { return atPeriod(6) }
+	a.Tick()
+	readRepush := func(c net.Conn) KeyPush {
+		t.Helper()
+		_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+		var kp KeyPush
+		if err := readFrame(c, &kp); err != nil {
+			t.Fatalf("read re-push: %v", err)
+		}
+		return kp
+	}
+	rp1 := readRepush(c1)
+	rp2 := readRepush(c2)
+	if rp1.Period != 6 || rp2.Period != 6 {
+		t.Fatalf("re-push periods = %d,%d want 6,6", rp1.Period, rp2.Period)
+	}
+	if !nonZero(rp1.KESSignKey) || !bytes.Equal(rp1.KESSignKey, rp2.KESSignKey) {
+		t.Fatal("broadcast delivered a zeroed or divergent signing key across subscribers")
 	}
 }
 

--- a/internal/kesagent/service_test.go
+++ b/internal/kesagent/service_test.go
@@ -89,6 +89,9 @@ func TestServiceServeKeyMode(t *testing.T) {
 	}
 
 	conn := dial(t, sock)
+	// Bound every read below so a handler that fails to send a frame fails the
+	// test fast instead of blocking until the go-test timeout.
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
 
 	var hello Hello
 	if err := readFrame(conn, &hello); err != nil {
@@ -144,6 +147,9 @@ func TestServiceSignMode(t *testing.T) {
 	go func() { _ = a.ServeService(ctx, ln) }()
 
 	conn := dial(t, sock)
+	// Bound every read below so a handler that fails to send a frame fails the
+	// test fast instead of blocking until the go-test timeout.
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
 	var hello Hello
 	if err := readFrame(conn, &hello); err != nil {
 		t.Fatalf("read hello: %v", err)

--- a/internal/kesagent/service_test.go
+++ b/internal/kesagent/service_test.go
@@ -179,3 +179,79 @@ func TestServiceSignMode(t *testing.T) {
 		t.Fatal("expected error for past-period sign request")
 	}
 }
+
+// TestServeServiceShutdownWithIdleConnection guards against a shutdown hang
+// symmetric to TestServeControlShutdownWithIdleConnection: handleSign has no
+// way to observe ctx cancellation while blocked in readFrame on an idle
+// client, so ServeService must force-close tracked connections on shutdown
+// rather than relying on the client to disconnect.
+func TestServeServiceShutdownWithIdleConnection(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(1))
+	sock := shortSocketPath(t, "sign-shutdown.sock")
+	ln, err := ListenUnix(sock, 0o600)
+	if err != nil {
+		t.Fatalf("ListenUnix: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() { done <- a.ServeService(ctx, ln) }()
+
+	conn := dial(t, sock) // stays open and idle; never sends a sign request
+	var hello Hello
+	if err := readFrame(conn, &hello); err != nil {
+		t.Fatalf("read service hello: %v", err)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ServeService returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ServeService did not return within 2s of an idle connection outliving shutdown")
+	}
+}
+
+// TestServeServiceListenerCloseUnblocksIdleHandler guards against the other
+// half of the same hang: a listener closed directly (without ctx being
+// cancelled) takes the non-context Accept-error return path, which must
+// still close tracked connections before the deferred wg.Wait(), or an idle
+// client's handler blocked in readFrame would keep ServeService from
+// returning forever.
+func TestServeServiceListenerCloseUnblocksIdleHandler(t *testing.T) {
+	cold := newColdKey(t)
+	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(1))
+	sock := shortSocketPath(t, "sign-lnclose.sock")
+	ln, err := ListenUnix(sock, 0o600)
+	if err != nil {
+		t.Fatalf("ListenUnix: %v", err)
+	}
+	// Note: ctx is intentionally never cancelled; only the listener is
+	// closed, so the ctx-cancellation goroutine's conns.closeAll() never
+	// runs and the fix under test is the accept-error return path's own
+	// cleanup.
+	ctx := context.Background()
+
+	done := make(chan error, 1)
+	go func() { done <- a.ServeService(ctx, ln) }()
+
+	conn := dial(t, sock) // stays open and idle; never sends a sign request
+	var hello Hello
+	if err := readFrame(conn, &hello); err != nil {
+		t.Fatalf("read service hello: %v", err)
+	}
+
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+	select {
+	case <-done:
+		// Any return (with or without an Accept error) is fine; what matters
+		// is that it doesn't hang on the idle handler.
+	case <-time.After(2 * time.Second):
+		t.Fatal("ServeService did not return within 2s of a direct listener close with an idle connection")
+	}
+}

--- a/internal/kesagent/service_umask_unix_test.go
+++ b/internal/kesagent/service_umask_unix_test.go
@@ -63,10 +63,13 @@ func TestListenUnixMode0600UnderPermissiveUmask(t *testing.T) {
 // staging was introduced, so it must keep working — via the umask-bracketed
 // fallback — rather than failing with "invalid argument".
 func TestListenUnixNearPathnameLimit(t *testing.T) {
-	// sockaddr_un.sun_path holds 108 bytes including the NUL terminator.
-	const maxSunPath = 107
+	// sun_path is 108 bytes on Linux but 104 on macOS and the BSDs, so take it
+	// from the platform's own sockaddr rather than assuming Linux's size: a
+	// hardcoded 107 would build paths this platform cannot bind at all, testing
+	// a bind failure instead of the fallback.
+	maxSunPath := len(syscall.RawSockaddrUnix{}.Path) - 1
 	// The staged path adds "/.kes-sock-<10 random>/s" to the parent directory.
-	const stagingOverhead = len("/.kes-sock-0123456789/s")
+	stagingOverhead := len("/.kes-sock-0123456789/s")
 
 	base := "s.sock"
 	dir := t.TempDir()

--- a/internal/kesagent/service_umask_unix_test.go
+++ b/internal/kesagent/service_umask_unix_test.go
@@ -56,3 +56,63 @@ func TestListenUnixMode0600UnderPermissiveUmask(t *testing.T) {
 	}
 	_ = conn.Close()
 }
+
+// TestListenUnixNearPathnameLimit covers a socket path that fits within the
+// platform's sockaddr_un limit but leaves no room for the staging directory
+// component ListenUnix normally binds inside. Such a path bound fine before
+// staging was introduced, so it must keep working — via the umask-bracketed
+// fallback — rather than failing with "invalid argument".
+func TestListenUnixNearPathnameLimit(t *testing.T) {
+	// sockaddr_un.sun_path holds 108 bytes including the NUL terminator.
+	const maxSunPath = 107
+	// The staged path adds "/.kes-sock-<10 random>/s" to the parent directory.
+	const stagingOverhead = len("/.kes-sock-0123456789/s")
+
+	base := "s.sock"
+	dir := t.TempDir()
+	// Pad the directory so the final path still fits but the staged one cannot.
+	target := maxSunPath - len(base) - 1
+	if len(dir) > target {
+		t.Skipf("temp dir %q (%d bytes) is already too long for this case", dir, len(dir))
+	}
+	for len(dir)+stagingOverhead <= maxSunPath {
+		next := dir + "/p"
+		if len(next)+1+len(base) > maxSunPath {
+			break
+		}
+		if err := os.Mkdir(next, 0o700); err != nil {
+			t.Fatalf("mkdir %q: %v", next, err)
+		}
+		dir = next
+	}
+	sock := dir + "/" + base
+	if len(sock) > maxSunPath {
+		t.Fatalf("constructed path %d bytes, want <= %d", len(sock), maxSunPath)
+	}
+	if len(dir)+stagingOverhead <= maxSunPath {
+		t.Skipf("could not build a directory long enough to overflow staging (dir %d bytes)", len(dir))
+	}
+
+	// Permissive umask: the fallback must still publish a 0600 socket.
+	old := syscall.Umask(0)
+	defer syscall.Umask(old)
+
+	ln, err := ListenUnix(sock, 0o600)
+	if err != nil {
+		t.Fatalf("ListenUnix(%d-byte path): %v", len(sock), err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	fi, err := os.Stat(sock)
+	if err != nil {
+		t.Fatalf("stat socket: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("socket mode = %04o, want 0600 even on the fallback path", perm)
+	}
+	conn, err := net.DialTimeout("unix", sock, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial published socket: %v", err)
+	}
+	_ = conn.Close()
+}

--- a/internal/kesagent/service_umask_unix_test.go
+++ b/internal/kesagent/service_umask_unix_test.go
@@ -1,0 +1,58 @@
+//go:build unix
+
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kesagent
+
+import (
+	"net"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestListenUnixMode0600UnderPermissiveUmask verifies ListenUnix publishes the
+// socket at its final restrictive mode even under a permissive umask (0), where
+// a plain net.Listen would create it world-writable and only tighten it one
+// syscall later — a window in which a connection could be made that survives the
+// chmod. The socket at its advertised path must be connectable and never
+// group/other accessible.
+func TestListenUnixMode0600UnderPermissiveUmask(t *testing.T) {
+	old := syscall.Umask(0)
+	defer syscall.Umask(old)
+
+	sock := shortSocketPath(t, "umask.sock")
+	ln, err := ListenUnix(sock, 0o600)
+	if err != nil {
+		t.Fatalf("ListenUnix: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	fi, err := os.Stat(sock)
+	if err != nil {
+		t.Fatalf("stat socket: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("socket mode = %04o under umask 0, want 0600 (no group/other access)", perm)
+	}
+	// The published path must be a working listener (kernel accepts into the
+	// backlog without an Accept call).
+	conn, err := net.DialTimeout("unix", sock, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial published socket: %v", err)
+	}
+	_ = conn.Close()
+}

--- a/internal/kesagent/umask_other.go
+++ b/internal/kesagent/umask_other.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !unix
+
+package kesagent
+
+// withTightUmask has no effect on platforms without a process umask; the
+// caller still applies the requested mode explicitly.
+func withTightUmask(fn func() error) error {
+	return fn()
+}

--- a/internal/kesagent/umask_unix.go
+++ b/internal/kesagent/umask_unix.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unix
+
+package kesagent
+
+import "syscall"
+
+// withTightUmask runs fn with the process umask set to 0177, so any file it
+// creates is born with at most owner read/write and never passes through a
+// world-accessible state.
+//
+// The umask is process-global, so this is only sound for callers that are not
+// creating other files concurrently. It is used solely as the fallback path in
+// ListenUnix, where the preferred staging-directory approach does not fit
+// within the platform's socket pathname limit.
+func withTightUmask(fn func() error) error {
+	old := syscall.Umask(0o177)
+	defer syscall.Umask(old)
+	return fn()
+}

--- a/internal/kesagent/umask_unix.go
+++ b/internal/kesagent/umask_unix.go
@@ -16,17 +16,27 @@
 
 package kesagent
 
-import "syscall"
+import (
+	"sync"
+	"syscall"
+)
 
 // withTightUmask runs fn with the process umask set to 0177, so any file it
 // creates is born with at most owner read/write and never passes through a
 // world-accessible state.
 //
-// The umask is process-global, so this is only sound for callers that are not
-// creating other files concurrently. It is used solely as the fallback path in
-// ListenUnix, where the preferred staging-directory approach does not fit
+// umaskMu serializes the critical section: two concurrent callers would
+// otherwise let one restore the original umask while the other has not yet
+// created its file, so that file would be born with the permissive mode.
+var umaskMu sync.Mutex
+
+// The umask is process-global, so this still cannot protect files created by
+// unrelated goroutines while it is held. It is used solely as the fallback path
+// in ListenUnix, where the preferred staging-directory approach does not fit
 // within the platform's socket pathname limit.
 func withTightUmask(fn func() error) error {
+	umaskMu.Lock()
+	defer umaskMu.Unlock()
 	old := syscall.Umask(0o177)
 	defer syscall.Umask(old)
 	return fn()


### PR DESCRIPTION
Adds a KES agent daemon (`bursa kes-agent`) that holds a block-production KES signing key, evolves it forward-securely each KES period, and serves it to a Go block producer (dingo) over Unix sockets. Root module stays pure-Go (`CGO_ENABLED=0`); secure memory uses `syscall.Mlock`, not cgo/libsodium.

## Daemon

`internal/kesagent/` plus a `bursa kes-agent` cobra subcommand and a `kes_agent` config block (`internal/config`). YAML config, Prometheus metrics, structured logging, graceful shutdown, fail-fast boot validation, socket perms 0600 (configurable).

## Two service modes (`kes_agent.mode`)

- `serve-key`: pushes `{kes_sign_key, period, kes_vkey, opcert}` to the connected producer on connect and on every evolve/new-key.
- `sign`: accepts `{period, message}` and returns the KES signature at that period; the key never leaves the agent.

## Wire protocol

Length-prefixed frames (4-byte big-endian length + JSON payload, 1 MiB cap) on both sockets, with a version handshake (`bursa-kes-agent/1`). Full format documented in the `kesagent` package doc comment.

## Control socket

`gen-staged-key` (generate a fresh KES key into a staging slot, return its verification key only), `install-key` (accept opcert bytes; verify the cold signature under the configured cold verification key, that it commits to the staged KES vkey, and KES-period sanity; then promote staged->active and start serving), `drop-key`, `info` (version, active key period/start/end, staged vkey, exhaustion, guard floor). The agent holds only the cold vkey; opcert issuance stays with the cold signer / cardano-cli.

## Secure memory + interim erasure

`internal/kesagent/securemem` is a pure-Go locked buffer: allocate, `syscall.Mlock`, Set/Bytes/Clone/Zeroize (barrier-safe wipe), Munlock+wipe on Close. On a GOOS without mlock it falls back to a plain buffer (`Locked()` reports false). KES key material is held here. On evolve, `kes.Update` is followed by wiping the spent key's `Data` and the transient evolved copy (interim forward-erasure); marked `// TODO adopt gouroboros SecretKey.Zeroize once pinned`.

## Evolution scheduler

Computes the current KES period from genesis params (`system_start`, `slot_length`, `slots_per_kes_period`) and evolves the active key up to it on a ticker. If the target exceeds the available evolutions the key is marked exhausted and logged; the daemon does not crash and requires a new install.

## Monotonic period guard (anti-rollback)

A self-contained durable store (atomic-write JSON file) tracks the highest KES period served/signed. A period below the floor is refused (`ErrPeriodRollback`); an equal period is allowed (a producer signs multiple headers within one KES period). Independent of the signer watermark store; can adopt it later.

## Tests

securemem (mlock/fallback, Zeroize wipes, Close); period math + scheduler evolve/exhaustion; serve-key mode (in-process client receives the current key and a re-push on evolve); sign mode (signature verifies via `kes.VerifySignedKES` at the evolution period; wrong/past period rejected); control commands (gen->install->serving, opcert cold-key/KES-vkey/future-period mismatches rejected, drop, info); monotonic guard (rollback refused, durable across reload; install below floor refused); socket perms. Race-clean on the socket + scheduler tests.

## Follow-ons (not in this PR)

- dingo `KESSigner` client seam wiring `builder`<->`PoolCredentials` to this socket.
- Agent-to-agent HA bootstrap/handover.
- Adopt gouroboros `SecretKey.Zeroize` / forward-secure `Update` once pinned.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `bursa kes-agent` daemon that manages a Cardano block‑production KES key, evolves it per KES period, and serves Go producers over Unix sockets in `serve-key` and `sign` modes. It tightens custody, anti‑rollback, and shutdown to prevent key leakage, rollbacks, and resource exhaustion; in `serve-key`, old behavior could queue stale pushes, new behavior drops queued pushes below an advanced period‑guard floor.

**Key details**
- Wire and sockets: service/control Unix sockets with a `bursa-kes-agent/1` handshake and 1 MiB capped length‑prefixed JSON frames. Atomic staged socket creation preserves exact modes under permissive umask; independent `service_socket_mode`/`control_socket_mode` (default 0600) with validation; equal service/control paths are rejected. Connections are capped; all accepted conns are closed on every shutdown path; late arrivals are closed immediately.
- Modes and custody: `serve-key` pushes `{kes_sign_key, period, kes_vkey, opcert}` on connect/evolve, gated on a persisted monotonic period‑guard; retries while unsynced and drops queued pushes below a newer guard floor. `sign` accepts `{period, message}` and returns a KES signature. Each subscriber gets its own signing‑key clone; all plaintext copies are wiped. Warns when `syscall.Mlock` is unavailable.
- Control/evolution: `gen-staged-key`, `install-key` (validates cold signature, KES vkey/period bounds, and opcert; keeps the previous active key if guard authorization fails), `drop-key` (active|staged|all), `info`. On evolve‑store failure, the key is discarded and `ErrNoActiveKey` is returned. The active end period is bounded by min(`max_kes_evolutions`, the KES tree limit).
- Guard/config/metrics: durable monotonic period guard (atomic rename + directory fsync) refuses rollbacks, allows equal‑period signing, skips persistence when unchanged, rolls back the in‑memory floor on persist failure while keeping the committed floor; retries authorization/broadcast on transient store errors. New `kes_agent` config (mode, sockets, per‑socket modes, `system_start`, `slot_length` > 0, `slots_per_kes_period`, `max_kes_evolutions`, `evolve_interval`, `guard_file`, `cold_vkey_file`/`cold_vkey_hex`); `cold_vkey_file` accepts raw 32‑byte binaries and rejects text‑like files. Optional Prometheus metrics with pinned names.

**Migration**
- Configs using `kes_agent.socket_mode` must switch to `kes_agent.service_socket_mode` and `kes_agent.control_socket_mode`.

<sup>Written for commit 27bd3e13a63d0ca41a4374db0d7af09ac2b07c70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a KES agent command for key generation, installation, signing, key evolution, and status management.
  * Added configurable service and control Unix sockets with permission settings.
  * Added optional Prometheus metrics for agent activity and key health.
  * Added support for inline or file-based cold verification keys.
* **Security**
  * Added operational-certificate validation, secure handling of key material, and protection against period rollback.
* **Reliability**
  * Added graceful shutdown, key exhaustion handling, and durable guard-state protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->