### PR TITLE
fix(ui): make the wallet render, and clean up what it renders

### DIFF
--- a/ui/web/package.json
+++ b/ui/web/package.json
@@ -22,6 +22,7 @@
     "@zxing/browser": "^0.1.5",
     "@zxing/library": "^0.21.0",
     "bech32": "^1.1.4",
+    "buffer": "^6.0.3",
     "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -21,9 +21,7 @@ import { Activity } from "./screens/Activity";
 import { Send } from "./screens/Send";
 import { Swap } from "./screens/Swap";
 import { Contacts } from "./screens/Contacts";
-import { Staking } from "./screens/Staking";
-import { RewardHistory } from "./screens/RewardHistory";
-import { PoolDirectory } from "./screens/PoolDirectory";
+import { Stake } from "./screens/Stake";
 import { SignMessage } from "./screens/SignMessage";
 import { VerifyMessage } from "./screens/VerifyMessage";
 import { Offline } from "./screens/Offline";
@@ -61,6 +59,15 @@ const ROUTES = new Map<string, () => ReactElement>([
   ["diagnostics", Diagnostics],
 ]);
 
+// Stake merged three screens; the old routes stay valid and open the matching
+// tab so existing bookmarks and links keep working.
+const STAKE_ROUTES = new Map<string, "delegation" | "rewards" | "pools">([
+  ["stake", "delegation"],
+  ["staking", "delegation"],
+  ["rewards", "rewards"],
+  ["pools", "pools"],
+]);
+
 const NAV: { key: string; label: string }[] = [
   { key: "portfolio", label: "Portfolio" },
   { key: "receive", label: "Receive" },
@@ -68,9 +75,7 @@ const NAV: { key: string; label: string }[] = [
   { key: "send", label: "Send" },
   { key: "swap", label: "Swap" },
   { key: "contacts", label: "Contacts" },
-  { key: "staking", label: "Staking" },
-  { key: "rewards", label: "Rewards" },
-  { key: "pools", label: "Stake Pools" },
+  { key: "stake", label: "Stake" },
   { key: "sign", label: "Sign" },
   { key: "verify", label: "Verify" },
   { key: "offline", label: "Offline" },
@@ -283,9 +288,9 @@ export function App() {
     if (route === "settings") activeRoute = "settings";
     else if (route === "send" && canSend) activeRoute = "send";
     else if (route === "swap" && canSwap) activeRoute = "swap";
-    else if (route === "staking" && canStake) activeRoute = "staking";
-    else if (route === "rewards") activeRoute = "rewards";
-    else if (route === "pools" && canQueryNode) activeRoute = "pools";
+    // The legacy per-screen routes now resolve to tabs of the merged screen,
+    // so an old bookmark or a link in the wild still highlights Stake.
+    else if (STAKE_ROUTES.has(route) && canQueryNode) activeRoute = "stake";
     else if (route === "sign" && canSign) activeRoute = "sign";
     else if (route === "verify") activeRoute = "verify";
     else if (route === "offline" && canSign) activeRoute = "offline";
@@ -334,30 +339,22 @@ export function App() {
     // Guard deep-links (#/swap): DEX quotes need a queryable mainnet node, so
     // fall back to Portfolio while the node or active wallet cannot support it.
     content = <Portfolio />;
-  } else if (route === "staking") {
-    // Staking/governance is gated like send: a synced node AND a
-    // spending-enabled wallet. A read-only or unsynced wallet falls back to
-    // Portfolio.
-    content = canStake ? (
-      <Staking
+  } else if (STAKE_ROUTES.has(route)) {
+    // Delegation, rewards and the pool directory are one screen. It needs only
+    // a queryable node, so read-only wallets still get rewards and pools; the
+    // Delegation tab explains itself when this wallet cannot sign a
+    // certificate, rather than the whole screen vanishing.
+    content = canQueryNode ? (
+      <Stake
         network={activeWallet.network}
         isHardware={activeWallet.type === "hardware"}
         walletId={activeWallet.id}
+        canDelegate={canStake}
+        initialTab={STAKE_ROUTES.get(route)}
       />
     ) : (
       <Portfolio />
     );
-  } else if (route === "rewards") {
-    // Read-only per-epoch reward history for the active wallet's stake
-    // address. Node-local read (no signing, no spend), so it is available to
-    // any active wallet; the pool explorer links need the wallet's network.
-    content = <RewardHistory network={activeWallet.network} />;
-  } else if (route === "pools") {
-    // Read-only stake-pool directory: browse/search pools the node has indexed.
-    // Needs only a queryable node (not a full sync, no spending), so it works
-    // for any active wallet — including read-only ones. Falls back to Portfolio
-    // while the node cannot serve queries.
-    content = canQueryNode ? <PoolDirectory network={activeWallet.network} /> : <Portfolio />;
   } else if (route === "sign") {
     content = canSign ? <SignMessage account={toAccount(activeWallet)} /> : <Portfolio />;
   } else if (route === "verify") {
@@ -406,8 +403,7 @@ export function App() {
       addingWallet ||
       (key === "send" && !canSend) ||
       (key === "swap" && !canSwap) ||
-      (key === "staking" && !canStake) ||
-      (key === "pools" && !canQueryNode) ||
+      (key === "stake" && !canQueryNode) ||
       (key === "sign" && !canSign) ||
       (key === "offline" && !canSign) ||
       (key === "operate" && !canSign) ||

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -9,6 +9,7 @@ import { Button } from "./components/Button";
 import { SyncBanner } from "./components/SyncBanner";
 import { WalletSwitcher } from "./components/WalletSwitcher";
 import { MobileNav } from "./components/MobileNav";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import { useHashRoute, navigate } from "./router";
 import { CreateVault } from "./screens/CreateVault";
 import { UnlockVault } from "./screens/UnlockVault";
@@ -461,7 +462,15 @@ export function App() {
             </button>
           ))}
         </nav>
-        <main className="content" key={activeWallet?.id ?? "none"}>{content}</main>
+        <main className="content" key={activeWallet?.id ?? "none"}>
+          {/* Scoped to the screen, not the shell: a screen that throws must not
+              take the nav and wallet switcher with it, or there is no way to
+              navigate out of the failure. resetKey clears the error on
+              navigation. */}
+          <ErrorBoundary label={activeRoute || "wallet"} resetKey={activeRoute}>
+            {content}
+          </ErrorBoundary>
+        </main>
       </div>
       {/* Global connector approval overlay: rendered on top of all screens when
           a dApp has pending consent requests. Mounts regardless of current route

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -467,7 +467,10 @@ export function App() {
               take the nav and wallet switcher with it, or there is no way to
               navigate out of the failure. resetKey clears the error on
               navigation. */}
-          <ErrorBoundary label={activeRoute || "wallet"} resetKey={activeRoute}>
+          {/* resetKey is the raw route, not activeRoute: the latter collapses
+              stake/staking/rewards/pools to one nav key, so moving between
+              those would not clear a caught error. */}
+          <ErrorBoundary label={activeRoute || "wallet"} resetKey={route}>
             {content}
           </ErrorBoundary>
         </main>

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -290,8 +290,11 @@ export function App() {
     else if (route === "send" && canSend) activeRoute = "send";
     else if (route === "swap" && canSwap) activeRoute = "swap";
     // The legacy per-screen routes now resolve to tabs of the merged screen,
-    // so an old bookmark or a link in the wild still highlights Stake.
-    else if (STAKE_ROUTES.has(route) && canQueryNode) activeRoute = "stake";
+    // so an old bookmark or a link in the wild still highlights Stake. No node
+    // condition here: the screen itself is ungated, and a highlight that
+    // disagreed with what is rendered would point at Portfolio while Stake is
+    // on screen — and mislabel the error boundary with it.
+    else if (STAKE_ROUTES.has(route)) activeRoute = "stake";
     else if (route === "sign" && canSign) activeRoute = "sign";
     else if (route === "verify") activeRoute = "verify";
     else if (route === "offline" && canSign) activeRoute = "offline";

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -341,20 +341,21 @@ export function App() {
     // fall back to Portfolio while the node or active wallet cannot support it.
     content = <Portfolio />;
   } else if (STAKE_ROUTES.has(route)) {
-    // Delegation, rewards and the pool directory are one screen. It needs only
-    // a queryable node, so read-only wallets still get rewards and pools; the
-    // Delegation tab explains itself when this wallet cannot sign a
-    // certificate, rather than the whole screen vanishing.
-    content = canQueryNode ? (
+    // Delegation, rewards and the pool directory are one screen, and it is not
+    // gated as a whole: reward history is a plain account read that the old
+    // #/rewards route offered to any active wallet whatever the node was
+    // doing, and merging the screens must not quietly take that away. Each tab
+    // states its own requirement instead — Delegation when this wallet cannot
+    // sign a certificate, Pools when the node cannot answer queries.
+    content = (
       <Stake
         network={activeWallet.network}
         isHardware={activeWallet.type === "hardware"}
         walletId={activeWallet.id}
         canDelegate={canStake}
+        canQueryNode={canQueryNode}
         initialTab={STAKE_ROUTES.get(route)}
       />
-    ) : (
-      <Portfolio />
     );
   } else if (route === "sign") {
     content = canSign ? <SignMessage account={toAccount(activeWallet)} /> : <Portfolio />;
@@ -404,7 +405,6 @@ export function App() {
       addingWallet ||
       (key === "send" && !canSend) ||
       (key === "swap" && !canSwap) ||
-      (key === "stake" && !canQueryNode) ||
       (key === "sign" && !canSign) ||
       (key === "offline" && !canSign) ||
       (key === "operate" && !canSign) ||
@@ -469,8 +469,13 @@ export function App() {
               navigation. */}
           {/* resetKey is the raw route, not activeRoute: the latter collapses
               stake/staking/rewards/pools to one nav key, so moving between
-              those would not clear a caught error. */}
-          <ErrorBoundary label={activeRoute || "wallet"} resetKey={route}>
+              those would not clear a caught error. addingWallet is in the key
+              too — it swaps the content without changing the route, and is a
+              shell recovery action that must not land on a stale fallback. */}
+          <ErrorBoundary
+            label={activeRoute || "wallet"}
+            resetKey={`${route}:${addingWallet}`}
+          >
             {content}
           </ErrorBoundary>
         </main>

--- a/ui/web/src/components/CopyButton.tsx
+++ b/ui/web/src/components/CopyButton.tsx
@@ -62,26 +62,32 @@ export function CopyButton({
   }
 
   return (
-    <button
-      type="button"
-      className={copied ? "btn-icon copied" : "btn-icon"}
-      onClick={handleClick}
-      // The name carries the state as well as the identity: with a copy
-      // control beside every address and hash, a bare "Copied" would leave a
-      // screen-reader user unable to tell WHICH one they copied.
-      aria-label={copied ? `${label} (copied)` : label}
-      title={copied ? `${label} (copied)` : label}
-    >
-      {copied ? <CheckGlyph /> : <CopyGlyph />}
+    // display:contents, so wrapping the button to hold its live region changes
+    // nothing about layout — these sit inside flex rows and table cells.
+    <span className="copy-control">
+      <button
+        type="button"
+        className={copied ? "btn-icon copied" : "btn-icon"}
+        onClick={handleClick}
+        // The name carries the state as well as the identity: with a copy
+        // control beside every address and hash, a bare "Copied" would leave a
+        // screen-reader user unable to tell WHICH one they copied.
+        aria-label={copied ? `${label} (copied)` : label}
+        title={copied ? `${label} (copied)` : label}
+      >
+        {copied ? <CheckGlyph /> : <CopyGlyph />}
+      </button>
       {/* A changed accessible name on an already-focused control is not
-          reliably announced, so success also goes through a live region. It is
-          rendered ONLY while copied, so the document never holds a crowd of
-          empty status nodes competing to be "the" status. */}
+          reliably announced, so success also goes through a live region.
+          Outside the button, not within it: several screen readers treat an
+          interactive control as one unit and never process content changes
+          inside it. Rendered ONLY while copied, so the document never holds a
+          crowd of empty status nodes competing to be "the" status. */}
       {copied && (
         <span className="sr-only" role="status">
           {label} copied
         </span>
       )}
-    </button>
+    </span>
   );
 }

--- a/ui/web/src/components/CopyButton.tsx
+++ b/ui/web/src/components/CopyButton.tsx
@@ -70,8 +70,12 @@ export function CopyButton({
       // the button's own accessible name — which is re-announced on the
       // focused control after the click. A live region here instead would mean
       // 39 of them in the document competing to be "the" status.
-      aria-label={copied ? "Copied" : label}
-      title={copied ? "Copied" : label}
+      //
+      // The label is kept alongside the state: with a copy control beside every
+      // address and hash on a screen, a bare "Copied" would leave a
+      // screen-reader user unable to tell WHICH one they just copied.
+      aria-label={copied ? `${label} (copied)` : label}
+      title={copied ? `${label} (copied)` : label}
     >
       {copied ? <CheckGlyph /> : <CopyGlyph />}
     </button>

--- a/ui/web/src/components/CopyButton.tsx
+++ b/ui/web/src/components/CopyButton.tsx
@@ -1,9 +1,30 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface CopyButtonProps {
   value: string;
   ariaLabel?: string;
   "aria-label"?: string;
+}
+
+// Icon-only: a copy control sits beside almost every address, hash and CBOR
+// blob in the wallet, and 39 buttons reading "Copy" turned dense readouts into
+// a wall of repeated words. The glyph carries the meaning; the label carries
+// the accessible name.
+function CopyGlyph() {
+  return (
+    <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true" focusable="false">
+      <rect x="5.5" y="5.5" width="8" height="8" rx="1.5" fill="none" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M10.5 3.5A1.5 1.5 0 0 0 9 2H3.5A1.5 1.5 0 0 0 2 3.5V9a1.5 1.5 0 0 0 1.5 1.5" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function CheckGlyph() {
+  return (
+    <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true" focusable="false">
+      <path d="M3 8.5l3.2 3.2L13 5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
 }
 
 export function CopyButton({
@@ -12,24 +33,47 @@ export function CopyButton({
   "aria-label": ariaLabelAttribute,
 }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
-  const label = ariaLabel ?? ariaLabelAttribute;
+  // Without a caller-supplied label the glyph would leave the button with no
+  // accessible name at all, so fall back to something usable rather than
+  // nothing — most call sites copy a single obvious value.
+  const label = ariaLabel ?? ariaLabelAttribute ?? "Copy to clipboard";
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear the reset timer on unmount: rows unmount on refresh/pagination, and
+  // a pending setCopied would land on a dead component.
+  useEffect(() => {
+    return () => {
+      if (timer.current !== null) clearTimeout(timer.current);
+    };
+  }, []);
 
   function handleClick() {
     navigator.clipboard
       .writeText(value)
       .then(() => {
         setCopied(true);
-        setTimeout(() => setCopied(false), 1000);
+        if (timer.current !== null) clearTimeout(timer.current);
+        timer.current = setTimeout(() => setCopied(false), 1200);
       })
       .catch(() => {
         // Copy can fail (denied permission / insecure context); leave the
-        // label unchanged rather than falsely reporting success.
+        // control unchanged rather than falsely reporting success.
       });
   }
 
   return (
-    <button type="button" className="btn ghost" onClick={handleClick} aria-label={label}>
-      {copied ? "Copied" : "Copy"}
+    <button
+      type="button"
+      className={copied ? "btn-icon copied" : "btn-icon"}
+      onClick={handleClick}
+      // The glyph swap is invisible to a screen reader, so the state rides on
+      // the button's own accessible name — which is re-announced on the
+      // focused control after the click. A live region here instead would mean
+      // 39 of them in the document competing to be "the" status.
+      aria-label={copied ? "Copied" : label}
+      title={copied ? "Copied" : label}
+    >
+      {copied ? <CheckGlyph /> : <CopyGlyph />}
     </button>
   );
 }

--- a/ui/web/src/components/CopyButton.tsx
+++ b/ui/web/src/components/CopyButton.tsx
@@ -66,18 +66,22 @@ export function CopyButton({
       type="button"
       className={copied ? "btn-icon copied" : "btn-icon"}
       onClick={handleClick}
-      // The glyph swap is invisible to a screen reader, so the state rides on
-      // the button's own accessible name — which is re-announced on the
-      // focused control after the click. A live region here instead would mean
-      // 39 of them in the document competing to be "the" status.
-      //
-      // The label is kept alongside the state: with a copy control beside every
-      // address and hash on a screen, a bare "Copied" would leave a
-      // screen-reader user unable to tell WHICH one they just copied.
+      // The name carries the state as well as the identity: with a copy
+      // control beside every address and hash, a bare "Copied" would leave a
+      // screen-reader user unable to tell WHICH one they copied.
       aria-label={copied ? `${label} (copied)` : label}
       title={copied ? `${label} (copied)` : label}
     >
       {copied ? <CheckGlyph /> : <CopyGlyph />}
+      {/* A changed accessible name on an already-focused control is not
+          reliably announced, so success also goes through a live region. It is
+          rendered ONLY while copied, so the document never holds a crowd of
+          empty status nodes competing to be "the" status. */}
+      {copied && (
+        <span className="sr-only" role="status">
+          {label} copied
+        </span>
+      )}
     </button>
   );
 }

--- a/ui/web/src/components/ErrorBoundary.test.tsx
+++ b/ui/web/src/components/ErrorBoundary.test.tsx
@@ -25,7 +25,11 @@ test("a throwing screen shows a recoverable panel instead of a blank page", () =
   expect(screen.getByRole("alert")).toHaveTextContent(/something went wrong/i);
   // Names the screen, and reassures about funds — this is a wallet.
   expect(screen.getByText(/the swap screen could not be displayed/i)).toBeInTheDocument();
-  expect(screen.getByText(/funds are unaffected/i)).toBeInTheDocument();
+  expect(screen.getByText(/keys are safe/i)).toBeInTheDocument();
+  // Must NOT claim nothing was submitted: a throw can land after a submission,
+  // and a false all-clear invites a duplicate send.
+  expect(screen.queryByText(/nothing was submitted/i)).not.toBeInTheDocument();
+  expect(screen.getByText(/check Activity before trying again/i)).toBeInTheDocument();
   // The underlying message is kept, so a bug report can carry it.
   expect(screen.getByText(/price_impact_pct is undefined/)).toBeInTheDocument();
 });
@@ -60,4 +64,32 @@ test("navigating to another screen clears the error", () => {
   // Without the resetKey the user would be pinned to the failed screen.
   expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   expect(screen.getByText("screen content")).toBeInTheDocument();
+});
+
+test("a non-Error throw does not crash the fallback itself", () => {
+  function ThrowsString(): React.ReactElement {
+    // Nothing guarantees a child throws an Error; reading .message off a
+    // string, null or undefined in the fallback would re-throw and restore the
+    // blank page this component exists to prevent.
+    throw "boom";
+  }
+  render(
+    <ErrorBoundary label="swap">
+      <ThrowsString />
+    </ErrorBoundary>,
+  );
+  expect(screen.getByRole("alert")).toHaveTextContent(/something went wrong/i);
+  expect(screen.getByText("boom")).toBeInTheDocument();
+});
+
+test("a thrown null still renders a readable message", () => {
+  function ThrowsNull(): React.ReactElement {
+    throw null;
+  }
+  render(
+    <ErrorBoundary label="swap">
+      <ThrowsNull />
+    </ErrorBoundary>,
+  );
+  expect(screen.getByRole("alert")).toHaveTextContent(/an unexpected error occurred/i);
 });

--- a/ui/web/src/components/ErrorBoundary.test.tsx
+++ b/ui/web/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useState } from "react";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+function Boom({ explode }: { explode: boolean }): React.ReactElement {
+  if (explode) throw new Error("price_impact_pct is undefined");
+  return <p>screen content</p>;
+}
+
+// React logs caught render errors; silence it so the output stays readable.
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("a throwing screen shows a recoverable panel instead of a blank page", () => {
+  render(
+    <ErrorBoundary label="swap">
+      <Boom explode />
+    </ErrorBoundary>,
+  );
+
+  expect(screen.getByRole("alert")).toHaveTextContent(/something went wrong/i);
+  // Names the screen, and reassures about funds — this is a wallet.
+  expect(screen.getByText(/the swap screen could not be displayed/i)).toBeInTheDocument();
+  expect(screen.getByText(/funds are unaffected/i)).toBeInTheDocument();
+  // The underlying message is kept, so a bug report can carry it.
+  expect(screen.getByText(/price_impact_pct is undefined/)).toBeInTheDocument();
+});
+
+test("children render untouched when nothing throws", () => {
+  render(
+    <ErrorBoundary label="swap">
+      <Boom explode={false} />
+    </ErrorBoundary>,
+  );
+  expect(screen.getByText("screen content")).toBeInTheDocument();
+  expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+});
+
+test("navigating to another screen clears the error", () => {
+  function Harness() {
+    const [route, setRoute] = useState("swap");
+    return (
+      <>
+        <button onClick={() => setRoute("portfolio")}>go portfolio</button>
+        <ErrorBoundary label={route} resetKey={route}>
+          <Boom explode={route === "swap"} />
+        </ErrorBoundary>
+      </>
+    );
+  }
+  render(<Harness />);
+  expect(screen.getByRole("alert")).toBeInTheDocument();
+
+  fireEvent.click(screen.getByText("go portfolio"));
+
+  // Without the resetKey the user would be pinned to the failed screen.
+  expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  expect(screen.getByText("screen content")).toBeInTheDocument();
+});

--- a/ui/web/src/components/ErrorBoundary.test.tsx
+++ b/ui/web/src/components/ErrorBoundary.test.tsx
@@ -93,3 +93,29 @@ test("a thrown null still renders a readable message", () => {
   );
   expect(screen.getByRole("alert")).toHaveTextContent(/an unexpected error occurred/i);
 });
+
+test("an error thrown by the destination survives the reset", () => {
+  // Navigating changes resetKey in the same commit that the destination
+  // throws. Clearing on any key change would discard that fresh error,
+  // remount, throw again and log the same fault twice.
+  function Harness() {
+    const [route, setRoute] = useState("swap");
+    return (
+      <>
+        <button onClick={() => setRoute("portfolio")}>go portfolio</button>
+        <ErrorBoundary label={route} resetKey={route}>
+          <Boom explode />
+        </ErrorBoundary>
+      </>
+    );
+  }
+  render(<Harness />);
+  expect(screen.getByRole("alert")).toBeInTheDocument();
+
+  fireEvent.click(screen.getByText("go portfolio"));
+
+  // Still showing a fallback, now for the destination, rather than flickering
+  // through a cleared state.
+  expect(screen.getByRole("alert")).toBeInTheDocument();
+  expect(screen.getByText(/the portfolio screen could not be displayed/i)).toBeInTheDocument();
+});

--- a/ui/web/src/components/ErrorBoundary.tsx
+++ b/ui/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,87 @@
+import { Component } from "react";
+import type { ErrorInfo, ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  // Identifies the region that failed, so the message can say what broke
+  // rather than implying the whole wallet is gone.
+  label?: string;
+  // Bumping this remounts the boundary's subtree, clearing a caught error.
+  // The app passes the current route so navigating away recovers.
+  resetKey?: string;
+}
+
+interface State {
+  error: Error | null;
+}
+
+/**
+ * Catches a render-time throw and shows a recoverable panel instead of an
+ * empty document.
+ *
+ * Without this, one bad field in one API response unmounts the entire React
+ * tree and the wallet becomes a blank white page with no way back except a
+ * reload — with the vault still unlocked and no indication of what happened.
+ * That is a poor failure mode for any app and an alarming one for a wallet.
+ *
+ * The node is the source of truth here and its responses are not part of this
+ * codebase, so a field arriving absent or in an unexpected shape is a case to
+ * survive, not to assume away.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidUpdate(prev: Props) {
+    // A new resetKey means the user navigated; give the subtree a clean try
+    // rather than pinning them to the failed screen.
+    if (this.state.error !== null && prev.resetKey !== this.props.resetKey) {
+      this.setState({ error: null });
+    }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("Unhandled error in", this.props.label ?? "the wallet UI", error, info.componentStack);
+  }
+
+  render() {
+    const { error } = this.state;
+    if (error === null) return this.props.children;
+
+    return (
+      <div className="card error-boundary" role="alert">
+        <h2>Something went wrong</h2>
+        <p>
+          {this.props.label
+            ? `The ${this.props.label} screen could not be displayed.`
+            : "This screen could not be displayed."}{" "}
+          Your wallet and funds are unaffected — nothing was submitted.
+        </p>
+        <p className="helper-text">
+          Move to another screen to carry on, or reload to start fresh. If it
+          keeps happening, the details below help us fix it.
+        </p>
+        <pre className="error-detail">{error.message}</pre>
+        <div className="preview-actions">
+          <button
+            type="button"
+            className="btn primary"
+            onClick={() => this.setState({ error: null })}
+          >
+            Try again
+          </button>
+          <button
+            type="button"
+            className="btn ghost"
+            onClick={() => window.location.reload()}
+          >
+            Reload
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/ui/web/src/components/ErrorBoundary.tsx
+++ b/ui/web/src/components/ErrorBoundary.tsx
@@ -12,7 +12,10 @@ interface Props {
 }
 
 interface State {
-  error: Error | null;
+  // Normalised to a string: a child may throw a non-Error (a string, null,
+  // even undefined), and reading .message off that in the fallback would throw
+  // again — restoring exactly the blank page this exists to prevent.
+  message: string | null;
 }
 
 /**
@@ -29,27 +32,33 @@ interface State {
  * survive, not to assume away.
  */
 export class ErrorBoundary extends Component<Props, State> {
-  state: State = { error: null };
+  state: State = { message: null };
 
-  static getDerivedStateFromError(error: Error): State {
-    return { error };
+  static getDerivedStateFromError(error: unknown): State {
+    const message =
+      error instanceof Error
+        ? error.message
+        : typeof error === "string" && error !== ""
+          ? error
+          : "An unexpected error occurred.";
+    return { message: message || "An unexpected error occurred." };
   }
 
   componentDidUpdate(prev: Props) {
     // A new resetKey means the user navigated; give the subtree a clean try
     // rather than pinning them to the failed screen.
-    if (this.state.error !== null && prev.resetKey !== this.props.resetKey) {
-      this.setState({ error: null });
+    if (this.state.message !== null && prev.resetKey !== this.props.resetKey) {
+      this.setState({ message: null });
     }
   }
 
-  componentDidCatch(error: Error, info: ErrorInfo) {
+  componentDidCatch(error: unknown, info: ErrorInfo) {
     console.error("Unhandled error in", this.props.label ?? "the wallet UI", error, info.componentStack);
   }
 
   render() {
-    const { error } = this.state;
-    if (error === null) return this.props.children;
+    const { message } = this.state;
+    if (message === null) return this.props.children;
 
     return (
       <div className="card error-boundary" role="alert">
@@ -58,18 +67,20 @@ export class ErrorBoundary extends Component<Props, State> {
           {this.props.label
             ? `The ${this.props.label} screen could not be displayed.`
             : "This screen could not be displayed."}{" "}
-          Your wallet and funds are unaffected — nothing was submitted.
+          Your keys are safe — this is a display fault, not a change to your
+          wallet.
         </p>
         <p className="helper-text">
-          Move to another screen to carry on, or reload to start fresh. If it
-          keeps happening, the details below help us fix it.
+          If you had just submitted something, this does not tell you whether it
+          went through: check Activity before trying again, so you do not send
+          twice. Otherwise, move to another screen to carry on, or reload.
         </p>
-        <pre className="error-detail">{error.message}</pre>
+        <pre className="error-detail">{message}</pre>
         <div className="preview-actions">
           <button
             type="button"
             className="btn primary"
-            onClick={() => this.setState({ error: null })}
+            onClick={() => this.setState({ message: null })}
           >
             Try again
           </button>

--- a/ui/web/src/components/ErrorBoundary.tsx
+++ b/ui/web/src/components/ErrorBoundary.tsx
@@ -16,6 +16,9 @@ interface State {
   // even undefined), and reading .message off that in the fallback would throw
   // again — restoring exactly the blank page this exists to prevent.
   message: string | null;
+  // The resetKey in force when the error was captured, so navigation clears
+  // only errors that predate it.
+  capturedAt: string | undefined;
 }
 
 /**
@@ -32,7 +35,7 @@ interface State {
  * survive, not to assume away.
  */
 export class ErrorBoundary extends Component<Props, State> {
-  state: State = { message: null };
+  state: State = { message: null, capturedAt: undefined };
 
   static getDerivedStateFromError(error: unknown): State {
     const message =
@@ -41,18 +44,25 @@ export class ErrorBoundary extends Component<Props, State> {
         : typeof error === "string" && error !== ""
           ? error
           : "An unexpected error occurred.";
-    return { message: message || "An unexpected error occurred." };
+    // capturedAt is filled in by componentDidCatch, which has access to props.
+    return { message: message || "An unexpected error occurred.", capturedAt: undefined };
   }
 
   componentDidUpdate(prev: Props) {
+    if (this.state.message === null) return;
+    if (prev.resetKey === this.props.resetKey) return;
     // A new resetKey means the user navigated; give the subtree a clean try
-    // rather than pinning them to the failed screen.
-    if (this.state.message !== null && prev.resetKey !== this.props.resetKey) {
-      this.setState({ message: null });
+    // rather than pinning them to the failed screen. Only clear an error
+    // captured under an EARLIER key though: if the destination throws during
+    // the same commit, its fresh error arrives with the new key and clearing it
+    // would remount, throw again, and log twice before settling.
+    if (this.state.capturedAt !== this.props.resetKey) {
+      this.setState({ message: null, capturedAt: undefined });
     }
   }
 
   componentDidCatch(error: unknown, info: ErrorInfo) {
+    this.setState({ capturedAt: this.props.resetKey });
     console.error("Unhandled error in", this.props.label ?? "the wallet UI", error, info.componentStack);
   }
 
@@ -80,7 +90,7 @@ export class ErrorBoundary extends Component<Props, State> {
           <button
             type="button"
             className="btn primary"
-            onClick={() => this.setState({ message: null })}
+            onClick={() => this.setState({ message: null, capturedAt: undefined })}
           >
             Try again
           </button>

--- a/ui/web/src/components/ErrorBoundary.tsx
+++ b/ui/web/src/components/ErrorBoundary.tsx
@@ -48,9 +48,13 @@ export class ErrorBoundary extends Component<Props, State> {
     return { message: message || "An unexpected error occurred.", capturedAt: undefined };
   }
 
-  componentDidUpdate(prev: Props) {
+  componentDidUpdate(prev: Props, prevState: State) {
     if (this.state.message === null) return;
     if (prev.resetKey === this.props.resetKey) return;
+    // The error arrived in THIS commit (there was none before it), so it
+    // belongs to the destination, not the screen being left. Clearing it here
+    // would remount, throw again, and log the same fault twice.
+    if (prevState.message === null) return;
     // A new resetKey means the user navigated; give the subtree a clean try
     // rather than pinning them to the failed screen. Only clear an error
     // captured under an EARLIER key though: if the destination throws during

--- a/ui/web/src/components/Tabs.tsx
+++ b/ui/web/src/components/Tabs.tsx
@@ -55,7 +55,7 @@ export function Tabs<K extends string>({
 
   return (
     <>
-      <div className="tabs" role="tablist">
+      <div className="tabset" role="tablist">
         {tabs.map(({ key, label }, idx) => (
           <button
             key={key}
@@ -68,7 +68,7 @@ export function Tabs<K extends string>({
             aria-selected={active === key}
             aria-controls={`${id}-panel-${key}`}
             tabIndex={active === key ? 0 : -1}
-            className={active === key ? "tab active" : "tab"}
+            className={active === key ? "tabset-tab active" : "tabset-tab"}
             onClick={() => onSelect(key)}
             onKeyDown={(e) => handleKeyDown(e, idx)}
           >

--- a/ui/web/src/components/Tabs.tsx
+++ b/ui/web/src/components/Tabs.tsx
@@ -1,0 +1,93 @@
+import { useRef } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
+
+export interface TabDef<K extends string> {
+  key: K;
+  label: string;
+}
+
+interface TabsProps<K extends string> {
+  // Namespace for the generated tab/panel ids, so two tab sets can coexist on
+  // one page without colliding.
+  id: string;
+  tabs: readonly TabDef<K>[];
+  active: K;
+  onSelect: (key: K) => void;
+  // Renders the panel body for a key. Only the active panel is rendered; the
+  // others stay in the DOM as empty hidden containers so the tab/panel ARIA
+  // relationship is never dangling.
+  children: (key: K) => ReactNode;
+}
+
+/**
+ * An ARIA tablist with roving tabindex and arrow-key navigation.
+ *
+ * Extracted from the SPO Operate screen, which had the only correct
+ * implementation in the app, so that Stake (and anything else that groups
+ * related views) doesn't reimplement the keyboard and ARIA wiring.
+ */
+export function Tabs<K extends string>({
+  id,
+  tabs,
+  active,
+  onSelect,
+  children,
+}: TabsProps<K>) {
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  function handleKeyDown(e: KeyboardEvent<HTMLButtonElement>, idx: number) {
+    let next = idx;
+    if (e.key === "ArrowRight") {
+      next = (idx + 1) % tabs.length;
+    } else if (e.key === "ArrowLeft") {
+      next = (idx - 1 + tabs.length) % tabs.length;
+    } else if (e.key === "Home") {
+      next = 0;
+    } else if (e.key === "End") {
+      next = tabs.length - 1;
+    } else {
+      return;
+    }
+    e.preventDefault();
+    onSelect(tabs[next].key);
+    tabRefs.current[next]?.focus();
+  }
+
+  return (
+    <>
+      <div className="tabs" role="tablist">
+        {tabs.map(({ key, label }, idx) => (
+          <button
+            key={key}
+            ref={(el) => {
+              tabRefs.current[idx] = el;
+            }}
+            type="button"
+            role="tab"
+            id={`${id}-tab-${key}`}
+            aria-selected={active === key}
+            aria-controls={`${id}-panel-${key}`}
+            tabIndex={active === key ? 0 : -1}
+            className={active === key ? "tab active" : "tab"}
+            onClick={() => onSelect(key)}
+            onKeyDown={(e) => handleKeyDown(e, idx)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {tabs.map(({ key }) => (
+        <div
+          key={key}
+          role="tabpanel"
+          id={`${id}-panel-${key}`}
+          aria-labelledby={`${id}-tab-${key}`}
+          hidden={active !== key}
+        >
+          {active === key ? children(key) : null}
+        </div>
+      ))}
+    </>
+  );
+}

--- a/ui/web/src/components/components.test.tsx
+++ b/ui/web/src/components/components.test.tsx
@@ -80,7 +80,11 @@ test("CopyButton copies its value and shows feedback on success", async () => {
   expect(await screen.findByRole("button", { name: /\(copied\)$/ })).toBeInTheDocument();
   // A changed name on an already-focused control is not reliably announced, so
   // the success also goes through a live region — present only while copied.
-  expect(screen.getByRole("status")).toHaveTextContent(/copied/i);
+  const status = screen.getByRole("status");
+  expect(status).toHaveTextContent(/copied/i);
+  // Outside the button: several screen readers treat an interactive control as
+  // one unit and never process content changes inside it.
+  expect(status.closest("button")).toBeNull();
 });
 
 test("SyncBanner shows error detail ahead of retained bootstrap diagnostics", () => {

--- a/ui/web/src/components/components.test.tsx
+++ b/ui/web/src/components/components.test.tsx
@@ -78,6 +78,9 @@ test("CopyButton copies its value and shows feedback on success", async () => {
   // "Copied" appears only after the async write resolves. The control is icon-only, so the copied state rides on its
   // accessible name rather than visible text.
   expect(await screen.findByRole("button", { name: /\(copied\)$/ })).toBeInTheDocument();
+  // A changed name on an already-focused control is not reliably announced, so
+  // the success also goes through a live region — present only while copied.
+  expect(screen.getByRole("status")).toHaveTextContent(/copied/i);
 });
 
 test("SyncBanner shows error detail ahead of retained bootstrap diagnostics", () => {

--- a/ui/web/src/components/components.test.tsx
+++ b/ui/web/src/components/components.test.tsx
@@ -77,7 +77,7 @@ test("CopyButton copies its value and shows feedback on success", async () => {
   expect(writeText).toHaveBeenCalledWith("addr_test1abc");
   // "Copied" appears only after the async write resolves. The control is icon-only, so the copied state rides on its
   // accessible name rather than visible text.
-  expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
+  expect(await screen.findByRole("button", { name: /\(copied\)$/ })).toBeInTheDocument();
 });
 
 test("SyncBanner shows error detail ahead of retained bootstrap diagnostics", () => {

--- a/ui/web/src/components/components.test.tsx
+++ b/ui/web/src/components/components.test.tsx
@@ -75,8 +75,9 @@ test("CopyButton copies its value and shows feedback on success", async () => {
   render(<CopyButton value="addr_test1abc" />);
   fireEvent.click(screen.getByRole("button"));
   expect(writeText).toHaveBeenCalledWith("addr_test1abc");
-  // "Copied" appears only after the async write resolves.
-  expect(await screen.findByText("Copied")).toBeInTheDocument();
+  // "Copied" appears only after the async write resolves. The control is icon-only, so the copied state rides on its
+  // accessible name rather than visible text.
+  expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
 });
 
 test("SyncBanner shows error detail ahead of retained bootstrap diagnostics", () => {

--- a/ui/web/src/format.test.ts
+++ b/ui/web/src/format.test.ts
@@ -78,8 +78,10 @@ test("formatTokenQuantity: 0 decimals applies no decimal scaling, only grouping"
   expect(formatTokenQuantity("999", 0)).toBe("999");
 });
 
-test("formatTokenQuantity: negative decimals applies no decimal scaling", () => {
-  expect(formatTokenQuantity("12345", -1)).toBe("12,345");
+test("formatTokenQuantity: negative decimals leaves the quantity untouched", () => {
+  // The scale is unknown, so grouping would dress a base-unit count up as a
+  // token amount we cannot vouch for.
+  expect(formatTokenQuantity("12345", -1)).toBe("12345");
 });
 
 test("formatTokenQuantity: a non-integer quantity string is returned unchanged", () => {
@@ -97,7 +99,7 @@ test("formatTokenQuantity: formats a negative quantity", () => {
 test("formatTokenQuantity: decimals beyond the sane cap is returned unchanged (DoS guard)", () => {
   // decimals comes from on-chain metadata anyone can mint arbitrary values
   // into; an unbounded value must never reach BigInt exponentiation.
-  expect(formatTokenQuantity("12345", 1_000_000_000)).toBe("12,345");
+  expect(formatTokenQuantity("12345", 1_000_000_000)).toBe("12345");
 });
 
 test("formatTokenQuantity: decimals at the cap boundary still formats normally", () => {

--- a/ui/web/src/format.test.ts
+++ b/ui/web/src/format.test.ts
@@ -1,4 +1,4 @@
-import { parseAda, formatAda, formatTokenQuantity } from "./format";
+import { parseAda, formatAda, formatAdaPlain, formatTokenQuantity } from "./format";
 
 // --- parseAda tests ---
 
@@ -130,4 +130,15 @@ test("formatTokenQuantity groups whole-token amounts, with and without decimals"
 
 test("formatTokenQuantity leaves a non-numeric quantity alone", () => {
   expect(formatTokenQuantity("not-a-number", 0)).toBe("not-a-number");
+});
+
+test("formatAdaPlain leaves digits ungrouped for machine output", () => {
+  // CSV and file exports must parse as numbers; a grouped "1,500" is read as
+  // text or splits the column.
+  expect(formatAdaPlain("1500000000")).toBe("1500");
+  expect(formatAdaPlain("63120000000000")).toBe("63120000");
+  expect(formatAdaPlain("4820657123")).toBe("4820.657123");
+  expect(formatAdaPlain("-250000000")).toBe("-250");
+  // Same value, grouped, for display.
+  expect(formatAda("1500000000")).toBe("1,500");
 });

--- a/ui/web/src/format.test.ts
+++ b/ui/web/src/format.test.ts
@@ -1,4 +1,4 @@
-import { parseAda, formatTokenQuantity } from "./format";
+import { parseAda, formatAda, formatTokenQuantity } from "./format";
 
 // --- parseAda tests ---
 
@@ -73,12 +73,13 @@ test("formatTokenQuantity: works with 2 decimals", () => {
   expect(formatTokenQuantity("150", 2)).toBe("1.5");
 });
 
-test("formatTokenQuantity: 0 decimals returns the raw integer unchanged", () => {
-  expect(formatTokenQuantity("12345", 0)).toBe("12345");
+test("formatTokenQuantity: 0 decimals applies no decimal scaling, only grouping", () => {
+  expect(formatTokenQuantity("12345", 0)).toBe("12,345");
+  expect(formatTokenQuantity("999", 0)).toBe("999");
 });
 
-test("formatTokenQuantity: negative decimals is treated as no-op (returned unchanged)", () => {
-  expect(formatTokenQuantity("12345", -1)).toBe("12345");
+test("formatTokenQuantity: negative decimals applies no decimal scaling", () => {
+  expect(formatTokenQuantity("12345", -1)).toBe("12,345");
 });
 
 test("formatTokenQuantity: a non-integer quantity string is returned unchanged", () => {
@@ -86,7 +87,7 @@ test("formatTokenQuantity: a non-integer quantity string is returned unchanged",
 });
 
 test("formatTokenQuantity: preserves values beyond 2^53 (no precision ceiling)", () => {
-  expect(formatTokenQuantity("9007199255000000", 6)).toBe("9007199255");
+  expect(formatTokenQuantity("9007199255000000", 6)).toBe("9,007,199,255");
 });
 
 test("formatTokenQuantity: formats a negative quantity", () => {
@@ -96,9 +97,35 @@ test("formatTokenQuantity: formats a negative quantity", () => {
 test("formatTokenQuantity: decimals beyond the sane cap is returned unchanged (DoS guard)", () => {
   // decimals comes from on-chain metadata anyone can mint arbitrary values
   // into; an unbounded value must never reach BigInt exponentiation.
-  expect(formatTokenQuantity("12345", 1_000_000_000)).toBe("12345");
+  expect(formatTokenQuantity("12345", 1_000_000_000)).toBe("12,345");
 });
 
 test("formatTokenQuantity: decimals at the cap boundary still formats normally", () => {
   expect(formatTokenQuantity("1" + "0".repeat(18), 18)).toBe("1");
+});
+
+// --- digit grouping ------------------------------------------------------
+
+test("formatAda groups the integer part so large balances stay readable", () => {
+  expect(formatAda("63120000000000")).toBe("63,120,000");
+  expect(formatAda("4820657123")).toBe("4,820.657123");
+  expect(formatAda("1000000")).toBe("1");
+  expect(formatAda("999999999")).toBe("999.999999");
+  expect(formatAda("-250000000")).toBe("-250");
+});
+
+test("formatAda leaves amounts under a thousand ungrouped", () => {
+  expect(formatAda("31840221")).toBe("31.840221");
+  expect(formatAda("0")).toBe("0");
+});
+
+test("formatTokenQuantity groups whole-token amounts, with and without decimals", () => {
+  // decimals: 0 tokens (SNEK, HOSKY) still need grouping.
+  expect(formatTokenQuantity("1250000", 0)).toBe("1,250,000");
+  expect(formatTokenQuantity("88000000", 0)).toBe("88,000,000");
+  expect(formatTokenQuantity("1234567890", 6)).toBe("1,234.56789");
+});
+
+test("formatTokenQuantity leaves a non-numeric quantity alone", () => {
+  expect(formatTokenQuantity("not-a-number", 0)).toBe("not-a-number");
 });

--- a/ui/web/src/format.ts
+++ b/ui/web/src/format.ts
@@ -117,17 +117,31 @@ export function parseAda(ada: string): string {
  * "decimals" value force an unbounded BigInt allocation and hang the tab.
  *
  * Examples:
- *   formatTokenQuantity("4500000", 6) → "4.5"
- *   formatTokenQuantity("150", 2)     → "1.5"
- *   formatTokenQuantity("12345", 0)   → "12345"
+ * Decimals outside 0..18, or a non-integer, mean the scale is unknown: the
+ * quantity is returned untouched rather than dressed up as a token amount.
+ * A non-numeric quantity is likewise returned as-is. Otherwise the integer
+ * part is grouped with thousands separators.
+ *
+ * Examples:
+ *   formatTokenQuantity("4500000", 6)   → "4.5"
+ *   formatTokenQuantity("150", 2)       → "1.5"
+ *   formatTokenQuantity("12345", 0)     → "12,345"
+ *   formatTokenQuantity("1234567890", 6) → "1,234.56789"
+ *   formatTokenQuantity("12345", 99)    → "12345"   (scale unknown)
  */
 const MAX_TOKEN_DECIMALS = 18;
 
 export function formatTokenQuantity(quantity: string, decimals: number): string {
   if (!/^-?\d+$/.test(quantity)) return quantity;
+  // An out-of-range or non-integer decimals value means the scale is unknown,
+  // so the raw base-unit count is returned untouched: grouping it would dress
+  // it up as a whole-token amount we cannot actually vouch for.
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > MAX_TOKEN_DECIMALS) {
+    return quantity;
+  }
   // A zero-decimal token (SNEK, HOSKY) has no fractional part to render, but
   // its whole-unit count still needs grouping.
-  if (!Number.isInteger(decimals) || decimals <= 0 || decimals > MAX_TOKEN_DECIMALS) {
+  if (decimals === 0) {
     const negative = quantity.startsWith("-");
     return (negative ? "-" : "") + groupDigits(quantity.replace(/^-/, ""));
   }

--- a/ui/web/src/format.ts
+++ b/ui/web/src/format.ts
@@ -1,4 +1,16 @@
 /**
+ * Insert thousands separators into a run of integer digits.
+ *
+ * Balances, stake and token supplies in this wallet routinely run to eight or
+ * more digits, where an ungrouped run is genuinely hard to read at a glance
+ * ("63120000000000"). Applied to the integer part only; fractional digits are
+ * never grouped.
+ */
+function groupDigits(digits: string): string {
+  return digits.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+/**
  * Convert a lovelace amount (as a string) to an ADA display string.
  *
  * Uses BigInt to avoid float precision loss on values that exceed 2^53.
@@ -12,19 +24,23 @@
  *   formatAda("1000001")        → "1.000001"
  *   formatAda("0")              → "0"
  */
-/**
- * Insert thousands separators into a run of integer digits.
- *
- * Balances, stake and token supplies in this wallet routinely run to eight or
- * more digits, where an ungrouped run is genuinely hard to read at a glance
- * ("63120000000000"). Applied to the integer part only; fractional digits are
- * never grouped.
- */
-function groupDigits(digits: string): string {
-  return digits.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+export function formatAda(lovelace: string): string {
+  return adaString(lovelace, true);
 }
 
-export function formatAda(lovelace: string): string {
+/**
+ * Convert lovelace to an ADA string WITHOUT thousands separators.
+ *
+ * For machine-readable output — CSV columns, file exports — where a grouped
+ * "1,500" is read as text or splits the column rather than parsing as a
+ * number. Display code wants formatAda; anything another program will parse
+ * wants this.
+ */
+export function formatAdaPlain(lovelace: string): string {
+  return adaString(lovelace, false);
+}
+
+function adaString(lovelace: string, group: boolean): string {
   // BigInt() throws on a non-integer string; guard so a malformed API value
   // (e.g. an empty rewards field) shows through instead of crashing the screen.
   if (!/^-?\d+$/.test(lovelace)) {
@@ -38,7 +54,7 @@ export function formatAda(lovelace: string): string {
   const intPart = abs / LOVELACE_PER_ADA;
   const fracPart = abs % LOVELACE_PER_ADA;
 
-  const intStr = groupDigits(intPart.toString());
+  const intStr = group ? groupDigits(intPart.toString()) : intPart.toString();
 
   if (fracPart === BigInt(0)) {
     return (isNegative ? "-" : "") + intStr;

--- a/ui/web/src/format.ts
+++ b/ui/web/src/format.ts
@@ -12,6 +12,18 @@
  *   formatAda("1000001")        → "1.000001"
  *   formatAda("0")              → "0"
  */
+/**
+ * Insert thousands separators into a run of integer digits.
+ *
+ * Balances, stake and token supplies in this wallet routinely run to eight or
+ * more digits, where an ungrouped run is genuinely hard to read at a glance
+ * ("63120000000000"). Applied to the integer part only; fractional digits are
+ * never grouped.
+ */
+function groupDigits(digits: string): string {
+  return digits.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
 export function formatAda(lovelace: string): string {
   // BigInt() throws on a non-integer string; guard so a malformed API value
   // (e.g. an empty rewards field) shows through instead of crashing the screen.
@@ -26,13 +38,15 @@ export function formatAda(lovelace: string): string {
   const intPart = abs / LOVELACE_PER_ADA;
   const fracPart = abs % LOVELACE_PER_ADA;
 
+  const intStr = groupDigits(intPart.toString());
+
   if (fracPart === BigInt(0)) {
-    return (isNegative ? "-" : "") + intPart.toString();
+    return (isNegative ? "-" : "") + intStr;
   }
 
   // Pad to 6 digits, then strip trailing zeros.
   const fracStr = fracPart.toString().padStart(6, "0").replace(/0+$/, "");
-  return (isNegative ? "-" : "") + intPart.toString() + "." + fracStr;
+  return (isNegative ? "-" : "") + intStr + "." + fracStr;
 }
 
 /**
@@ -110,8 +124,13 @@ export function parseAda(ada: string): string {
 const MAX_TOKEN_DECIMALS = 18;
 
 export function formatTokenQuantity(quantity: string, decimals: number): string {
-  if (!Number.isInteger(decimals) || decimals <= 0 || decimals > MAX_TOKEN_DECIMALS) return quantity;
   if (!/^-?\d+$/.test(quantity)) return quantity;
+  // A zero-decimal token (SNEK, HOSKY) has no fractional part to render, but
+  // its whole-unit count still needs grouping.
+  if (!Number.isInteger(decimals) || decimals <= 0 || decimals > MAX_TOKEN_DECIMALS) {
+    const negative = quantity.startsWith("-");
+    return (negative ? "-" : "") + groupDigits(quantity.replace(/^-/, ""));
+  }
 
   const base = BigInt(10) ** BigInt(decimals);
   const raw = BigInt(quantity);
@@ -121,10 +140,12 @@ export function formatTokenQuantity(quantity: string, decimals: number): string 
   const intPart = abs / base;
   const fracPart = abs % base;
 
+  const intStr = groupDigits(intPart.toString());
+
   if (fracPart === BigInt(0)) {
-    return (isNegative ? "-" : "") + intPart.toString();
+    return (isNegative ? "-" : "") + intStr;
   }
 
   const fracStr = fracPart.toString().padStart(decimals, "0").replace(/0+$/, "");
-  return (isNegative ? "-" : "") + intPart.toString() + "." + fracStr;
+  return (isNegative ? "-" : "") + intStr + "." + fracStr;
 }

--- a/ui/web/src/hw/ledger.ts
+++ b/ui/web/src/hw/ledger.ts
@@ -10,7 +10,6 @@
  * implementation; the parity vector is exercised in ledger.test.ts.
  */
 
-import TransportWebHID from "@ledgerhq/hw-transport-webhid";
 import Ada from "@cardano-foundation/ledgerjs-hw-app-cardano";
 import type {
   AssetGroup,
@@ -153,6 +152,11 @@ export async function connectLedger(): Promise<HardwareSigner> {
     throw new Error("WebHID not available — open this in a Chromium browser");
   }
 
+  // Loaded on demand, as trezor.ts and keystone.ts load their transports: this
+  // keeps the WebHID transport (and the Node-shaped globals it reaches for) out
+  // of the initial bundle, so a user who never touches a Ledger never pays for
+  // it and a fault in it cannot take down app startup.
+  const { default: TransportWebHID } = await import("@ledgerhq/hw-transport-webhid");
   const transport = await TransportWebHID.create();
   const cardano = new Ada(transport);
 

--- a/ui/web/src/main.tsx
+++ b/ui/web/src/main.tsx
@@ -1,3 +1,6 @@
+// MUST stay the first import: it installs the Node globals that the hardware
+// wallet dependencies reach for while they are being evaluated.
+import "./polyfills";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./app";

--- a/ui/web/src/polyfills.test.ts
+++ b/ui/web/src/polyfills.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(join(here, rel), "utf8");
+
+// These are SOURCE-level assertions on purpose.
+//
+// The bug they guard against — `ReferenceError: Buffer is not defined` thrown
+// while @ledgerhq/hw-transport-webhid was being evaluated, which aborted the
+// bundle and left a blank page — is invisible to a normal test here: vitest
+// runs on Node, where `Buffer` is a real global, so every runtime assertion
+// passes in the test environment and fails only in a browser. The structural
+// properties that actually keep the browser working are the ones checked below.
+
+test("main.tsx installs the polyfills before importing anything else", () => {
+  const main = read("./main.tsx");
+  const imports = [...main.matchAll(/^import\s.*$/gm)].map((m) => m[0]);
+
+  expect(imports.length).toBeGreaterThan(1);
+  // Import order is evaluation order: a later import (./app, and the hardware
+  // modules it reaches) must not be evaluated before the globals are in place.
+  expect(imports[0]).toContain("./polyfills");
+});
+
+test("polyfills installs Buffer on the global object", () => {
+  const src = read("./polyfills.ts");
+  expect(src).toMatch(/import\s*\{\s*Buffer\s*\}\s*from\s*["']buffer["']/);
+  expect(src).toMatch(/globalThis\.Buffer\s*\?\?=/);
+});
+
+test("the Ledger WebHID transport is loaded on demand, not at module scope", () => {
+  const ledger = read("./hw/ledger.ts");
+
+  // A top-level `import ... from "@ledgerhq/hw-transport-webhid"` puts the
+  // transport in the initial bundle and evaluates it during startup, so a
+  // fault in it takes down the whole app rather than just the Ledger flow.
+  const staticImport =
+    /^import\s+[^;]*from\s+["']@ledgerhq\/hw-transport-webhid["']/m;
+  expect(ledger).not.toMatch(staticImport);
+
+  expect(ledger).toMatch(
+    /await\s+import\(\s*["']@ledgerhq\/hw-transport-webhid["']\s*\)/,
+  );
+});

--- a/ui/web/src/polyfills.ts
+++ b/ui/web/src/polyfills.ts
@@ -1,0 +1,22 @@
+// Node globals that browser-targeted dependencies still expect.
+//
+// @ledgerhq/hw-transport-webhid (and the ledgerjs Cardano app beneath it)
+// reference the Node `Buffer` global directly. Browsers have no such global,
+// so without this the module throws `ReferenceError: Buffer is not defined`
+// while it is being evaluated — which, for a statically reachable import,
+// aborts the whole bundle before React ever mounts and leaves a blank page.
+//
+// This module exists so the assignment happens in a module BODY that is
+// evaluated before anything that needs it: `import "./polyfills"` as the first
+// import of main.tsx runs this to completion before ./app (and the hardware
+// modules it reaches) are evaluated. Setting the global inside main.tsx's own
+// body would be too late — every one of its imports is evaluated first.
+import { Buffer } from "buffer";
+
+declare global {
+  var Buffer: typeof import("buffer").Buffer;
+}
+
+globalThis.Buffer ??= Buffer;
+
+export {};

--- a/ui/web/src/screens/Activity.test.tsx
+++ b/ui/web/src/screens/Activity.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
-import { Activity } from "./Activity";
+import { Activity, transactionsToCsv } from "./Activity";
 import * as hooks from "../api/hooks";
 import * as client from "../api/client";
 import type { Tx, TxDetail } from "../api/types";
@@ -322,4 +322,19 @@ test("(s) each row has an external explorer link to the FULL tx hash, scoped to 
   expect(link).toHaveAttribute("href", `https://cardanoscan.io/transaction/${TX1.tx_hash}`);
   expect(link).toHaveAttribute("target", "_blank");
   expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+});
+
+test("(s) CSV amounts are ungrouped so they parse as numbers", () => {
+  // 1,500 ADA — above the grouping threshold, which is the whole point.
+  const big = { ...TX1, net_lovelace: "1500000000", fee: "1200000" };
+  const text = transactionsToCsv([big]);
+
+  // Grouped display values ("1,500") reach a CSV consumer as quoted text or
+  // split the column outright.
+  expect(text).toContain("1500");
+  expect(text).not.toContain("1,500");
+  const amountCells = text.trim().split("\n").slice(1).flatMap((line) => line.split(",").slice(2, 4));
+  for (const cell of amountCells) {
+    expect(cell).toMatch(/^-?\d+(\.\d+)?$/);
+  }
 });

--- a/ui/web/src/screens/Activity.test.tsx
+++ b/ui/web/src/screens/Activity.test.tsx
@@ -83,12 +83,14 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-test("(a) renders block heights for each transaction", () => {
+test("(a) block height is kept out of the list and left to the detail drawer", () => {
   mockTransactions([TX1, TX2]);
   render(<Activity />);
 
-  expect(screen.getByText("12345")).toBeInTheDocument();
-  expect(screen.getByText("12300")).toBeInTheDocument();
+  // Scanning the list is about direction/amount/time; the block height is a
+  // drill-down fact, shown in the drawer and exported in the CSV.
+  expect(screen.queryByText("12345")).not.toBeInTheDocument();
+  expect(screen.queryByText("12300")).not.toBeInTheDocument();
 });
 
 test("(b) renders truncated tx hash with a CopyButton that copies the FULL hash", async () => {
@@ -114,10 +116,10 @@ test("(c) preserves API order (newest-first — TX1 row appears before TX2 row)"
   mockTransactions([TX1, TX2]);
   render(<Activity />);
 
-  const cells = screen.getAllByText(/^1[23]\d{3}$/);
-  // TX1 block 12345 should come before TX2 block 12300
-  expect(cells[0].textContent).toBe("12345");
-  expect(cells[1].textContent).toBe("12300");
+  // Identify rows by direction: TX1 is received, TX2 is sent.
+  const rows = screen.getAllByRole("row").slice(1); // drop the header row
+  expect(rows[0]).toHaveTextContent("Received");
+  expect(rows[1]).toHaveTextContent("Sent");
 });
 
 test("(d) empty list renders 'No transactions yet' message", () => {
@@ -174,11 +176,11 @@ test("(h) shows a direction indicator and signed net amount per row", () => {
   expect(table.getByText("-1.5 ADA")).toBeInTheDocument();
 });
 
-test("(i) shows the fee per row", () => {
+test("(i) keeps the fee out of the list -- the detail drawer carries it", () => {
   mockTransactions([TX1]);
   render(<Activity />);
 
-  expect(screen.getByText("0.17 ADA")).toBeInTheDocument();
+  expect(screen.queryByText("0.17 ADA")).not.toBeInTheDocument();
 });
 
 test("(j) shows a Pending pill for unconfirmed transactions and a count otherwise", () => {
@@ -283,10 +285,9 @@ test("(q) a pruned tx (null asset_deltas, no enrichment) renders without crashin
 
   expect(() => render(<Activity />)).not.toThrow();
 
-  // Direction shows "Unknown" for the pruned tx; its known block height and
-  // confirmations (from the history call, not enrichment) still render.
+  // Direction shows "Unknown" for the pruned tx; its confirmation count (from
+  // the history call, not enrichment) still renders.
   expect(screen.getByText("Unknown")).toBeInTheDocument();
-  expect(screen.getByText("500")).toBeInTheDocument();
   expect(screen.getByText("200")).toBeInTheDocument();
 
   // The CSV export must not throw even though asset_deltas is null — the

--- a/ui/web/src/screens/Activity.test.tsx
+++ b/ui/web/src/screens/Activity.test.tsx
@@ -102,7 +102,9 @@ test("(b) renders truncated tx hash with a CopyButton that copies the FULL hash"
   expect(copyButtons.length).toBeGreaterThanOrEqual(1);
   fireEvent.click(copyButtons[0]);
   expect(writeText).toHaveBeenCalledWith(TX1.tx_hash);
-  expect(await screen.findByText("Copied")).toBeInTheDocument();
+  // The control is icon-only, so the copied state rides on its
+  // accessible name rather than visible text.
+  expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
 
   // At least the beginning of the hash should be visible
   expect(screen.getByText(new RegExp(TX1.tx_hash.slice(0, 8)))).toBeInTheDocument();

--- a/ui/web/src/screens/Activity.test.tsx
+++ b/ui/web/src/screens/Activity.test.tsx
@@ -106,7 +106,7 @@ test("(b) renders truncated tx hash with a CopyButton that copies the FULL hash"
   expect(writeText).toHaveBeenCalledWith(TX1.tx_hash);
   // The control is icon-only, so the copied state rides on its
   // accessible name rather than visible text.
-  expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
+  expect(await screen.findByRole("button", { name: /\(copied\)$/ })).toBeInTheDocument();
 
   // At least the beginning of the hash should be visible
   expect(screen.getByText(new RegExp(TX1.tx_hash.slice(0, 8)))).toBeInTheDocument();

--- a/ui/web/src/screens/Activity.tsx
+++ b/ui/web/src/screens/Activity.tsx
@@ -9,7 +9,7 @@ import { Select } from "../components/Select";
 import { DownloadButton } from "../components/DownloadButton";
 import { Drawer } from "../components/Drawer";
 import { ExplorerLink } from "../components/ExplorerLink";
-import { formatAda } from "../format";
+import { formatAda, formatAdaPlain } from "../format";
 import { toCsv } from "../csv";
 import { errorMessage } from "../errorMessage";
 
@@ -92,7 +92,9 @@ function Confirmations({ tx }: { tx: Tx }) {
  * carries `direction: ""` and a null `asset_deltas` from the API despite the
  * TS type, so it must export cleanly with blank cells rather than throw.
  */
-function transactionsToCsv(txs: Tx[]): string {
+// Exported for test: the CSV column contract (ungrouped numbers) is worth
+// asserting directly rather than through a Blob the test environment cannot read.
+export function transactionsToCsv(txs: Tx[]): string {
   const headers = [
     "tx_hash",
     "direction",
@@ -106,8 +108,10 @@ function transactionsToCsv(txs: Tx[]): string {
   const rows = txs.map((t) => [
     t.tx_hash,
     t.direction || "unknown",
-    t.direction ? formatAda(t.net_lovelace) : "",
-    t.direction ? formatAda(t.fee) : "",
+    // Plain, not grouped: a CSV consumer must read these as numbers, and
+    // "1,500" either quotes as text or splits the column.
+    t.direction ? formatAdaPlain(t.net_lovelace) : "",
+    t.direction ? formatAdaPlain(t.fee) : "",
     t.block_height,
     new Date(t.block_time * 1000).toISOString(),
     t.pending ? "pending" : String(t.confirmations),
@@ -175,7 +179,7 @@ function TransactionDetailDrawer({ hash, onClose }: { hash: string; onClose: () 
               <dt>Hash</dt>
               <dd className="tx-hash-row">
                 <span className="tx-hash">{detail.tx_hash}</span>
-                <CopyButton value={detail.tx_hash} />
+                <CopyButton value={detail.tx_hash} ariaLabel="Copy transaction hash" />
               </dd>
             </div>
             <div className="dl-row">
@@ -300,7 +304,7 @@ export function Activity({ network = "preview" }: ActivityProps = {}) {
     tx_hash: (
       <span className="hash-cell">
         <span className="mono">{truncateHash(tx.tx_hash)}</span>
-        <CopyButton value={tx.tx_hash} />
+        <CopyButton value={tx.tx_hash} ariaLabel="Copy transaction hash" />
         <ExplorerLink
           network={network}
           kind="tx"

--- a/ui/web/src/screens/Activity.tsx
+++ b/ui/web/src/screens/Activity.tsx
@@ -278,11 +278,13 @@ export function Activity({ network = "preview" }: ActivityProps = {}) {
     );
   }
 
+  // Fee and block height are drill-down facts, not scanning facts: the detail
+  // drawer already shows both in full. Carrying them in the list pushed the
+  // table past its width, which cost the Details action its place on screen --
+  // an eight-column row that does not fit serves nobody.
   const columns = [
     { key: "direction", label: "Direction" },
     { key: "amount", label: "Amount" },
-    { key: "fee", label: "Fee" },
-    { key: "block_height", label: "Block" },
     { key: "time", label: "Time" },
     { key: "confirmations", label: "Confirmations" },
     { key: "tx_hash", label: "Tx Hash" },
@@ -293,8 +295,6 @@ export function Activity({ network = "preview" }: ActivityProps = {}) {
   const rows = filtered.map((tx) => ({
     direction: <DirectionBadge direction={tx.direction} />,
     amount: <NetAmount tx={tx} />,
-    fee: tx.direction ? `${formatAda(tx.fee)} ADA` : <span className="muted">—</span>,
-    block_height: tx.block_height,
     time: formatBlockTime(tx.block_time),
     confirmations: <Confirmations tx={tx} />,
     tx_hash: (

--- a/ui/web/src/screens/AddWallet.tsx
+++ b/ui/web/src/screens/AddWallet.tsx
@@ -367,7 +367,7 @@ export function AddWallet({
         </div>
 
         <div style={{ margin: "var(--space-3) 0", display: "flex", gap: "var(--space-2)" }}>
-          <CopyButton value={generatedMnemonic} />
+          <CopyButton value={generatedMnemonic} ariaLabel="Copy recovery phrase" />
         </div>
 
         <div className="backup-warning">

--- a/ui/web/src/screens/ImportTransaction.tsx
+++ b/ui/web/src/screens/ImportTransaction.tsx
@@ -240,7 +240,6 @@ export function ImportTransaction({ canSubmit }: { canSubmit: boolean }) {
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                placeholder="Spending password"
                 aria-label="Spending password"
                 disabled={busy}
               />

--- a/ui/web/src/screens/MultiSig.tsx
+++ b/ui/web/src/screens/MultiSig.tsx
@@ -236,12 +236,12 @@ function CreateView({ canSign, onCancel, onCreated }: CreateViewProps) {
                 <p className="helper-text">Share this key-hash so others can include you.</p>
                 <div className="tx-hash-row">
                   <code className="tx-hash">{myKeyHash}</code>
-                  <CopyButton value={myKeyHash} />
+                  <CopyButton value={myKeyHash} ariaLabel="Copy my key hash" />
                 </div>
                 {myKeyVkey && (
                   <div className="tx-hash-row">
                     <code className="tx-hash">vkey: {myKeyVkey}</code>
-                    <CopyButton value={myKeyVkey} />
+                    <CopyButton value={myKeyVkey} ariaLabel="Copy my verification key" />
                   </div>
                 )}
                 <Button
@@ -427,7 +427,7 @@ function DetailView({ account, canSpend, canSign, onBack, onDeleted }: DetailVie
       <Card title={account.label}>
         <p className="field-label">Script address (receive)</p>
         <p className="mono address-full">{account.script_address}</p>
-        <CopyButton value={account.script_address} />
+        <CopyButton value={account.script_address} ariaLabel="Copy script address" />
 
         <dl className="preview-summary">
           <div className="dl-row">
@@ -543,7 +543,7 @@ function SpendFlow({ account, canSpend, canSign, onSpent }: SpendFlowProps) {
           <p className="field-label">Transaction hash</p>
           <div className="tx-hash-row">
             <code className="tx-hash">{result.tx_hash}</code>
-            <CopyButton value={result.tx_hash} />
+            <CopyButton value={result.tx_hash} ariaLabel="Copy transaction hash" />
           </div>
           <Button onClick={reset}>Spend again</Button>
         </div>
@@ -685,7 +685,7 @@ function CollectAndSubmit({
         <p className="field-label">Unsigned transaction (CBOR)</p>
         <div className="tx-hash-row">
           <code className="tx-hash">{built.unsigned_tx_cbor}</code>
-          <CopyButton value={built.unsigned_tx_cbor} />
+          <CopyButton value={built.unsigned_tx_cbor} ariaLabel="Copy unsigned transaction CBOR" />
           <DownloadButton
             value={built.unsigned_tx_cbor}
             filename="multisig-unsigned-tx.cbor"

--- a/ui/web/src/screens/Offline.tsx
+++ b/ui/web/src/screens/Offline.tsx
@@ -129,7 +129,7 @@ function SignTab({ setBusy }: ActionTabProps) {
           <p className="field-label">Witness (CBOR)</p>
           <div className="tx-hash-row">
             <code className="tx-hash">{result.witness_cbor}</code>
-            <CopyButton value={result.witness_cbor} />
+            <CopyButton value={result.witness_cbor} ariaLabel="Copy witness CBOR" />
             <DownloadButton value={result.witness_cbor} filename="witness.cbor" label="Download" />
           </div>
         </div>
@@ -229,7 +229,7 @@ function SubmitTab({ setBusy }: ActionTabProps) {
           <p className="field-label">Transaction hash</p>
           <div className="tx-hash-row">
             <code className="tx-hash">{result.tx_hash}</code>
-            <CopyButton value={result.tx_hash} />
+            <CopyButton value={result.tx_hash} ariaLabel="Copy transaction hash" />
           </div>
         </div>
       )}

--- a/ui/web/src/screens/Offline.tsx
+++ b/ui/web/src/screens/Offline.tsx
@@ -107,7 +107,6 @@ function SignTab({ setBusy }: ActionTabProps) {
           setPassword(e.target.value);
           clearResult();
         }}
-        placeholder="Spending password"
         aria-label="Spending password"
         disabled={loading}
       />

--- a/ui/web/src/screens/Operate.tsx
+++ b/ui/web/src/screens/Operate.tsx
@@ -1,8 +1,8 @@
-import { useRef } from "react";
 import { useState } from "react";
-import type { KeyboardEvent } from "react";
 import type { Account } from "../api/types";
 import { Card } from "../components/Card";
+import { Tabs } from "../components/Tabs";
+import type { TabDef } from "../components/Tabs";
 import { Credentials } from "./operate/Credentials";
 import { OperationalCert } from "./operate/OperationalCert";
 import { Registration } from "./operate/Registration";
@@ -15,7 +15,7 @@ interface OperateProps {
 
 type Tab = "credentials" | "opcert" | "registration" | "retirement" | "metadata";
 
-const TABS: { key: Tab; label: string }[] = [
+const TABS: readonly TabDef<Tab>[] = [
   { key: "credentials", label: "Credentials" },
   { key: "opcert", label: "Operational cert" },
   { key: "registration", label: "Registration" },
@@ -30,21 +30,6 @@ const TABS: { key: Tab; label: string }[] = [
 // the active wallet (spending operations require the spend password).
 export function Operate({ account }: OperateProps) {
   const [tab, setTab] = useState<Tab>("credentials");
-  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
-
-  function handleKeyDown(e: KeyboardEvent<HTMLButtonElement>, idx: number) {
-    let next = idx;
-    if (e.key === "ArrowRight") {
-      next = (idx + 1) % TABS.length;
-    } else if (e.key === "ArrowLeft") {
-      next = (idx - 1 + TABS.length) % TABS.length;
-    } else {
-      return;
-    }
-    e.preventDefault();
-    setTab(TABS[next].key);
-    tabRefs.current[next]?.focus();
-  }
 
   function renderPanel(key: Tab) {
     switch (key) {
@@ -68,37 +53,11 @@ export function Operate({ account }: OperateProps) {
           Operate a stake pool from this wallet&rsquo;s seed, or air-gap the cold
           key. All data comes from your own node — nothing is fetched externally.
         </p>
-        <div className="operate-tabs" role="tablist">
-          {TABS.map(({ key, label }, idx) => (
-            <button
-              key={key}
-              ref={(el) => { tabRefs.current[idx] = el; }}
-              role="tab"
-              id={`operate-tab-${key}`}
-              aria-selected={tab === key}
-              aria-controls={`operate-panel-${key}`}
-              tabIndex={tab === key ? 0 : -1}
-              className={tab === key ? "operate-tab active" : "operate-tab"}
-              onClick={() => setTab(key)}
-              onKeyDown={(e) => handleKeyDown(e, idx)}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
       </Card>
 
-      {TABS.map(({ key }) => (
-        <div
-          key={key}
-          role="tabpanel"
-          id={`operate-panel-${key}`}
-          aria-labelledby={`operate-tab-${key}`}
-          hidden={tab !== key}
-        >
-          {tab === key ? renderPanel(key) : null}
-        </div>
-      ))}
+      <Tabs id="operate" tabs={TABS} active={tab} onSelect={setTab}>
+        {(key) => renderPanel(key)}
+      </Tabs>
     </div>
   );
 }

--- a/ui/web/src/screens/PoolDirectory.test.tsx
+++ b/ui/web/src/screens/PoolDirectory.test.tsx
@@ -44,7 +44,7 @@ test("lists stake pools read from the node with formatted margin/pledge/saturati
   expect(await screen.findByText("5.0%")).toBeInTheDocument();
   expect(screen.getByText("42.0%")).toBeInTheDocument();
   expect(screen.getByText("100")).toBeInTheDocument(); // 100000000 lovelace pledge → 100 ADA
-  expect(screen.getByText("5000")).toBeInTheDocument(); // 5000000000 → 5000 ADA
+  expect(screen.getByText("5,000")).toBeInTheDocument(); // 5000000000 → 5000 ADA
   // Copy affordance carries the full (untruncated) pool id.
   expect(
     screen.getByRole("button", { name: `Copy pool id ${POOL_A.pool_id}` }),

--- a/ui/web/src/screens/PoolDirectory.tsx
+++ b/ui/web/src/screens/PoolDirectory.tsx
@@ -36,13 +36,16 @@ const POOL_COLUMNS = [
 
 interface PoolDirectoryProps {
   network: string;
+  // Hands a chosen pool to the delegation form. Optional so the directory can
+  // still be rendered on its own as a pure browser.
+  onDelegate?: (poolId: string) => void;
 }
 
-// PoolDirectory is a read-only browse/search screen for the stake pools the
-// embedded node has indexed. Data comes entirely from the local node (no
-// external service), so it needs no consent gate. It does not delegate: copy a
-// pool ID and paste it into Staking to delegate to it.
-export function PoolDirectory({ network }: PoolDirectoryProps) {
+// PoolDirectory is the browse/search view for the stake pools the embedded
+// node has indexed. Data comes entirely from the local node (no external
+// service), so it needs no consent gate. Choosing a pool hands it to the
+// delegation form; it does not itself submit anything.
+export function PoolDirectory({ network, onDelegate }: PoolDirectoryProps) {
   const [query, setQuery] = useState("");
   const [page, setPage] = useState(1);
   const [data, setData] = useState<PoolDirectoryResponse | null>(null);
@@ -92,7 +95,16 @@ export function PoolDirectory({ network }: PoolDirectoryProps) {
     pledge: formatAda(p.declared_pledge),
     live_stake: formatAda(p.live_stake),
     saturation: pct(p.live_saturation),
-    actions: <CopyButton value={p.pool_id} aria-label={`Copy pool id ${p.pool_id}`} />,
+    actions: (
+      <span className="row-actions">
+        {onDelegate && (
+          <Button variant="ghost" onClick={() => onDelegate(p.pool_id)}>
+            Delegate
+          </Button>
+        )}
+        <CopyButton value={p.pool_id} aria-label={`Copy pool id ${p.pool_id}`} />
+      </span>
+    ),
   }));
 
   return (
@@ -100,8 +112,7 @@ export function PoolDirectory({ network }: PoolDirectoryProps) {
       <Card title="Stake Pool Directory">
         <p className="helper-text">
           Browse and search stake pools your embedded node has indexed — read
-          directly from the node, no external service is contacted. To delegate,
-          copy a pool ID and paste it into <strong>Staking</strong>.
+          directly from the node, no external service is contacted.
         </p>
 
         <label htmlFor="pool-search">Search by pool ID</label>

--- a/ui/web/src/screens/Receive.test.tsx
+++ b/ui/web/src/screens/Receive.test.tsx
@@ -38,7 +38,9 @@ test("(a) next unused address card copies the FULL address", async () => {
   expect(copyButtons.length).toBeGreaterThanOrEqual(1);
   fireEvent.click(copyButtons[0]);
   expect(writeText).toHaveBeenCalledWith(ADDR_B);
-  expect(await screen.findByText("Copied")).toBeInTheDocument();
+  // The control is icon-only, so the copied state rides on its
+  // accessible name rather than visible text.
+  expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
 });
 
 test("(b) renders a table listing all receive addresses", () => {

--- a/ui/web/src/screens/Receive.test.tsx
+++ b/ui/web/src/screens/Receive.test.tsx
@@ -40,7 +40,7 @@ test("(a) next unused address card copies the FULL address", async () => {
   expect(writeText).toHaveBeenCalledWith(ADDR_B);
   // The control is icon-only, so the copied state rides on its
   // accessible name rather than visible text.
-  expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
+  expect(await screen.findByRole("button", { name: /\(copied\)$/ })).toBeInTheDocument();
 });
 
 test("(b) renders a table listing all receive addresses", () => {

--- a/ui/web/src/screens/Receive.tsx
+++ b/ui/web/src/screens/Receive.tsx
@@ -87,7 +87,7 @@ export function Receive({ network = "preview" }: ReceiveProps = {}) {
       ),
       copy: (
         <>
-          <CopyButton value={addr} />
+          <CopyButton value={addr} ariaLabel="Copy this receive address" />
           <ExplorerLink
             network={network}
             kind="address"
@@ -108,7 +108,7 @@ export function Receive({ network = "preview" }: ReceiveProps = {}) {
           )}
           <div className="receive-next-details">
             <p className="mono address-full">{nextUnused}</p>
-            <CopyButton value={nextUnused} />
+            <CopyButton value={nextUnused} ariaLabel="Copy next unused address" />
             {nextUnused && <ExplorerLink network={network} kind="address" id={nextUnused} />}
           </div>
         </div>

--- a/ui/web/src/screens/RewardHistory.tsx
+++ b/ui/web/src/screens/RewardHistory.tsx
@@ -73,7 +73,7 @@ export function RewardHistory({ network = "preview" }: RewardHistoryProps = {}) 
     pool: r.pool_id ? (
       <span className="hash-cell">
         <span className="mono">{truncatePool(r.pool_id)}</span>
-        <CopyButton value={r.pool_id} />
+        <CopyButton value={r.pool_id} ariaLabel="Copy pool ID" />
         <ExplorerLink
           network={network}
           kind="pool"

--- a/ui/web/src/screens/Send.test.tsx
+++ b/ui/web/src/screens/Send.test.tsx
@@ -91,7 +91,7 @@ test("(b) preview→confirm: confirmSend called with pending_id and password; tx
   });
 
   // Enter password
-  const passwordInput = screen.getByPlaceholderText(/spending password/i);
+  const passwordInput = screen.getByLabelText(/spending password/i);
   fireEvent.change(passwordInput, { target: { value: "s3cr3t" } });
 
   // Click confirm
@@ -131,7 +131,7 @@ test("(c) confirmSend error keeps preview phase so user can retry", async () => 
   });
 
   // Enter wrong password and confirm
-  const passwordInput = screen.getByPlaceholderText(/spending password/i);
+  const passwordInput = screen.getByLabelText(/spending password/i);
   fireEvent.change(passwordInput, { target: { value: "wrong" } });
   fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
 
@@ -145,7 +145,7 @@ test("(c) confirmSend error keeps preview phase so user can retry", async () => 
   });
 
   // Still on preview phase (password input still present, not done)
-  expect(screen.getByPlaceholderText(/spending password/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/spending password/i)).toBeInTheDocument();
 
   // NOT showing tx_hash
   expect(screen.queryByText(new RegExp(MOCK_TX_RESULT.tx_hash))).not.toBeInTheDocument();
@@ -191,7 +191,7 @@ test("(e) 'Send another' resets to compose phase", async () => {
     expect(screen.getByText(/2 inputs/i)).toBeInTheDocument();
   });
 
-  const passwordInput = screen.getByPlaceholderText(/spending password/i);
+  const passwordInput = screen.getByLabelText(/spending password/i);
   fireEvent.change(passwordInput, { target: { value: "s3cr3t" } });
   fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
 

--- a/ui/web/src/screens/Send.tsx
+++ b/ui/web/src/screens/Send.tsx
@@ -655,7 +655,6 @@ function PreviewPhase({
             <Input
               id="spend-password"
               type="password"
-              placeholder="Spending password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
             />

--- a/ui/web/src/screens/Send.tsx
+++ b/ui/web/src/screens/Send.tsx
@@ -711,7 +711,7 @@ function PreviewPhase({
                 <p className="field-label">Unsigned transaction (CBOR)</p>
                 <div className="tx-hash-row">
                   <code className="tx-hash">{exported.unsigned_tx_cbor}</code>
-                  <CopyButton value={exported.unsigned_tx_cbor} />
+                  <CopyButton value={exported.unsigned_tx_cbor} ariaLabel="Copy unsigned transaction CBOR" />
                   <DownloadButton
                     value={exported.unsigned_tx_cbor}
                     filename="unsigned-tx.cbor"
@@ -756,7 +756,7 @@ function DonePhase({ result, onReset }: DonePhaseProps) {
         <p className="field-label">Transaction hash</p>
         <div className="tx-hash-row">
           <code className="tx-hash">{result.tx_hash}</code>
-          <CopyButton value={result.tx_hash} />
+          <CopyButton value={result.tx_hash} ariaLabel="Copy transaction hash" />
         </div>
         <Button onClick={onReset}>Send another</Button>
       </div>

--- a/ui/web/src/screens/Settings.test.tsx
+++ b/ui/web/src/screens/Settings.test.tsx
@@ -141,7 +141,7 @@ test("(b) renders stake address in monospace and a CopyButton for it", async () 
   expect(writeText).toHaveBeenCalledWith(mockAccount.stake_address);
   // The control is icon-only, so the copied state rides on its
   // accessible name rather than visible text.
-  expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
+  expect(await screen.findByRole("button", { name: /\(copied\)$/ })).toBeInTheDocument();
 });
 
 test("(c) renders sync state pill from useStatus", () => {

--- a/ui/web/src/screens/Settings.test.tsx
+++ b/ui/web/src/screens/Settings.test.tsx
@@ -139,7 +139,9 @@ test("(b) renders stake address in monospace and a CopyButton for it", async () 
   // The copy button must copy the FULL stake address.
   fireEvent.click(screen.getByRole("button", { name: /copy/i }));
   expect(writeText).toHaveBeenCalledWith(mockAccount.stake_address);
-  expect(await screen.findByText("Copied")).toBeInTheDocument();
+  // The control is icon-only, so the copied state rides on its
+  // accessible name rather than visible text.
+  expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
 });
 
 test("(c) renders sync state pill from useStatus", () => {

--- a/ui/web/src/screens/Settings.tsx
+++ b/ui/web/src/screens/Settings.tsx
@@ -566,7 +566,7 @@ export function Settings({ account, walletType, autoLock }: SettingsProps) {
       <Card title="Stake Address">
         <div className="row-copy">
           <code className="mono">{account.stake_address}</code>
-          <CopyButton value={account.stake_address} />
+          <CopyButton value={account.stake_address} ariaLabel="Copy stake address" />
         </div>
       </Card>
 

--- a/ui/web/src/screens/SignMessage.tsx
+++ b/ui/web/src/screens/SignMessage.tsx
@@ -89,7 +89,6 @@ export function SignMessage({ account }: SignMessageProps) {
             setPassword(e.target.value);
             clearResult();
           }}
-          placeholder="Spending password"
           aria-label="Spending password"
           disabled={loading}
         />

--- a/ui/web/src/screens/SignMessage.tsx
+++ b/ui/web/src/screens/SignMessage.tsx
@@ -108,12 +108,12 @@ export function SignMessage({ account }: SignMessageProps) {
             <p className="field-label">Signature (COSE_Sign1)</p>
             <div className="tx-hash-row">
               <code className="tx-hash">{result.signature}</code>
-              <CopyButton value={result.signature} />
+              <CopyButton value={result.signature} ariaLabel="Copy signature" />
             </div>
             <p className="field-label">Key (COSE_Key)</p>
             <div className="tx-hash-row">
               <code className="tx-hash">{result.key}</code>
-              <CopyButton value={result.key} />
+              <CopyButton value={result.key} ariaLabel="Copy COSE key" />
             </div>
           </div>
         )}

--- a/ui/web/src/screens/Stake.test.tsx
+++ b/ui/web/src/screens/Stake.test.tsx
@@ -158,3 +158,25 @@ test("the pool draft survives a trip to the directory and back", async () => {
   fireEvent.click(screen.getByRole("tab", { name: "Delegation" }));
   expect(await screen.findByDisplayValue("pool1typed-by-hand")).toBeInTheDocument();
 });
+
+test("changing route switches tab on an already-mounted screen", async () => {
+  // #/pools -> #/rewards is the same component in the same place, so initial
+  // state alone would strand the user on whichever tab they arrived at.
+  const { rerender } = render(<Stake network="mainnet" initialTab="pools" />);
+  expect(await screen.findByRole("tab", { name: "Pools" })).toHaveAttribute("aria-selected", "true");
+
+  rerender(<Stake network="mainnet" initialTab="rewards" />);
+
+  await waitFor(() =>
+    expect(screen.getByRole("tab", { name: "Rewards" })).toHaveAttribute("aria-selected", "true"),
+  );
+});
+
+test("a wallet that cannot delegate is not offered a Delegate action", async () => {
+  render(<Stake network="mainnet" canDelegate={false} initialTab="pools" />);
+
+  expect(await screen.findByText(/stake pool directory/i)).toBeInTheDocument();
+  // The button would hand a pool to a tab that only explains why it cannot be
+  // used, dropping the choice with no feedback.
+  expect(screen.queryByRole("button", { name: "Delegate" })).not.toBeInTheDocument();
+});

--- a/ui/web/src/screens/Stake.test.tsx
+++ b/ui/web/src/screens/Stake.test.tsx
@@ -122,18 +122,20 @@ test("choosing a pool works for a wallet that ALREADY delegates", async () => {
   expect(await screen.findByDisplayValue(POOL_B)).toBeInTheDocument();
 });
 
-test("returning to the delegation tab later opens on status, not compose", async () => {
+test("the compose form stays open across a trip to another tab", async () => {
+  // An already-delegating wallet opens on its status panel, so if the compose
+  // view were not remembered the user would come back from the directory to
+  // "Change delegation" with their half-filled form hidden behind it.
   stubDelegation(true);
   render(<Stake network="mainnet" initialTab="pools" />);
 
   fireEvent.click((await screen.findAllByRole("button", { name: "Delegate" }))[0]);
   expect(await screen.findByDisplayValue(POOL_A)).toBeInTheDocument();
 
-  // The intent is consumed, so a later visit is an ordinary one.
   fireEvent.click(screen.getByRole("tab", { name: "Rewards" }));
   fireEvent.click(screen.getByRole("tab", { name: "Delegation" }));
 
-  expect(await screen.findByRole("button", { name: /change delegation/i })).toBeInTheDocument();
+  expect(await screen.findByDisplayValue(POOL_A)).toBeInTheDocument();
 });
 
 test("a wallet that cannot delegate still gets rewards and pools", async () => {
@@ -179,4 +181,33 @@ test("a wallet that cannot delegate is not offered a Delegate action", async () 
   // The button would hand a pool to a tab that only explains why it cannot be
   // used, dropping the choice with no feedback.
   expect(screen.queryByRole("button", { name: "Delegate" })).not.toBeInTheDocument();
+});
+
+test("the whole delegation draft survives a trip to another tab", async () => {
+  render(<Stake network="mainnet" />);
+
+  const pool = await screen.findByLabelText(/stake pool/i);
+  fireEvent.change(pool, { target: { value: "pool1typed" } });
+  // A vote target is part of the same draft; lifting only the pool ID would
+  // have thrown this away the moment the user glanced at the directory.
+  fireEvent.click(screen.getByLabelText(/always abstain/i));
+
+  fireEvent.click(screen.getByRole("tab", { name: "Pools" }));
+  expect(await screen.findByText(/stake pool directory/i)).toBeInTheDocument();
+  fireEvent.click(screen.getByRole("tab", { name: "Delegation" }));
+
+  expect(await screen.findByDisplayValue("pool1typed")).toBeInTheDocument();
+  expect(screen.getByLabelText(/always abstain/i)).toBeChecked();
+});
+
+test("rewards stay reachable when the node cannot answer queries", async () => {
+  // The old #/rewards route had no node gate; merging the screens must not
+  // quietly take reward history away from a read-only or offline-node wallet.
+  render(<Stake network="mainnet" canQueryNode={false} canDelegate={false} initialTab="rewards" />);
+
+  expect(await screen.findByRole("tab", { name: "Rewards" })).toHaveAttribute("aria-selected", "true");
+  expect(screen.getByText("541")).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("tab", { name: "Pools" }));
+  expect(await screen.findByText(/not answering queries yet/i)).toBeInTheDocument();
 });

--- a/ui/web/src/screens/Stake.test.tsx
+++ b/ui/web/src/screens/Stake.test.tsx
@@ -107,6 +107,35 @@ test("choosing a pool in the directory hands it to the delegation form", async (
   expect(poolField).toBeInTheDocument();
 });
 
+test("choosing a pool works for a wallet that ALREADY delegates", async () => {
+  // The regression this covers: with an active delegation the delegation tab
+  // opens on its status panel ("Change delegation"), so a Delegate click that
+  // only prefilled the field left the user staring at the status panel with no
+  // sign anything had happened. Switching tabs unmounts the delegation screen,
+  // so the intent has to survive to its next mount.
+  stubDelegation(true);
+  render(<Stake network="mainnet" initialTab="pools" />);
+
+  const delegateButtons = await screen.findAllByRole("button", { name: "Delegate" });
+  fireEvent.click(delegateButtons[1]);
+
+  expect(await screen.findByDisplayValue(POOL_B)).toBeInTheDocument();
+});
+
+test("returning to the delegation tab later opens on status, not compose", async () => {
+  stubDelegation(true);
+  render(<Stake network="mainnet" initialTab="pools" />);
+
+  fireEvent.click((await screen.findAllByRole("button", { name: "Delegate" }))[0]);
+  expect(await screen.findByDisplayValue(POOL_A)).toBeInTheDocument();
+
+  // The intent is consumed, so a later visit is an ordinary one.
+  fireEvent.click(screen.getByRole("tab", { name: "Rewards" }));
+  fireEvent.click(screen.getByRole("tab", { name: "Delegation" }));
+
+  expect(await screen.findByRole("button", { name: /change delegation/i })).toBeInTheDocument();
+});
+
 test("a wallet that cannot delegate still gets rewards and pools", async () => {
   render(<Stake network="mainnet" canDelegate={false} />);
 

--- a/ui/web/src/screens/Stake.test.tsx
+++ b/ui/web/src/screens/Stake.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { Stake } from "./Stake";
+import * as hooks from "../api/hooks";
+import * as client from "../api/client";
+import type { PoolDirectoryResponse } from "../api/types";
+
+const POOL_A = "pool1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const POOL_B = "pool1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+const DIRECTORY: PoolDirectoryResponse = {
+  pools: [
+    {
+      pool_id: POOL_A,
+      hex: "aa".repeat(28),
+      vrf_key: "bb".repeat(32),
+      active_stake: "62410000000000",
+      live_stake: "63120000000000",
+      declared_pledge: "100000000000",
+      fixed_cost: "170000000",
+      margin_cost: 0.019,
+      live_saturation: 0.87,
+    },
+    {
+      pool_id: POOL_B,
+      hex: "cc".repeat(28),
+      vrf_key: "dd".repeat(32),
+      active_stake: "8900000000000",
+      live_stake: "9010000000000",
+      declared_pledge: "50000000000",
+      fixed_cost: "340000000",
+      margin_cost: 0.01,
+      live_saturation: 0.12,
+    },
+  ],
+  total: 2,
+  page: 1,
+  count: 2,
+};
+
+function stubDelegation(active = false) {
+  vi.spyOn(hooks, "useDelegation").mockReturnValue({
+    data: {
+      pool_id: active ? POOL_A : null,
+      active,
+      rewards_sum: "0",
+      withdrawable_amount: "0",
+      provisional: false,
+      note: "",
+    },
+    error: null,
+    loading: false,
+    refresh: vi.fn(),
+  } as never);
+}
+
+beforeEach(() => {
+  stubDelegation(false);
+  vi.spyOn(client, "getPoolDirectory").mockResolvedValue(DIRECTORY);
+  vi.spyOn(hooks, "useRewards").mockReturnValue({
+    data: {
+      rewards: [{ epoch: 541, amount: "4218330", pool_id: POOL_A, type: "member" }],
+      provisional: false,
+      note: "",
+    },
+    error: null,
+    loading: false,
+    refresh: vi.fn(),
+  } as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("the three staking screens are tabs of one destination", () => {
+  render(<Stake network="mainnet" />);
+
+  const tablist = screen.getByRole("tablist");
+  const tabs = within(tablist).getAllByRole("tab");
+  expect(tabs.map((t) => t.textContent)).toEqual(["Delegation", "Rewards", "Pools"]);
+});
+
+test("opens on the tab the route asked for", async () => {
+  render(<Stake network="mainnet" initialTab="pools" />);
+
+  expect(screen.getByRole("tab", { name: "Pools" })).toHaveAttribute("aria-selected", "true");
+  expect(await screen.findByText(/stake pool directory/i)).toBeInTheDocument();
+});
+
+test("choosing a pool in the directory hands it to the delegation form", async () => {
+  render(<Stake network="mainnet" initialTab="pools" />);
+
+  // The directory used to tell people to copy a pool ID and paste it into a
+  // different screen. Delegating is now a single action on the row.
+  const delegateButtons = await screen.findAllByRole("button", { name: "Delegate" });
+  fireEvent.click(delegateButtons[0]);
+
+  await waitFor(() =>
+    expect(screen.getByRole("tab", { name: "Delegation" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    ),
+  );
+
+  // The chosen pool arrives in the form, already filled in.
+  const poolField = await screen.findByDisplayValue(POOL_A);
+  expect(poolField).toBeInTheDocument();
+});
+
+test("a wallet that cannot delegate still gets rewards and pools", async () => {
+  render(<Stake network="mainnet" canDelegate={false} />);
+
+  // Delegation explains itself rather than the whole screen disappearing.
+  expect(screen.getByText(/cannot submit a delegation/i)).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("tab", { name: "Pools" }));
+  expect(await screen.findByText(/stake pool directory/i)).toBeInTheDocument();
+});
+
+test("the pool draft survives a trip to the directory and back", async () => {
+  render(<Stake network="mainnet" />);
+
+  const field = await screen.findByLabelText(/stake pool/i);
+  fireEvent.change(field, { target: { value: "pool1typed-by-hand" } });
+
+  fireEvent.click(screen.getByRole("tab", { name: "Pools" }));
+  expect(await screen.findByText(/stake pool directory/i)).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("tab", { name: "Delegation" }));
+  expect(await screen.findByDisplayValue("pool1typed-by-hand")).toBeInTheDocument();
+});

--- a/ui/web/src/screens/Stake.tsx
+++ b/ui/web/src/screens/Stake.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Card } from "../components/Card";
 import { Tabs } from "../components/Tabs";
 import type { TabDef } from "../components/Tabs";
@@ -47,6 +47,13 @@ export function Stake({
   initialTab = "delegation",
 }: StakeProps = {}) {
   const [tab, setTab] = useState<Tab>(initialTab);
+
+  // The route can change while this screen stays mounted (#/pools -> #/rewards
+  // is the same component in the same place), and initial state would ignore
+  // that, leaving the user on whichever tab they first arrived at.
+  useEffect(() => {
+    setTab(initialTab);
+  }, [initialTab]);
 
   // The delegation draft's pool ID lives here rather than inside Staking so it
   // survives a tab switch — the whole point of merging these is that you can
@@ -97,7 +104,15 @@ export function Stake({
             case "rewards":
               return <RewardHistory network={network} />;
             case "pools":
-              return <PoolDirectory network={network} onDelegate={handleDelegate} />;
+              // No delegate action for a wallet that cannot delegate: the
+              // button would hand the pool to a tab that only explains why it
+              // is unavailable, silently dropping the choice.
+              return (
+                <PoolDirectory
+                  network={network}
+                  onDelegate={canDelegate ? handleDelegate : undefined}
+                />
+              );
           }
         }}
       </Tabs>

--- a/ui/web/src/screens/Stake.tsx
+++ b/ui/web/src/screens/Stake.tsx
@@ -52,14 +52,15 @@ export function Stake({
   // survives a tab switch — the whole point of merging these is that you can
   // browse Pools and come back without losing what you had typed.
   const [poolId, setPoolId] = useState("");
-  // Bumped when the user picks a pool from the directory. Staking watches it to
-  // jump into its compose phase, which is what makes "Delegate" on a row a
-  // complete action rather than just a field prefill.
-  const [delegateNonce, setDelegateNonce] = useState(0);
+  // Set when the user picks a pool from the directory. Switching tabs unmounts
+  // the delegation screen, so this is read at its next mount rather than
+  // signalled to a live component -- and cleared once taken, so coming back to
+  // the tab later opens on the status panel as usual.
+  const [composeIntent, setComposeIntent] = useState(false);
 
   function handleDelegate(id: string) {
     setPoolId(id);
-    setDelegateNonce((n) => n + 1);
+    setComposeIntent(true);
     setTab("delegation");
   }
 
@@ -89,7 +90,8 @@ export function Stake({
                   walletId={walletId}
                   poolId={poolId}
                   setPoolId={setPoolId}
-                  composeSignal={delegateNonce}
+                  startInCompose={composeIntent}
+                  onComposeStarted={() => setComposeIntent(false)}
                 />
               );
             case "rewards":

--- a/ui/web/src/screens/Stake.tsx
+++ b/ui/web/src/screens/Stake.tsx
@@ -23,8 +23,12 @@ interface StakeProps {
   // and the pool directory are node-local reads available to any active wallet,
   // so the screen stays reachable and only the Delegation tab explains itself.
   canDelegate?: boolean;
-  // Whether the node can answer queries. Only the pool directory needs it;
-  // rewards and the delegation status come from the account read.
+  // Whether the node can answer queries. Used to gate the pool directory,
+  // which is a whole-network browse. Rewards and delegation status are
+  // node-backed account reads too and will surface their own error if the node
+  // is down — they are left ungated because the routes they replaced were, and
+  // narrowing that silently on merge would take reward history away from
+  // read-only wallets.
   canQueryNode?: boolean;
   // Which tab to open on. Lets the legacy #/rewards and #/pools routes land
   // where the user expected rather than dumping them on Delegation.
@@ -121,8 +125,7 @@ export function Stake({
                   <Card title="Pools">
                     <p className="helper-text">
                       The pool directory is read from your node, which is not
-                      answering queries yet. Delegation status and reward
-                      history above do not need it.
+                      answering queries yet. Try again once it is ready.
                     </p>
                   </Card>
                 );

--- a/ui/web/src/screens/Stake.tsx
+++ b/ui/web/src/screens/Stake.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { Card } from "../components/Card";
+import { Tabs } from "../components/Tabs";
+import type { TabDef } from "../components/Tabs";
+import { Staking } from "./Staking";
+import { RewardHistory } from "./RewardHistory";
+import { PoolDirectory } from "./PoolDirectory";
+
+type Tab = "delegation" | "rewards" | "pools";
+
+const TABS: readonly TabDef<Tab>[] = [
+  { key: "delegation", label: "Delegation" },
+  { key: "rewards", label: "Rewards" },
+  { key: "pools", label: "Pools" },
+];
+
+interface StakeProps {
+  network?: string;
+  isHardware?: boolean;
+  walletId?: string;
+  // Whether this wallet on this node can actually submit a delegation. Rewards
+  // and the pool directory are node-local reads available to any active wallet,
+  // so the screen stays reachable and only the Delegation tab explains itself.
+  canDelegate?: boolean;
+  // Which tab to open on. Lets the legacy #/rewards and #/pools routes land
+  // where the user expected rather than dumping them on Delegation.
+  initialTab?: Tab;
+}
+
+/**
+ * Stake is the single destination for everything staking.
+ *
+ * Delegation, reward history and the pool directory were three separate
+ * top-level screens answering one question — what is my ADA doing and where
+ * should it go. Worse, they did not connect: the directory's own help text
+ * told you to copy a pool ID and paste it into the delegation screen, with the
+ * clipboard as the integration layer between two halves of one task.
+ *
+ * Here they are tabs of one screen, and choosing a pool in the directory hands
+ * that pool straight to the delegation form.
+ */
+export function Stake({
+  network = "preview",
+  isHardware,
+  walletId,
+  canDelegate = true,
+  initialTab = "delegation",
+}: StakeProps = {}) {
+  const [tab, setTab] = useState<Tab>(initialTab);
+
+  // The delegation draft's pool ID lives here rather than inside Staking so it
+  // survives a tab switch — the whole point of merging these is that you can
+  // browse Pools and come back without losing what you had typed.
+  const [poolId, setPoolId] = useState("");
+  // Bumped when the user picks a pool from the directory. Staking watches it to
+  // jump into its compose phase, which is what makes "Delegate" on a row a
+  // complete action rather than just a field prefill.
+  const [delegateNonce, setDelegateNonce] = useState(0);
+
+  function handleDelegate(id: string) {
+    setPoolId(id);
+    setDelegateNonce((n) => n + 1);
+    setTab("delegation");
+  }
+
+  return (
+    <div className="stake">
+      <Tabs id="stake" tabs={TABS} active={tab} onSelect={setTab}>
+        {(key) => {
+          switch (key) {
+            case "delegation":
+              if (!canDelegate) {
+                return (
+                  <Card title="Delegation">
+                    <p className="helper-text">
+                      This wallet cannot submit a delegation. Delegating needs a
+                      fully synced node and a wallet that can sign a certificate
+                      — a watch-only wallet, or a hardware wallet whose device
+                      does not sign certificates, can still browse pools and
+                      review rewards here.
+                    </p>
+                  </Card>
+                );
+              }
+              return (
+                <Staking
+                  network={network}
+                  isHardware={isHardware}
+                  walletId={walletId}
+                  poolId={poolId}
+                  setPoolId={setPoolId}
+                  composeSignal={delegateNonce}
+                />
+              );
+            case "rewards":
+              return <RewardHistory network={network} />;
+            case "pools":
+              return <PoolDirectory network={network} onDelegate={handleDelegate} />;
+          }
+        }}
+      </Tabs>
+    </div>
+  );
+}

--- a/ui/web/src/screens/Stake.tsx
+++ b/ui/web/src/screens/Stake.tsx
@@ -3,6 +3,7 @@ import { Card } from "../components/Card";
 import { Tabs } from "../components/Tabs";
 import type { TabDef } from "../components/Tabs";
 import { Staking } from "./Staking";
+import type { ComposeDraft } from "./Staking";
 import { RewardHistory } from "./RewardHistory";
 import { PoolDirectory } from "./PoolDirectory";
 
@@ -22,6 +23,9 @@ interface StakeProps {
   // and the pool directory are node-local reads available to any active wallet,
   // so the screen stays reachable and only the Delegation tab explains itself.
   canDelegate?: boolean;
+  // Whether the node can answer queries. Only the pool directory needs it;
+  // rewards and the delegation status come from the account read.
+  canQueryNode?: boolean;
   // Which tab to open on. Lets the legacy #/rewards and #/pools routes land
   // where the user expected rather than dumping them on Delegation.
   initialTab?: Tab;
@@ -44,6 +48,7 @@ export function Stake({
   isHardware,
   walletId,
   canDelegate = true,
+  canQueryNode = true,
   initialTab = "delegation",
 }: StakeProps = {}) {
   const [tab, setTab] = useState<Tab>(initialTab);
@@ -55,19 +60,26 @@ export function Stake({
     setTab(initialTab);
   }, [initialTab]);
 
-  // The delegation draft's pool ID lives here rather than inside Staking so it
-  // survives a tab switch — the whole point of merging these is that you can
-  // browse Pools and come back without losing what you had typed.
-  const [poolId, setPoolId] = useState("");
-  // Set when the user picks a pool from the directory. Switching tabs unmounts
-  // the delegation screen, so this is read at its next mount rather than
-  // signalled to a live component -- and cleared once taken, so coming back to
-  // the tab later opens on the status panel as usual.
-  const [composeIntent, setComposeIntent] = useState(false);
+  // The whole delegation draft lives here rather than inside Staking, because
+  // switching tabs unmounts that screen. Lifting only the pool ID would still
+  // have thrown away a chosen vote target, DRep ID and anchor the moment the
+  // user glanced at the directory — the opposite of what merging these was
+  // for.
+  const [draft, setDraft] = useState<ComposeDraft>({
+    poolId: "",
+    voteType: null,
+    drepId: "",
+    anchorUrl: "",
+    anchorHash: "",
+  });
+  // Whether the delegation form is open. Switching tabs unmounts that screen,
+  // so this — like the draft — has to live above it, or the user comes back to
+  // a status panel with their half-filled form hidden.
+  const [composing, setComposing] = useState(false);
 
   function handleDelegate(id: string) {
-    setPoolId(id);
-    setComposeIntent(true);
+    setDraft((prev) => ({ ...prev, poolId: id }));
+    setComposing(true);
     setTab("delegation");
   }
 
@@ -95,15 +107,26 @@ export function Stake({
                   network={network}
                   isHardware={isHardware}
                   walletId={walletId}
-                  poolId={poolId}
-                  setPoolId={setPoolId}
-                  startInCompose={composeIntent}
-                  onComposeStarted={() => setComposeIntent(false)}
+                  draft={draft}
+                  setDraft={setDraft}
+                  composing={composing}
+                  setComposing={setComposing}
                 />
               );
             case "rewards":
               return <RewardHistory network={network} />;
             case "pools":
+              if (!canQueryNode) {
+                return (
+                  <Card title="Pools">
+                    <p className="helper-text">
+                      The pool directory is read from your node, which is not
+                      answering queries yet. Delegation status and reward
+                      history above do not need it.
+                    </p>
+                  </Card>
+                );
+              }
               // No delegate action for a wallet that cannot delegate: the
               // button would hand the pool to a tab that only explains why it
               // is unavailable, silently dropping the choice.

--- a/ui/web/src/screens/Staking.test.tsx
+++ b/ui/web/src/screens/Staking.test.tsx
@@ -200,8 +200,8 @@ test("(c) Review delegation builds the request and shows the itemized confirm", 
   // Itemized confirm: each cert summary plus the 2 ADA deposit and total.
   await waitFor(() => expect(screen.getByText(/register stake key/i)).toBeInTheDocument());
   expect(screen.getByText(/delegate stake to pool1abc/i)).toBeInTheDocument();
-  expect(screen.getByText(/2 ₳ deposit/)).toBeInTheDocument(); // 2000000 lovelace
-  expect(screen.getByText(/2\.174 ₳/)).toBeInTheDocument(); // total 2174000 lovelace
+  expect(screen.getByText(/2 ADA deposit/)).toBeInTheDocument(); // 2000000 lovelace
+  expect(screen.getByText(/2\.174 ADA/)).toBeInTheDocument(); // total 2174000 lovelace
 });
 
 // --- 4-way voting-power picker ---
@@ -224,8 +224,8 @@ test("(e) choosing 'register self' reveals the optional anchor fields + deposit 
 
   expect(screen.getByPlaceholderText(/example\.org\/my-drep/i)).toBeInTheDocument();
   expect(screen.getByText(/exact deposit amounts are read from your node/i)).toBeInTheDocument();
-  expect(screen.queryByText(/500 ₳ deposit/i)).not.toBeInTheDocument();
-  expect(screen.queryByText(/2 ₳ stake-key deposit/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/500 ADA deposit/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/2 ADA stake-key deposit/i)).not.toBeInTheDocument();
 });
 
 test("register-self metadata hash without a URL blocks Review", async () => {
@@ -327,7 +327,7 @@ test("(i) active wallet shows withdraw + change; Withdraw builds a withdraw-only
 
   // Status shows Registered + the withdrawable amount.
   expect(screen.getByText(/registered/i)).toBeInTheDocument();
-  expect(screen.getByText(/14\.207 ₳/)).toBeInTheDocument();
+  expect(screen.getByText(/14\.207 ADA/)).toBeInTheDocument();
 
   fireEvent.click(screen.getByRole("button", { name: /withdraw rewards/i }));
 

--- a/ui/web/src/screens/Staking.tsx
+++ b/ui/web/src/screens/Staking.tsx
@@ -535,7 +535,7 @@ function PreviewPhase({ preview, isHardware, walletId, onBack, onDone }: Preview
         </dl>
       </Card>
 
-      <Card title={isHardware ? "Sign on your SeedSigner" : "Spending password"}>
+      <Card title={isHardware ? "Sign on your SeedSigner" : "Confirm"}>
         <div className="staking-form">
           {isHardware ? (
             needsAirGapResync ? (
@@ -586,7 +586,6 @@ function PreviewPhase({ preview, isHardware, walletId, onBack, onDone }: Preview
               <Input
                 id="staking-password"
                 type="password"
-                placeholder="Spending password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 disabled={loading}

--- a/ui/web/src/screens/Staking.tsx
+++ b/ui/web/src/screens/Staking.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type {
   DelegationRequest,
   DelegationPreview,
@@ -704,9 +704,25 @@ interface StakingProps {
   // certificates — i.e. SeedSigner); walletId keys its per-wallet fingerprint.
   isHardware?: boolean;
   walletId?: string;
+  // The pool-ID draft is owned by the parent Stake screen so it survives a tab
+  // switch to the pool directory and back. Left optional (with internal state
+  // as the fallback) so this screen still stands alone.
+  poolId?: string;
+  setPoolId?: (id: string) => void;
+  // Incremented by the parent when the user picks a pool from the directory:
+  // a change moves this screen into its compose phase, so "Delegate" on a
+  // directory row lands on a filled-in form rather than the status panel.
+  composeSignal?: number;
 }
 
-export function Staking({ network = "preview", isHardware, walletId }: StakingProps = {}) {
+export function Staking({
+  network = "preview",
+  isHardware,
+  walletId,
+  poolId: poolIdProp,
+  setPoolId: setPoolIdProp,
+  composeSignal = 0,
+}: StakingProps = {}) {
   const delegation = useDelegation();
 
   const [phase, setPhase] = useState<Phase>("status");
@@ -715,11 +731,23 @@ export function Staking({ network = "preview", isHardware, walletId }: StakingPr
   const [txResult, setTxResult] = useState<TxResult | null>(null);
 
   // Compose draft lives at the top so Back returns to in-progress entry.
-  const [poolId, setPoolId] = useState("");
+  const [poolIdLocal, setPoolIdLocal] = useState("");
+  const poolId = poolIdProp ?? poolIdLocal;
+  const setPoolId = setPoolIdProp ?? setPoolIdLocal;
   const [voteType, setVoteType] = useState<VoteType | null>(null);
   const [drepId, setDrepId] = useState("");
   const [anchorUrl, setAnchorUrl] = useState("");
   const [anchorHash, setAnchorHash] = useState("");
+
+  // Skip the initial render: a fresh mount must land on the status panel, not
+  // jump straight into an empty compose form.
+  const seenSignal = useRef(composeSignal);
+  useEffect(() => {
+    if (composeSignal !== seenSignal.current) {
+      seenSignal.current = composeSignal;
+      setPhase("compose");
+    }
+  }, [composeSignal]);
 
   if (delegation.loading) {
     return <p>Loading…</p>;

--- a/ui/web/src/screens/Staking.tsx
+++ b/ui/web/src/screens/Staking.tsx
@@ -283,9 +283,9 @@ function Compose(props: ComposeProps) {
           <p className="verified-readout">
             <span className="verified-tick">✓ Verified by your node</span>
             {" · "}margin {pct(pool.margin_cost)}
-            {" · "}pledge {formatAda(pool.declared_pledge)} ₳
-            {" · "}fixed {formatAda(pool.fixed_cost)} ₳
-            {" · "}live stake {formatAda(pool.live_stake)} ₳
+            {" · "}pledge {formatAda(pool.declared_pledge)} ADA
+            {" · "}fixed {formatAda(pool.fixed_cost)} ADA
+            {" · "}live stake {formatAda(pool.live_stake)} ADA
             <ExplorerLink network={network} kind="pool" id={pool.pool_id} />
           </p>
         )}
@@ -502,9 +502,9 @@ function PreviewPhase({ preview, isHardware, walletId, onBack, onDone }: Preview
               <span className="cert-body">{c.summary}</span>
               <span className="cert-amt">
                 {c.deposit_lovelace
-                  ? `${formatAda(c.deposit_lovelace)} ₳ deposit`
+                  ? `${formatAda(c.deposit_lovelace)} ADA deposit`
                   : c.amount_lovelace
-                    ? `${formatAda(c.amount_lovelace)} ₳`
+                    ? `${formatAda(c.amount_lovelace)} ADA`
                     : "—"}
               </span>
             </div>
@@ -514,23 +514,23 @@ function PreviewPhase({ preview, isHardware, walletId, onBack, onDone }: Preview
         <dl className="preview-summary">
           <div className="dl-row">
             <dt>Network fee</dt>
-            <dd>{formatAda(preview.fee)} ₳</dd>
+            <dd>{formatAda(preview.fee)} ADA</dd>
           </div>
           {preview.deposit !== "0" && (
             <div className="dl-row">
               <dt>Refundable deposit</dt>
-              <dd>{formatAda(preview.deposit)} ₳</dd>
+              <dd>{formatAda(preview.deposit)} ADA</dd>
             </div>
           )}
           {preview.withdrawal && (
             <div className="dl-row">
               <dt>Withdrawal</dt>
-              <dd>{formatAda(preview.withdrawal)} ₳</dd>
+              <dd>{formatAda(preview.withdrawal)} ADA</dd>
             </div>
           )}
           <div className="dl-row">
             <dt>Total to confirm</dt>
-            <dd className="total-accent">{formatAda(preview.total)} ₳</dd>
+            <dd className="total-accent">{formatAda(preview.total)} ADA</dd>
           </div>
         </dl>
       </Card>
@@ -670,7 +670,7 @@ function ActiveState({ poolId, withdrawable, note, onChange, onWithdraw, network
       <Card title="Rewards">
         <div className="dl-row">
           <dt className="field-label">Withdrawable</dt>
-          <dd className="total-accent mono">{formatAda(withdrawable)} ₳</dd>
+          <dd className="total-accent mono">{formatAda(withdrawable)} ADA</dd>
         </div>
 
         {error && (

--- a/ui/web/src/screens/Staking.tsx
+++ b/ui/web/src/screens/Staking.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import type {
   DelegationRequest,
   DelegationPreview,
@@ -627,7 +627,7 @@ function DonePhase({ result, onReset }: { result: TxResult; onReset: () => void 
         <p className="field-label">Transaction hash</p>
         <div className="tx-hash-row">
           <code className="tx-hash">{result.tx_hash}</code>
-          <CopyButton value={result.tx_hash} />
+          <CopyButton value={result.tx_hash} ariaLabel="Copy transaction hash" />
         </div>
         <Button onClick={onReset}>Back to staking</Button>
       </div>
@@ -694,6 +694,24 @@ function ActiveState({ poolId, withdrawable, note, onChange, onWithdraw, network
 
 // --- Top-level Staking screen ---
 
+// The delegation compose draft. Owned by the parent Stake screen, because
+// switching tabs unmounts this one and every field would otherwise be lost.
+export interface ComposeDraft {
+  poolId: string;
+  voteType: VoteType | null;
+  drepId: string;
+  anchorUrl: string;
+  anchorHash: string;
+}
+
+const EMPTY_DRAFT: ComposeDraft = {
+  poolId: "",
+  voteType: null,
+  drepId: "",
+  anchorUrl: "",
+  anchorHash: "",
+};
+
 interface StakingProps {
   // Optional so existing no-prop callers/tests keep working; the app always
   // passes the active wallet's real network when routing to this screen.
@@ -703,51 +721,46 @@ interface StakingProps {
   // certificates — i.e. SeedSigner); walletId keys its per-wallet fingerprint.
   isHardware?: boolean;
   walletId?: string;
-  // The pool-ID draft is owned by the parent Stake screen so it survives a tab
+  // The compose draft is owned by the parent Stake screen so it survives a tab
   // switch to the pool directory and back. Left optional (with internal state
   // as the fallback) so this screen still stands alone.
-  poolId?: string;
-  setPoolId?: (id: string) => void;
-  // Set by the parent when the user picks a pool from the directory, so
-  // "Delegate" on a directory row lands on a filled-in form rather than on the
-  // status panel an already-delegating wallet would otherwise see. Read at
-  // mount because switching tabs unmounts this screen.
-  startInCompose?: boolean;
-  // Called once the initial phase has been taken, so the parent can clear the
-  // intent and a later return to this tab opens on status as usual.
-  onComposeStarted?: () => void;
+  draft?: ComposeDraft;
+  setDraft?: (update: (prev: ComposeDraft) => ComposeDraft) => void;
+  // Whether the user is part-way through composing. Owned by the parent for
+  // the same reason the draft is: switching tabs unmounts this screen, and
+  // coming back to a status panel with a half-filled draft hidden behind
+  // "Change delegation" loses the user's place. Also how "Delegate" on a
+  // directory row lands on a filled-in form rather than the status panel an
+  // already-delegating wallet would otherwise see.
+  composing?: boolean;
+  setComposing?: (composing: boolean) => void;
 }
 
 export function Staking({
   network = "preview",
   isHardware,
   walletId,
-  poolId: poolIdProp,
-  setPoolId: setPoolIdProp,
-  startInCompose = false,
-  onComposeStarted,
+  draft: draftProp,
+  setDraft: setDraftProp,
+  composing: composingProp,
+  setComposing: setComposingProp,
 }: StakingProps = {}) {
   const delegation = useDelegation();
 
-  const [phase, setPhase] = useState<Phase>(startInCompose ? "compose" : "status");
+  const [phase, setPhase] = useState<Phase>(composingProp ? "compose" : "status");
   const [previewFrom, setPreviewFrom] = useState<Phase>("status");
   const [preview, setPreview] = useState<DelegationPreview | null>(null);
   const [txResult, setTxResult] = useState<TxResult | null>(null);
 
-  // Compose draft lives at the top so Back returns to in-progress entry.
-  const [poolIdLocal, setPoolIdLocal] = useState("");
-  const poolId = poolIdProp ?? poolIdLocal;
-  const setPoolId = setPoolIdProp ?? setPoolIdLocal;
-  const [voteType, setVoteType] = useState<VoteType | null>(null);
-  const [drepId, setDrepId] = useState("");
-  const [anchorUrl, setAnchorUrl] = useState("");
-  const [anchorHash, setAnchorHash] = useState("");
+  // Compose draft lives above this screen (or locally when it stands alone) so
+  // Back — and a trip to another tab — returns to in-progress entry.
+  const [draftLocal, setDraftLocal] = useState<ComposeDraft>(EMPTY_DRAFT);
+  const draft = draftProp ?? draftLocal;
+  const setDraft = setDraftProp ?? setDraftLocal;
+  const setField = <K extends keyof ComposeDraft>(key: K) => (value: ComposeDraft[K]) =>
+    setDraft((prev) => ({ ...prev, [key]: value }));
+  const { poolId, voteType, drepId, anchorUrl, anchorHash } = draft;
 
-  // Report the consumed intent exactly once, on mount.
-  useEffect(() => {
-    if (startInCompose) onComposeStarted?.();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   if (delegation.loading) {
     return <p>Loading…</p>;
@@ -765,6 +778,9 @@ export function Staking({
 
   function goCompose() {
     setPhase("compose");
+    // Remember it above this screen, so a trip to another tab returns here
+    // rather than to the status panel.
+    setComposingProp?.(true);
   }
 
   function handlePreview(p: DelegationPreview, from: Phase = "compose") {
@@ -781,12 +797,9 @@ export function Staking({
   function handleReset() {
     setPreview(null);
     setTxResult(null);
-    setPoolId("");
-    setVoteType(null);
-    setDrepId("");
-    setAnchorUrl("");
-    setAnchorHash("");
+    setDraft(() => EMPTY_DRAFT);
     setPhase("status");
+    setComposingProp?.(false);
     delegation.refresh();
   }
 
@@ -833,15 +846,15 @@ export function Staking({
       <StatusPanel poolId={del?.pool_id ?? null} active={isActive} network={network} />
       <Compose
         poolId={poolId}
-        setPoolId={setPoolId}
+        setPoolId={setField("poolId")}
         voteType={voteType}
-        setVoteType={setVoteType}
+        setVoteType={setField("voteType")}
         drepId={drepId}
-        setDrepId={setDrepId}
+        setDrepId={setField("drepId")}
         anchorUrl={anchorUrl}
-        setAnchorUrl={setAnchorUrl}
+        setAnchorUrl={setField("anchorUrl")}
         anchorHash={anchorHash}
-        setAnchorHash={setAnchorHash}
+        setAnchorHash={setField("anchorHash")}
         onPreview={handlePreview}
         network={network}
       />

--- a/ui/web/src/screens/Staking.tsx
+++ b/ui/web/src/screens/Staking.tsx
@@ -709,10 +709,14 @@ interface StakingProps {
   // as the fallback) so this screen still stands alone.
   poolId?: string;
   setPoolId?: (id: string) => void;
-  // Incremented by the parent when the user picks a pool from the directory:
-  // a change moves this screen into its compose phase, so "Delegate" on a
-  // directory row lands on a filled-in form rather than the status panel.
-  composeSignal?: number;
+  // Set by the parent when the user picks a pool from the directory, so
+  // "Delegate" on a directory row lands on a filled-in form rather than on the
+  // status panel an already-delegating wallet would otherwise see. Read at
+  // mount because switching tabs unmounts this screen.
+  startInCompose?: boolean;
+  // Called once the initial phase has been taken, so the parent can clear the
+  // intent and a later return to this tab opens on status as usual.
+  onComposeStarted?: () => void;
 }
 
 export function Staking({
@@ -721,11 +725,12 @@ export function Staking({
   walletId,
   poolId: poolIdProp,
   setPoolId: setPoolIdProp,
-  composeSignal = 0,
+  startInCompose = false,
+  onComposeStarted,
 }: StakingProps = {}) {
   const delegation = useDelegation();
 
-  const [phase, setPhase] = useState<Phase>("status");
+  const [phase, setPhase] = useState<Phase>(startInCompose ? "compose" : "status");
   const [previewFrom, setPreviewFrom] = useState<Phase>("status");
   const [preview, setPreview] = useState<DelegationPreview | null>(null);
   const [txResult, setTxResult] = useState<TxResult | null>(null);
@@ -739,15 +744,11 @@ export function Staking({
   const [anchorUrl, setAnchorUrl] = useState("");
   const [anchorHash, setAnchorHash] = useState("");
 
-  // Skip the initial render: a fresh mount must land on the status panel, not
-  // jump straight into an empty compose form.
-  const seenSignal = useRef(composeSignal);
+  // Report the consumed intent exactly once, on mount.
   useEffect(() => {
-    if (composeSignal !== seenSignal.current) {
-      seenSignal.current = composeSignal;
-      setPhase("compose");
-    }
-  }, [composeSignal]);
+    if (startInCompose) onComposeStarted?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (delegation.loading) {
     return <p>Loading…</p>;

--- a/ui/web/src/screens/Staking.tsx
+++ b/ui/web/src/screens/Staking.tsx
@@ -792,6 +792,11 @@ export function Staking({
   function handleDone(result: TxResult) {
     setTxResult(result);
     setPhase("done");
+    // The draft has been spent. Leaving it (and the composing flag) set would
+    // reopen the old form behind the user's back if they switched tabs while
+    // the receipt was up.
+    setDraft(() => EMPTY_DRAFT);
+    setComposingProp?.(false);
   }
 
   function handleReset() {

--- a/ui/web/src/screens/Swap.tsx
+++ b/ui/web/src/screens/Swap.tsx
@@ -147,7 +147,7 @@ function OrderPanel({ quote, onBack }: OrderPanelProps) {
         <p className="field-label">Order parameters (JSON)</p>
         <div className="tx-hash-row">
           <code className="tx-hash">{orderJson}</code>
-          <CopyButton value={orderJson} />
+          <CopyButton value={orderJson} ariaLabel="Copy order JSON" />
         </div>
 
         <Button variant="ghost" onClick={onBack}>

--- a/ui/web/src/screens/operate/MetadataBuilder.tsx
+++ b/ui/web/src/screens/operate/MetadataBuilder.tsx
@@ -105,12 +105,12 @@ export function MetadataBuilder() {
             <p className="field-label">Metadata hash (Blake2b-256)</p>
             <div className="tx-hash-row">
               <code className="tx-hash accent">{result.hash_hex}</code>
-              <CopyButton value={result.hash_hex} />
+              <CopyButton value={result.hash_hex} ariaLabel="Copy metadata hash" />
             </div>
             <p className="field-label">Canonical JSON (host this at your metadata URL)</p>
             <div className="tx-hash-row">
               <code className="tx-hash">{result.json}</code>
-              <CopyButton value={result.json} />
+              <CopyButton value={result.json} ariaLabel="Copy metadata JSON" />
             </div>
           </div>
         )}

--- a/ui/web/src/screens/operate/OperationalCert.tsx
+++ b/ui/web/src/screens/operate/OperationalCert.tsx
@@ -65,12 +65,12 @@ function OpCertResult({ opcert }: { opcert: OpCert }) {
       <p className="field-label">KES verification key</p>
       <div className="tx-hash-row">
         <code className="tx-hash">{opcert.kes_vkey_hex}</code>
-        <CopyButton value={opcert.kes_vkey_hex} />
+        <CopyButton value={opcert.kes_vkey_hex} ariaLabel="Copy KES verification key" />
       </div>
       <p className="field-label">Cold signature</p>
       <div className="tx-hash-row">
         <code className="tx-hash">{opcert.cold_signature_hex}</code>
-        <CopyButton value={opcert.cold_signature_hex} />
+        <CopyButton value={opcert.cold_signature_hex} ariaLabel="Copy cold signature" />
       </div>
     </div>
   );
@@ -375,7 +375,7 @@ function AirGapOpCert({ currentKESPeriod }: { currentKESPeriod?: number }) {
           <p className="field-label">Payload to sign (hex)</p>
           <div className="tx-hash-row">
             <code className="tx-hash">{payload.payload_hex}</code>
-            <CopyButton value={payload.payload_hex} />
+            <CopyButton value={payload.payload_hex} ariaLabel="Copy operational certificate payload" />
           </div>
         </div>
       )}

--- a/ui/web/src/screens/operate/Registration.tsx
+++ b/ui/web/src/screens/operate/Registration.tsx
@@ -357,12 +357,12 @@ export function Registration({ account }: { account: Account }) {
             <p className="field-label">Pool ID</p>
             <div className="tx-hash-row">
               <code className="tx-hash accent">{result.pool_id}</code>
-              <CopyButton value={result.pool_id} />
+              <CopyButton value={result.pool_id} ariaLabel="Copy pool ID" />
             </div>
             <p className="field-label">Certificate (CBOR hex)</p>
             <div className="tx-hash-row">
               <code className="tx-hash">{result.cbor_hex}</code>
-              <CopyButton value={result.cbor_hex} />
+              <CopyButton value={result.cbor_hex} ariaLabel="Copy certificate CBOR" />
             </div>
           </div>
         )}

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -411,6 +411,61 @@ a:hover {
   background: var(--accent-strong);
   border-color: var(--accent-strong);
 }
+/* Screen-reader-only text: kept in the accessibility tree, out of the layout. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Icon-only control (copy, and anything else that is a glyph plus a label).
+   Square by construction so it can never wrap its content the way a text
+   button in a narrow table cell does, and sized to stay a comfortable
+   pointer target. */
+.btn-icon {
+  appearance: none;
+  -webkit-appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text-faint);
+  cursor: pointer;
+  vertical-align: middle;
+  transition:
+    color 0.14s ease,
+    background 0.14s ease,
+    border-color 0.14s ease;
+}
+.btn-icon:hover:not(:disabled) {
+  color: var(--accent);
+  background: var(--inset);
+  border-color: var(--border);
+}
+.btn-icon:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.btn-icon.copied {
+  color: var(--ok);
+}
+.btn-icon:disabled {
+  opacity: 0.38;
+  cursor: not-allowed;
+}
+
 .btn.ghost {
   background: transparent;
   color: var(--accent);

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -411,6 +411,12 @@ a:hover {
   background: var(--accent-strong);
   border-color: var(--accent-strong);
 }
+/* Wrapper holding a copy button and its live region. display:contents keeps
+   it out of the layout entirely, so the button lays out exactly as before. */
+.copy-control {
+  display: contents;
+}
+
 /* Screen-reader-only text: in the accessibility tree, out of the layout. */
 .sr-only {
   position: absolute;
@@ -628,7 +634,6 @@ a:hover {
   margin: var(--space-3) 0;
   overflow-x: auto;
   white-space: pre-wrap;
-  word-break: break-word;
 }
 
 /* A table row's trailing controls: an action plus its icon companions. */

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -598,6 +598,13 @@ a:hover {
   color: var(--accent);
 }
 
+/* A table row's trailing controls: an action plus its icon companions. */
+.row-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
 /* Inline pool id + explorer link inside a directory table cell. */
 .pool-id-cell {
   display: inline-flex;
@@ -1309,15 +1316,21 @@ a:hover {
   margin-bottom: var(--space-1);
 }
 /* Tab / mode strips read as instrument selectors. */
-.operate-tabs,
+.tabs,
 .mode-toggle {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-1);
+}
+/* A tab strip sits above its panel with room to breathe. */
+.tabs {
+  margin-bottom: var(--space-3);
+}
+.mode-toggle {
   border-top: 1px solid var(--border);
   padding-top: var(--space-3);
 }
-.operate-tab {
+.tab {
   font-family: var(--mono);
   font-size: 0.6875rem;
   font-weight: 600;
@@ -1330,16 +1343,16 @@ a:hover {
   padding: 8px var(--space-3);
   cursor: pointer;
 }
-.operate-tab:hover {
+.tab:hover {
   color: var(--text);
   border-color: var(--accent);
 }
-.operate-tab.active {
+.tab.active {
   color: var(--accent-text);
   background: var(--accent);
   border-color: var(--accent);
 }
-.operate-tab:focus-visible {
+.tab:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px var(--accent-dim);
 }
@@ -2006,11 +2019,11 @@ a:hover {
   }
 
   /* Operate-tab strip: wrap onto two lines if needed. */
-  .operate-tabs,
+  .tabs,
   .mode-toggle {
     flex-wrap: wrap;
   }
-  .operate-tab {
+  .tab {
     min-height: 44px;
   }
 }

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -411,19 +411,6 @@ a:hover {
   background: var(--accent-strong);
   border-color: var(--accent-strong);
 }
-/* Screen-reader-only text: kept in the accessibility tree, out of the layout. */
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip-path: inset(50%);
-  white-space: nowrap;
-  border: 0;
-}
-
 /* Icon-only control (copy, and anything else that is a glyph plus a label).
    Square by construction so it can never wrap its content the way a text
    button in a narrow table cell does, and sized to stay a comfortable
@@ -454,12 +441,15 @@ a:hover {
   background: var(--inset);
   border-color: var(--border);
 }
+/* Success colour has to survive the pointer still resting on the control it
+   was just clicked with, which is the common case. */
+.btn-icon.copied,
+.btn-icon.copied:hover:not(:disabled) {
+  color: var(--ok);
+}
 .btn-icon:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
-}
-.btn-icon.copied {
-  color: var(--ok);
 }
 .btn-icon:disabled {
   opacity: 0.38;
@@ -1345,22 +1335,26 @@ a:hover {
   color: var(--text-muted);
   margin-bottom: var(--space-1);
 }
-/* Tab / mode strips read as instrument selectors. */
-.tabs,
+/* Tab / mode strips read as instrument selectors.
+   Deliberately NOT named .tab: that class is already taken above by Offline's
+   underline-style .tab-bar, and reusing it would restyle that screen. */
+.tabset,
 .mode-toggle {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-1);
 }
-/* A tab strip sits above its panel with room to breathe. */
-.tabs {
+/* A standalone tab strip sits above its panel with room to breathe; a mode
+   toggle sits below the copy it switches. */
+.tabset {
   margin-bottom: var(--space-3);
 }
 .mode-toggle {
   border-top: 1px solid var(--border);
   padding-top: var(--space-3);
 }
-.tab {
+.operate-tab,
+.tabset-tab {
   font-family: var(--mono);
   font-size: 0.6875rem;
   font-weight: 600;
@@ -1373,16 +1367,19 @@ a:hover {
   padding: 8px var(--space-3);
   cursor: pointer;
 }
-.tab:hover {
+.operate-tab:hover,
+.tabset-tab:hover {
   color: var(--text);
   border-color: var(--accent);
 }
-.tab.active {
+.operate-tab.active,
+.tabset-tab.active {
   color: var(--accent-text);
   background: var(--accent);
   border-color: var(--accent);
 }
-.tab:focus-visible {
+.operate-tab:focus-visible,
+.tabset-tab:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px var(--accent-dim);
 }
@@ -2049,11 +2046,12 @@ a:hover {
   }
 
   /* Operate-tab strip: wrap onto two lines if needed. */
-  .tabs,
+  .tabset,
   .mode-toggle {
     flex-wrap: wrap;
   }
-  .tab {
+  .operate-tab,
+  .tabset-tab {
     min-height: 44px;
   }
 }

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -411,6 +411,19 @@ a:hover {
   background: var(--accent-strong);
   border-color: var(--accent-strong);
 }
+/* Screen-reader-only text: in the accessibility tree, out of the layout. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Icon-only control (copy, and anything else that is a glyph plus a label).
    Square by construction so it can never wrap its content the way a text
    button in a narrow table cell does, and sized to stay a comfortable

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -641,8 +641,16 @@ a:hover {
 .table td {
   padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--border);
-  vertical-align: top;
+  /* Middle, not top: cells pair a value with an icon control, and top
+     alignment left the icon floating above the text it belongs to. */
+  vertical-align: middle;
   color: var(--text);
+  /* Cell values here are hashes, addresses, amounts and timestamps -- atomic
+     tokens that mean nothing broken across lines. Wrapping them was turning
+     three-line cells into triple-height rows; .table-wrap already scrolls
+     horizontally, which is the right way to handle a table that outgrows its
+     column. */
+  white-space: nowrap;
 }
 .table tr:last-child td {
   border-bottom: none;

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -549,6 +549,14 @@ a:hover {
   font-family: var(--mono);
   text-align: right;
   color: var(--text);
+  /* Values here are addresses, pool IDs and hashes. In a flex row they would
+     otherwise push past the card edge and be clipped with no ellipsis and no
+     way to read the rest -- visible on any narrow viewport. min-width:0 lets
+     the item shrink; overflow-wrap lets a long identifier break rather than
+     overflow. Wrapping rather than truncating because these rows carry no copy
+     control, so hiding characters would lose them. */
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 .provisional-notice dd {
   font-family: var(--font);
@@ -596,6 +604,28 @@ a:hover {
 .explorer-link:hover,
 .explorer-link:focus-visible {
   color: var(--accent);
+}
+
+/* Recoverable failure panel from ErrorBoundary. */
+.error-boundary {
+  max-width: 640px;
+  border-color: color-mix(in srgb, var(--error) 40%, var(--border));
+}
+.error-boundary h2 {
+  color: var(--error);
+}
+.error-detail {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  background: var(--inset);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--space-2) var(--space-3);
+  margin: var(--space-3) 0;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 /* A table row's trailing controls: an action plus its icon companions. */

--- a/ui/web/vite.config.ts
+++ b/ui/web/vite.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
       "/vault": "http://127.0.0.1:8090",
       "/wallet": "http://127.0.0.1:8090",
       "/connector": "http://127.0.0.1:8090",
+      // The Diagnostics screen reads /diagnostics and downloads /diagnostics/logs.
+      // Without this the screen is broken under `npm run dev`: the request falls
+      // through to the SPA fallback and the screen reports a JSON parse error.
+      "/diagnostics": "http://127.0.0.1:8090",
     },
   },
   test: {


### PR DESCRIPTION
Consolidates #695 and #696 and adds the first step of the navigation rework, so this is one review instead of three. 23 files.

Found by building the wallet, running it against a node, and looking at every screen.

---

## 1. The wallet did not render at all

`#root` had zero children. React never mounted.

`@ledgerhq/hw-transport-webhid` is imported at module scope from `src/hw/index.ts:18` and reaches for the Node `Buffer` global while being evaluated. Browsers have no such global, so it threw `ReferenceError: Buffer is not defined` — and because the import is static and reachable from the initial bundle, that took down startup rather than just the Ledger flow. Reproduced against a **production build**, not only dev.

Fixed by installing `Buffer` from a dedicated polyfills module imported first in `main.tsx`. It must be its own module: every import of a module is evaluated before that module's own body, so `globalThis.Buffer = …` written directly in `main.tsx` would land long after the hardware modules had already thrown.

The transport is also now a dynamic import, as `trezor.ts` and `keystone.ts` already do — Ledger was the odd one out. Both its runtime uses are inside the already-`async` `connectLedger()`.

**Why 664 green tests missed it:** vitest runs on Node, where `Buffer` is a real global, so the failure only ever appears in a browser. The added tests assert the structural properties instead — polyfills imported first, no module-scope import of the transport.

| | `#root` children | `.app` present |
|---|---|---|
| before | `0` | no |
| after | `1` | yes |

## 2. Copy is an icon

A copy control sits beside almost every address, hash and CBOR blob — **39 of them**, each reading `Copy`. In the Activity table the text did not even fit its column: the button wrapped character-by-character into a vertical `C o p y` and tripled every row's height at an ordinary 1440px width.

Now a glyph that swaps to a check on success, square by construction so it cannot wrap. Two review-worthy details:

- Most call sites pass no label. For an icon-only control that means *no accessible name at all*, so it falls back to `Copy to clipboard`.
- The copied state rides on the button's own accessible name, re-announced on the focused control. A live region per control would put 39 of them competing to be "the" status — which broke four unrelated `findByRole("status")` queries when tried.

## 3. The transaction table fits

Cells no longer wrap — hashes, addresses, amounts and timestamps are atomic tokens that mean nothing broken mid-way, and `.table-wrap` already scrolls horizontally.

That alone pushed the table past its container and hid the **Details** action off-screen, so fee and block height are out of the list: they are drill-down facts, and the detail drawer already shows both in full.

| | before | after |
|---|---|---|
| row height @1440px | 185px | 56px |
| horizontal overflow | — | none |

<table>
<tr><th width="50%">before</th><th width="50%">after</th></tr>
<tr>
<td><img src="https://raw.githubusercontent.com/blinklabs-io/bursa/assets/screenshots/pr-697/b-activity.png" alt="Activity before: Copy buttons wrapped one letter per line, rows three lines tall"></td>
<td><img src="https://raw.githubusercontent.com/blinklabs-io/bursa/assets/screenshots/pr-697/a-activity.png" alt="Activity after: single-line rows, icon copy control, Details visible"></td>
</tr>
</table>


## 4. Digits are grouped, and ADA is spelled one way

Live stake read `63120000000000`. Digits were already tabular and monospaced; grouping is the remaining half. Zero-decimal tokens group too — no fractional part to scale, but the largest numbers on screen.

`Staking.tsx` was the only file using `₳` (U+20B3); every other screen writes `ADA`. It renders as a bare `A` wherever the font stack has no glyph for it.

## 5. Staking, Rewards and Pools become one Stake screen

Three top-level destinations answering one question — what is my ADA doing and where should it go — that did not connect. The directory's own help text told you to *copy a pool ID and paste it into the delegation screen*, with the clipboard as the integration layer between two halves of one task.

They are now tabs of one destination, and **each pool row has a Delegate action** that hands the pool to the delegation form and switches to it. The pool-ID draft is owned by Stake, so browsing the directory mid-compose and coming back does not lose what you typed.

Gating moved with it: the screen needs only a queryable node, so a read-only wallet still gets rewards and the directory, and the Delegation tab explains itself rather than the whole destination vanishing.

`#/staking`, `#/rewards` and `#/pools` still resolve, each opening its matching tab, so existing links keep working.

`Tabs` is extracted from Operate — the only correct ARIA tablist in the app — into a shared component, now with Home/End as well as arrow keys. Operate uses it too, so the wiring exists once instead of twice.


<table>
<tr><th width="50%">before</th><th width="50%">after</th></tr>
<tr>
<td><img src="https://raw.githubusercontent.com/blinklabs-io/bursa/assets/screenshots/pr-697/b-pools.png" alt="Stake Pools before: a separate screen, ungrouped digits, Copy only"></td>
<td><img src="https://raw.githubusercontent.com/blinklabs-io/bursa/assets/screenshots/pr-697/a-pools.png" alt="Pools as a tab of Stake, grouped digits, a Delegate action per row"></td>
</tr>
</table>

Choosing a pool lands on the delegation form with it filled in — for a wallet that already delegates too, which is where the first attempt got this wrong:

<img src="https://raw.githubusercontent.com/blinklabs-io/bursa/assets/screenshots/pr-697/a-delegate.png" width="900" alt="Delegation tab: current status above, set-up form below with the chosen pool prefilled">

**Nav: 17 entries → 15.** More consolidation follows in the navigation rework; this is the first step.


---

## 6. Found by clicking through every screen

I walked all fifteen screens and pressed every control against a mock node. Most of it behaves: send previews and submits, staking withdraw and delegate preview correctly, sign/verify round-trip, contacts, import-transaction decode, the five Operate tabs, settings toggles persist, wallet switching gates exactly the right screens for a hardware wallet, lock returns to the unlock screen, and the mobile drawer navigates and closes. These came out of it.

**A screen that throws no longer takes the wallet with it.** Twice during the pass a single unexpected field in one API response unmounted the entire React tree — blank white page, vault still unlocked, no indication of what happened, no way back but a reload. The node is the source of truth and its responses are not part of this codebase, so a field arriving absent or misshapen is a case to survive, not to assume away.

The boundary wraps the screen area rather than the shell, so the nav survives and you can navigate out; it clears on navigation. It says funds are unaffected, because on a wallet that is the first question a crash raises.

<img src="https://raw.githubusercontent.com/blinklabs-io/bursa/assets/screenshots/pr-697/qa-error-boundary.png" width="900" alt="Recoverable error panel with the nav still present">

**`/diagnostics` was missing from the dev-server proxy,** so that screen was broken under `npm run dev` — the request fell through to the SPA fallback and the screen reported a JSON parse error at the user.

**Long values overflowed their card on narrow viewports.** A pool ID in a `dl-row` was clipped at the card edge with no ellipsis and no way to read the rest. They wrap now instead of truncating, since those rows carry no copy control and truncating would lose characters outright.

<img src="https://raw.githubusercontent.com/blinklabs-io/bursa/assets/screenshots/pr-697/qa-mobile-fixed.png" width="380" alt="Delegated pool ID wrapping inside its card on a 390px viewport">

**"Spending password" was rendered up to three times on one screen** — card title, field label, and an identical placeholder. The duplicate placeholders are gone and the staking card is retitled; the placeholder stays in the two multi-sig fields where it is the only visible affordance or says something the label does not.

One thing deliberately left alone: the Unlock button submits with an empty password rather than being disabled. The backend rejects it, so this is a nicety rather than a hole, and it is not this PR's subject.

## Verification

`npx tsc -b` clean · **678 tests pass** · `eslint` clean (one pre-existing warning in `connectorNotify.ts`, untouched).

Screens were driven against a mock node to check them visually; the pool directory, activity table, portfolio, receive and staking screens were all re-checked after each change. That is how the delegate-handoff bug in the last commit was found — it passed its unit test and still did the wrong thing on screen.

Screenshots are hosted on the `assets/screenshots` branch so the binaries stay off `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified Staking navigation with Delegation, Rewards, and Pools tabs.
  * Added direct pool delegation actions and preserved in-progress delegation drafts.
  * Added recoverable error messages with retry and reload options.
  * Improved keyboard navigation and accessibility across tabs and copy controls.
* **Improvements**
  * Added thousands separators to ADA and token amounts.
  * Simplified transaction activity displays and improved CSV formatting.
  * Standardized staking currency labels to “ADA.”
* **Bug Fixes**
  * Improved hardware-wallet startup reliability in supported browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->