### PR TITLE
feat(ui): fold actions and housekeeping out of the nav (15 → 9)

### DIFF
--- a/ui/web/src/app.test.tsx
+++ b/ui/web/src/app.test.tsx
@@ -749,19 +749,50 @@ test("a wallet that cannot spend gets a disabled Send, not a dead end", async ()
 
 test("the routes the absorbed screens used to own still resolve", async () => {
   // Old links and bookmarks must not break just because the screen moved.
-  for (const [hash, expected] of [
-    ["#/contacts", "Settings"],
-    ["#/sign", "Settings"],
-    ["#/verify", "Settings"],
-    ["#/diagnostics", "Settings"],
-    ["#/receive", "Portfolio"],
+  // Asserting the nav highlight alone is not enough: every one of these
+  // highlights Settings, so a mis-mapped SETTINGS_ROUTES entry would sail
+  // through while opening the wrong panel. Check the panel that opened.
+  for (const [hash, navEntry, panel] of [
+    ["#/contacts", "Settings", "Address book"],
+    ["#/sign", "Settings", "Tools"],
+    ["#/verify", "Settings", "Tools"],
+    ["#/diagnostics", "Settings", "Diagnostics"],
+    ["#/settings", "Settings", "General"],
   ] as const) {
     window.location.hash = hash;
     const sidebar = await unlockAndGetSidebar(walletA);
-    const active = within(sidebar).getByRole("button", { name: expected });
-    expect(active).toHaveAttribute("aria-current", "page");
+
+    expect(within(sidebar).getByRole("button", { name: navEntry })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(await screen.findByRole("tab", { name: panel })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
     cleanup();
     vi.restoreAllMocks();
     stubAutoLock(0);
   }
+});
+
+test("#/receive opens Receive while the nav still points at Portfolio", async () => {
+  // Send and Receive are Portfolio actions, so the highlight is deliberate —
+  // but the screen on display is Receive, and the error boundary must say so
+  // rather than blaming Portfolio for a fault in a different screen.
+  vi.spyOn(hooks, "useAddresses").mockReturnValue({
+    data: { receive: ["addr_test1abc"], used: [], next_unused: "addr_test1abc" },
+    error: null,
+    loading: false,
+    refresh: vi.fn(),
+  } as never);
+  window.location.hash = "#/receive";
+  const sidebar = await unlockAndGetSidebar(walletA);
+
+  expect(within(sidebar).getByRole("button", { name: "Portfolio" })).toHaveAttribute(
+    "aria-current",
+    "page",
+  );
+  expect(await screen.findByText(/next unused address/i)).toBeInTheDocument();
 });

--- a/ui/web/src/app.test.tsx
+++ b/ui/web/src/app.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent, act, within } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, act, within, cleanup } from "@testing-library/react";
 import { App } from "./app";
 import * as hooks from "./api/hooks";
 import * as client from "./api/client";
@@ -677,4 +677,91 @@ test("[Fix 1] changing the auto-lock timeout in Settings propagates to the idle 
 
   expect(lockSpy).not.toHaveBeenCalled();
   vi.useRealTimers();
+});
+
+// --- Absorbed destinations ------------------------------------------------
+
+// Unlocks with the given wallet and returns the desktop sidebar, so nav
+// assertions are not confused by the mobile drawer rendering the same labels.
+async function unlockAndGetSidebar(wallet: WalletView): Promise<HTMLElement> {
+  stubStatus("ready");
+  stubVault({ exists: true, locked: true, wallet_count: 1 });
+  quietPortfolio();
+  vi.spyOn(client, "unlockVault").mockResolvedValue([{ ...wallet, active: true }]);
+
+  render(<App />);
+  fireEvent.change(screen.getByLabelText(/vault password/i), { target: { value: "vault-password-xyz" } });
+  fireEvent.click(screen.getByRole("button", { name: /^unlock$/i }));
+
+  await waitFor(() => expect(document.querySelector(".sidebar")).not.toBeNull());
+  return document.querySelector(".sidebar") as HTMLElement;
+}
+
+test("the nav carries only destinations, not actions or housekeeping", async () => {
+  const sidebar = await unlockAndGetSidebar(walletA);
+  const q = within(sidebar);
+
+  expect(
+    q.getAllByRole("button").map((b) => b.textContent).filter((t) =>
+      ["Portfolio", "Activity", "Stake", "Swap", "Multi-sig", "Import Tx", "Offline", "Operate", "Settings"].includes(t ?? ""),
+    ),
+  ).toHaveLength(9);
+
+  // Send and Receive are actions on the Portfolio; the rest are Settings
+  // panels. None of them earns a nav entry.
+  for (const gone of ["Send", "Receive", "Contacts", "Sign", "Verify", "Diagnostics"]) {
+    expect(q.queryByRole("button", { name: gone })).not.toBeInTheDocument();
+  }
+});
+
+test("Send and Receive are offered on the balance they act on", async () => {
+  await unlockAndGetSidebar(walletA);
+
+  const main = document.querySelector("main") as HTMLElement;
+  const q = within(main);
+  expect(await q.findByRole("button", { name: "Send" })).toBeInTheDocument();
+  expect(q.getByRole("button", { name: "Receive" })).toBeInTheDocument();
+});
+
+test("Send on the Portfolio actually reaches the send flow", async () => {
+  // Send is no longer in the nav, so this button is the only way in. Asserting
+  // it renders is not enough — it has to be enabled and it has to navigate.
+  await unlockAndGetSidebar(walletA);
+  const main = document.querySelector("main") as HTMLElement;
+
+  const send = await within(main).findByRole("button", { name: "Send" });
+  expect(send).toBeEnabled();
+
+  fireEvent.click(send);
+
+  await waitFor(() => expect(window.location.hash).toBe("#/send"));
+  expect(await screen.findByText(/send ada/i)).toBeInTheDocument();
+});
+
+test("a wallet that cannot spend gets a disabled Send, not a dead end", async () => {
+  await unlockAndGetSidebar({ ...walletA, type: "read_only" });
+  const main = document.querySelector("main") as HTMLElement;
+
+  expect(await within(main).findByRole("button", { name: "Send" })).toBeDisabled();
+  // Receive needs nothing, so it stays available.
+  expect(within(main).getByRole("button", { name: "Receive" })).toBeEnabled();
+});
+
+test("the routes the absorbed screens used to own still resolve", async () => {
+  // Old links and bookmarks must not break just because the screen moved.
+  for (const [hash, expected] of [
+    ["#/contacts", "Settings"],
+    ["#/sign", "Settings"],
+    ["#/verify", "Settings"],
+    ["#/diagnostics", "Settings"],
+    ["#/receive", "Portfolio"],
+  ] as const) {
+    window.location.hash = hash;
+    const sidebar = await unlockAndGetSidebar(walletA);
+    const active = within(sidebar).getByRole("button", { name: expected });
+    expect(active).toHaveAttribute("aria-current", "page");
+    cleanup();
+    vi.restoreAllMocks();
+    stubAutoLock(0);
+  }
 });

--- a/ui/web/src/app.test.tsx
+++ b/ui/web/src/app.test.tsx
@@ -778,9 +778,7 @@ test("the routes the absorbed screens used to own still resolve", async () => {
 });
 
 test("#/receive opens Receive while the nav still points at Portfolio", async () => {
-  // Send and Receive are Portfolio actions, so the highlight is deliberate —
-  // but the screen on display is Receive, and the error boundary must say so
-  // rather than blaming Portfolio for a fault in a different screen.
+  // Send and Receive are Portfolio actions, so the highlight is deliberate.
   vi.spyOn(hooks, "useAddresses").mockReturnValue({
     data: { receive: ["addr_test1abc"], used: [], next_unused: "addr_test1abc" },
     error: null,
@@ -795,4 +793,38 @@ test("#/receive opens Receive while the nav still points at Portfolio", async ()
     "page",
   );
   expect(await screen.findByText(/next unused address/i)).toBeInTheDocument();
+});
+
+test("a fault in Receive is reported as Receive, not as Portfolio", async () => {
+  // The nav highlight collapses receive onto Portfolio, so the boundary label
+  // has to come from somewhere else — otherwise a crash here sends the reader
+  // to a screen that is working fine. Exercise the boundary rather than
+  // asserting the label indirectly.
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(hooks, "useAddresses").mockImplementation(() => {
+    throw new Error("addresses blew up");
+  });
+  window.location.hash = "#/receive";
+  await unlockAndGetSidebar(walletA);
+
+  const alert = await screen.findByRole("alert");
+  expect(alert).toHaveTextContent(/the receive screen could not be displayed/i);
+  expect(alert).not.toHaveTextContent(/portfolio/i);
+});
+
+test("a route that falls back to Portfolio is reported as Portfolio", async () => {
+  // #/swap on a testnet wallet declines the request and renders Portfolio, so
+  // naming the route the user asked for would point at a screen that never
+  // appeared.
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  // Not useBalance: the unlock helper stubs that one, and its stub would win.
+  vi.spyOn(hooks, "useAssetMetadata").mockImplementation(() => {
+    throw new Error("metadata blew up");
+  });
+  window.location.hash = "#/swap";
+  await unlockAndGetSidebar(walletA); // preview network → canSwap is false
+
+  const alert = await screen.findByRole("alert");
+  expect(alert).toHaveTextContent(/the portfolio screen could not be displayed/i);
+  expect(alert).not.toHaveTextContent(/swap screen/i);
 });

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -312,6 +312,15 @@ export function App() {
     else activeRoute = "portfolio";
   }
 
+  // What the boundary calls the failed screen. Deliberately NOT activeRoute:
+  // that is the NAV highlight, which collapses several routes onto one entry
+  // (send/receive highlight Portfolio, the stake family highlights Stake). A
+  // fallback reading "the portfolio screen could not be displayed" while Send
+  // is what broke sends the reader to the wrong place.
+  const screenLabel = addingWallet
+    ? "add wallet"
+    : route || "wallet";
+
   let content: ReactElement;
   if (addingWallet) {
     content = (
@@ -486,7 +495,7 @@ export function App() {
               too — it swaps the content without changing the route, and is a
               shell recovery action that must not land on a stale fallback. */}
           <ErrorBoundary
-            label={activeRoute || "wallet"}
+            label={screenLabel}
             resetKey={`${route}:${addingWallet}`}
           >
             {content}

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -314,15 +314,19 @@ export function App() {
 
   // What the boundary calls the failed screen. Deliberately NOT activeRoute:
   // that is the NAV highlight, which collapses several routes onto one entry
-  // (send/receive highlight Portfolio, the stake family highlights Stake). A
+  // (send/receive highlight Portfolio, the stake family highlights Stake), so a
   // fallback reading "the portfolio screen could not be displayed" while Send
   // is what broke sends the reader to the wrong place.
-  const screenLabel = addingWallet
-    ? "add wallet"
-    : route || "wallet";
+  //
+  // Nor is the raw route enough on its own: several branches below decline the
+  // requested screen and render Portfolio instead, and naming the route the
+  // user ASKED for would point at a screen that is not on display either. Each
+  // such branch corrects this to what it actually rendered.
+  let screenLabel = route || "wallet";
 
   let content: ReactElement;
   if (addingWallet) {
+    screenLabel = "add wallet";
     content = (
       <AddWallet
         network={network}
@@ -331,6 +335,7 @@ export function App() {
       />
     );
   } else if (activeWallet === null) {
+    screenLabel = "wallet";
     // Unlocked with multiple wallets and none selected yet: prompt to pick one.
     // On mobile the sidebar is hidden, so direct the user to the drawer instead.
     content = (
@@ -354,12 +359,14 @@ export function App() {
       />
     );
   } else if (route === "send" && !canSend) {
+    screenLabel = "portfolio";
     content = <Portfolio canSend={canSend} />;
   } else if (route === "send" && canSend) {
     content = <Send isHardware={activeWallet.type === "hardware"} walletId={activeWallet.id} />;
   } else if (route === "swap" && !canSwap) {
     // Guard deep-links (#/swap): DEX quotes need a queryable mainnet node, so
     // fall back to Portfolio while the node or active wallet cannot support it.
+    screenLabel = "portfolio";
     content = <Portfolio canSend={canSend} />;
   } else if (STAKE_ROUTES.has(route)) {
     // Delegation, rewards and the pool directory are one screen, and it is not
@@ -381,12 +388,14 @@ export function App() {
   } else if (route === "offline") {
     // Air-gap signing needs the active wallet's seed (to sign) but no node for
     // the sign step; falls back to Portfolio without an active wallet.
+    if (!canSign) screenLabel = "portfolio";
     content = canSign ? <Offline /> : <Portfolio canSend={canSend} />;
   } else if (route === "operate") {
     // Pool operations derive cold/VRF/KES keys from the seed and need the spend
     // password. A wallet must be active; otherwise fall back to Portfolio. Most
     // pool ops are offline; only retirement submission needs a synced node,
     // gated at the API.
+    if (!canSign) screenLabel = "portfolio";
     content = canSign ? <Operate account={toAccount(activeWallet)} /> : <Portfolio canSend={canSend} />;
   } else if (route === "multisig") {
     // Managing multi-sig accounts (list/create/view) is local state and works on
@@ -397,6 +406,7 @@ export function App() {
     // Importing a transaction built elsewhere needs the active wallet's seed
     // to add a signature (like Offline/Operate); submitting is separately
     // gated inside the screen on the node being ready (canSubmit).
+    if (!canSign) screenLabel = "portfolio";
     content = canSign ? <ImportTransaction canSubmit={isReady} /> : <Portfolio canSend={canSend} />;
   } else if (route === "receive") {
     // Explorer links on each address need the active wallet's real network
@@ -413,6 +423,7 @@ export function App() {
     // Send is not in the nav, is the only way to reach the send flow. Resolving
     // it through the props-less ROUTES map would silently disable it.
     const Screen = ROUTES.get(route);
+    if (!Screen) screenLabel = "portfolio";
     content = Screen && route !== "portfolio" ? <Screen /> : <Portfolio canSend={canSend} />;
   }
 

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -21,16 +21,12 @@ import { Receive } from "./screens/Receive";
 import { Activity } from "./screens/Activity";
 import { Send } from "./screens/Send";
 import { Swap } from "./screens/Swap";
-import { Contacts } from "./screens/Contacts";
 import { Stake } from "./screens/Stake";
-import { SignMessage } from "./screens/SignMessage";
-import { VerifyMessage } from "./screens/VerifyMessage";
 import { Offline } from "./screens/Offline";
 import { Operate } from "./screens/Operate";
 import { MultiSig } from "./screens/MultiSig";
 import { ImportTransaction } from "./screens/ImportTransaction";
 import { Settings } from "./screens/Settings";
-import { Diagnostics } from "./screens/Diagnostics";
 import { ConnectorApproval } from "./screens/ConnectorApproval";
 
 // A Map (not a plain object) so a crafted hash like "#/constructor" or
@@ -53,11 +49,6 @@ const ROUTES = new Map<string, () => ReactElement>([
   ["activity", Activity],
   ["send", Send],
   ["swap", Swap],
-  ["contacts", Contacts],
-  // Diagnostics is node-level and takes no props, so it resolves straight from
-  // this map (via the final content-selection else) and is highlighted through
-  // ROUTES.has below.
-  ["diagnostics", Diagnostics],
 ]);
 
 // Stake merged three screens; the old routes stay valid and open the matching
@@ -69,21 +60,30 @@ const STAKE_ROUTES = new Map<string, "delegation" | "rewards" | "pools">([
   ["pools", "pools"],
 ]);
 
+// Settings absorbed the address book, message signing/verification and node
+// diagnostics as panels; these routes still resolve so old links keep working.
+const SETTINGS_ROUTES = new Map<string, "general" | "contacts" | "tools" | "diagnostics">([
+  ["settings", "general"],
+  ["contacts", "contacts"],
+  ["sign", "tools"],
+  ["verify", "tools"],
+  ["diagnostics", "diagnostics"],
+]);
+
+// Send and Receive are actions on the Portfolio rather than destinations, so
+// they keep their routes (deep links, and the Portfolio buttons) without
+// costing a nav entry.
+const PORTFOLIO_ROUTES = new Set(["portfolio", "send", "receive"]);
+
 const NAV: { key: string; label: string }[] = [
   { key: "portfolio", label: "Portfolio" },
-  { key: "receive", label: "Receive" },
   { key: "activity", label: "Activity" },
-  { key: "send", label: "Send" },
-  { key: "swap", label: "Swap" },
-  { key: "contacts", label: "Contacts" },
   { key: "stake", label: "Stake" },
-  { key: "sign", label: "Sign" },
-  { key: "verify", label: "Verify" },
-  { key: "offline", label: "Offline" },
-  { key: "operate", label: "Operate" },
+  { key: "swap", label: "Swap" },
   { key: "multisig", label: "Multi-sig" },
   { key: "import", label: "Import Tx" },
-  { key: "diagnostics", label: "Diagnostics" },
+  { key: "offline", label: "Offline" },
+  { key: "operate", label: "Operate" },
   { key: "settings", label: "Settings" },
 ];
 
@@ -295,8 +295,8 @@ export function App() {
   // resolution below) so the sidebar can highlight the active route.
   let activeRoute = "";
   if (!addingWallet && activeWallet !== null) {
-    if (route === "settings") activeRoute = "settings";
-    else if (route === "send" && canSend) activeRoute = "send";
+    if (SETTINGS_ROUTES.has(route)) activeRoute = "settings";
+    else if (PORTFOLIO_ROUTES.has(route)) activeRoute = "portfolio";
     else if (route === "swap" && canSwap) activeRoute = "swap";
     // The legacy per-screen routes now resolve to tabs of the merged screen,
     // so an old bookmark or a link in the wild still highlights Stake. No node
@@ -304,13 +304,11 @@ export function App() {
     // disagreed with what is rendered would point at Portfolio while Stake is
     // on screen — and mislabel the error boundary with it.
     else if (STAKE_ROUTES.has(route)) activeRoute = "stake";
-    else if (route === "sign" && canSign) activeRoute = "sign";
-    else if (route === "verify") activeRoute = "verify";
     else if (route === "offline" && canSign) activeRoute = "offline";
     else if (route === "operate" && canSign) activeRoute = "operate";
     else if (route === "multisig") activeRoute = "multisig";
     else if (route === "import" && canSign) activeRoute = "import";
-    else if (ROUTES.has(route) && route !== "send" && route !== "swap") activeRoute = route;
+    else if (ROUTES.has(route) && route !== "swap") activeRoute = route;
     else activeRoute = "portfolio";
   }
 
@@ -336,22 +334,24 @@ export function App() {
         </p>
       </section>
     );
-  } else if (route === "settings") {
+  } else if (SETTINGS_ROUTES.has(route)) {
     content = (
       <Settings
         account={toAccount(activeWallet)}
         walletType={activeWallet.type}
         autoLock={autoLock}
+        canSign={canSign}
+        initialTab={SETTINGS_ROUTES.get(route)}
       />
     );
   } else if (route === "send" && !canSend) {
-    content = <Portfolio />;
+    content = <Portfolio canSend={canSend} />;
   } else if (route === "send" && canSend) {
     content = <Send isHardware={activeWallet.type === "hardware"} walletId={activeWallet.id} />;
   } else if (route === "swap" && !canSwap) {
     // Guard deep-links (#/swap): DEX quotes need a queryable mainnet node, so
     // fall back to Portfolio while the node or active wallet cannot support it.
-    content = <Portfolio />;
+    content = <Portfolio canSend={canSend} />;
   } else if (STAKE_ROUTES.has(route)) {
     // Delegation, rewards and the pool directory are one screen, and it is not
     // gated as a whole: reward history is a plain account read that the old
@@ -369,22 +369,16 @@ export function App() {
         initialTab={STAKE_ROUTES.get(route)}
       />
     );
-  } else if (route === "sign") {
-    content = canSign ? <SignMessage account={toAccount(activeWallet)} /> : <Portfolio />;
-  } else if (route === "verify") {
-    // Verification is pure crypto — available to any active wallet, even
-    // read-only, since it neither needs a node nor the keystore.
-    content = <VerifyMessage />;
   } else if (route === "offline") {
     // Air-gap signing needs the active wallet's seed (to sign) but no node for
     // the sign step; falls back to Portfolio without an active wallet.
-    content = canSign ? <Offline /> : <Portfolio />;
+    content = canSign ? <Offline /> : <Portfolio canSend={canSend} />;
   } else if (route === "operate") {
     // Pool operations derive cold/VRF/KES keys from the seed and need the spend
     // password. A wallet must be active; otherwise fall back to Portfolio. Most
     // pool ops are offline; only retirement submission needs a synced node,
     // gated at the API.
-    content = canSign ? <Operate account={toAccount(activeWallet)} /> : <Portfolio />;
+    content = canSign ? <Operate account={toAccount(activeWallet)} /> : <Portfolio canSend={canSend} />;
   } else if (route === "multisig") {
     // Managing multi-sig accounts (list/create/view) is local state and works on
     // any active wallet. Building and submitting spends requires a synced node;
@@ -394,7 +388,7 @@ export function App() {
     // Importing a transaction built elsewhere needs the active wallet's seed
     // to add a signature (like Offline/Operate); submitting is separately
     // gated inside the screen on the node being ready (canSubmit).
-    content = canSign ? <ImportTransaction canSubmit={isReady} /> : <Portfolio />;
+    content = canSign ? <ImportTransaction canSubmit={isReady} /> : <Portfolio canSend={canSend} />;
   } else if (route === "receive") {
     // Explorer links on each address need the active wallet's real network
     // (preview/preprod/mainnet), which the generic ROUTES map (no props)
@@ -405,8 +399,12 @@ export function App() {
     // active wallet's network.
     content = <Activity network={activeWallet.network} />;
   } else {
-    const Screen = ROUTES.get(route) ?? Portfolio;
-    content = <Screen />;
+    // Portfolio is both a listed route and the fallback for anything
+    // unrecognised, and it needs canSend for its Send action — which, now that
+    // Send is not in the nav, is the only way to reach the send flow. Resolving
+    // it through the props-less ROUTES map would silently disable it.
+    const Screen = ROUTES.get(route);
+    content = Screen && route !== "portfolio" ? <Screen /> : <Portfolio canSend={canSend} />;
   }
 
   // Build the nav item descriptors once, shared between desktop sidebar and
@@ -415,9 +413,7 @@ export function App() {
     const gated =
       activeWallet === null ||
       addingWallet ||
-      (key === "send" && !canSend) ||
       (key === "swap" && !canSwap) ||
-      (key === "sign" && !canSign) ||
       (key === "offline" && !canSign) ||
       (key === "operate" && !canSign) ||
       (key === "import" && !canSign);

--- a/ui/web/src/components/AccountSwitcher.test.tsx
+++ b/ui/web/src/components/AccountSwitcher.test.tsx
@@ -93,7 +93,7 @@ test("lists every account with its label, marks the active one, and overlays nod
   expect(screen.getByText("Account #0")).toBeInTheDocument();
   expect(screen.getByText("Account #1")).toBeInTheDocument();
   // Balances are not on the WalletView — they arrive once useAccounts resolves.
-  expect(await screen.findByText("1.5 ₳")).toBeInTheDocument();
+  expect(await screen.findByText("1.5 ADA")).toBeInTheDocument();
 
   const active = screen.getByRole("button", { name: /account #0/i });
   expect(active).toHaveAttribute("aria-current", "true");
@@ -109,7 +109,7 @@ test("renders accounts without balances when /wallet/accounts is unavailable", a
   // The list still renders from the WalletView; no balance chip is shown.
   expect(screen.getByText("Account #0")).toBeInTheDocument();
   await waitFor(() => expect(client.getAccounts).toHaveBeenCalled());
-  expect(screen.queryByText(/₳/)).not.toBeInTheDocument();
+  expect(screen.queryByText(/ADA/)).not.toBeInTheDocument();
 });
 
 test("selecting an inactive account switches it server-side and reports the result", async () => {

--- a/ui/web/src/components/AccountSwitcher.tsx
+++ b/ui/web/src/components/AccountSwitcher.tsx
@@ -114,7 +114,7 @@ export function AccountSwitcher({ wallet, onChanged }: AccountSwitcherProps) {
               >
                 <span className="account-name">{a.label}</span>
                 {bal && (
-                  <span className="account-balance">{formatAda(bal.lovelace)} ₳</span>
+                  <span className="account-balance">{formatAda(bal.lovelace)} ADA</span>
                 )}
               </button>
             </li>

--- a/ui/web/src/screens/Portfolio.tsx
+++ b/ui/web/src/screens/Portfolio.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { useBalance, useDelegation, useAssetMetadata, useNfts, useNftMedia } from "../api/hooks";
+import { Button } from "../components/Button";
 import { Card } from "../components/Card";
 import { Table } from "../components/Table";
 import { StatusPill } from "../components/StatusPill";
@@ -60,7 +61,13 @@ function NftGallery() {
   return <NftList />;
 }
 
-export function Portfolio() {
+interface PortfolioProps {
+  // Whether this wallet on this node can build a spend. Receive needs nothing,
+  // so it is always offered.
+  canSend?: boolean;
+}
+
+export function Portfolio({ canSend = false }: PortfolioProps = {}) {
   const balance = useBalance();
   const delegation = useDelegation();
   const [query, setQuery] = useState("");
@@ -110,6 +117,17 @@ export function Portfolio() {
     <div className="portfolio">
       <Card title="Balance">
         <p className="balance-ada">{formatAda(lovelace)} ADA</p>
+        {/* Send and Receive are actions, not places. They sit on the balance
+            they act on — where you already are when you decide to move funds —
+            rather than costing two entries in a nav you have to scan. */}
+        <div className="portfolio-actions">
+          <Button onClick={() => navigate("send")} disabled={!canSend}>
+            Send
+          </Button>
+          <Button variant="ghost" onClick={() => navigate("receive")}>
+            Receive
+          </Button>
+        </div>
       </Card>
 
       <Card title="Native Tokens">

--- a/ui/web/src/screens/Settings.tsx
+++ b/ui/web/src/screens/Settings.tsx
@@ -5,6 +5,12 @@ import {
   type FormEvent,
 } from "react";
 import { Card } from "../components/Card";
+import { Tabs } from "../components/Tabs";
+import type { TabDef } from "../components/Tabs";
+import { Contacts } from "./Contacts";
+import { Diagnostics } from "./Diagnostics";
+import { SignMessage } from "./SignMessage";
+import { VerifyMessage } from "./VerifyMessage";
 import { StatusPill } from "../components/StatusPill";
 import { CopyButton } from "../components/CopyButton";
 import { Button } from "../components/Button";
@@ -462,7 +468,7 @@ function TPMCard({
   );
 }
 
-export function Settings({ account, walletType, autoLock }: SettingsProps) {
+function GeneralSettings({ account, walletType, autoLock }: SettingsProps) {
   const status = useStatus();
   const tpmStatusQuery = useTPMStatus();
   const [connectorMissing, setConnectorMissing] = useState(false);
@@ -765,6 +771,88 @@ export function Settings({ account, walletType, autoLock }: SettingsProps) {
           ) : null}
         </Card>
       )}
+    </div>
+  );
+}
+
+type SettingsTab = "general" | "contacts" | "tools" | "diagnostics";
+
+const SETTINGS_TABS: readonly TabDef<SettingsTab>[] = [
+  { key: "general", label: "General" },
+  { key: "contacts", label: "Address book" },
+  { key: "tools", label: "Tools" },
+  { key: "diagnostics", label: "Diagnostics" },
+];
+
+interface SettingsScreenProps extends SettingsProps {
+  // Which panel to open on, so the routes these screens used to own still land
+  // where their old links pointed.
+  initialTab?: SettingsTab;
+  // Message signing needs the wallet's seed; a hardware or watch-only wallet
+  // gets the explanation rather than a form that cannot work.
+  canSign?: boolean;
+}
+
+/**
+ * Settings is where the wallet's own housekeeping lives.
+ *
+ * Address book, message signing/verification and node diagnostics were four
+ * more top-level destinations, each used rarely and none of them a place you
+ * go to do wallet work. They are panels here, which is what they always were.
+ */
+export function Settings({
+  account,
+  walletType,
+  autoLock,
+  initialTab = "general",
+  canSign = false,
+}: SettingsScreenProps) {
+  const [tab, setTab] = useState<SettingsTab>(initialTab);
+
+  // The route can change under a mounted screen (#/contacts -> #/diagnostics),
+  // and initial state alone would ignore it.
+  useEffect(() => {
+    setTab(initialTab);
+  }, [initialTab]);
+
+  return (
+    <div className="screen-settings-shell">
+      <Tabs id="settings" tabs={SETTINGS_TABS} active={tab} onSelect={setTab}>
+        {(key) => {
+          switch (key) {
+            case "general":
+              return (
+                <GeneralSettings
+                  account={account}
+                  walletType={walletType}
+                  autoLock={autoLock}
+                />
+              );
+            case "contacts":
+              return <Contacts />;
+            case "tools":
+              return canSign ? (
+                <div className="settings-tools">
+                  <SignMessage account={account} />
+                  <VerifyMessage />
+                </div>
+              ) : (
+                <div className="settings-tools">
+                  <Card title="Sign message">
+                    <p className="helper-text">
+                      Signing a message needs this wallet&rsquo;s seed, which a
+                      hardware or watch-only wallet does not hold here.
+                      Verifying a signature works for any wallet.
+                    </p>
+                  </Card>
+                  <VerifyMessage />
+                </div>
+              );
+            case "diagnostics":
+              return <Diagnostics />;
+          }
+        }}
+      </Tabs>
     </div>
   );
 }

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -319,6 +319,12 @@ a:hover {
   outline-offset: -2px;
 }
 .account-name {
+  /* Let the label give way to the balance instead of wrapping "Account 0"
+     onto two lines in a 232px sidebar. */
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-size: 0.8125rem;
   font-weight: 600;
 }
@@ -415,6 +421,14 @@ a:hover {
   text-transform: uppercase;
   color: var(--text-muted);
   margin-bottom: var(--space-3);
+}
+
+/* The balance card's primary actions. */
+.portfolio-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
 }
 
 /* Hero readout — the balance, in big gold monospace. */


### PR DESCRIPTION
Second step of the navigation rework, after #697. **Nav goes from 15 entries to 9, and fits a laptop viewport without scrolling for the first time.**

Nothing is removed — things move to where they belong.

<table>
<tr><th width="50%">before — 15 entries</th><th width="50%">after — 9, with Send/Receive on the balance</th></tr>
<tr>
<td><img src="https://raw.githubusercontent.com/blinklabs-io/bursa/assets/screenshots/pr-704/ia-before.png" alt="Sidebar with fifteen flat entries"></td>
<td><img src="https://raw.githubusercontent.com/blinklabs-io/bursa/assets/screenshots/pr-704/ia-portfolio.png" alt="Nine-entry sidebar, Send and Receive as buttons under the balance"></td>
</tr>
</table>

## Send and Receive are actions, not places

They now sit on the balance card they act on — where you already are when you decide to move funds — rather than costing two entries in a list you have to scan. A primary button on the screen you land on is *more* prominent than a sidebar row, not less; it is also how Lace, Yoroi and Eternl handle it.

They keep their routes. Deep links, the connector, and anything else pointing at `#/send` still work; only the way in moved.

## The address book, message tools and diagnostics are Settings panels

Four more top-level entries, each rarely used, none of them somewhere you go to *do wallet work*. Settings gains the shared `Tabs` component from #697 rather than growing into a dozen stacked cards.

<img src="https://raw.githubusercontent.com/blinklabs-io/bursa/assets/screenshots/pr-704/ia-settings-tools.png" width="900" alt="Settings with General, Address book, Tools and Diagnostics tabs; Tools showing Sign and Verify">

Signing needs the wallet's seed, so the Tools panel explains itself for a hardware or watch-only wallet instead of presenting a form that cannot work. Verification is pure crypto and stays available to any wallet.

## Old links keep working

Every route these screens used to own still resolves and opens the matching panel, and the nav highlight follows:

| route | opens | highlights |
|---|---|---|
| `#/contacts` | Settings → Address book | Settings |
| `#/sign`, `#/verify` | Settings → Tools | Settings |
| `#/diagnostics` | Settings → Diagnostics | Settings |
| `#/send`, `#/receive` | the screen itself | Portfolio |

## Rebased onto multi-account (#666)

That PR's account switcher sits inside the wallet list, and the shorter nav is what gives it room: even with two wallets and two accounts the sidebar no longer scrolls.

Two small fixes to it are folded in here, since this PR is already reshaping that sidebar:

- Its balances used `₳` (U+20B3), which renders as a bare **A** wherever the font stack has no glyph for it — the same defect #697 removed from `Staking`. Spelled `ADA`, as everywhere else in the wallet.
- The account label now truncates instead of wrapping "Account 0" onto two lines in a 232px sidebar.

## Verification

`tsc` clean · **700 tests pass** · `eslint` clean (one pre-existing warning in `connectorNotify.ts`, untouched). 7 files.

Driven in a browser against a mock node: all nine nav entries, all four Settings panels, every legacy route above, and mobile at 390px (drawer lists 9, tab strip fits, no horizontal overflow). After the rebase, also that switching account actually switches it, not merely that the switcher renders.

Cubic caught a P0 on the first push — Portfolio resolved through the props-less `ROUTES` map, so `canSend` defaulted false and the Send button was permanently disabled, which with Send out of the nav made sending unreachable. Fixed, with a test I confirmed fails against the broken commit. Worth naming the gap: every check I had run was structural (does it render, does the route resolve, does the nav highlight) and none of them pressed the button.

## What follows

The last step of the agreed rework is structural rather than cosmetic: multi-sig accounts move into the wallet switcher (`WalletType` already has `multi_signature`), Import Tx and Offline become modes of the send/sign flow, Pool Ops appears only when enabled, and a ⌘K palette with a visible trigger covers everything demoted. That takes the nav to 5.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Send and Receive actions to the Portfolio screen.
  * Disabled sending for wallets that cannot spend.
  * Consolidated Contacts, signing, verification, and Diagnostics into Settings tabs.
  * Preserved access to legacy routes and Settings panel mappings.
  * Improved sidebar navigation to show destination screens more clearly.

* **UI Improvements**
  * Balance displays now use the `ADA` label.
  * Long account names are truncated neatly.
  * Portfolio actions have improved spacing and layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->