### PR TITLE
fix(ui): install a Buffer polyfill so the wallet renders

### DIFF
--- a/ui/web/package.json
+++ b/ui/web/package.json
@@ -22,6 +22,7 @@
     "@zxing/browser": "^0.1.5",
     "@zxing/library": "^0.21.0",
     "bech32": "^1.1.4",
+    "buffer": "^6.0.3",
     "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/ui/web/src/hw/ledger.ts
+++ b/ui/web/src/hw/ledger.ts
@@ -10,7 +10,6 @@
  * implementation; the parity vector is exercised in ledger.test.ts.
  */
 
-import TransportWebHID from "@ledgerhq/hw-transport-webhid";
 import Ada from "@cardano-foundation/ledgerjs-hw-app-cardano";
 import type {
   AssetGroup,
@@ -153,6 +152,11 @@ export async function connectLedger(): Promise<HardwareSigner> {
     throw new Error("WebHID not available — open this in a Chromium browser");
   }
 
+  // Loaded on demand, as trezor.ts and keystone.ts load their transports: this
+  // keeps the WebHID transport (and the Node-shaped globals it reaches for) out
+  // of the initial bundle, so a user who never touches a Ledger never pays for
+  // it and a fault in it cannot take down app startup.
+  const { default: TransportWebHID } = await import("@ledgerhq/hw-transport-webhid");
   const transport = await TransportWebHID.create();
   const cardano = new Ada(transport);
 

--- a/ui/web/src/main.tsx
+++ b/ui/web/src/main.tsx
@@ -1,3 +1,6 @@
+// MUST stay the first import: it installs the Node globals that the hardware
+// wallet dependencies reach for while they are being evaluated.
+import "./polyfills";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/ui/web/src/polyfills.test.ts
+++ b/ui/web/src/polyfills.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(join(here, rel), "utf8");
+
+// These are SOURCE-level assertions on purpose.
+//
+// The bug they guard against — `ReferenceError: Buffer is not defined` thrown
+// while @ledgerhq/hw-transport-webhid was being evaluated, which aborted the
+// bundle and left a blank page — is invisible to a normal test here: vitest
+// runs on Node, where `Buffer` is a real global, so every runtime assertion
+// passes in the test environment and fails only in a browser. The structural
+// properties that actually keep the browser working are the ones checked below.
+
+test("main.tsx installs the polyfills before importing anything else", () => {
+  const main = read("./main.tsx");
+  const imports = [...main.matchAll(/^import\s.*$/gm)].map((m) => m[0]);
+
+  expect(imports.length).toBeGreaterThan(1);
+  // Import order is evaluation order: a later import (./app, and the hardware
+  // modules it reaches) must not be evaluated before the globals are in place.
+  expect(imports[0]).toContain("./polyfills");
+});
+
+test("polyfills installs Buffer on the global object", () => {
+  const src = read("./polyfills.ts");
+  expect(src).toMatch(/import\s*\{\s*Buffer\s*\}\s*from\s*["']buffer["']/);
+  expect(src).toMatch(/globalThis\.Buffer\s*\?\?=/);
+});
+
+test("the Ledger WebHID transport is loaded on demand, not at module scope", () => {
+  const ledger = read("./hw/ledger.ts");
+
+  // A top-level `import ... from "@ledgerhq/hw-transport-webhid"` puts the
+  // transport in the initial bundle and evaluates it during startup, so a
+  // fault in it takes down the whole app rather than just the Ledger flow.
+  const staticImport =
+    /^import\s+[^;]*from\s+["']@ledgerhq\/hw-transport-webhid["']/m;
+  expect(ledger).not.toMatch(staticImport);
+
+  expect(ledger).toMatch(
+    /await\s+import\(\s*["']@ledgerhq\/hw-transport-webhid["']\s*\)/,
+  );
+});

--- a/ui/web/src/polyfills.ts
+++ b/ui/web/src/polyfills.ts
@@ -1,0 +1,22 @@
+// Node globals that browser-targeted dependencies still expect.
+//
+// @ledgerhq/hw-transport-webhid (and the ledgerjs Cardano app beneath it)
+// reference the Node `Buffer` global directly. Browsers have no such global,
+// so without this the module throws `ReferenceError: Buffer is not defined`
+// while it is being evaluated — which, for a statically reachable import,
+// aborts the whole bundle before React ever mounts and leaves a blank page.
+//
+// This module exists so the assignment happens in a module BODY that is
+// evaluated before anything that needs it: `import "./polyfills"` as the first
+// import of main.tsx runs this to completion before ./app (and the hardware
+// modules it reaches) are evaluated. Setting the global inside main.tsx's own
+// body would be too late — every one of its imports is evaluated first.
+import { Buffer } from "buffer";
+
+declare global {
+  var Buffer: typeof import("buffer").Buffer;
+}
+
+globalThis.Buffer ??= Buffer;
+
+export {};


### PR DESCRIPTION
## The problem

The wallet renders a **blank page**. `#root` has zero children — React never mounts.

`@ledgerhq/hw-transport-webhid` is imported at module scope from `src/hw/index.ts:18` and reaches for the Node `Buffer` global while it is being evaluated. Browsers have no such global, so the module throws:

```
ReferenceError: Buffer is not defined
```

Because the import is static and reachable from the initial bundle, that abort takes down startup entirely rather than just the Ledger flow.

This reproduces against a **production build**, not only in dev.

## The fix

**1. Install `Buffer` from a dedicated polyfills module, imported first in `main.tsx`.**

It has to be its own module rather than an assignment in `main.tsx`: ES module evaluation runs every import of a module before that module's own body, so `globalThis.Buffer = …` written directly in `main.tsx` would land long after `./app` and the hardware modules beneath it had already been evaluated and thrown.

**2. Load the WebHID transport with a dynamic import.**

`trezor.ts:143` and `keystone.ts:425` already load their transports this way; Ledger was the odd one out. Both of its runtime uses are inside the already-`async` `connectLedger()`, so this is a contained change. It keeps the transport out of the initial bundle — a user who never connects a Ledger never pays for it, and a fault in it can no longer take down startup.

## Why the existing tests missed it

vitest runs on Node, where `Buffer` is a real global. Every runtime assertion passes in the test environment and the failure appears only in a browser — which is why 664 green tests sat alongside a wallet that would not open.

The added tests therefore assert the *structural* properties that keep the browser working: that `./polyfills` is the first import in `main.tsx`, and that the transport has no module-scope import.

## Verification

Built and served the production bundle, then loaded it:

| | `#root` children | `.app` present |
|---|---|---|
| before | `0` | no |
| after | `1` | yes |

`npx tsc -b` clean · 664 tests pass · `eslint` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the blank wallet page by installing a browser `Buffer` polyfill and lazy-loading the Ledger WebHID transport. Previously, a static import of `@ledgerhq/hw-transport-webhid` accessed `Buffer` during module evaluation and crashed startup; now the app mounts and Ledger loads only when needed.

**Review notes**
- Adds `buffer` dependency and `src/polyfills.ts`; `main.tsx` imports it first to install `globalThis.Buffer`.
- Loads `@ledgerhq/hw-transport-webhid` with a dynamic import inside `connectLedger()` to keep it out of the initial bundle.
- Adds source-level tests enforcing polyfills-first import order and no module-scope import of the Ledger transport.
- Required: keep `import "./polyfills"` as the first import in `main.tsx` and avoid top-level imports of `@ledgerhq/hw-transport-webhid`.

<sup>Written for commit 2ec788201caef8ef940131905ce215449dd3d04c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

