### PR TITLE
feat(ui): a permanent affordance for the command line

### DIFF
--- a/ui/web/src/app.test.tsx
+++ b/ui/web/src/app.test.tsx
@@ -831,6 +831,20 @@ test.each([
   await waitFor(() => expect(document.querySelector(".palette")).toBeNull());
 });
 
+// The nav carries five destinations; everything else lives in the palette, so
+// the palette needs a permanent affordance in the chrome rather than only a
+// keyboard shortcut. Drive it: click the glyph, get the dialog.
+test("the command line has a permanent affordance in the chrome", async () => {
+  const sidebar = await unlockAndGetSidebar(walletA);
+
+  const cli = within(sidebar).getByRole("button", { name: /open the command line/i });
+  expect(cli).toBeEnabled();
+
+  fireEvent.click(cli);
+
+  expect(await screen.findByRole("dialog", { name: /command palette/i })).toBeInTheDocument();
+});
+
 test("Send and Receive are offered on the balance they act on", async () => {
   await unlockAndGetSidebar(walletA);
 

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -37,6 +37,7 @@ import { Operate } from "./screens/Operate";
 import { ImportTransaction } from "./screens/ImportTransaction";
 import { Settings } from "./screens/Settings";
 import { ConnectorApproval } from "./screens/ConnectorApproval";
+import { CliButton } from "./components/CliButton";
 
 // A Map (not a plain object) so a crafted hash like "#/constructor" or
 // "#/toString" can't resolve to an inherited Object.prototype member and get
@@ -608,7 +609,10 @@ export function App() {
         {/* Desktop sidebar. Hidden on mobile via CSS. */}
         <nav className="sidebar">
           <div className="brand">
-            <span className="brand-mark">BVRSA</span>
+            <div className="brand-row">
+              <span className="brand-mark">BVRSA</span>
+              <CliButton onOpen={() => setPaletteOpen(true)} />
+            </div>
             <span className="brand-motto">nodvs tvvs · claves tvæ</span>
           </div>
           <WalletSwitcher

--- a/ui/web/src/components/CliButton.tsx
+++ b/ui/web/src/components/CliButton.tsx
@@ -36,9 +36,15 @@ interface CliButtonProps {
   // Lets the two layouts size and place the same control differently without a
   // second component.
   className?: string;
+  // True while another surface owns the screen — the mobile drawer, which covers
+  // the top bar rather than unmounting it. Being covered is only a visual and
+  // pointer fact: without this the control keeps its place in the accessibility
+  // tree and the tab order, and a screen reader still offers it, ahead of the
+  // drawer, because the top bar comes first in the DOM.
+  inactive?: boolean;
 }
 
-export function CliButton({ onOpen, className }: CliButtonProps) {
+export function CliButton({ onOpen, className, inactive }: CliButtonProps) {
   return (
     <button
       type="button"
@@ -47,6 +53,8 @@ export function CliButton({ onOpen, className }: CliButtonProps) {
       aria-haspopup="dialog"
       aria-label="Open the command line"
       title="Command line — search and run anything"
+      aria-hidden={inactive}
+      tabIndex={inactive ? -1 : undefined}
     >
       <PromptGlyph />
     </button>

--- a/ui/web/src/components/CliButton.tsx
+++ b/ui/web/src/components/CliButton.tsx
@@ -1,0 +1,54 @@
+// The palette is this wallet's command line: with the nav down to five
+// destinations, everything else — governance, the DRep directory, offline
+// signing, finishing someone else's transaction, pool operations — is reached
+// through it. So it deserves a permanent, compact affordance in the chrome
+// rather than only the sidebar's wide "Search…" pill, which is desktop-only, and
+// Cmd/Ctrl-K, which does not exist on a touch device.
+//
+// Glyph-only by design (compare CopyButton): a terminal prompt reads faster than
+// a word at this size and gives the feature one identity across both layouts.
+// The accessible name and the native tooltip carry the meaning for anyone who
+// needs it spelled out.
+function PromptGlyph() {
+  return (
+    <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true" focusable="false">
+      <path
+        d="M3.5 5.25L6.25 8 3.5 10.75"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M8.75 11h3.75"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+interface CliButtonProps {
+  onOpen: () => void;
+  // Lets the two layouts size and place the same control differently without a
+  // second component.
+  className?: string;
+}
+
+export function CliButton({ onOpen, className }: CliButtonProps) {
+  return (
+    <button
+      type="button"
+      className={className ? `cli-button ${className}` : "cli-button"}
+      onClick={onOpen}
+      aria-haspopup="dialog"
+      aria-label="Open the command line"
+      title="Command line — search and run anything"
+    >
+      <PromptGlyph />
+    </button>
+  );
+}

--- a/ui/web/src/components/MobileNav.tsx
+++ b/ui/web/src/components/MobileNav.tsx
@@ -16,6 +16,7 @@ import { useEffect, useRef, useState } from "react";
 import type { Status, WalletView } from "../api/types";
 import type { Tone } from "./StatusPill";
 import { WalletSwitcher } from "./WalletSwitcher";
+import { CliButton } from "./CliButton";
 
 const FOCUSABLE_SELECTOR = [
   "a[href]",
@@ -189,6 +190,13 @@ export function MobileNav({
           )}
           {stateChip}
         </div>
+
+        {onOpenPalette && (
+          <CliButton
+            onOpen={onOpenPalette}
+            className="cli-button-mobile"
+          />
+        )}
 
         <button
           ref={hamburgerRef}

--- a/ui/web/src/components/MobileNav.tsx
+++ b/ui/web/src/components/MobileNav.tsx
@@ -195,6 +195,7 @@ export function MobileNav({
           <CliButton
             onOpen={onOpenPalette}
             className="cli-button-mobile"
+            inactive={open}
           />
         )}
 

--- a/ui/web/src/components/components.test.tsx
+++ b/ui/web/src/components/components.test.tsx
@@ -120,6 +120,22 @@ test("the mobile command line does not require opening the drawer first", () => 
   expect(onOpenPalette).toHaveBeenCalledTimes(1);
 });
 
+// The drawer overlay covers the top bar and the Tab trap keeps keyboard focus
+// inside the drawer, but the overlay is itself aria-hidden — so without the same
+// treatment the hamburger beside it gets, a screen reader still announces this
+// control as available, and before the drawer, since the top bar comes first.
+test("the mobile command line leaves the accessibility tree while the drawer is open", () => {
+  renderMobileNav({ onOpenPalette: vi.fn() });
+
+  const cli = screen.getByRole("button", { name: /open the command line/i });
+
+  fireEvent.click(screen.getByRole("button", { name: /open menu/i }));
+
+  expect(cli).toHaveAttribute("aria-hidden", "true");
+  expect(cli).toHaveAttribute("tabindex", "-1");
+  expect(screen.queryByRole("button", { name: /open the command line/i })).toBeNull();
+});
+
 test("SyncBanner shows error detail ahead of retained bootstrap diagnostics", () => {
   render(
     <SyncBanner

--- a/ui/web/src/components/components.test.tsx
+++ b/ui/web/src/components/components.test.tsx
@@ -87,6 +87,39 @@ test("CopyButton copies its value and shows feedback on success", async () => {
   expect(status.closest("button")).toBeNull();
 });
 
+// On a touch layout there is no Cmd/Ctrl-K and the sidebar's "Search…" pill is
+// hidden, so this button is the palette's only one-tap route in. Asserting it
+// renders is not enough — it has to actually fire.
+test("the mobile top bar opens the command line in one tap", () => {
+  const onOpenPalette = vi.fn();
+  renderMobileNav({ onOpenPalette });
+
+  const cli = screen.getByRole("button", { name: /open the command line/i });
+  expect(cli).toBeEnabled();
+
+  fireEvent.click(cli);
+
+  expect(onOpenPalette).toHaveBeenCalledTimes(1);
+});
+
+// The drawer does not have to be open for it to work: needing two taps to reach
+// the surface that carries most destinations is the thing this fixes.
+test("the mobile command line does not require opening the drawer first", () => {
+  const onOpenPalette = vi.fn();
+  renderMobileNav({ onOpenPalette });
+
+  // The drawer panel is always in the DOM (it slides in via a class), so assert
+  // the state a user would perceive: the menu is still shut.
+  expect(screen.getByRole("button", { name: /open menu/i })).toHaveAttribute("aria-expanded", "false");
+  expect(document.querySelector(".mobile-drawer-open")).toBeNull();
+
+  fireEvent.click(screen.getByRole("button", { name: /open the command line/i }));
+
+  expect(document.querySelector(".mobile-drawer-open")).toBeNull();
+
+  expect(onOpenPalette).toHaveBeenCalledTimes(1);
+});
+
 test("SyncBanner shows error detail ahead of retained bootstrap diagnostics", () => {
   render(
     <SyncBanner

--- a/ui/web/src/styles/global.css
+++ b/ui/web/src/styles/global.css
@@ -67,6 +67,39 @@ a:hover {
 .brand {
   padding: var(--space-2) var(--space-2) var(--space-4);
 }
+.brand-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+/* The command line's permanent affordance. Sized to sit quietly beside the
+   wordmark; the wide "Search…" pill below it still teaches the shortcut. */
+.cli-button {
+  appearance: none;
+  -webkit-appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--inset);
+  color: var(--muted);
+  cursor: pointer;
+}
+.cli-button:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.cli-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .brand-mark {
   display: block;
   font-size: 1.35rem;
@@ -2159,6 +2192,17 @@ a:hover {
   }
 
   /* Hamburger: at least 44 × 44 px tap target. */
+  /* Matches the hamburger beside it: a 44px touch target, chromeless. */
+  .cli-button-mobile {
+    width: 44px;
+    height: 44px;
+    border: none;
+    background: transparent;
+  }
+  .cli-button-mobile:hover {
+    background: var(--inset);
+  }
+
   .mobile-hamburger {
     appearance: none;
     -webkit-appearance: none;


### PR DESCRIPTION
## What

The nav carries five destinations. Everything else — governance actions, the
DRep directory, offline signing, finishing a transaction someone sent you, pool
operations, the address book — is reached through the command palette.

Its only ways in were the sidebar's wide `Search…` pill, which the mobile layout
hides, and Cmd/Ctrl-K, which a touch device does not have. So on mobile the
palette was reachable only from the drawer's search entry, two taps deep.

This adds one glyph-only control and puts it in the chrome of both layouts:
beside the wordmark in the sidebar, and beside the hamburger in the mobile top
bar, where it takes the same 44px touch target. A terminal prompt reads faster
than a word at that size and gives the palette one identity across layouts; the
accessible name (`Open the command line`) and a native tooltip carry the meaning.

The `Search…` pill stays. It teaches the keyboard shortcut, which a glyph cannot.

## Verifying

Driven in a browser against a real preview node at both viewports, and each new
test was confirmed to fail with the button removed.

- `vitest` 771 passed
- `tsc --noEmit` clean
- `eslint` clean (one pre-existing warning in `connectorNotify.ts`, untouched)

Tests assert behaviour rather than rendering: the control is enabled, clicking it
opens the palette dialog, and on mobile it does so without opening the drawer.

## Screens

Sidebar, beside the wordmark:

![The command line button beside the BVRSA wordmark](https://raw.githubusercontent.com/blinklabs-io/bursa/assets/screenshots/pr-711/cli-desktop.png)

Mobile top bar, paired with the menu button:

![The command line button beside the hamburger in the mobile top bar](https://raw.githubusercontent.com/blinklabs-io/bursa/assets/screenshots/pr-711/cli-mobile.png)

With the drawer open, the overlay covers the top bar. There is no visual change
here — the button is unchanged on screen — but it now leaves the accessibility
tree and tab order, matching the hamburger beside it. Verified in the live DOM
with the drawer open: `aria-hidden="true"`, `tabindex="-1"`.

![The mobile drawer open over the top bar, with the command line button covered by the overlay](https://raw.githubusercontent.com/blinklabs-io/bursa/assets/screenshots/pr-711/cli-mobile-drawer-open.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent command palette button to the desktop navigation.
  * Added command palette access to the mobile top bar.
  * Added terminal-themed icons, tooltips, keyboard accessibility, and responsive styling.
  * Mobile command palette access is temporarily disabled while the navigation drawer is open.

* **Tests**
  * Added coverage for desktop and mobile command palette interactions and accessibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
