### PR TITLE
ci: bound apt network timeout so the webview job can't hang for hours

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -267,6 +267,12 @@ jobs:
       - name: Install Linux webview dependencies
         if: matrix.os == 'linux'
         run: |
+          # Bound apt's per-connection network wait and enable retries so a
+          # stalled mirror fails fast and retries instead of hanging the job for
+          # hours (apt has no default fetch timeout here, which periodically left
+          # this step stuck in `apt-get update` until the 6h max-runtime kill).
+          printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+            | sudo tee /etc/apt/apt.conf.d/99network-timeouts >/dev/null
           sudo apt-get update
           sudo apt-get install -y gcc pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev
 

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -124,6 +124,12 @@ jobs:
       - name: Install Linux webview dependencies
         if: matrix.os == 'linux'
         run: |
+          # Bound apt's per-connection network wait and enable retries so a
+          # stalled mirror fails fast and retries instead of hanging the job for
+          # hours (apt has no default fetch timeout here, which periodically left
+          # this step stuck in `apt-get update` until the 6h max-runtime kill).
+          printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+            | sudo tee /etc/apt/apt.conf.d/99network-timeouts >/dev/null
           sudo apt-get update
           sudo apt-get install -y gcc pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev
       # The webview binary embeds the SPA, so the //go:embed dist target must be


### PR DESCRIPTION
## Problem
The **Install Linux webview dependencies** step in `ui-webview (linux)` periodically hung and was killed as `cancelled` after GitHub's **6-hour** max job runtime, repeatedly blocking UI PRs.

Job log from a stuck run shows `apt-get update` fetching indexes, then going silent mid-fetch (last line `Get:5 …noble-security InRelease`) until the 6h kill — the `install` step never ran. Root cause: **`apt-get` has no default per-connection fetch timeout here**, so a slow/unresponsive mirror connection hangs indefinitely rather than failing.

## Fix
Before fetching, write an `apt.conf.d` snippet bounding apt's network behavior:

```
Acquire::Retries "3";
Acquire::http::Timeout "30";
Acquire::https::Timeout "30";
```

A stalled mirror connection now times out in ~30s and retries (up to 3×); if a mirror is truly unreachable the step fails in minutes and is re-runnable, instead of burning a 6-hour run. Applied to the identical step in both `ui.yml` (CI) and `publish.yml` (release).

This is the root-cause fix (bounding the unbounded network wait), not a job-level `timeout-minutes` cap.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound `apt` network waits in the Linux webview dependency step to stop CI hangs on slow mirrors. Old behavior: `apt-get update` could stall until the 6‑hour job cap. New behavior: each connection times out after 30s and retries up to 3 times, failing fast if a mirror is unreachable.

**Review notes**
- Writes `/etc/apt/apt.conf.d/99network-timeouts` with `Acquire::Retries "3"`, `Acquire::http::Timeout "30"`, and `Acquire::https::Timeout "30"` before `apt-get update` in `ui.yml` and `publish.yml`.
- Applies only when `matrix.os == 'linux'`; macOS/Windows paths unchanged.
- Effect: stuck runs become quick retries or failures; installed packages and subsequent steps are unchanged.

<sup>Written for commit fbded3344bb75b59c1c15b468c2d25961ae821bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of Linux dependency installation during publishing and UI workflow runs.
  * Added automatic retry handling and 30-second HTTP/HTTPS timeouts for package updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->