### PR TITLE
refactor(ui): drop unemitted TxSummary kind values

### DIFF
--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -123,7 +123,7 @@ type TxSummarySigner struct {
 // multisig vs. already complete) and reports which of the wallet's own keys
 // could still add a required signature.
 type TxSummary struct {
-	Kind               string            `json:"kind"` // "vkey"|"native_multisig"|"complete"|"unknown"
+	Kind               string            `json:"kind"` // "vkey"|"native_multisig"
 	Outputs            []TxSummaryOutput `json:"outputs"`
 	Fee                string            `json:"fee"`
 	TTL                uint64            `json:"ttl,omitempty"`

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -777,7 +777,7 @@ export interface TxSummaryMultiSig {
 
 // spend.TxSummary, with the api-layer's optional multisig.TxInfo attached.
 export interface TxSummary {
-  kind: "vkey" | "native_multisig" | "complete" | "unknown";
+  kind: "vkey" | "native_multisig";
   outputs: TxSummaryOutput[];
   fee: string;
   ttl?: number;

--- a/ui/web/src/screens/ImportTransaction.tsx
+++ b/ui/web/src/screens/ImportTransaction.tsx
@@ -160,13 +160,6 @@ export function ImportTransaction({ canSubmit }: { canSubmit: boolean }) {
 
       {summary && (
         <div className="import-preview">
-          {summary.kind === "unknown" && (
-            <p role="alert" className="warn-text">
-              Some parts of this transaction could not be decoded. Review carefully
-              before signing.
-            </p>
-          )}
-
           <dl className="preview-summary">
             <div className="dl-row">
               <dt>Fee</dt>


### PR DESCRIPTION
The transaction summary's `kind` allowed `complete` and `unknown`, but the backend only ever emits `vkey` and `native_multisig`. This narrows the TypeScript union to the emitted values, removes the unreachable `kind === "unknown"` warning branch in the Import screen, and updates the Go doc comment to match. No behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrow `TxSummary.kind` to only 'vkey' and 'native_multisig' to match backend output and simplify the Import screen. Removed unused 'complete'/'unknown' kinds and the unreachable warning; no behavior change.

<sup>Written for commit 3d4230fc89df816875383b98c78b6f75818a5f82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

