### PR TITLE
feat(signer): certificate/vote-kind + per-caller policy

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,16 @@ type SignerConfig struct {
 	Backends      []SignerBackendConfig `yaml:"backends"`
 	Keys          []SignerKeyConfig     `yaml:"keys"`
 	Callers       []SignerCallerConfig  `yaml:"callers"`
+	// CallerPolicies optionally narrows a caller's authority for specific keys.
+	// Shape: caller subject -> key hash (hex) -> tx-policy overrides (mapped to
+	// policy.CallerTxOverride at setup). An override can only further restrict
+	// the key's base policy (intersection); it never widens authority.
+	CallerPolicies map[string]map[string]map[string]any `yaml:"caller_policies"`
+	// PolicyHookURL, when set, enables an external policy hook: after the static
+	// policy allows, the signer POSTs the parsed operation summary and signs only
+	// on an allow response (fail closed). Off by default.
+	PolicyHookURL       string `yaml:"policy_hook_url"        envconfig:"SIGNER_POLICY_HOOK_URL"`
+	PolicyHookTimeoutMs uint   `yaml:"policy_hook_timeout_ms" envconfig:"SIGNER_POLICY_HOOK_TIMEOUT_MS"`
 }
 
 // SignerCallerConfig grants a JWT subject access to specific keys.

