### PR TITLE
fix(ui): nil-guard PolicyFromScript and sort DecodeTx withdrawals

### DIFF
--- a/ui/internal/multisig/importtx_test.go
+++ b/ui/internal/multisig/importtx_test.go
@@ -68,6 +68,16 @@ func TestPolicyFromScript_TimeLocked(t *testing.T) {
 	}
 }
 
+// TestPolicyFromScript_Nil covers a nil native script (e.g. a malformed
+// imported tx with no witness script attached): it must return ErrInvalidTx
+// rather than panicking on the nil dereference.
+func TestPolicyFromScript_Nil(t *testing.T) {
+	_, err := PolicyFromScript(nil)
+	if !errors.Is(err, ErrInvalidTx) {
+		t.Fatalf("PolicyFromScript(nil) error = %v, want ErrInvalidTx", err)
+	}
+}
+
 // TestPolicyFromScript_UnsupportedShape covers a script shape composeScript
 // never emits (a bare pubkey script, with no threshold clause at all): it
 // must be rejected as ErrInvalidTx, not silently accepted or panicked on.

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -262,6 +262,9 @@ func composeScript(p Policy) (*bursa.NativeScript, error) {
 // produces) is rejected as ErrInvalidTx rather than silently accepted or
 // panicked on.
 func PolicyFromScript(ns *bursa.NativeScript) (Policy, error) {
+	if ns == nil {
+		return Policy{}, fmt.Errorf("%w: nil native script", ErrInvalidTx)
+	}
 	var p Policy
 	// composeScript emits exactly one threshold clause and at most one clause of
 	// each time-lock type. A non-canonical script (multiple N-of-K clauses, or

--- a/ui/internal/spend/importtx_test.go
+++ b/ui/internal/spend/importtx_test.go
@@ -6,10 +6,13 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"sort"
 	"testing"
 
 	apollo "github.com/Salvionied/apollo/v2"
+	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
 
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/wallet"
@@ -149,6 +152,85 @@ func TestDecodeTx_VkeySummary(t *testing.T) {
 	if !found {
 		t.Errorf("wallet_can_add %+v does not contain expected payment key hash %s", got.WalletCanAdd, wantKeyHash)
 	}
+}
+
+// TestDecodeTx_WithdrawalsSortedByAddress covers a transaction with multiple
+// reward withdrawals. TxWithdrawals is a Go map (randomized iteration order),
+// so without an explicit sort the rendered summary's Withdrawals would come
+// back in a different order on every call. This builds a fixture with two
+// withdrawals whose reward addresses are deliberately out of lexical order
+// as constructed, and asserts DecodeTx always reports them sorted.
+func TestDecodeTx_WithdrawalsSortedByAddress(t *testing.T) {
+	svc, _, unsignedCbor := buildUnsignedSendFixture(t)
+	txBytes, err := hex.DecodeString(unsignedCbor)
+	if err != nil {
+		t.Fatalf("decode unsigned cbor: %v", err)
+	}
+
+	var outer []cbor.RawMessage
+	if _, err := cbor.Decode(txBytes, &outer); err != nil {
+		t.Fatalf("decode tx as CBOR array: %v", err)
+	}
+	if len(outer) < 1 {
+		t.Fatal("tx array has no body element")
+	}
+
+	var body conway.ConwayTransactionBody
+	if _, err := cbor.Decode(outer[0], &body); err != nil {
+		t.Fatalf("decode tx body: %v", err)
+	}
+
+	addrHi, err := lcommon.NewAddressFromParts(lcommon.AddressTypeNoneKey, lcommon.AddressNetworkTestnet, nil, bytesRepeat(0xff, 28))
+	if err != nil {
+		t.Fatalf("NewAddressFromParts(hi): %v", err)
+	}
+	addrLo, err := lcommon.NewAddressFromParts(lcommon.AddressTypeNoneKey, lcommon.AddressNetworkTestnet, nil, bytesRepeat(0x00, 28))
+	if err != nil {
+		t.Fatalf("NewAddressFromParts(lo): %v", err)
+	}
+	// Insert the map entries "backwards" (higher address first) so a naive
+	// unsorted append would very likely fail a strict order check; the real
+	// guard is the assertion against a lexically-sorted `want` below, which
+	// holds regardless of map iteration order.
+	body.TxWithdrawals = map[*lcommon.Address]uint64{
+		&addrHi: 3_000_000,
+		&addrLo: 1_500_000,
+	}
+
+	newBodyBytes, err := cbor.Encode(&body)
+	if err != nil {
+		t.Fatalf("encode modified tx body: %v", err)
+	}
+	outer[0] = cbor.RawMessage(newBodyBytes)
+
+	newTxBytes, err := cbor.Encode(outer)
+	if err != nil {
+		t.Fatalf("encode modified tx: %v", err)
+	}
+
+	got, err := svc.DecodeTx(context.Background(), hex.EncodeToString(newTxBytes))
+	if err != nil {
+		t.Fatalf("DecodeTx: %v", err)
+	}
+	if len(got.Withdrawals) != 2 {
+		t.Fatalf("got %d withdrawals, want 2: %+v", len(got.Withdrawals), got.Withdrawals)
+	}
+	want := []string{addrHi.String(), addrLo.String()}
+	sort.Strings(want)
+	gotAddrs := []string{got.Withdrawals[0].Address, got.Withdrawals[1].Address}
+	if gotAddrs[0] != want[0] || gotAddrs[1] != want[1] {
+		t.Fatalf("withdrawals order = %v, want sorted %v", gotAddrs, want)
+	}
+}
+
+// bytesRepeat returns an n-byte slice with every byte set to b, for
+// constructing distinct fixed-length key hashes in tests.
+func bytesRepeat(b byte, n int) []byte {
+	s := make([]byte, n)
+	for i := range s {
+		s[i] = b
+	}
+	return s
 }
 
 func TestCosignTx_MergesPreservingExisting(t *testing.T) {

--- a/ui/internal/spend/importtx_test.go
+++ b/ui/internal/spend/importtx_test.go
@@ -208,18 +208,26 @@ func TestDecodeTx_WithdrawalsSortedByAddress(t *testing.T) {
 		t.Fatalf("encode modified tx: %v", err)
 	}
 
-	got, err := svc.DecodeTx(context.Background(), hex.EncodeToString(newTxBytes))
-	if err != nil {
-		t.Fatalf("DecodeTx: %v", err)
-	}
-	if len(got.Withdrawals) != 2 {
-		t.Fatalf("got %d withdrawals, want 2: %+v", len(got.Withdrawals), got.Withdrawals)
-	}
 	want := []string{addrHi.String(), addrLo.String()}
 	sort.Strings(want)
-	gotAddrs := []string{got.Withdrawals[0].Address, got.Withdrawals[1].Address}
-	if gotAddrs[0] != want[0] || gotAddrs[1] != want[1] {
-		t.Fatalf("withdrawals order = %v, want sorted %v", gotAddrs, want)
+
+	// DecodeTx re-parses TxWithdrawals from the tx body on every call, and Go
+	// randomizes map iteration order per-run, so a single call would only
+	// catch a dropped sort about half the time. Repeat the decode so the test
+	// reliably fails if the production sort is ever removed.
+	txHex := hex.EncodeToString(newTxBytes)
+	for attempt := 0; attempt < 32; attempt++ {
+		got, err := svc.DecodeTx(context.Background(), txHex)
+		if err != nil {
+			t.Fatalf("DecodeTx (attempt %d): %v", attempt, err)
+		}
+		if len(got.Withdrawals) != 2 {
+			t.Fatalf("attempt %d: got %d withdrawals, want 2: %+v", attempt, len(got.Withdrawals), got.Withdrawals)
+		}
+		gotAddrs := []string{got.Withdrawals[0].Address, got.Withdrawals[1].Address}
+		if gotAddrs[0] != want[0] || gotAddrs[1] != want[1] {
+			t.Fatalf("attempt %d: withdrawals order = %v, want sorted %v", attempt, gotAddrs, want)
+		}
 	}
 }
 

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -1495,6 +1495,8 @@ func (s *Service) DecodeTx(ctx context.Context, txCbor string) (TxSummary, error
 	for _, c := range tx.Body.Certificates() {
 		out.Certificates = append(out.Certificates, certLabel(c))
 	}
+	// TxWithdrawals is a Go map (randomized iteration); collect then sort by
+	// reward address so out.Withdrawals is deterministic.
 	for addr, amount := range tx.Body.TxWithdrawals {
 		if addr == nil {
 			continue
@@ -1504,6 +1506,9 @@ func (s *Service) DecodeTx(ctx context.Context, txCbor string) (TxSummary, error
 			Lovelace: strconv.FormatUint(amount, 10),
 		})
 	}
+	sort.Slice(out.Withdrawals, func(i, j int) bool {
+		return out.Withdrawals[i].Address < out.Withdrawals[j].Address
+	})
 
 	// Existing signatures already present in the witness set. A witness counts
 	// toward `present` (the "already covered" set used for wallet_can_add and


### PR DESCRIPTION
Two small robustness fixes in the import-transaction backend paths:

- `PolicyFromScript(nil)` panicked on a nil script; it now returns `ErrInvalidTx`.
- `DecodeTx` rendered multiple withdrawals in nondeterministic map-iteration order; they are now sorted by reward address for stable output.

Both are covered by tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the import-transaction backend by nil-guarding `PolicyFromScript` and making `DecodeTx` withdrawals deterministic. Prevents panics on malformed inputs and keeps summaries stable.

- **Bug Fixes**
  - `PolicyFromScript(nil)` now returns `ErrInvalidTx` instead of panicking.
  - `DecodeTx` sorts withdrawals by reward address; regression test loops decoding to enforce deterministic order.

<sup>Written for commit ffc66c8cd0f7284a3cf424349252e96bfc637e28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid multisignature scripts are now handled safely with a clear transaction error instead of causing a crash.
  - Transaction withdrawal details now appear in a consistent order, ensuring stable and predictable output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->