### PR TITLE
refactor(ui): share extractTxBodyCbor between spend and connector

### DIFF
--- a/ui/internal/connector/backend.go
+++ b/ui/internal/connector/backend.go
@@ -338,7 +338,7 @@ func (b *WalletBackend) SignTx(ctx context.Context, txHex string, partialSign bo
 	// signing target) is blake2b-256 of these exact body bytes; re-encoding the
 	// decoded struct can produce a different (canonicalised) byte sequence, which
 	// would make every witness sign the wrong hash and the node reject the tx.
-	bodyCbor, err := extractTxBodyCbor(txBytes)
+	bodyCbor, err := spend.ExtractTxBodyCbor(txBytes)
 	if err != nil {
 		return "", err
 	}
@@ -358,25 +358,6 @@ func (b *WalletBackend) SignTx(ctx context.Context, txHex string, partialSign bo
 		return "", err
 	}
 	return hex.EncodeToString(wsCbor), nil
-}
-
-// extractTxBodyCbor returns the raw CBOR bytes of the transaction body (element
-// [0] of the outer transaction array), preserving them exactly as supplied so the
-// signing hash (blake2b-256 of the body) matches what the node computes. It does
-// NOT re-encode the decoded struct.
-func extractTxBodyCbor(txBytes []byte) ([]byte, error) {
-	var outer []gocbor.RawMessage
-	if _, err := gocbor.Decode(txBytes, &outer); err != nil {
-		return nil, fmt.Errorf("decode tx as CBOR array: %w", err)
-	}
-	if len(outer) < 1 {
-		return nil, errors.New("transaction CBOR array is empty (no body element)")
-	}
-	body := []byte(outer[0])
-	if len(body) == 0 {
-		return nil, errors.New("transaction body element is empty")
-	}
-	return body, nil
 }
 
 // resolveInputAddresses looks up which of this wallet's derived receive or

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -1594,22 +1594,33 @@ func (s *Service) addInputKeyHashes(ctx context.Context, tx *conway.ConwayTransa
 	return resolvedAll
 }
 
-// extractTxBodyCbor returns the raw CBOR bytes of the transaction body (element
+// ExtractTxBodyCbor returns the raw CBOR bytes of the transaction body (element
 // [0] of the outer transaction array), preserving them exactly as supplied so the
 // signing hash (blake2b-256 of the body) matches what the node computes. It does
-// NOT re-encode the decoded struct. This mirrors connector.extractTxBodyCbor;
-// CosignTx uses this copy so the spend package does not depend on connector.
-func extractTxBodyCbor(txBytes []byte) ([]byte, error) {
+// NOT re-encode the decoded struct. This is the canonical implementation shared
+// with the connector package (CIP-30 signing); spend's own call sites use the
+// private extractTxBodyCbor below, which wraps these errors with ErrInvalidTx.
+func ExtractTxBodyCbor(txBytes []byte) ([]byte, error) {
 	var outer []cbor.RawMessage
 	if _, err := cbor.Decode(txBytes, &outer); err != nil {
-		return nil, fmt.Errorf("%w: decode tx as CBOR array: %w", ErrInvalidTx, err)
+		return nil, fmt.Errorf("decode tx as CBOR array: %w", err)
 	}
 	if len(outer) < 1 {
-		return nil, fmt.Errorf("%w: transaction CBOR array is empty (no body element)", ErrInvalidTx)
+		return nil, errors.New("transaction CBOR array is empty (no body element)")
 	}
 	body := []byte(outer[0])
 	if len(body) == 0 {
-		return nil, fmt.Errorf("%w: transaction body element is empty", ErrInvalidTx)
+		return nil, errors.New("transaction body element is empty")
+	}
+	return body, nil
+}
+
+// extractTxBodyCbor wraps ExtractTxBodyCbor's errors with ErrInvalidTx so
+// spend's internal call sites keep their existing error classification.
+func extractTxBodyCbor(txBytes []byte) ([]byte, error) {
+	body, err := ExtractTxBodyCbor(txBytes)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidTx, err)
 	}
 	return body, nil
 }


### PR DESCRIPTION
The spend and connector packages carried near-identical copies of `extractTxBodyCbor` (slice element [0] of the outer tx CBOR array). This exports a single canonical `spend.ExtractTxBodyCbor` (bare errors) and has the connector call it, removing the duplicate. spend keeps its `ErrInvalidTx`-wrapped behavior at its own call sites; connector's bare-error behavior is unchanged. No behavior change; existing tests cover both.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated duplicated tx-body CBOR extraction into a single `spend.ExtractTxBodyCbor`, and updated `connector` to use it. No behavior changes; `spend` keeps `ErrInvalidTx` wrapping and `connector` continues returning bare errors.

- **Refactors**
  - Exported `ExtractTxBodyCbor` in `spend` as the canonical helper.
  - Removed the local `extractTxBodyCbor` from `connector` and called `spend.ExtractTxBodyCbor`.
  - Kept an internal `spend` wrapper to preserve existing error classification.

<sup>Written for commit bcf2bb200b91660f54bfea947a4291edc1a1cd9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