--- a/internal/signer/api/server.go
+++ b/internal/signer/api/server.go
@@ -197,7 +197,9 @@ func (s *Server) handleSign(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-		res, perr, err := s.coord.SignTx(r.Context(), []byte(req.Cbor), signers)
+		// Thread the authenticated caller so the coordinator can apply any
+		// per-caller policy override.
+		res, perr, err := s.coord.SignTx(signer.WithCaller(r.Context(), caller), []byte(req.Cbor), signers)
 		if err != nil {
 			if signer.IsBadRequest(err) {
 				s.audit(r, caller, "tx", "bad_request", "audit_id", auditID, "signers", req.Signers, "error", err.Error())

--- a/internal/signer/api/server_test.go
+++ b/internal/signer/api/server_test.go
@@ -40,6 +40,7 @@ type fakeCardano struct{ pub ed25519.PublicKey }
 func (fakeCardano) Inspect([]byte) (*bursa.TxInspection, error) {
 	return &bursa.TxInspection{TxId: "deadbeef", TTL: 1, Outputs: []bursa.TxOutput{{Address: "addr1ok", Lovelace: "1"}}}, nil
 }
+func (fakeCardano) Operations([]byte) (policy.TxOps, error)                { return policy.TxOps{}, nil }
 func (fakeCardano) TxID([]byte) ([]byte, error)                            { return make([]byte, 32), nil }
 func (fakeCardano) Assemble([]byte, []lcommon.VkeyWitness) ([]byte, error) { return []byte{0x9}, nil }
 

--- a/internal/signer/coordinator.go
+++ b/internal/signer/coordinator.go
@@ -73,6 +73,25 @@ type Deps struct {
 	Cardano   operation.Cardano
 	Logger    *slog.Logger
 	Metrics   *Metrics
+	// PolicyHook, when non-nil, is consulted after the static policy allows a
+	// tx-signing decision; signing proceeds only if it returns nil (fail closed).
+	PolicyHook PolicyHook
+}
+
+// callerCtxKey types the context value carrying the authenticated caller.
+type callerCtxKey struct{}
+
+// WithCaller returns a context carrying the authenticated caller subject so
+// that SignTx can apply any per-caller policy override. The API layer sets this
+// from its authenticated request context before invoking the coordinator.
+func WithCaller(ctx context.Context, caller string) context.Context {
+	return context.WithValue(ctx, callerCtxKey{}, caller)
+}
+
+// callerFromContext returns the caller subject set by WithCaller, or "".
+func callerFromContext(ctx context.Context) string {
+	s, _ := ctx.Value(callerCtxKey{}).(string)
+	return s
 }
 
 // Coordinator orchestrates a single signing request end-to-end.
@@ -151,6 +170,11 @@ func (c *Coordinator) SignTx(ctx context.Context, cborInput []byte, signers []st
 	if err != nil {
 		return nil, nil, fmt.Errorf("%w: %w", errBadRequest, err)
 	}
+	ops, err := c.deps.Cardano.Operations(raw)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: %w", errBadRequest, err)
+	}
+	caller := callerFromContext(ctx)
 	txid, err := c.deps.Cardano.TxID(raw)
 	if err != nil {
 		return nil, nil, fmt.Errorf("%w: %w", errBadRequest, err)
@@ -194,12 +218,24 @@ func (c *Coordinator) SignTx(ctx context.Context, cborInput []byte, signers []st
 			c.deps.Metrics.observeBackendError("resolver")
 			continue
 		}
-		if dec := c.deps.Policy.EvaluateTx(hash, insp); !dec.Allow {
+		if dec := c.deps.Policy.EvaluateTx(hash, insp, policy.WithCaller(caller), policy.WithOps(ops)); !dec.Allow {
 			errs = append(errs, SignerError{Signer: s, Code: CodeDenied, Reason: dec.Reason})
 			c.deps.Logger.Info("sign", "type", "tx", "caller-key", hash.String(), "txid", insp.TxId, "result", "denied", "reason", dec.Reason)
 			c.deps.Metrics.observe("tx", string(CodeDenied))
 			c.deps.Metrics.observeDeny(string(CodeDenied))
 			continue
+		}
+		// Optional external policy hook: consulted only after the static policy
+		// allows, and fail-closed (any error denies signing).
+		if c.deps.PolicyHook != nil {
+			sum := summarizeTx(caller, hash.String(), insp, ops)
+			if herr := c.deps.PolicyHook.Authorize(ctx, sum); herr != nil {
+				errs = append(errs, SignerError{Signer: s, Code: CodeDenied, Reason: herr.Error()})
+				c.deps.Logger.Info("sign", "type", "tx", "caller-key", hash.String(), "txid", insp.TxId, "result", "denied", "reason", "policy hook: "+herr.Error())
+				c.deps.Metrics.observe("tx", string(CodeDenied))
+				c.deps.Metrics.observeDeny(string(CodeDenied))
+				continue
+			}
 		}
 		watermarkCommitted := false
 		if c.deps.WMMode == watermark.ModeEnforce {

--- a/internal/signer/coordinator_ops_test.go
+++ b/internal/signer/coordinator_ops_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/bursa/internal/signer/backend"
+	"github.com/blinklabs-io/bursa/internal/signer/policy"
+	"github.com/blinklabs-io/bursa/internal/signer/watermark"
+)
+
+// coordForEngine wires a coordinator around a caller-provided engine and card.
+func coordForEngine(t *testing.T, k *fakeKey, eng *policy.Engine, card fakeCardano, hook PolicyHook) *Coordinator {
+	t.Helper()
+	return New(Deps{
+		Resolver:   backend.NewResolver(fakeBackend{key: k}),
+		Policy:     eng,
+		Watermark:  watermark.NewMemWatermark(),
+		WMMode:     watermark.ModeEnforce,
+		Cardano:    card,
+		PolicyHook: hook,
+	})
+}
+
+// TestSignTx_CallerOverride verifies the per-caller override reaches the engine
+// through the request context: caller "bob" is denied a cert tx the base policy
+// (and caller "alice") allow.
+func TestSignTx_CallerOverride(t *testing.T) {
+	k := newFakeKey(t)
+	base := policy.KeyPolicy{
+		Hash:            k.hash.String(),
+		AllowedRequests: []string{"tx"},
+		Tx:              &policy.TxPolicy{AllowCertificates: true},
+	}
+	eng, err := policy.NewEngine([]policy.KeyPolicy{base})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	eng.SetCallerPolicies(map[string]map[backend.KeyHash]*policy.CallerTxOverride{
+		"bob": {k.hash: {ForbidCertificates: true}},
+	})
+	card := fakeCardano{
+		insp:      &bursa.TxInspection{TxId: "abc", CertificateCount: 1},
+		ops:       policy.TxOps{Certificates: []string{policy.CertStakeDelegation}},
+		txid:      make([]byte, 32),
+		assembled: []byte{0x01},
+	}
+	c := coordForEngine(t, k, eng, card, nil)
+
+	// alice: allowed by base policy.
+	res, perr, err := c.SignTx(WithCaller(context.Background(), "alice"), []byte("11"), []string{k.hash.String()})
+	if err != nil {
+		t.Fatalf("SignTx(alice): %v", err)
+	}
+	if len(perr) != 0 || len(res.Witnesses) != 1 {
+		t.Fatalf("alice expected 1 witness, no errors; got perr=%+v wits=%d", perr, len(res.Witnesses))
+	}
+
+	// bob: denied by the caller override.
+	res, perr, err = c.SignTx(WithCaller(context.Background(), "bob"), []byte("11"), []string{k.hash.String()})
+	if err != nil {
+		t.Fatalf("SignTx(bob): %v", err)
+	}
+	if len(res.Witnesses) != 0 || len(perr) != 1 || perr[0].Code != CodeDenied {
+		t.Fatalf("bob expected one denied signer, got res=%+v perr=%+v", res, perr)
+	}
+}
+
+// TestSignTx_OperationsError confirms an undecodable operation set fails the
+// request closed (bad request), never signing.
+func TestSignTx_OperationsError(t *testing.T) {
+	k := newFakeKey(t)
+	pol := policy.KeyPolicy{Hash: k.hash.String(), AllowedRequests: []string{"tx"}, Tx: &policy.TxPolicy{}}
+	eng, err := policy.NewEngine([]policy.KeyPolicy{pol})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	card := fakeCardano{
+		insp:   &bursa.TxInspection{TxId: "abc"},
+		opsErr: errors.New("cannot decode operations"),
+		txid:   make([]byte, 32),
+	}
+	c := coordForEngine(t, k, eng, card, nil)
+	_, _, err = c.SignTx(context.Background(), []byte("11"), []string{k.hash.String()})
+	if err == nil || !IsBadRequest(err) {
+		t.Fatalf("expected bad-request hard error on operations decode failure, got %v", err)
+	}
+}
+
+type stubHook struct{ err error }
+
+func (h stubHook) Authorize(context.Context, OperationSummary) error { return h.err }
+
+// TestSignTx_PolicyHook confirms the hook gates signing after static policy:
+// an allow response signs; a deny/error response fails closed.
+func TestSignTx_PolicyHook(t *testing.T) {
+	newCoord := func(t *testing.T, hook PolicyHook) (*Coordinator, *fakeKey) {
+		k := newFakeKey(t)
+		pol := policy.KeyPolicy{
+			Hash:            k.hash.String(),
+			AllowedRequests: []string{"tx"},
+			Tx:              &policy.TxPolicy{},
+		}
+		eng, err := policy.NewEngine([]policy.KeyPolicy{pol})
+		if err != nil {
+			t.Fatalf("NewEngine: %v", err)
+		}
+		card := fakeCardano{
+			insp:      &bursa.TxInspection{TxId: "abc"},
+			txid:      make([]byte, 32),
+			assembled: []byte{0x01},
+		}
+		return coordForEngine(t, k, eng, card, hook), k
+	}
+
+	t.Run("allow", func(t *testing.T) {
+		c, k := newCoord(t, stubHook{err: nil})
+		res, perr, err := c.SignTx(context.Background(), []byte("11"), []string{k.hash.String()})
+		if err != nil {
+			t.Fatalf("SignTx: %v", err)
+		}
+		if len(perr) != 0 || len(res.Witnesses) != 1 {
+			t.Fatalf("hook-allow expected 1 witness, got perr=%+v wits=%d", perr, len(res.Witnesses))
+		}
+	})
+
+	t.Run("deny fails closed", func(t *testing.T) {
+		c, k := newCoord(t, stubHook{err: errors.New("hook says no")})
+		res, perr, err := c.SignTx(context.Background(), []byte("11"), []string{k.hash.String()})
+		if err != nil {
+			t.Fatalf("SignTx: %v", err)
+		}
+		if len(res.Witnesses) != 0 || len(perr) != 1 || perr[0].Code != CodeDenied {
+			t.Fatalf("hook-deny expected one denied signer, got res=%+v perr=%+v", res, perr)
+		}
+	})
+}

--- a/internal/signer/coordinator_test.go
+++ b/internal/signer/coordinator_test.go
@@ -32,11 +32,14 @@ import (
 
 type fakeCardano struct {
 	insp      *bursa.TxInspection
+	ops       policy.TxOps
+	opsErr    error
 	txid      []byte
 	assembled []byte
 }
 
 func (f fakeCardano) Inspect([]byte) (*bursa.TxInspection, error) { return f.insp, nil }
+func (f fakeCardano) Operations([]byte) (policy.TxOps, error)     { return f.ops, f.opsErr }
 func (f fakeCardano) TxID([]byte) ([]byte, error)                 { return f.txid, nil }
 func (f fakeCardano) Assemble([]byte, []lcommon.VkeyWitness) ([]byte, error) {
 	return f.assembled, nil

--- a/internal/signer/operation/cardano.go
+++ b/internal/signer/operation/cardano.go
@@ -17,16 +17,22 @@ package operation
 import (
 	"encoding/hex"
 	"fmt"
+	"sort"
 
 	"github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/bursa/internal/signer/policy"
+	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
 // Cardano is the subset of the bursa toolkit the coordinator needs. It is an
 // interface so the coordinator can be tested with a fake.
 type Cardano interface {
-	// Inspect decodes a transaction into its structured summary.
+	// Inspect decodes a transaction into its structured summary (counts/booleans).
 	Inspect(txCbor []byte) (*bursa.TxInspection, error)
+	// Operations decodes the operation TYPES present in a transaction — the
+	// certificate kinds and governance voters — for per-kind policy gating.
+	Operations(txCbor []byte) (policy.TxOps, error)
 	// TxID returns the 32-byte transaction id (the witness signing message).
 	TxID(txCbor []byte) ([]byte, error)
 	// Assemble merges vkey witnesses into a transaction, preserving the body.
@@ -38,6 +44,43 @@ type BursaCardano struct{}
 
 func (BursaCardano) Inspect(txCbor []byte) (*bursa.TxInspection, error) {
 	return bursa.InspectTransaction(txCbor)
+}
+
+// Operations decodes the certificate kinds and governance voter identities from
+// a transaction. Certificate kinds are returned in transaction order; voters
+// are sorted (by kind then id) for deterministic output. Voter DRep credential
+// ids are hex-encoded.
+func (BursaCardano) Operations(txCbor []byte) (policy.TxOps, error) {
+	txType, err := ledger.DetermineTransactionType(txCbor)
+	if err != nil {
+		return policy.TxOps{}, fmt.Errorf("failed to determine transaction era: %w", err)
+	}
+	tx, err := ledger.NewTransactionFromCbor(txType, txCbor)
+	if err != nil {
+		return policy.TxOps{}, fmt.Errorf("failed to decode transaction: %w", err)
+	}
+	var ops policy.TxOps
+	for _, cert := range tx.Certificates() {
+		ops.Certificates = append(ops.Certificates, policy.CertificateKindName(cert.Type()))
+	}
+	for voter := range tx.VotingProcedures() {
+		if voter == nil {
+			continue
+		}
+		kind := policy.VoterKindName(voter.Type)
+		vi := policy.VoterInfo{Kind: kind}
+		if policy.IsDrepVoterKind(kind) {
+			vi.DrepId = hex.EncodeToString(voter.Hash[:])
+		}
+		ops.Voters = append(ops.Voters, vi)
+	}
+	sort.Slice(ops.Voters, func(i, j int) bool {
+		if ops.Voters[i].Kind != ops.Voters[j].Kind {
+			return ops.Voters[i].Kind < ops.Voters[j].Kind
+		}
+		return ops.Voters[i].DrepId < ops.Voters[j].DrepId
+	})
+	return ops, nil
 }
 
 func (BursaCardano) TxID(txCbor []byte) ([]byte, error) {

--- a/internal/signer/operation/cardano_test.go
+++ b/internal/signer/operation/cardano_test.go
@@ -14,7 +14,13 @@
 
 package operation
 
-import "testing"
+import (
+	"os"
+	"testing"
+
+	"github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/bursa/internal/signer/policy"
+)
 
 // compile-time assertion that the real adapter satisfies the interface.
 var _ Cardano = BursaCardano{}
@@ -22,5 +28,31 @@ var _ Cardano = BursaCardano{}
 func TestBursaCardano_TxID_BadInput(t *testing.T) {
 	if _, err := (BursaCardano{}).TxID([]byte{0x00}); err == nil {
 		t.Fatalf("expected error decoding garbage tx")
+	}
+}
+
+func TestBursaCardano_Operations_BadInput(t *testing.T) {
+	if _, err := (BursaCardano{}).Operations([]byte{0x00}); err == nil {
+		t.Fatalf("expected error decoding garbage tx")
+	}
+}
+
+// TestBursaCardano_Operations_RealTx decodes the Conway fixture (one pool
+// registration certificate) and confirms the typed certificate kind surfaces.
+func TestBursaCardano_Operations_RealTx(t *testing.T) {
+	raw, err := os.ReadFile("../testdata/conway-unsigned.tx")
+	if err != nil {
+		t.Fatalf("fixture missing: %v", err)
+	}
+	cbor, err := bursa.ReadCborInput(raw)
+	if err != nil {
+		t.Fatalf("ReadCborInput: %v", err)
+	}
+	ops, err := (BursaCardano{}).Operations(cbor)
+	if err != nil {
+		t.Fatalf("Operations: %v", err)
+	}
+	if len(ops.Certificates) != 1 || ops.Certificates[0] != policy.CertPoolRegistration {
+		t.Fatalf("expected [pool_registration], got %v", ops.Certificates)
 	}
 }

--- a/internal/signer/policy/policy.go
+++ b/internal/signer/policy/policy.go
@@ -25,6 +25,14 @@ import (
 )
 
 // TxPolicy constrains transaction signing for a key.
+//
+// Certificate and governance-vote authorization each have two mutually-aware
+// forms. The coarse boolean (AllowCertificates / AllowVotes) is the original
+// allow-all / deny switch. The typed allow-lists (AllowedCertificates /
+// AllowedVoterKinds / AllowedDrepIds) provide per-kind gating: when an
+// allow-list is non-empty it takes precedence over the boolean and permits
+// only the listed kinds. An absent boolean and an empty allow-list preserve
+// deny-by-default.
 type TxPolicy struct {
 	Networks                  []string `yaml:"networks"                    json:"networks"`
 	AllowedOutputs            []string `yaml:"allowed_outputs"             json:"allowed_outputs"`
@@ -39,6 +47,59 @@ type TxPolicy struct {
 	AllowProposals            bool     `yaml:"allow_proposals"             json:"allow_proposals"`
 	AllowTreasury             bool     `yaml:"allow_treasury"              json:"allow_treasury"`
 	RequireValidityUpperBound bool     `yaml:"require_validity_upper_bound" json:"require_validity_upper_bound"`
+
+	// AllowedCertificates, when non-empty, restricts the transaction to only
+	// these certificate kinds (see CertificateKindName for the vocabulary). It
+	// overrides AllowCertificates.
+	AllowedCertificates []string `yaml:"allowed_certificates" json:"allowed_certificates"`
+	// AllowedVoterKinds, when non-empty, restricts governance voting procedures
+	// to only these voter kinds (see VoterKindName). AllowedDrepIds, when
+	// non-empty, further restricts DRep voters to the listed hex credential
+	// ids. Either being non-empty selects allow-list mode, overriding AllowVotes.
+	AllowedVoterKinds []string `yaml:"allowed_voter_kinds" json:"allowed_voter_kinds"`
+	AllowedDrepIds    []string `yaml:"allowed_drep_ids"    json:"allowed_drep_ids"`
+}
+
+// VoterInfo identifies one governance voter present in a transaction's voting
+// procedures. Kind is the VoterKindName; DrepId is the hex-encoded credential
+// hash for DRep voters and "" for committee/pool voters.
+type VoterInfo struct {
+	Kind   string
+	DrepId string
+}
+
+// TxOps carries the operation TYPES decoded from a transaction — the typed
+// companion to the counts/booleans on bursa.TxInspection. It is produced by the
+// operation layer and consumed by per-kind policy gating.
+type TxOps struct {
+	// Certificates lists the certificate kind name of every certificate in the
+	// transaction, in transaction order (see CertificateKindName).
+	Certificates []string
+	// Voters lists every governance voter in the transaction's voting procedures.
+	Voters []VoterInfo
+}
+
+// CallerTxOverride further restricts a key's tx policy for one caller. Every
+// field is subtractive: an unset field imposes no additional restriction, and
+// a set field can only tighten. It is evaluated in addition to (never in place
+// of) the key's base tx policy, so it can never grant authority the base
+// policy denies — the effective decision is the intersection of both.
+type CallerTxOverride struct {
+	Networks            []string `yaml:"networks"             json:"networks"`
+	AllowedOutputs      []string `yaml:"allowed_outputs"      json:"allowed_outputs"`
+	MaxOutputAda        uint64   `yaml:"max_output_ada"       json:"max_output_ada"`
+	MaxTotalOutAda      uint64   `yaml:"max_total_out_ada"    json:"max_total_out_ada"`
+	MaxFeeAda           uint64   `yaml:"max_fee_ada"          json:"max_fee_ada"`
+	AllowedCertificates []string `yaml:"allowed_certificates" json:"allowed_certificates"`
+	AllowedVoterKinds   []string `yaml:"allowed_voter_kinds"  json:"allowed_voter_kinds"`
+	AllowedDrepIds      []string `yaml:"allowed_drep_ids"     json:"allowed_drep_ids"`
+	// Forbid* deny an entire category outright regardless of the base policy.
+	ForbidCertificates bool `yaml:"forbid_certificates" json:"forbid_certificates"`
+	ForbidMint         bool `yaml:"forbid_mint"         json:"forbid_mint"`
+	ForbidWithdrawals  bool `yaml:"forbid_withdrawals"  json:"forbid_withdrawals"`
+	ForbidVotes        bool `yaml:"forbid_votes"        json:"forbid_votes"`
+	ForbidProposals    bool `yaml:"forbid_proposals"    json:"forbid_proposals"`
+	ForbidTreasury     bool `yaml:"forbid_treasury"     json:"forbid_treasury"`
 }
 
 // CIP8Policy constrains data signing for a key.
@@ -60,6 +121,120 @@ func (p KeyPolicy) allows(reqType string) bool {
 	return slices.Contains(p.AllowedRequests, reqType)
 }
 
+// Certificate kind names. These are the stable vocabulary used in
+// allowed_certificates policy lists and in TxOps.Certificates. They mirror the
+// gouroboros CertificateType ordinals.
+const (
+	CertStakeRegistration               = "stake_registration"
+	CertStakeDeregistration             = "stake_deregistration"
+	CertStakeDelegation                 = "stake_delegation"
+	CertPoolRegistration                = "pool_registration"
+	CertPoolRetirement                  = "pool_retirement"
+	CertGenesisKeyDelegation            = "genesis_key_delegation"
+	CertMoveInstantaneousRewards        = "move_instantaneous_rewards"
+	CertRegistration                    = "registration"
+	CertDeregistration                  = "deregistration"
+	CertVoteDelegation                  = "vote_delegation"
+	CertStakeVoteDelegation             = "stake_vote_delegation"
+	CertStakeRegistrationDelegation     = "stake_registration_delegation"
+	CertVoteRegistrationDelegation      = "vote_registration_delegation"
+	CertStakeVoteRegistrationDelegation = "stake_vote_registration_delegation"
+	CertAuthCommitteeHot                = "auth_committee_hot"
+	CertResignCommitteeCold             = "resign_committee_cold"
+	CertDrepRegistration                = "drep_registration"
+	CertDrepDeregistration              = "drep_deregistration"
+	CertDrepUpdate                      = "drep_update"
+)
+
+// certKindNames maps gouroboros CertificateType ordinals to kind names.
+var certKindNames = map[uint]string{
+	0:  CertStakeRegistration,
+	1:  CertStakeDeregistration,
+	2:  CertStakeDelegation,
+	3:  CertPoolRegistration,
+	4:  CertPoolRetirement,
+	5:  CertGenesisKeyDelegation,
+	6:  CertMoveInstantaneousRewards,
+	7:  CertRegistration,
+	8:  CertDeregistration,
+	9:  CertVoteDelegation,
+	10: CertStakeVoteDelegation,
+	11: CertStakeRegistrationDelegation,
+	12: CertVoteRegistrationDelegation,
+	13: CertStakeVoteRegistrationDelegation,
+	14: CertAuthCommitteeHot,
+	15: CertResignCommitteeCold,
+	16: CertDrepRegistration,
+	17: CertDrepDeregistration,
+	18: CertDrepUpdate,
+}
+
+// CertificateKindName returns the stable kind name for a gouroboros
+// CertificateType ordinal, or "unknown_certificate_<n>" for an unrecognized
+// type so that gating on an unknown certificate fails closed (it will not match
+// any configured allow-list entry).
+func CertificateKindName(certType uint) string {
+	if n, ok := certKindNames[certType]; ok {
+		return n
+	}
+	return fmt.Sprintf("unknown_certificate_%d", certType)
+}
+
+// Governance voter kind names, used in allowed_voter_kinds and VoterInfo.Kind.
+const (
+	VoterCommitteeHotKey    = "committee_hot_key"
+	VoterCommitteeHotScript = "committee_hot_script"
+	VoterDrepKey            = "drep_key"
+	VoterDrepScript         = "drep_script"
+	VoterStakingPoolKey     = "staking_pool_key"
+)
+
+var voterKindNames = map[uint8]string{
+	0: VoterCommitteeHotKey,
+	1: VoterCommitteeHotScript,
+	2: VoterDrepKey,
+	3: VoterDrepScript,
+	4: VoterStakingPoolKey,
+}
+
+// VoterKindName returns the stable kind name for a gouroboros voter Type, or
+// "unknown_voter_<n>" for an unrecognized type (fails closed under gating).
+func VoterKindName(voterType uint8) string {
+	if n, ok := voterKindNames[voterType]; ok {
+		return n
+	}
+	return fmt.Sprintf("unknown_voter_%d", voterType)
+}
+
+// IsDrepVoterKind reports whether a voter kind identifies a DRep (whose
+// credential id is subject to allowed_drep_ids gating).
+func IsDrepVoterKind(kind string) bool {
+	return kind == VoterDrepKey || kind == VoterDrepScript
+}
+
+// evalConfig holds the optional inputs threaded into EvaluateTx.
+type evalConfig struct {
+	caller string
+	ops    TxOps
+}
+
+// EvalOption configures an EvaluateTx call. Absent options preserve the
+// original two-argument behavior (no caller override, no per-kind gating).
+type EvalOption func(*evalConfig)
+
+// WithCaller threads the authenticated caller into policy evaluation so that a
+// configured per-caller override (see SetCallerPolicies) can further restrict
+// the key's base policy.
+func WithCaller(caller string) EvalOption {
+	return func(c *evalConfig) { c.caller = caller }
+}
+
+// WithOps supplies the decoded operation types (certificate kinds, voters) that
+// per-kind allow-list gating evaluates.
+func WithOps(ops TxOps) EvalOption {
+	return func(c *evalConfig) { c.ops = ops }
+}
+
 // Decision is the outcome of a policy evaluation.
 type Decision struct {
 	Allow  bool
@@ -74,6 +249,9 @@ func allow() Decision { return Decision{Allow: true} }
 // Engine evaluates requests against per-key policies.
 type Engine struct {
 	byHash map[backend.KeyHash]KeyPolicy
+	// callerOverrides holds optional per-caller, per-key tx restrictions that
+	// intersect with (only narrow) the key's base policy. caller -> key -> override.
+	callerOverrides map[string]map[backend.KeyHash]*CallerTxOverride
 }
 
 // NewEngine indexes the policies by key hash, validating each hash.
@@ -93,6 +271,9 @@ func NewEngine(policies []KeyPolicy) (*Engine, error) {
 			cp := *p.Tx
 			cp.Networks = append([]string(nil), p.Tx.Networks...)
 			cp.AllowedOutputs = append([]string(nil), p.Tx.AllowedOutputs...)
+			cp.AllowedCertificates = append([]string(nil), p.Tx.AllowedCertificates...)
+			cp.AllowedVoterKinds = append([]string(nil), p.Tx.AllowedVoterKinds...)
+			cp.AllowedDrepIds = append([]string(nil), p.Tx.AllowedDrepIds...)
 			p.Tx = &cp
 		}
 		if p.CIP8 != nil {
@@ -109,6 +290,63 @@ func NewEngine(policies []KeyPolicy) (*Engine, error) {
 func (e *Engine) PolicyFor(hash backend.KeyHash) (KeyPolicy, bool) {
 	p, ok := e.byHash[hash]
 	return p, ok
+}
+
+// SetCallerPolicies installs optional per-caller tx overrides, keyed
+// caller-subject -> key-hash. An override can only further restrict the key's
+// base policy (see CallerTxOverride); it never widens authority. Overrides are
+// deep-copied. Passing nil clears any installed overrides. Intended to be
+// called once at setup before serving, alongside NewEngine.
+func (e *Engine) SetCallerPolicies(overrides map[string]map[backend.KeyHash]*CallerTxOverride) {
+	if len(overrides) == 0 {
+		e.callerOverrides = nil
+		return
+	}
+	cp := make(map[string]map[backend.KeyHash]*CallerTxOverride, len(overrides))
+	for caller, byKey := range overrides {
+		if len(byKey) == 0 {
+			continue
+		}
+		m := make(map[backend.KeyHash]*CallerTxOverride, len(byKey))
+		for h, ov := range byKey {
+			if ov == nil {
+				continue
+			}
+			cov := *ov
+			cov.Networks = append([]string(nil), ov.Networks...)
+			cov.AllowedOutputs = append([]string(nil), ov.AllowedOutputs...)
+			cov.AllowedCertificates = append([]string(nil), ov.AllowedCertificates...)
+			cov.AllowedVoterKinds = append([]string(nil), ov.AllowedVoterKinds...)
+			cov.AllowedDrepIds = append([]string(nil), ov.AllowedDrepIds...)
+			m[h] = &cov
+		}
+		if len(m) > 0 {
+			cp[caller] = m
+		}
+	}
+	if len(cp) == 0 {
+		cp = nil
+	}
+	e.callerOverrides = cp
+}
+
+// callerOverride returns the override for a caller+key, if any is installed.
+func (e *Engine) callerOverride(caller string, hash backend.KeyHash) (*CallerTxOverride, bool) {
+	if caller == "" || e.callerOverrides == nil {
+		return nil, false
+	}
+	byKey := e.callerOverrides[caller]
+	if byKey == nil {
+		return nil, false
+	}
+	// Explicit nil guard (rather than returning the map read directly) so the
+	// second (bool) result is correlated with a guaranteed non-nil pointer: the
+	// "ok" path can only return a non-nil *CallerTxOverride.
+	ov := byKey[hash]
+	if ov == nil {
+		return nil, false
+	}
+	return ov, true
 }
 
 const lovelacePerAda = 1_000_000
@@ -135,9 +373,34 @@ func contains(set []string, v string) bool {
 	return slices.Contains(set, v)
 }
 
+// parseLovelace parses a decimal lovelace string. An empty string is zero; a
+// non-numeric string reports false so callers can fail closed.
+func parseLovelace(s string) (*big.Int, bool) {
+	if s == "" {
+		return new(big.Int), true
+	}
+	v, ok := new(big.Int).SetString(s, 10)
+	return v, ok
+}
+
+// adaToLovelace converts an ADA bound to lovelace without uint64 overflow.
+func adaToLovelace(ada uint64) *big.Int {
+	return new(big.Int).Mul(new(big.Int).SetUint64(ada), big.NewInt(lovelacePerAda))
+}
+
 // EvaluateTx authorizes (or denies) signing the inspected transaction with the
 // key identified by hash. Deny-by-default: absent policy denies.
-func (e *Engine) EvaluateTx(hash backend.KeyHash, insp *bursa.TxInspection) Decision {
+//
+// With no options this preserves the original coarse boolean gating. Supplying
+// WithOps enables per-kind allow-list gating (allowed_certificates /
+// allowed_voter_kinds / allowed_drep_ids); supplying WithCaller applies any
+// per-caller override, which can only further restrict the decision (the
+// effective result is the intersection of the base policy and the override).
+func (e *Engine) EvaluateTx(hash backend.KeyHash, insp *bursa.TxInspection, opts ...EvalOption) Decision {
+	var cfg evalConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
 	if insp == nil {
 		return deny("transaction inspection is nil")
 	}
@@ -215,8 +478,8 @@ func (e *Engine) EvaluateTx(hash backend.KeyHash, insp *bursa.TxInspection) Deci
 			return deny("total outputs plus fee exceed max_total_out_ada")
 		}
 	}
-	if insp.CertificateCount > 0 && !tp.AllowCertificates {
-		return deny("transaction contains certificates")
+	if d := gateCertificates(tp, insp, cfg.ops); !d.Allow {
+		return d
 	}
 	if insp.HasMint && !tp.AllowMint {
 		return deny("transaction mints/burns assets")
@@ -224,8 +487,8 @@ func (e *Engine) EvaluateTx(hash backend.KeyHash, insp *bursa.TxInspection) Deci
 	if insp.WithdrawalCount > 0 && !tp.AllowWithdrawals {
 		return deny("transaction contains reward withdrawals")
 	}
-	if insp.VotingProcedureCount > 0 && !tp.AllowVotes {
-		return deny("transaction contains governance voting procedures")
+	if d := gateVotes(tp, insp, cfg.ops); !d.Allow {
+		return d
 	}
 	if insp.ProposalProcedureCount > 0 && !tp.AllowProposals {
 		return deny("transaction contains governance proposal procedures")
@@ -235,6 +498,152 @@ func (e *Engine) EvaluateTx(hash backend.KeyHash, insp *bursa.TxInspection) Deci
 	}
 	if tp.RequireValidityUpperBound && insp.TTL == 0 {
 		return deny("transaction has no validity upper bound (TTL)")
+	}
+	// Per-caller override: intersect with (only narrow) the base decision.
+	if ov, ok := e.callerOverride(cfg.caller, hash); ok {
+		if d := evalOverride(ov, insp, cfg.ops); !d.Allow {
+			return d
+		}
+	}
+	return allow()
+}
+
+// gateCertificates applies the certificate authorization: an allow-list, when
+// configured, permits only the listed kinds; otherwise the coarse boolean
+// applies. A tx that carries certificates but whose kinds could not be decoded
+// (empty ops under allow-list mode) fails closed.
+func gateCertificates(tp *TxPolicy, insp *bursa.TxInspection, ops TxOps) Decision {
+	if insp.CertificateCount == 0 {
+		return allow()
+	}
+	if len(tp.AllowedCertificates) > 0 {
+		if len(ops.Certificates) == 0 {
+			return deny("certificate kinds unavailable for allowed_certificates evaluation")
+		}
+		for _, k := range ops.Certificates {
+			if !contains(tp.AllowedCertificates, k) {
+				return deny("certificate kind %q is not permitted by allowed_certificates", k)
+			}
+		}
+		return allow()
+	}
+	if !tp.AllowCertificates {
+		return deny("transaction contains certificates")
+	}
+	return allow()
+}
+
+// gateVotes applies governance-vote authorization: when a voter-kind or
+// DRep-id allow-list is configured, every voter must satisfy it; otherwise the
+// coarse boolean applies. Voting procedures whose voters could not be decoded
+// (empty ops under allow-list mode) fail closed.
+func gateVotes(tp *TxPolicy, insp *bursa.TxInspection, ops TxOps) Decision {
+	if insp.VotingProcedureCount == 0 {
+		return allow()
+	}
+	if len(tp.AllowedVoterKinds) > 0 || len(tp.AllowedDrepIds) > 0 {
+		if len(ops.Voters) == 0 {
+			return deny("voter details unavailable for vote allow-list evaluation")
+		}
+		return gateVoters(tp.AllowedVoterKinds, tp.AllowedDrepIds, ops.Voters)
+	}
+	if !tp.AllowVotes {
+		return deny("transaction contains governance voting procedures")
+	}
+	return allow()
+}
+
+// gateVoters denies unless every voter satisfies the voter-kind allow-list (when
+// set) and, for DRep voters, the DRep-id allow-list (when set). When only a
+// DRep-id list is set, non-DRep voters are denied (they carry no id to match).
+func gateVoters(allowedKinds, allowedDreps []string, voters []VoterInfo) Decision {
+	for _, v := range voters {
+		if len(allowedKinds) > 0 && !contains(allowedKinds, v.Kind) {
+			return deny("voter kind %q is not permitted by allowed_voter_kinds", v.Kind)
+		}
+		if len(allowedDreps) > 0 {
+			if v.DrepId == "" || !contains(allowedDreps, v.DrepId) {
+				return deny("voter %q is not an allowed DRep (allowed_drep_ids)", v.Kind)
+			}
+		}
+	}
+	return allow()
+}
+
+// evalOverride applies a per-caller CallerTxOverride. Every check is
+// subtractive: only set fields can add a denial, so the override can only
+// narrow the base decision, never widen it.
+func evalOverride(ov *CallerTxOverride, insp *bursa.TxInspection, ops TxOps) Decision {
+	if ov.MaxFeeAda > 0 {
+		fee, ok := parseLovelace(insp.Fee)
+		if !ok {
+			return deny("unparseable fee %q", insp.Fee)
+		}
+		if fee.Cmp(adaToLovelace(ov.MaxFeeAda)) > 0 {
+			return deny("fee %s exceeds caller override max_fee_ada", insp.Fee)
+		}
+	}
+	total := new(big.Int)
+	maxOut := adaToLovelace(ov.MaxOutputAda)
+	for _, out := range insp.Outputs {
+		if len(ov.Networks) > 0 && !contains(ov.Networks, networkOfAddress(out.Address)) {
+			return deny("output address %s is not on a caller-override allowed network", out.Address)
+		}
+		if len(ov.AllowedOutputs) > 0 && !contains(ov.AllowedOutputs, out.Address) {
+			return deny("output address %s is not in the caller-override allowlist", out.Address)
+		}
+		lov, ok := parseLovelace(out.Lovelace)
+		if !ok {
+			return deny("unparseable output lovelace %q", out.Lovelace)
+		}
+		if ov.MaxOutputAda > 0 && lov.Cmp(maxOut) > 0 {
+			return deny("output %s lovelace exceeds caller override max_output_ada", out.Lovelace)
+		}
+		total.Add(total, lov)
+	}
+	if ov.MaxTotalOutAda > 0 {
+		if fee, ok := parseLovelace(insp.Fee); ok {
+			total.Add(total, fee)
+		}
+		if total.Cmp(adaToLovelace(ov.MaxTotalOutAda)) > 0 {
+			return deny("total outputs plus fee exceed caller override max_total_out_ada")
+		}
+	}
+	if ov.ForbidCertificates && insp.CertificateCount > 0 {
+		return deny("caller override forbids certificates")
+	}
+	if len(ov.AllowedCertificates) > 0 && insp.CertificateCount > 0 {
+		if len(ops.Certificates) == 0 {
+			return deny("certificate kinds unavailable for caller override allowed_certificates")
+		}
+		for _, k := range ops.Certificates {
+			if !contains(ov.AllowedCertificates, k) {
+				return deny("certificate kind %q is not permitted by caller override", k)
+			}
+		}
+	}
+	if ov.ForbidMint && insp.HasMint {
+		return deny("caller override forbids minting/burning")
+	}
+	if ov.ForbidWithdrawals && insp.WithdrawalCount > 0 {
+		return deny("caller override forbids reward withdrawals")
+	}
+	if ov.ForbidVotes && insp.VotingProcedureCount > 0 {
+		return deny("caller override forbids governance votes")
+	}
+	if (len(ov.AllowedVoterKinds) > 0 || len(ov.AllowedDrepIds) > 0) && insp.VotingProcedureCount > 0 {
+		if len(ops.Voters) == 0 {
+			return deny("voter details unavailable for caller override vote allow-list")
+		}
+		if d := gateVoters(ov.AllowedVoterKinds, ov.AllowedDrepIds, ops.Voters); !d.Allow {
+			return d
+		}
+	}
+	if ov.ForbidProposals && insp.ProposalProcedureCount > 0 {
+		return deny("caller override forbids governance proposals")
+	}
+	if ov.ForbidTreasury && insp.HasTreasuryDonation {
+		return deny("caller override forbids treasury donations")
 	}
 	return allow()
 }

--- a/internal/signer/policy/policy_ops_test.go
+++ b/internal/signer/policy/policy_ops_test.go
@@ -1,0 +1,223 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/bursa/internal/signer/backend"
+)
+
+func TestCertificateKindName(t *testing.T) {
+	if got := CertificateKindName(2); got != CertStakeDelegation {
+		t.Fatalf("cert type 2: want %q, got %q", CertStakeDelegation, got)
+	}
+	if got := CertificateKindName(16); got != CertDrepRegistration {
+		t.Fatalf("cert type 16: want %q, got %q", CertDrepRegistration, got)
+	}
+	// Unknown type must not collide with any real kind (fails closed under gating).
+	if got := CertificateKindName(99); got != "unknown_certificate_99" {
+		t.Fatalf("unknown cert type: got %q", got)
+	}
+}
+
+func TestVoterKindName(t *testing.T) {
+	if got := VoterKindName(2); got != VoterDrepKey {
+		t.Fatalf("voter type 2: want %q, got %q", VoterDrepKey, got)
+	}
+	if !IsDrepVoterKind(VoterDrepScript) || IsDrepVoterKind(VoterStakingPoolKey) {
+		t.Fatalf("IsDrepVoterKind classification wrong")
+	}
+	if got := VoterKindName(200); got != "unknown_voter_200" {
+		t.Fatalf("unknown voter type: got %q", got)
+	}
+}
+
+// A tx with one certificate; kinds supplied via WithOps.
+func certTx() *bursa.TxInspection {
+	return &bursa.TxInspection{TTL: 1, CertificateCount: 1}
+}
+
+func TestEvaluateTx_CertificateAllowList(t *testing.T) {
+	e, h := engineWith(t, KeyPolicy{
+		AllowedRequests: []string{"tx"},
+		// allow-list mode: only stake_delegation permitted (AllowCertificates left false)
+		Tx: &TxPolicy{AllowedCertificates: []string{CertStakeDelegation, CertVoteDelegation}},
+	})
+
+	// stake_delegation is listed -> allow
+	if d := e.EvaluateTx(h, certTx(), WithOps(TxOps{Certificates: []string{CertStakeDelegation}})); !d.Allow {
+		t.Fatalf("expected allow for stake_delegation: %s", d.Reason)
+	}
+	// pool_retirement is NOT listed -> deny
+	if d := e.EvaluateTx(h, certTx(), WithOps(TxOps{Certificates: []string{CertPoolRetirement}})); d.Allow {
+		t.Fatalf("expected deny for pool_retirement not in allowed_certificates")
+	}
+	// mixed: one listed, one not -> deny
+	if d := e.EvaluateTx(h, &bursa.TxInspection{TTL: 1, CertificateCount: 2},
+		WithOps(TxOps{Certificates: []string{CertStakeDelegation, CertPoolRetirement}})); d.Allow {
+		t.Fatalf("expected deny when any cert kind is not permitted")
+	}
+	// allow-list mode but kinds unavailable (empty ops) -> fail closed
+	if d := e.EvaluateTx(h, certTx()); d.Allow {
+		t.Fatalf("expected deny: allow-list mode with no decoded kinds must fail closed")
+	}
+}
+
+func TestEvaluateTx_CertificateAllowAllBoolStillWorks(t *testing.T) {
+	e, h := engineWith(t, KeyPolicy{
+		AllowedRequests: []string{"tx"},
+		Tx:              &TxPolicy{AllowCertificates: true}, // allow-all, no list
+	})
+	// Any cert kind passes under the allow-all bool.
+	if d := e.EvaluateTx(h, certTx(), WithOps(TxOps{Certificates: []string{CertPoolRetirement}})); !d.Allow {
+		t.Fatalf("expected allow-all bool to permit any cert: %s", d.Reason)
+	}
+}
+
+func TestEvaluateTx_CertificateDenyByDefault(t *testing.T) {
+	e, h := engineWith(t, KeyPolicy{AllowedRequests: []string{"tx"}, Tx: &TxPolicy{}})
+	if d := e.EvaluateTx(h, certTx(), WithOps(TxOps{Certificates: []string{CertStakeDelegation}})); d.Allow {
+		t.Fatalf("expected deny-by-default: no bool, no list")
+	}
+}
+
+func voteTx() *bursa.TxInspection {
+	return &bursa.TxInspection{TTL: 1, VotingProcedureCount: 1}
+}
+
+func TestEvaluateTx_VoteVoterKindGate(t *testing.T) {
+	e, h := engineWith(t, KeyPolicy{
+		AllowedRequests: []string{"tx"},
+		Tx:              &TxPolicy{AllowedVoterKinds: []string{VoterDrepKey}},
+	})
+	// DRep voter -> allow
+	if d := e.EvaluateTx(h, voteTx(), WithOps(TxOps{Voters: []VoterInfo{{Kind: VoterDrepKey, DrepId: "aa"}}})); !d.Allow {
+		t.Fatalf("expected allow for drep_key voter: %s", d.Reason)
+	}
+	// Staking-pool voter -> deny (not in allowed_voter_kinds)
+	if d := e.EvaluateTx(h, voteTx(), WithOps(TxOps{Voters: []VoterInfo{{Kind: VoterStakingPoolKey}}})); d.Allow {
+		t.Fatalf("expected deny for staking_pool_key voter")
+	}
+}
+
+func TestEvaluateTx_VoteDrepIdAllowList(t *testing.T) {
+	e, h := engineWith(t, KeyPolicy{
+		AllowedRequests: []string{"tx"},
+		Tx:              &TxPolicy{AllowedDrepIds: []string{"deadbeef"}},
+	})
+	// Allowed DRep id -> allow
+	if d := e.EvaluateTx(h, voteTx(), WithOps(TxOps{Voters: []VoterInfo{{Kind: VoterDrepKey, DrepId: "deadbeef"}}})); !d.Allow {
+		t.Fatalf("expected allow for listed drep id: %s", d.Reason)
+	}
+	// Different DRep id -> deny
+	if d := e.EvaluateTx(h, voteTx(), WithOps(TxOps{Voters: []VoterInfo{{Kind: VoterDrepKey, DrepId: "00"}}})); d.Allow {
+		t.Fatalf("expected deny for unlisted drep id")
+	}
+	// Non-DRep voter under a drep-id list -> deny (no id to match)
+	if d := e.EvaluateTx(h, voteTx(), WithOps(TxOps{Voters: []VoterInfo{{Kind: VoterStakingPoolKey}}})); d.Allow {
+		t.Fatalf("expected deny for non-drep voter under drep-id allow-list")
+	}
+}
+
+func TestEvaluateTx_VoteAllowAllBoolStillWorks(t *testing.T) {
+	e, h := engineWith(t, KeyPolicy{AllowedRequests: []string{"tx"}, Tx: &TxPolicy{AllowVotes: true}})
+	if d := e.EvaluateTx(h, voteTx(), WithOps(TxOps{Voters: []VoterInfo{{Kind: VoterStakingPoolKey}}})); !d.Allow {
+		t.Fatalf("expected allow_votes bool to permit any voter: %s", d.Reason)
+	}
+}
+
+const hashB = "00000000000000000000000000000000000000000000000000000042"
+
+// buildEngineWithOverride wires one key (base policy) plus a per-caller override.
+func buildEngineWithOverride(t *testing.T, base KeyPolicy, caller string, ov *CallerTxOverride) (*Engine, backend.KeyHash) {
+	t.Helper()
+	base.Hash = hashB
+	e, err := NewEngine([]KeyPolicy{base})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	h := mustHash(t, hashB)
+	e.SetCallerPolicies(map[string]map[backend.KeyHash]*CallerTxOverride{
+		caller: {h: ov},
+	})
+	return e, h
+}
+
+func TestEvaluateTx_CallerOverrideNarrows(t *testing.T) {
+	// Base policy: up to 100 ADA fee, certs allowed (allow-all).
+	base := KeyPolicy{
+		AllowedRequests: []string{"tx"},
+		Tx:              &TxPolicy{MaxFeeAda: 100, AllowCertificates: true},
+	}
+	// Caller "bob" is restricted to a 1-ADA fee cap and no certificates.
+	ov := &CallerTxOverride{MaxFeeAda: 1, ForbidCertificates: true}
+	e, h := buildEngineWithOverride(t, base, "bob", ov)
+
+	feeTx := &bursa.TxInspection{TTL: 1, Fee: "5000000"} // 5 ADA
+
+	// alice (no override) is bounded only by the base policy -> allow.
+	if d := e.EvaluateTx(h, feeTx, WithCaller("alice")); !d.Allow {
+		t.Fatalf("alice (no override) expected allow: %s", d.Reason)
+	}
+	// bob's override caps fee at 1 ADA -> deny.
+	if d := e.EvaluateTx(h, feeTx, WithCaller("bob")); d.Allow {
+		t.Fatalf("bob (override) expected deny on fee cap")
+	}
+	// bob signing a cert tx -> denied by ForbidCertificates even though base allows.
+	if d := e.EvaluateTx(h, &bursa.TxInspection{TTL: 1, CertificateCount: 1},
+		WithCaller("bob"), WithOps(TxOps{Certificates: []string{CertStakeDelegation}})); d.Allow {
+		t.Fatalf("bob (override) expected deny on forbid_certificates")
+	}
+	// alice may still sign the cert tx (base allows certs).
+	if d := e.EvaluateTx(h, &bursa.TxInspection{TTL: 1, CertificateCount: 1},
+		WithCaller("alice"), WithOps(TxOps{Certificates: []string{CertStakeDelegation}})); !d.Allow {
+		t.Fatalf("alice expected allow on cert tx: %s", d.Reason)
+	}
+}
+
+func TestEvaluateTx_CallerOverrideCannotWiden(t *testing.T) {
+	// Base policy denies certificates entirely.
+	base := KeyPolicy{AllowedRequests: []string{"tx"}, Tx: &TxPolicy{}}
+	// A (misguided) override that "allows" a cert kind must NOT grant it, because
+	// the base decision is required and already denies.
+	ov := &CallerTxOverride{AllowedCertificates: []string{CertStakeDelegation}}
+	e, h := buildEngineWithOverride(t, base, "carol", ov)
+
+	if d := e.EvaluateTx(h, &bursa.TxInspection{TTL: 1, CertificateCount: 1},
+		WithCaller("carol"), WithOps(TxOps{Certificates: []string{CertStakeDelegation}})); d.Allow {
+		t.Fatalf("override must not widen: cert denied by base must stay denied")
+	}
+}
+
+func TestSetCallerPolicies_ClearAndCopy(t *testing.T) {
+	base := KeyPolicy{AllowedRequests: []string{"tx"}, Tx: &TxPolicy{AllowCertificates: true}}
+	ov := &CallerTxOverride{ForbidCertificates: true}
+	e, h := buildEngineWithOverride(t, base, "dave", ov)
+
+	// Mutating the caller's original override slice/struct must not affect the engine.
+	ov.ForbidCertificates = false
+	certTxn := &bursa.TxInspection{TTL: 1, CertificateCount: 1}
+	if d := e.EvaluateTx(h, certTxn, WithCaller("dave"), WithOps(TxOps{Certificates: []string{CertStakeDelegation}})); d.Allow {
+		t.Fatalf("engine must retain deep-copied override (post-mutation)")
+	}
+
+	// Clearing overrides restores base behavior (certs allowed).
+	e.SetCallerPolicies(nil)
+	if d := e.EvaluateTx(h, certTxn, WithCaller("dave"), WithOps(TxOps{Certificates: []string{CertStakeDelegation}})); !d.Allow {
+		t.Fatalf("after clearing overrides, base policy should allow certs: %s", d.Reason)
+	}
+}

--- a/internal/signer/policyhook.go
+++ b/internal/signer/policyhook.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signer
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/bursa/internal/signer/policy"
+)
+
+// HookOutput is one transaction output in an OperationSummary.
+type HookOutput struct {
+	Address   string `json:"address"`
+	Lovelace  string `json:"lovelace"`
+	HasAssets bool   `json:"has_assets,omitempty"`
+}
+
+// OperationSummary is the parsed request sent to an external policy hook. It
+// contains no secrets — only the caller, the signing key, and the decoded
+// operation types/amounts/destinations.
+type OperationSummary struct {
+	Type         string       `json:"type"` // "tx"
+	Caller       string       `json:"caller"`
+	Key          string       `json:"key"`
+	TxID         string       `json:"tx_id"`
+	Fee          string       `json:"fee,omitempty"`
+	Outputs      []HookOutput `json:"outputs,omitempty"`
+	Certificates []string     `json:"certificates,omitempty"`
+	VoterKinds   []string     `json:"voter_kinds,omitempty"`
+	DrepIds      []string     `json:"drep_ids,omitempty"`
+}
+
+// PolicyHook is an optional external authorization step consulted after the
+// static policy allows a request. Authorize must return nil to permit signing;
+// any error denies it. Implementations MUST fail closed (deny on transport,
+// timeout, or malformed response).
+type PolicyHook interface {
+	Authorize(ctx context.Context, sum OperationSummary) error
+}
+
+// summarizeTx builds an OperationSummary for a tx-signing decision.
+func summarizeTx(caller, key string, insp *bursa.TxInspection, ops policy.TxOps) OperationSummary {
+	sum := OperationSummary{
+		Type:         "tx",
+		Caller:       caller,
+		Key:          key,
+		Certificates: ops.Certificates,
+	}
+	if insp != nil {
+		sum.TxID = insp.TxId
+		sum.Fee = insp.Fee
+		for _, o := range insp.Outputs {
+			sum.Outputs = append(sum.Outputs, HookOutput{
+				Address:   o.Address,
+				Lovelace:  o.Lovelace,
+				HasAssets: o.HasAssets,
+			})
+		}
+	}
+	for _, v := range ops.Voters {
+		sum.VoterKinds = append(sum.VoterKinds, v.Kind)
+		if v.DrepId != "" {
+			sum.DrepIds = append(sum.DrepIds, v.DrepId)
+		}
+	}
+	return sum
+}
+
+// HTTPPolicyHook POSTs the operation summary as JSON to a configured URL and
+// signs only on an explicit allow. The endpoint must return HTTP 200 with a
+// JSON body {"allow": true}; any other status, a non-allow body, or a
+// transport/timeout error denies (fail closed).
+type HTTPPolicyHook struct {
+	url    string
+	client *http.Client
+}
+
+// NewHTTPPolicyHook builds an HTTP policy hook. A non-positive timeout defaults
+// to 5 seconds.
+func NewHTTPPolicyHook(url string, timeout time.Duration) *HTTPPolicyHook {
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	return &HTTPPolicyHook{url: url, client: &http.Client{Timeout: timeout}}
+}
+
+func (h *HTTPPolicyHook) Authorize(ctx context.Context, sum OperationSummary) error {
+	body, err := json.Marshal(sum)
+	if err != nil {
+		return fmt.Errorf("policy hook: marshal summary: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("policy hook: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("policy hook: request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("policy hook: denied (status %d)", resp.StatusCode)
+	}
+	var decision struct {
+		Allow  bool   `json:"allow"`
+		Reason string `json:"reason"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&decision); err != nil {
+		return fmt.Errorf("policy hook: unreadable response: %w", err)
+	}
+	if !decision.Allow {
+		if decision.Reason != "" {
+			return fmt.Errorf("policy hook denied: %s", decision.Reason)
+		}
+		return errors.New("policy hook denied")
+	}
+	return nil
+}

--- a/internal/signer/policyhook_test.go
+++ b/internal/signer/policyhook_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signer
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/bursa"
+	"github.com/blinklabs-io/bursa/internal/signer/policy"
+)
+
+func testSummary() OperationSummary {
+	return summarizeTx("alice", "cafe", &bursa.TxInspection{TxId: "abc", Fee: "1000000",
+		Outputs: []bursa.TxOutput{{Address: "addr1x", Lovelace: "1000000"}}},
+		policy.TxOps{Certificates: []string{policy.CertStakeDelegation},
+			Voters: []policy.VoterInfo{{Kind: policy.VoterDrepKey, DrepId: "beef"}}})
+}
+
+func TestHTTPPolicyHook_Allow(t *testing.T) {
+	var gotType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var sum OperationSummary
+		_ = json.NewDecoder(r.Body).Decode(&sum)
+		gotType = sum.Type
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"allow": true}`))
+	}))
+	defer srv.Close()
+
+	h := NewHTTPPolicyHook(srv.URL, time.Second)
+	if err := h.Authorize(context.Background(), testSummary()); err != nil {
+		t.Fatalf("expected allow, got %v", err)
+	}
+	if gotType != "tx" {
+		t.Fatalf("hook did not receive summary type; got %q", gotType)
+	}
+}
+
+func TestHTTPPolicyHook_DenyBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"allow": false, "reason": "nope"}`))
+	}))
+	defer srv.Close()
+
+	h := NewHTTPPolicyHook(srv.URL, time.Second)
+	if err := h.Authorize(context.Background(), testSummary()); err == nil {
+		t.Fatalf("expected deny on allow=false body")
+	}
+}
+
+func TestHTTPPolicyHook_NonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	h := NewHTTPPolicyHook(srv.URL, time.Second)
+	if err := h.Authorize(context.Background(), testSummary()); err == nil {
+		t.Fatalf("expected deny on non-200 status")
+	}
+}
+
+func TestHTTPPolicyHook_TimeoutFailsClosed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"allow": true}`))
+	}))
+	defer srv.Close()
+
+	h := NewHTTPPolicyHook(srv.URL, 10*time.Millisecond)
+	if err := h.Authorize(context.Background(), testSummary()); err == nil {
+		t.Fatalf("expected deny (fail closed) on timeout")
+	}
+}
+
+func TestHTTPPolicyHook_TransportErrorFailsClosed(t *testing.T) {
+	// Point at a closed server to force a transport error.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	h := NewHTTPPolicyHook(url, 100*time.Millisecond)
+	if err := h.Authorize(context.Background(), testSummary()); err == nil {
+		t.Fatalf("expected deny (fail closed) on transport error")
+	}
+}

--- a/internal/signer/setup.go
+++ b/internal/signer/setup.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/bursa/internal/config"
@@ -198,6 +199,56 @@ func BuildCallerACL(callers []config.SignerCallerConfig) (map[string][]backend.K
 		out[c.Subject] = hashes
 	}
 	return out, nil
+}
+
+// BuildCallerPolicies maps the configured caller_policies (caller -> key hash
+// hex -> raw tx-override map) into typed per-caller overrides for the policy
+// engine. Returns nil when none are configured. Each override is validated by a
+// JSON round-trip (unknown keys rejected) so a typo fails at boot.
+func BuildCallerPolicies(cfg map[string]map[string]map[string]any) (map[string]map[backend.KeyHash]*policy.CallerTxOverride, error) {
+	if len(cfg) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]map[backend.KeyHash]*policy.CallerTxOverride, len(cfg))
+	for caller, byKey := range cfg {
+		if caller == "" {
+			return nil, errors.New("signer.caller_policies entry has empty caller subject")
+		}
+		if len(byKey) == 0 {
+			continue
+		}
+		m := make(map[backend.KeyHash]*policy.CallerTxOverride, len(byKey))
+		for hashHex, raw := range byKey {
+			h, err := backend.ParseKeyHash(hashHex)
+			if err != nil {
+				return nil, fmt.Errorf("caller %q key %q: %w", caller, hashHex, err)
+			}
+			var ov policy.CallerTxOverride
+			if err := remap(raw, &ov); err != nil {
+				return nil, fmt.Errorf("caller %q key %q override: %w", caller, hashHex, err)
+			}
+			m[h] = &ov
+		}
+		out[caller] = m
+	}
+	return out, nil
+}
+
+// BuildPolicyHook constructs the optional external policy hook from config.
+// Returns nil when signer.policy_hook_url is unset (hook disabled).
+func BuildPolicyHook(cfg config.SignerConfig) PolicyHook {
+	if cfg.PolicyHookURL == "" {
+		return nil
+	}
+	// Bound the configured timeout before the signed conversion so a large
+	// value cannot overflow time.Duration (~292 years is far beyond any sane
+	// hook timeout).
+	timeoutMs := cfg.PolicyHookTimeoutMs
+	const maxTimeoutMs = uint(24 * 60 * 60 * 1000) // 1 day
+	if timeoutMs > maxTimeoutMs {
+		timeoutMs = maxTimeoutMs
+	}
+	return NewHTTPPolicyHook(cfg.PolicyHookURL, time.Duration(timeoutMs)*time.Millisecond)
 }
 
 // BuildWatermark constructs the configured watermark store and mode.

--- a/internal/signer/setup_policies_test.go
+++ b/internal/signer/setup_policies_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signer
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/bursa/internal/config"
+	"github.com/blinklabs-io/bursa/internal/signer/backend"
+)
+
+const testKeyHash = "00000000000000000000000000000000000000000000000000000001"
+
+func TestBuildCallerPolicies(t *testing.T) {
+	cfg := map[string]map[string]map[string]any{
+		"alice": {
+			testKeyHash: {
+				"max_fee_ada":         float64(2),
+				"forbid_certificates": true,
+				"allowed_voter_kinds": []any{"drep_key"},
+			},
+		},
+	}
+	out, err := BuildCallerPolicies(cfg)
+	if err != nil {
+		t.Fatalf("BuildCallerPolicies: %v", err)
+	}
+	h, _ := backend.ParseKeyHash(testKeyHash)
+	ov := out["alice"][h]
+	if ov == nil {
+		t.Fatalf("missing override for alice/%s", testKeyHash)
+	}
+	if ov.MaxFeeAda != 2 || !ov.ForbidCertificates || len(ov.AllowedVoterKinds) != 1 {
+		t.Fatalf("override not mapped correctly: %+v", ov)
+	}
+}
+
+func TestBuildCallerPolicies_Empty(t *testing.T) {
+	out, err := BuildCallerPolicies(nil)
+	if err != nil || out != nil {
+		t.Fatalf("expected nil,nil for empty config; got %v,%v", out, err)
+	}
+}
+
+func TestBuildCallerPolicies_BadHash(t *testing.T) {
+	cfg := map[string]map[string]map[string]any{
+		"alice": {"not-a-hash": {"max_fee_ada": float64(1)}},
+	}
+	if _, err := BuildCallerPolicies(cfg); err == nil {
+		t.Fatalf("expected error for invalid key hash")
+	}
+}
+
+func TestBuildCallerPolicies_UnknownField(t *testing.T) {
+	cfg := map[string]map[string]map[string]any{
+		"alice": {testKeyHash: {"bogus_field": true}},
+	}
+	if _, err := BuildCallerPolicies(cfg); err == nil {
+		t.Fatalf("expected error for unknown override field")
+	}
+}
+
+func TestBuildPolicyHook(t *testing.T) {
+	if h := BuildPolicyHook(config.SignerConfig{}); h != nil {
+		t.Fatalf("expected nil hook when policy_hook_url unset")
+	}
+	h := BuildPolicyHook(config.SignerConfig{PolicyHookURL: "http://localhost:9/decide", PolicyHookTimeoutMs: 250})
+	if h == nil {
+		t.Fatalf("expected a hook when policy_hook_url is set")
+	}
+}


### PR DESCRIPTION
Refs #768

Extends the remote-signer policy engine from coarse counts/booleans to Cardano-operation-aware, per-caller authorization.

## Typed operation inspection
`operation.Cardano` gains `Operations(txCbor) (policy.TxOps, error)`. `BursaCardano.Operations` decodes, via gouroboros ledger, the `TxOps`:
- `Certificates []string` — certificate kind name per certificate, in tx order (stake registration/deregistration/delegation, the combined delegation certs, pool registration/retirement, DRep registration/update/deregistration, committee auth/resign, MIR, genesis; unknown types map to `unknown_certificate_<n>` and fail closed).
- `Voters []VoterInfo{Kind, DrepId}` — governance voter kind per voting procedure (committee hot key/script, DRep key/script, staking-pool key), with hex DRep credential id for DRep voters.

The existing `bursa.TxInspection` counts/booleans are unchanged; the typed lists are the additive companion surfaced by the signer's operation layer.

## Per-kind policy (allow-lists)
`policy.TxPolicy` adds, alongside the existing `allow_certificates`/`allow_votes` booleans:
- `allowed_certificates: [<kind>, ...]`
- `allowed_voter_kinds: [<kind>, ...]`
- `allowed_drep_ids: [<hex>, ...]`

Semantics: a non-empty allow-list takes precedence over the bool and permits only the listed kinds; bare-bool `true` = allow-all (backward compatible); `false`/absent = deny (deny-by-default preserved). Under allow-list mode a cert/vote whose kinds could not be decoded fails closed. `EvaluateTx` rejects a tx containing a cert kind not in `allowed_certificates`, a voter kind not in `allowed_voter_kinds`, or (for DRep voters) a DRep id not in `allowed_drep_ids`, with a descriptive reason.

`EvaluateTx` is now `EvaluateTx(hash, insp, ...EvalOption)`; existing two-argument calls are unchanged. `WithOps(TxOps)` supplies decoded kinds; `WithCaller(string)` supplies the caller.

## Per-caller overrides (intersect-narrow)
`Engine.SetCallerPolicies(map[caller]map[keyHash]*CallerTxOverride)` installs optional per-caller, per-key overrides. Config: `signer.caller_policies: {<caller>: {<keyhash>: <tx-override>}}`.

`CallerTxOverride` is strictly subtractive (network/output allowlists, `max_*_ada` caps, `allowed_certificates`/`allowed_voter_kinds`/`allowed_drep_ids`, and `forbid_certificates`/`mint`/`withdrawals`/`votes`/`proposals`/`treasury`). It is evaluated in addition to — never in place of — the key's base policy: the effective decision is the intersection of both, so an override can only further restrict and can never grant authority the base policy denies. The caller is threaded from the API's authenticated context (`signer.WithCaller`) through `SignTx` into `EvaluateTx`.

## Optional remote policy hook
`signer.policy_hook_url` (+ `policy_hook_timeout_ms`), off by default. When set, after the static policy allows, the coordinator POSTs an `OperationSummary` (type/caller/key/tx-id/fee/outputs/certificates/voter kinds/DRep ids; no secrets) and signs only on an HTTP 200 `{"allow": true}` response. Any non-200, non-allow body, malformed response, transport error, or timeout denies (fail closed). Exposed via `Deps.PolicyHook`; `setup.BuildPolicyHook` constructs it from config.

## Tests
- Cert-kind gating: stake-delegation allowed when listed; pool-retirement denied when omitted; allow-all bool still passes; deny-by-default still denies; allow-list mode with undecoded kinds fails closed. Real-fixture decode (`Operations` on the Conway pool-registration tx).
- Vote gating by voter kind and by DRep-id allow-list (incl. non-DRep voter denied under a DRep-id list).
- Per-caller override: caller with no override allowed, caller with restrictive override denied for the same key+tx; a widening override does not grant beyond the base policy; deep-copy/clear semantics.
- Remote hook: allow-response signs; deny/non-200/timeout/transport-error fail closed (unit + httptest).
- Config mapping: `BuildCallerPolicies` (round-trip, bad hash, unknown field) and `BuildPolicyHook`.
- Existing policy/coordinator/api tests unchanged and green.

## Verify
`CGO_ENABLED=0 go build ./...`, `go vet ./...`, `go test ./...` all clean; `-race` green on policy + coordinator; `golangci-lint run ./...` -> 0 issues. Diff limited to `internal/signer/**` and `internal/config/**`; no `go.mod` change.

Daemon wiring (`cmd/bursa/signer.go` calling `SetCallerPolicies`/`BuildPolicyHook`) is intentionally left out of this diff per the scope boundary; the `setup.Build*` helpers make it a one-line integration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds operation-aware certificate and vote gating, per-caller per-key policy overrides, and an optional external HTTP policy hook to the signer. Backward compatible: existing booleans still work; allow-lists and overrides only narrow access.

- New Features
  - Typed tx ops: `Cardano.Operations` decodes certificate kinds and governance voters (with DRep IDs); decode errors return a bad request.
  - Per-kind allow-lists in `TxPolicy`: `allowed_certificates`, `allowed_voter_kinds`, `allowed_drep_ids` (non-empty lists override booleans and fail closed when kinds are unavailable).
  - Per-caller overrides: configure `signer.caller_policies`, evaluated via `policy.WithCaller`; overrides only restrict.
  - Optional external policy hook: set `signer.policy_hook_url` (+ `policy_hook_timeout_ms`) to `POST` an operation summary; sign only on HTTP 200 with `{"allow": true}`; any error/status denies.
  - Policy API: `EvaluateTx(hash, insp, policy.WithOps(TxOps), policy.WithCaller(caller))`; existing calls still work.

- Migration
  - No changes needed to keep current behavior.
  - To gate by kind, set allow-lists in key `TxPolicy`.
  - To apply per-caller limits, set `signer.caller_policies: {<caller>: {<keyhash>: <override>}}`.
  - To enable the hook, set `signer.policy_hook_url` and optionally `signer.policy_hook_timeout_ms`.

<sup>Written for commit 7bf3da5e4f2fa681d2ffcfe816ee081cdfead0e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

