### PR TITLE
fix(ui): icon-only copy control, readable digits, a table that fits

### DIFF
--- a/ui/web/src/components/CopyButton.tsx
+++ b/ui/web/src/components/CopyButton.tsx
@@ -1,9 +1,30 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface CopyButtonProps {
   value: string;
   ariaLabel?: string;
   "aria-label"?: string;
+}
+
+// Icon-only: a copy control sits beside almost every address, hash and CBOR
+// blob in the wallet, and 39 buttons reading "Copy" turned dense readouts into
+// a wall of repeated words. The glyph carries the meaning; the label carries
+// the accessible name.
+function CopyGlyph() {
+  return (
+    <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true" focusable="false">
+      <rect x="5.5" y="5.5" width="8" height="8" rx="1.5" fill="none" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M10.5 3.5A1.5 1.5 0 0 0 9 2H3.5A1.5 1.5 0 0 0 2 3.5V9a1.5 1.5 0 0 0 1.5 1.5" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function CheckGlyph() {
+  return (
+    <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true" focusable="false">
+      <path d="M3 8.5l3.2 3.2L13 5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
 }
 
 export function CopyButton({
@@ -12,24 +33,47 @@ export function CopyButton({
   "aria-label": ariaLabelAttribute,
 }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
-  const label = ariaLabel ?? ariaLabelAttribute;
+  // Without a caller-supplied label the glyph would leave the button with no
+  // accessible name at all, so fall back to something usable rather than
+  // nothing — most call sites copy a single obvious value.
+  const label = ariaLabel ?? ariaLabelAttribute ?? "Copy to clipboard";
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear the reset timer on unmount: rows unmount on refresh/pagination, and
+  // a pending setCopied would land on a dead component.
+  useEffect(() => {
+    return () => {
+      if (timer.current !== null) clearTimeout(timer.current);
+    };
+  }, []);
 
   function handleClick() {
     navigator.clipboard
       .writeText(value)
       .then(() => {
         setCopied(true);
-        setTimeout(() => setCopied(false), 1000);
+        if (timer.current !== null) clearTimeout(timer.current);
+        timer.current = setTimeout(() => setCopied(false), 1200);
       })
       .catch(() => {
         // Copy can fail (denied permission / insecure context); leave the
-        // label unchanged rather than falsely reporting success.
+        // control unchanged rather than falsely reporting success.
       });
   }
 
   return (
-    <button type="button" className="btn ghost" onClick={handleClick} aria-label={label}>
-      {copied ? "Copied" : "Copy"}
+    <button
+      type="button"
+      className={copied ? "btn-icon copied" : "btn-icon"}
+      onClick={handleClick}
+      // The glyph swap is invisible to a screen reader, so the state rides on
+      // the button's own accessible name — which is re-announced on the
+      // focused control after the click. A live region here instead would mean
+      // 39 of them in the document competing to be "the" status.
+      aria-label={copied ? "Copied" : label}
+      title={copied ? "Copied" : label}
+    >
+      {copied ? <CheckGlyph /> : <CopyGlyph />}
     </button>
   );
 }

--- a/ui/web/src/components/components.test.tsx
+++ b/ui/web/src/components/components.test.tsx
@@ -75,8 +75,9 @@ test("CopyButton copies its value and shows feedback on success", async () => {
   render(<CopyButton value="addr_test1abc" />);
   fireEvent.click(screen.getByRole("button"));
   expect(writeText).toHaveBeenCalledWith("addr_test1abc");
-  // "Copied" appears only after the async write resolves.
-  expect(await screen.findByText("Copied")).toBeInTheDocument();
+  // "Copied" appears only after the async write resolves. The control is icon-only, so the copied state rides on its
+  // accessible name rather than visible text.
+  expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
 });
 
 test("SyncBanner shows error detail ahead of retained bootstrap diagnostics", () => {

--- a/ui/web/src/format.test.ts
+++ b/ui/web/src/format.test.ts
@@ -1,4 +1,4 @@
-import { parseAda, formatTokenQuantity } from "./format";
+import { parseAda, formatAda, formatTokenQuantity } from "./format";
 
 // --- parseAda tests ---
 
@@ -73,12 +73,13 @@ test("formatTokenQuantity: works with 2 decimals", () => {
   expect(formatTokenQuantity("150", 2)).toBe("1.5");
 });
 
-test("formatTokenQuantity: 0 decimals returns the raw integer unchanged", () => {
-  expect(formatTokenQuantity("12345", 0)).toBe("12345");
+test("formatTokenQuantity: 0 decimals applies no decimal scaling, only grouping", () => {
+  expect(formatTokenQuantity("12345", 0)).toBe("12,345");
+  expect(formatTokenQuantity("999", 0)).toBe("999");
 });
 
-test("formatTokenQuantity: negative decimals is treated as no-op (returned unchanged)", () => {
-  expect(formatTokenQuantity("12345", -1)).toBe("12345");
+test("formatTokenQuantity: negative decimals applies no decimal scaling", () => {
+  expect(formatTokenQuantity("12345", -1)).toBe("12,345");
 });
 
 test("formatTokenQuantity: a non-integer quantity string is returned unchanged", () => {
@@ -86,7 +87,7 @@ test("formatTokenQuantity: a non-integer quantity string is returned unchanged",
 });
 
 test("formatTokenQuantity: preserves values beyond 2^53 (no precision ceiling)", () => {
-  expect(formatTokenQuantity("9007199255000000", 6)).toBe("9007199255");
+  expect(formatTokenQuantity("9007199255000000", 6)).toBe("9,007,199,255");
 });
 
 test("formatTokenQuantity: formats a negative quantity", () => {
@@ -96,9 +97,35 @@ test("formatTokenQuantity: formats a negative quantity", () => {
 test("formatTokenQuantity: decimals beyond the sane cap is returned unchanged (DoS guard)", () => {
   // decimals comes from on-chain metadata anyone can mint arbitrary values
   // into; an unbounded value must never reach BigInt exponentiation.
-  expect(formatTokenQuantity("12345", 1_000_000_000)).toBe("12345");
+  expect(formatTokenQuantity("12345", 1_000_000_000)).toBe("12,345");
 });
 
 test("formatTokenQuantity: decimals at the cap boundary still formats normally", () => {
   expect(formatTokenQuantity("1" + "0".repeat(18), 18)).toBe("1");
+});
+
+// --- digit grouping ------------------------------------------------------
+
+test("formatAda groups the integer part so large balances stay readable", () => {
+  expect(formatAda("63120000000000")).toBe("63,120,000");
+  expect(formatAda("4820657123")).toBe("4,820.657123");
+  expect(formatAda("1000000")).toBe("1");
+  expect(formatAda("999999999")).toBe("999.999999");
+  expect(formatAda("-250000000")).toBe("-250");
+});
+
+test("formatAda leaves amounts under a thousand ungrouped", () => {
+  expect(formatAda("31840221")).toBe("31.840221");
+  expect(formatAda("0")).toBe("0");
+});
+
+test("formatTokenQuantity groups whole-token amounts, with and without decimals", () => {
+  // decimals: 0 tokens (SNEK, HOSKY) still need grouping.
+  expect(formatTokenQuantity("1250000", 0)).toBe("1,250,000");
+  expect(formatTokenQuantity("88000000", 0)).toBe("88,000,000");
+  expect(formatTokenQuantity("1234567890", 6)).toBe("1,234.56789");
+});
+
+test("formatTokenQuantity leaves a non-numeric quantity alone", () => {
+  expect(formatTokenQuantity("not-a-number", 0)).toBe("not-a-number");
 });

--- a/ui/web/src/format.ts
+++ b/ui/web/src/format.ts
@@ -12,6 +12,18 @@
  *   formatAda("1000001")        → "1.000001"
  *   formatAda("0")              → "0"
  */
+/**
+ * Insert thousands separators into a run of integer digits.
+ *
+ * Balances, stake and token supplies in this wallet routinely run to eight or
+ * more digits, where an ungrouped run is genuinely hard to read at a glance
+ * ("63120000000000"). Applied to the integer part only; fractional digits are
+ * never grouped.
+ */
+function groupDigits(digits: string): string {
+  return digits.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
 export function formatAda(lovelace: string): string {
   // BigInt() throws on a non-integer string; guard so a malformed API value
   // (e.g. an empty rewards field) shows through instead of crashing the screen.
@@ -26,13 +38,15 @@ export function formatAda(lovelace: string): string {
   const intPart = abs / LOVELACE_PER_ADA;
   const fracPart = abs % LOVELACE_PER_ADA;
 
+  const intStr = groupDigits(intPart.toString());
+
   if (fracPart === BigInt(0)) {
-    return (isNegative ? "-" : "") + intPart.toString();
+    return (isNegative ? "-" : "") + intStr;
   }
 
   // Pad to 6 digits, then strip trailing zeros.
   const fracStr = fracPart.toString().padStart(6, "0").replace(/0+$/, "");
-  return (isNegative ? "-" : "") + intPart.toString() + "." + fracStr;
+  return (isNegative ? "-" : "") + intStr + "." + fracStr;
 }
 
 /**
@@ -110,8 +124,13 @@ export function parseAda(ada: string): string {
 const MAX_TOKEN_DECIMALS = 18;
 
 export function formatTokenQuantity(quantity: string, decimals: number): string {
-  if (!Number.isInteger(decimals) || decimals <= 0 || decimals > MAX_TOKEN_DECIMALS) return quantity;
   if (!/^-?\d+$/.test(quantity)) return quantity;
+  // A zero-decimal token (SNEK, HOSKY) has no fractional part to render, but
+  // its whole-unit count still needs grouping.
+  if (!Number.isInteger(decimals) || decimals <= 0 || decimals > MAX_TOKEN_DECIMALS) {
+    const negative = quantity.startsWith("-");
+    return (negative ? "-" : "") + groupDigits(quantity.replace(/^-/, ""));
+  }
 
   const base = BigInt(10) ** BigInt(decimals);
   const raw = BigInt(quantity);
@@ -121,10 +140,12 @@ export function formatTokenQuantity(quantity: string, decimals: number): string 
   const intPart = abs / base;
   const fracPart = abs % base;
 
+  const intStr = groupDigits(intPart.toString());
+
   if (fracPart === BigInt(0)) {
-    return (isNegative ? "-" : "") + intPart.toString();
+    return (isNegative ? "-" : "") + intStr;
   }
 
   const fracStr = fracPart.toString().padStart(decimals, "0").replace(/0+$/, "");
-  return (isNegative ? "-" : "") + intPart.toString() + "." + fracStr;
+  return (isNegative ? "-" : "") + intStr + "." + fracStr;
 }

--- a/ui/web/src/screens/Activity.test.tsx
+++ b/ui/web/src/screens/Activity.test.tsx
@@ -83,12 +83,14 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-test("(a) renders block heights for each transaction", () => {
+test("(a) block height is kept out of the list and left to the detail drawer", () => {
   mockTransactions([TX1, TX2]);
   render(<Activity />);
 
-  expect(screen.getByText("12345")).toBeInTheDocument();
-  expect(screen.getByText("12300")).toBeInTheDocument();
+  // Scanning the list is about direction/amount/time; the block height is a
+  // drill-down fact, shown in the drawer and exported in the CSV.
+  expect(screen.queryByText("12345")).not.toBeInTheDocument();
+  expect(screen.queryByText("12300")).not.toBeInTheDocument();
 });
 
 test("(b) renders truncated tx hash with a CopyButton that copies the FULL hash", async () => {
@@ -114,10 +116,10 @@ test("(c) preserves API order (newest-first — TX1 row appears before TX2 row)"
   mockTransactions([TX1, TX2]);
   render(<Activity />);
 
-  const cells = screen.getAllByText(/^1[23]\d{3}$/);
-  // TX1 block 12345 should come before TX2 block 12300
-  expect(cells[0].textContent).toBe("12345");
-  expect(cells[1].textContent).toBe("12300");
+  // Identify rows by direction: TX1 is received, TX2 is sent.
+  const rows = screen.getAllByRole("row").slice(1); // drop the header row
+  expect(rows[0]).toHaveTextContent("Received");
+  expect(rows[1]).toHaveTextContent("Sent");
 });
 
 test("(d) empty list renders 'No transactions yet' message", () => {
@@ -174,11 +176,11 @@ test("(h) shows a direction indicator and signed net amount per row", () => {
   expect(table.getByText("-1.5 ADA")).toBeInTheDocument();
 });
 
-test("(i) shows the fee per row", () => {
+test("(i) keeps the fee out of the list -- the detail drawer carries it", () => {
   mockTransactions([TX1]);
   render(<Activity />);
 
-  expect(screen.getByText("0.17 ADA")).toBeInTheDocument();
+  expect(screen.queryByText("0.17 ADA")).not.toBeInTheDocument();
 });
 
 test("(j) shows a Pending pill for unconfirmed transactions and a count otherwise", () => {
@@ -283,10 +285,9 @@ test("(q) a pruned tx (null asset_deltas, no enrichment) renders without crashin
 
   expect(() => render(<Activity />)).not.toThrow();
 
-  // Direction shows "Unknown" for the pruned tx; its known block height and
-  // confirmations (from the history call, not enrichment) still render.
+  // Direction shows "Unknown" for the pruned tx; its confirmation count (from
+  // the history call, not enrichment) still renders.
   expect(screen.getByText("Unknown")).toBeInTheDocument();
-  expect(screen.getByText("500")).toBeInTheDocument();
   expect(screen.getByText("200")).toBeInTheDocument();
 
   // The CSV export must not throw even though asset_deltas is null — the

--- a/ui/web/src/screens/Activity.test.tsx
+++ b/ui/web/src/screens/Activity.test.tsx
@@ -102,7 +102,9 @@ test("(b) renders truncated tx hash with a CopyButton that copies the FULL hash"
   expect(copyButtons.length).toBeGreaterThanOrEqual(1);
   fireEvent.click(copyButtons[0]);
   expect(writeText).toHaveBeenCalledWith(TX1.tx_hash);
-  expect(await screen.findByText("Copied")).toBeInTheDocument();
+  // The control is icon-only, so the copied state rides on its
+  // accessible name rather than visible text.
+  expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
 
   // At least the beginning of the hash should be visible
   expect(screen.getByText(new RegExp(TX1.tx_hash.slice(0, 8)))).toBeInTheDocument();

--- a/ui/web/src/screens/Activity.tsx
+++ b/ui/web/src/screens/Activity.tsx
@@ -278,11 +278,13 @@ export function Activity({ network = "preview" }: ActivityProps = {}) {
     );
   }
 
+  // Fee and block height are drill-down facts, not scanning facts: the detail
+  // drawer already shows both in full. Carrying them in the list pushed the
+  // table past its width, which cost the Details action its place on screen --
+  // an eight-column row that does not fit serves nobody.
   const columns = [
     { key: "direction", label: "Direction" },
     { key: "amount", label: "Amount" },
-    { key: "fee", label: "Fee" },
-    { key: "block_height", label: "Block" },
     { key: "time", label: "Time" },
     { key: "confirmations", label: "Confirmations" },
     { key: "tx_hash", label: "Tx Hash" },
@@ -293,8 +295,6 @@ export function Activity({ network = "preview" }: ActivityProps = {}) {
   const rows = filtered.map((tx) => ({
     direction: <DirectionBadge direction={tx.direction} />,
     amount: <NetAmount tx={tx} />,
-    fee: tx.direction ? `${formatAda(tx.fee)} ADA` : <span className="muted">—</span>,
-    block_height: tx.block_height,
     time: formatBlockTime(tx.block_time),
     confirmations: <Confirmations tx={tx} />,
     tx_hash: (

--- a/ui/web/src/screens/PoolDirectory.test.tsx
+++ b/ui/web/src/screens/PoolDirectory.test.tsx
@@ -44,7 +44,7 @@ test("lists stake pools read from the node with formatted margin/pledge/saturati
   expect(await screen.findByText("5.0%")).toBeInTheDocument();
   expect(screen.getByText("42.0%")).toBeInTheDocument();
   expect(screen.getByText("100")).toBeInTheDocument(); // 100000000 lovelace pledge → 100 ADA
-  expect(screen.getByText("5000")).toBeInTheDocument(); // 5000000000 → 5000 ADA
+  expect(screen.getByText("5,000")).toBeInTheDocument(); // 5000000000 → 5000 ADA
   // Copy affordance carries the full (untruncated) pool id.
   expect(
     screen.getByRole("button", { name: `Copy pool id ${POOL_A.pool_id}` }),

--- a/ui/web/src/screens/Receive.test.tsx
+++ b/ui/web/src/screens/Receive.test.tsx
@@ -38,7 +38,9 @@ test("(a) next unused address card copies the FULL address", async () => {
   expect(copyButtons.length).toBeGreaterThanOrEqual(1);
   fireEvent.click(copyButtons[0]);
   expect(writeText).toHaveBeenCalledWith(ADDR_B);
-  expect(await screen.findByText("Copied")).toBeInTheDocument();
+  // The control is icon-only, so the copied state rides on its
+  // accessible name rather than visible text.
+  expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
 });
 
 test("(b) renders a table listing all receive addresses", () => {

--- a/ui/web/src/screens/Settings.test.tsx
+++ b/ui/web/src/screens/Settings.test.tsx
@@ -139,7 +139,9 @@ test("(b) renders stake address in monospace and a CopyButton for it", async () 
   // The copy button must copy the FULL stake address.
   fireEvent.click(screen.getByRole("button", { name: /copy/i }));
   expect(writeText).toHaveBeenCalledWith(mockAccount.stake_address);
-  expect(await screen.findByText("Copied")).toBeInTheDocument();
+  // The control is icon-only, so the copied state rides on its
+  // accessible name rather than visible text.
+  expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
 });
 
 test("(c) renders sync state pill from useStatus", () => {

--- a/ui/web/src/screens/Staking.test.tsx
+++ b/ui/web/src/screens/Staking.test.tsx
@@ -200,8 +200,8 @@ test("(c) Review delegation builds the request and shows the itemized confirm", 
   // Itemized confirm: each cert summary plus the 2 ADA deposit and total.
   await waitFor(() => expect(screen.getByText(/register stake key/i)).toBeInTheDocument());
   expect(screen.getByText(/delegate stake to pool1abc/i)).toBeInTheDocument();
-  expect(screen.getByText(/2 ₳ deposit/)).toBeInTheDocument(); // 2000000 lovelace
-  expect(screen.getByText(/2\.174 ₳/)).toBeInTheDocument(); // total 2174000 lovelace
+  expect(screen.getByText(/2 ADA deposit/)).toBeInTheDocument(); // 2000000 lovelace
+  expect(screen.getByText(/2\.174 ADA/)).toBeInTheDocument(); // total 2174000 lovelace
 });
 
 // --- 4-way voting-power picker ---
@@ -224,8 +224,8 @@ test("(e) choosing 'register self' reveals the optional anchor fields + deposit 
 
   expect(screen.getByPlaceholderText(/example\.org\/my-drep/i)).toBeInTheDocument();
   expect(screen.getByText(/exact deposit amounts are read from your node/i)).toBeInTheDocument();
-  expect(screen.queryByText(/500 ₳ deposit/i)).not.toBeInTheDocument();
-  expect(screen.queryByText(/2 ₳ stake-key deposit/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/500 ADA deposit/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/2 ADA stake-key deposit/i)).not.toBeInTheDocument();
 });
 
 test("register-self metadata hash without a URL blocks Review", async () => {
@@ -327,7 +327,7 @@ test("(i) active wallet shows withdraw + change; Withdraw builds a withdraw-only
 
   // Status shows Registered + the withdrawable amount.
   expect(screen.getByText(/registered/i)).toBeInTheDocument();
-  expect(screen.getByText(/14\.207 ₳/)).toBeInTheDocument();
+  expect(screen.getByText(/14\.207 ADA/)).toBeInTheDocument();
 
   fireEvent.click(screen.getByRole("button", { name: /withdraw rewards/i }));
 

--- a/ui/web/src/screens/Staking.tsx
+++ b/ui/web/src/screens/Staking.tsx
@@ -283,9 +283,9 @@ function Compose(props: ComposeProps) {
           <p className="verified-readout">
             <span className="verified-tick">✓ Verified by your node</span>
             {" · "}margin {pct(pool.margin_cost)}
-            {" · "}pledge {formatAda(pool.declared_pledge)} ₳
-            {" · "}fixed {formatAda(pool.fixed_cost)} ₳
-            {" · "}live stake {formatAda(pool.live_stake)} ₳
+            {" · "}pledge {formatAda(pool.declared_pledge)} ADA
+            {" · "}fixed {formatAda(pool.fixed_cost)} ADA
+            {" · "}live stake {formatAda(pool.live_stake)} ADA
             <ExplorerLink network={network} kind="pool" id={pool.pool_id} />
           </p>
         )}
@@ -502,9 +502,9 @@ function PreviewPhase({ preview, isHardware, walletId, onBack, onDone }: Preview
               <span className="cert-body">{c.summary}</span>
               <span className="cert-amt">
                 {c.deposit_lovelace
-                  ? `${formatAda(c.deposit_lovelace)} ₳ deposit`
+                  ? `${formatAda(c.deposit_lovelace)} ADA deposit`
                   : c.amount_lovelace
-                    ? `${formatAda(c.amount_lovelace)} ₳`
+                    ? `${formatAda(c.amount_lovelace)} ADA`
                     : "—"}
               </span>
             </div>
@@ -514,23 +514,23 @@ function PreviewPhase({ preview, isHardware, walletId, onBack, onDone }: Preview
         <dl className="preview-summary">
           <div className="dl-row">
             <dt>Network fee</dt>
-            <dd>{formatAda(preview.fee)} ₳</dd>
+            <dd>{formatAda(preview.fee)} ADA</dd>
           </div>
           {preview.deposit !== "0" && (
             <div className="dl-row">
               <dt>Refundable deposit</dt>
-              <dd>{formatAda(preview.deposit)} ₳</dd>
+              <dd>{formatAda(preview.deposit)} ADA</dd>
             </div>
           )}
           {preview.withdrawal && (
             <div className="dl-row">
               <dt>Withdrawal</dt>
-              <dd>{formatAda(preview.withdrawal)} ₳</dd>
+              <dd>{formatAda(preview.withdrawal)} ADA</dd>
             </div>
           )}
           <div className="dl-row">
             <dt>Total to confirm</dt>
-            <dd className="total-accent">{formatAda(preview.total)} ₳</dd>
+            <dd className="total-accent">{formatAda(preview.total)} ADA</dd>
           </div>
         </dl>
       </Card>
@@ -670,7 +670,7 @@ function ActiveState({ poolId, withdrawable, note, onChange, onWithdraw, network
       <Card title="Rewards">
         <div className="dl-row">
           <dt className="field-label">Withdrawable</dt>
-          <dd className="total-accent mono">{formatAda(withdrawable)} ₳</dd>
+          <dd className="total-accent mono">{formatAda(withdrawable)} ADA</dd>
         </div>
 
         {error && (

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -411,6 +411,61 @@ a:hover {
   background: var(--accent-strong);
   border-color: var(--accent-strong);
 }
+/* Screen-reader-only text: kept in the accessibility tree, out of the layout. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Icon-only control (copy, and anything else that is a glyph plus a label).
+   Square by construction so it can never wrap its content the way a text
+   button in a narrow table cell does, and sized to stay a comfortable
+   pointer target. */
+.btn-icon {
+  appearance: none;
+  -webkit-appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text-faint);
+  cursor: pointer;
+  vertical-align: middle;
+  transition:
+    color 0.14s ease,
+    background 0.14s ease,
+    border-color 0.14s ease;
+}
+.btn-icon:hover:not(:disabled) {
+  color: var(--accent);
+  background: var(--inset);
+  border-color: var(--border);
+}
+.btn-icon:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.btn-icon.copied {
+  color: var(--ok);
+}
+.btn-icon:disabled {
+  opacity: 0.38;
+  cursor: not-allowed;
+}
+
 .btn.ghost {
   background: transparent;
   color: var(--accent);

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -641,8 +641,16 @@ a:hover {
 .table td {
   padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--border);
-  vertical-align: top;
+  /* Middle, not top: cells pair a value with an icon control, and top
+     alignment left the icon floating above the text it belongs to. */
+  vertical-align: middle;
   color: var(--text);
+  /* Cell values here are hashes, addresses, amounts and timestamps -- atomic
+     tokens that mean nothing broken across lines. Wrapping them was turning
+     three-line cells into triple-height rows; .table-wrap already scrolls
+     horizontally, which is the right way to handle a table that outgrows its
+     column. */
+  white-space: nowrap;
 }
 .table tr:last-child td {
   border-bottom: none;


### PR DESCRIPTION
Interface cleanup found by actually running the wallet and looking at it.

> Depends on #695 to render at all — the wallet is currently a blank page.

## Copy is an icon now

A copy control sits beside almost every address, hash and CBOR blob in the wallet — **39 of them**. Every one read `Copy`, which turned dense readouts into a wall of repeated words.

In the Activity table the text did not even fit its column: the button wrapped character-by-character into a vertical `C o p y` and tripled every row's height, at an ordinary 1440px desktop width.

It is now a glyph that swaps to a check on success, square by construction so it cannot wrap. All 39 call sites change through the one component.

Two details worth flagging for review:

- **Accessible name.** Most call sites pass no label. For an icon-only control that would mean *no accessible name at all*, so it falls back to `Copy to clipboard`.
- **State.** The copied state rides on the button's own accessible name, re-announced on the focused control after the click. A live region per control would have put 39 of them in the document competing to be "the" status — which broke four unrelated `findByRole("status")` queries when tried.

## The transaction table fits now

Cells no longer wrap: hashes, addresses, amounts and timestamps are atomic tokens that mean nothing broken mid-way, and `.table-wrap` already scrolls horizontally for a table that outgrows its column.

That alone made rows single-line but pushed the table past its container, hiding the **Details** action off-screen. Fee and block height are drill-down facts, not scanning facts, and the detail drawer already shows both in full — so they are out of the list.

| | before | after |
|---|---|---|
| row height @1440px | 185px | 56px |
| horizontal overflow | — | none |

## Digits are grouped

Live stake read `63120000000000`. Digits were already tabular and monospaced; grouping is the remaining half of making them readable. Zero-decimal tokens (SNEK, HOSKY) group too — they have no fractional part to scale, but their whole-unit counts are the largest numbers on screen.

## One unit spelling

`Staking.tsx` was the only file using `₳` (U+20B3); every other screen writes `ADA`. It renders as a bare `A` wherever the font stack has no glyph for it — which is what it did on the machine these screenshots came from.

## Verification

`npx tsc -b` clean · 668 tests pass · `eslint` clean (one pre-existing warning in `connectorNotify.ts`, untouched).

Four tests that asserted the old contract were retargeted rather than deleted: block height and fee are now asserted *absent* from the list, and the ordering test identifies rows by direction instead of by the removed block column.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the wallet UI readable and compact by replacing text copy buttons with an icon-only control, grouping digits in amounts, and trimming the Activity table so rows fit on one line. The list no longer shows Fee or Block, copy state is announced via the button’s accessible name, and the unit spells “ADA” instead of `₳`.

- Copy control: `CopyButton` is now icon-only, swaps to a check on success, and defaults its accessible name to “Copy to clipboard” when no label is provided. State is exposed via `aria-label`/`title`, not visible text, and a new `.btn-icon` style keeps the control square and non-wrapping across 39 call sites.
- Activity table: cells are no-wrap and middle-aligned; Fee and Block are removed from the list and remain in the detail drawer and CSV. This prevents horizontal overflow and keeps the Details action in view.
- Formatting: `formatAda` and `formatTokenQuantity` insert thousands separators in integer parts. Zero- or negative-decimal tokens now show grouped whole-unit counts.
- Unit spelling: Staking switches from `₳` to “ADA” to match other screens and avoid missing glyphs.

**Migration**
- If you relied on Fee or Block in the list, use the drawer or CSV export.
- Provide an `aria-label` to `CopyButton` when the copied value needs a specific accessible name; otherwise it falls back to “Copy to clipboard.”
- Expect comma-grouped amounts in UI and tests; update assertions that matched ungrouped numbers.
- Depends on #695 for the wallet to render.

<sup>Written for commit 0b760927908f6f1b8390acee620e2f4e7f39356a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

