### PR TITLE
fix(ui): don't enable Submit for an unrecognized native-script tx

### DIFF
--- a/ui/web/src/screens/ImportTransaction.test.tsx
+++ b/ui/web/src/screens/ImportTransaction.test.tsx
@@ -131,6 +131,32 @@ const multisigBelowThreshold: TxSummary = {
   },
 };
 
+test("multisig: submit stays disabled for an unrecognized native-script tx (threshold 0)", async () => {
+  vi.spyOn(client, "decodeTx").mockResolvedValue({
+    ...vkeySummary,
+    kind: "native_multisig",
+    wallet_can_add: [],
+    is_complete: true,
+    multisig: {
+      is_multisig: true,
+      threshold: 0,
+      signed_count: 0,
+      script_embedded: true,
+    },
+  });
+
+  render(<ImportTransaction canSubmit={true} />);
+
+  fireEvent.change(screen.getByLabelText(/transaction cbor/i), {
+    target: { value: "84a4" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /decode/i }));
+
+  const submitBtn = await screen.findByRole("button", { name: /submit to network/i });
+  expect(submitBtn).toBeDisabled();
+  expect(submitBtn).not.toHaveTextContent(/need 0 more/i);
+});
+
 test("multisig: cosign affordance shows and submit stays gated on threshold, then unlocks once met", async () => {
   const decodeSpy = vi.spyOn(client, "decodeTx").mockResolvedValue(multisigBelowThreshold);
   const cosignSpy = vi.spyOn(client, "cosignTx").mockResolvedValue({

--- a/ui/web/src/screens/ImportTransaction.tsx
+++ b/ui/web/src/screens/ImportTransaction.tsx
@@ -128,8 +128,9 @@ export function ImportTransaction({ canSubmit }: { canSubmit: boolean }) {
   // is_complete is meaningless for multisig (spend.DecodeTx reads it true
   // immediately since it never sees multisig required-signers) — gate
   // multisig readiness on the authoritative signed_count/threshold instead.
+  const msThreshold = ms?.threshold ?? 0;
   const readyToSubmit = ms?.is_multisig
-    ? ms.signed_count >= (ms.threshold ?? 0)
+    ? msThreshold > 0 && ms.signed_count >= msThreshold
     : (summary?.is_complete ?? false);
 
   return (


### PR DESCRIPTION
For a native-script tx whose script isn't a recognizable N-of-M policy, the backend reports `threshold: 0`, and the Import screen's readiness check (`signed_count >= (threshold ?? 0)`) evaluated to true — so "Submit to network" was enabled even though the backend rejects the transaction. Submit is now gated on a positive threshold. Covered by a new test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents enabling “Submit to network” for unrecognized native-script multisig transactions where the backend reports `threshold: 0`. Submit now requires a positive threshold to avoid backend rejection.

- **Bug Fixes**
  - Gate multisig readiness on `threshold > 0` and `signed_count >= threshold`.
  - Add a test to ensure submit stays disabled and hides “need 0 more” when `threshold: 0`.

<sup>Written for commit 2438a45099ca438c4def02686aa990ff610e7a85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

