### PR TITLE
fix(ui): three things the wallet said badly

### DIFF
--- a/ui/internal/wallet/service.go
+++ b/ui/internal/wallet/service.go
@@ -36,6 +36,13 @@ type AddressView struct {
 	NextUnused string   `json:"next_unused"`
 }
 
+// provisionalRewardsNote is shown to the user beside a provisional rewards
+// figure. It deliberately does not name dingo or its issue numbers: the person
+// reading it is looking at their own wallet, and an upstream tracker reference
+// tells them nothing they can act on. The cause stays recorded on
+// DelegationView below, where the people who can act on it will read it.
+const provisionalRewardsNote = "Rewards are provisional and may not match on-chain totals exactly."
+
 // DelegationView is the delegation/rewards summary. Rewards are provisional —
 // dingo has open reward-accounting bugs (#2373–#2376).
 type DelegationView struct {
@@ -522,7 +529,7 @@ func (s *Service) Delegation(ctx context.Context) (DelegationView, error) {
 			RewardsSum:   "0",
 			Withdrawable: "0",
 			Provisional:  true,
-			Note:         "rewards are provisional; dingo reward accounting has open issues (#2373-#2376)",
+			Note:         provisionalRewardsNote,
 		}, nil
 	}
 	info, err := s.chain.Account(ctx, acct.StakeAddress)
@@ -540,7 +547,7 @@ func (s *Service) Delegation(ctx context.Context) (DelegationView, error) {
 		RewardsSum:   info.RewardsSum,
 		Withdrawable: info.WithdrawableAmount,
 		Provisional:  true,
-		Note:         "rewards are provisional; dingo reward accounting has open issues (#2373-#2376)",
+		Note:         provisionalRewardsNote,
 	}, nil
 }
 
@@ -558,7 +565,7 @@ func (s *Service) Rewards(ctx context.Context) (RewardHistory, error) {
 		return RewardHistory{
 			Rewards:     []RewardEntry{},
 			Provisional: true,
-			Note:        "rewards are provisional; dingo reward accounting has open issues (#2373-#2376)",
+			Note:        provisionalRewardsNote,
 		}, nil
 	}
 	rewards, err := s.chain.AccountRewards(ctx, acct.StakeAddress)
@@ -578,6 +585,6 @@ func (s *Service) Rewards(ctx context.Context) (RewardHistory, error) {
 	return RewardHistory{
 		Rewards:     entries,
 		Provisional: true,
-		Note:        "rewards are provisional; dingo reward accounting has open issues (#2373-#2376)",
+		Note:        provisionalRewardsNote,
 	}, nil
 }

--- a/ui/internal/wallet/service_test.go
+++ b/ui/internal/wallet/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -856,5 +857,19 @@ func TestScriptAccountViewsSkipStakeLookups(t *testing.T) {
 	}
 	if len(rw.Rewards) != 0 {
 		t.Fatalf("Rewards = %+v, want an empty history", rw.Rewards)
+	}
+}
+
+// The note is shown verbatim beside the user's own rewards figure, so it must
+// not carry upstream tracker references. Naming dingo or an issue number tells
+// the reader nothing they can act on, and it leaked into the wallet UI once.
+func TestProvisionalRewardsNoteIsUserFacing(t *testing.T) {
+	for _, banned := range []string{"dingo", "#2373", "#2374", "#2375", "#2376", "open issues"} {
+		if strings.Contains(strings.ToLower(provisionalRewardsNote), strings.ToLower(banned)) {
+			t.Errorf("provisional rewards note leaks %q to the user: %q", banned, provisionalRewardsNote)
+		}
+	}
+	if provisionalRewardsNote == "" {
+		t.Fatal("provisional rewards note must still say something")
 	}
 }

--- a/ui/web/src/app.test.tsx
+++ b/ui/web/src/app.test.tsx
@@ -831,6 +831,36 @@ test.each([
   await waitFor(() => expect(document.querySelector(".palette")).toBeNull());
 });
 
+// The palette and the button on the balance both explain why Send is off. They
+// read from one string on purpose; asserting both here is what stops them
+// drifting into two different explanations of the same block.
+test("the palette and the balance agree on why Send is off", async () => {
+  // A syncing (not ready) node: the wallet can read, but not spend. Set up
+  // inline rather than through the helper, which always stubs a ready node.
+  stubStatus("syncing");
+  stubVault({ exists: true, locked: true, wallet_count: 1 });
+  quietPortfolio();
+  vi.spyOn(client, "unlockVault").mockResolvedValue([{ ...walletA, active: true }]);
+
+  render(<App />);
+  // A node that is not ready puts the Syncing view in front of the vault.
+  fireEvent.click(screen.getByRole("button", { name: /load wallet anyway/i }));
+  fireEvent.change(screen.getByLabelText(/vault password/i), { target: { value: "vault-password-xyz" } });
+  fireEvent.click(screen.getByRole("button", { name: /^unlock$/i }));
+  await waitFor(() => expect(document.querySelector(".sidebar")).not.toBeNull());
+  const sidebar = document.querySelector(".sidebar") as HTMLElement;
+
+  const main = document.querySelector("main") as HTMLElement;
+  expect(await within(main).findByRole("button", { name: "Send" })).toBeDisabled();
+  expect(within(main).getByText(/send is unavailable — needs a synced node/i)).toBeInTheDocument();
+
+  fireEvent.click(within(sidebar).getByRole("button", { name: /search/i }));
+  const palette = await screen.findByRole("dialog", { name: /command palette/i });
+  const send = within(palette).getByRole("option", { name: /^Send/ });
+  expect(send).toBeDisabled();
+  expect(send).toHaveTextContent(/needs a synced node/i);
+});
+
 test("Send and Receive are offered on the balance they act on", async () => {
   await unlockAndGetSidebar(walletA);
 

--- a/ui/web/src/app.tsx
+++ b/ui/web/src/app.tsx
@@ -180,6 +180,13 @@ export function App() {
     // otherwise would drop it into the seed-based one.
     (activeWallet?.type === "multi_signature" && multiSigAccount !== undefined)
   );
+
+  // Why Send is off, in one place: the palette and the button on the balance
+  // both show it, and two surfaces explaining the same block differently is
+  // how they drift.
+  const sendDisabledReason = !isReady
+    ? "Needs a synced node"
+    : "This wallet cannot spend";
   // Sign/Offline/Operate all need the wallet's seed (message signing, air-gap
   // signing, and cold/VRF/KES key derivation respectively). Hardware wallets
   // are seedless (xpub-only) and sign only via the on-device path Send uses,
@@ -433,7 +440,7 @@ export function App() {
     );
   } else if (SEND_ROUTES.has(route) && !canSend) {
     screenLabel = "portfolio";
-    content = <Portfolio canSend={canSend} multiSigError={multiSigError} />;
+    content = <Portfolio canSend={canSend} sendDisabledReason={sendDisabledReason} multiSigError={multiSigError} />;
   } else if (SEND_ROUTES.has(route) && canSend) {
     // A multi-signature wallet spends by collecting co-signer witnesses rather
     // than signing in one step, so Send means a different flow for it.
@@ -451,7 +458,7 @@ export function App() {
     // Guard deep-links (#/swap): DEX quotes need a queryable mainnet node, so
     // fall back to Portfolio while the node or active wallet cannot support it.
     screenLabel = "portfolio";
-    content = <Portfolio canSend={canSend} multiSigError={multiSigError} />;
+    content = <Portfolio canSend={canSend} sendDisabledReason={sendDisabledReason} multiSigError={multiSigError} />;
   } else if (STAKE_ROUTES.has(route)) {
     // Delegation, rewards and the pool directory are one screen, and it is not
     // gated as a whole: reward history is a plain account read that the old
@@ -473,20 +480,20 @@ export function App() {
     // Air-gap signing needs the active wallet's seed (to sign) but no node for
     // the sign step; falls back to Portfolio without an active wallet.
     if (!canSign) screenLabel = "portfolio";
-    content = canSign ? <Offline /> : <Portfolio canSend={canSend} multiSigError={multiSigError} />;
+    content = canSign ? <Offline /> : <Portfolio canSend={canSend} sendDisabledReason={sendDisabledReason} multiSigError={multiSigError} />;
   } else if (route === "operate") {
     // Pool operations derive cold/VRF/KES keys from the seed and need the spend
     // password. A wallet must be active; otherwise fall back to Portfolio. Most
     // pool ops are offline; only retirement submission needs a synced node,
     // gated at the API.
     if (!canSign) screenLabel = "portfolio";
-    content = canSign ? <Operate account={toAccount(activeWallet)} /> : <Portfolio canSend={canSend} multiSigError={multiSigError} />;
+    content = canSign ? <Operate account={toAccount(activeWallet)} /> : <Portfolio canSend={canSend} sendDisabledReason={sendDisabledReason} multiSigError={multiSigError} />;
   } else if (route === "import") {
     // Importing a transaction built elsewhere needs the active wallet's seed
     // to add a signature (like Offline/Operate); submitting is separately
     // gated inside the screen on the node being ready (canSubmit).
     if (!canSign) screenLabel = "portfolio";
-    content = canSign ? <ImportTransaction canSubmit={isReady} /> : <Portfolio canSend={canSend} multiSigError={multiSigError} />;
+    content = canSign ? <ImportTransaction canSubmit={isReady} /> : <Portfolio canSend={canSend} sendDisabledReason={sendDisabledReason} multiSigError={multiSigError} />;
   } else if (route === "receive") {
     // Explorer links on each address need the active wallet's real network
     // (preview/preprod/mainnet), which the generic ROUTES map (no props)
@@ -503,7 +510,7 @@ export function App() {
     // it through the props-less ROUTES map would silently disable it.
     const Screen = ROUTES.get(route);
     if (!Screen) screenLabel = "portfolio";
-    content = Screen && route !== "portfolio" ? <Screen /> : <Portfolio canSend={canSend} multiSigError={multiSigError} />;
+    content = Screen && route !== "portfolio" ? <Screen /> : <Portfolio canSend={canSend} sendDisabledReason={sendDisabledReason} multiSigError={multiSigError} />;
   }
 
   // Build the nav item descriptors once, shared between desktop sidebar and
@@ -526,9 +533,6 @@ export function App() {
     : !canQueryNode
       ? "Needs a synced node"
       : "Mainnet only";
-  const sendDisabledReason = !isReady
-    ? "Needs a synced node"
-    : "This wallet cannot spend";
   const commands: Command[] = [
     { id: "portfolio", label: "Portfolio", group: "Go", keywords: "balance tokens nfts home", run: () => navigate("portfolio") },
     { id: "activity", label: "Activity", group: "Go", keywords: "history transactions", run: () => navigate("activity") },

--- a/ui/web/src/screens/Portfolio.test.tsx
+++ b/ui/web/src/screens/Portfolio.test.tsx
@@ -308,3 +308,27 @@ test("NFT image load failure renders the empty thumbnail", () => {
   expect(screen.queryByRole("img", { name: "Token" })).not.toBeInTheDocument();
   expect(container.querySelector(".nft-thumb-empty")).toBeInTheDocument();
 });
+
+// A greyed Send with no reason leaves someone guessing whether the wallet is
+// broken or just waiting. The palette has always said why; the button now does.
+test("a disabled Send says why it is disabled", () => {
+  mockBalance("5000000", []);
+  mockDelegation();
+  mockAssetMetadata({});
+
+  render(<Portfolio canSend={false} sendDisabledReason="Needs a synced node" />);
+
+  expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+  expect(screen.getByText(/send is unavailable — needs a synced node/i)).toBeInTheDocument();
+});
+
+test("an enabled Send explains nothing", () => {
+  mockBalance("5000000", []);
+  mockDelegation();
+  mockAssetMetadata({});
+
+  render(<Portfolio canSend sendDisabledReason="Needs a synced node" />);
+
+  expect(screen.getByRole("button", { name: "Send" })).toBeEnabled();
+  expect(screen.queryByText(/send is unavailable/i)).not.toBeInTheDocument();
+});

--- a/ui/web/src/screens/Portfolio.test.tsx
+++ b/ui/web/src/screens/Portfolio.test.tsx
@@ -332,3 +332,23 @@ test("an enabled Send explains nothing", () => {
   expect(screen.getByRole("button", { name: "Send" })).toBeEnabled();
   expect(screen.queryByText(/send is unavailable/i)).not.toBeInTheDocument();
 });
+
+// A multi-signature wallet whose stored policy will not decode already gets an
+// alert saying it cannot spend. Repeating "Send is unavailable — this wallet
+// cannot spend" underneath the buttons says the same thing twice, more vaguely.
+test("an explicit multi-signature error is not restated as the generic reason", () => {
+  mockBalance("5000000", []);
+  mockDelegation();
+  mockAssetMetadata({});
+
+  render(
+    <Portfolio
+      canSend={false}
+      sendDisabledReason="This wallet cannot spend"
+      multiSigError="This wallet's multi-signature policy could not be read, so it cannot spend."
+    />,
+  );
+
+  expect(screen.getByRole("alert")).toHaveTextContent(/policy could not be read/i);
+  expect(screen.queryByText(/send is unavailable/i)).not.toBeInTheDocument();
+});

--- a/ui/web/src/screens/Portfolio.tsx
+++ b/ui/web/src/screens/Portfolio.tsx
@@ -69,9 +69,13 @@ interface PortfolioProps {
   // Whether this wallet on this node can build a spend. Receive needs nothing,
   // so it is always offered.
   canSend?: boolean;
+  // Why Send is off, when it is. A greyed button with no reason leaves someone
+  // guessing whether the wallet is broken or just waiting; the command palette
+  // has always said why, and this is the same string.
+  sendDisabledReason?: string;
 }
 
-export function Portfolio({ canSend = false, multiSigError }: PortfolioProps = {}) {
+export function Portfolio({ canSend = false, sendDisabledReason, multiSigError }: PortfolioProps = {}) {
   const balance = useBalance();
   const delegation = useDelegation();
   const [query, setQuery] = useState("");
@@ -137,6 +141,9 @@ export function Portfolio({ canSend = false, multiSigError }: PortfolioProps = {
             Receive
           </Button>
         </div>
+        {!canSend && sendDisabledReason && (
+          <p className="helper-text">Send is unavailable — {sendDisabledReason.toLowerCase()}.</p>
+        )}
       </Card>
 
       <Card title="Native Tokens">

--- a/ui/web/src/screens/Portfolio.tsx
+++ b/ui/web/src/screens/Portfolio.tsx
@@ -141,7 +141,10 @@ export function Portfolio({ canSend = false, sendDisabledReason, multiSigError }
             Receive
           </Button>
         </div>
-        {!canSend && sendDisabledReason && (
+        {/* Suppressed when multiSigError is already on screen: that alert names the
+            actual reason this wallet cannot spend, and the generic line under the
+            buttons would only restate it in weaker words. */}
+        {!canSend && !multiSigError && sendDisabledReason && (
           <p className="helper-text">Send is unavailable — {sendDisabledReason.toLowerCase()}.</p>
         )}
       </Card>

--- a/ui/web/src/screens/Syncing.test.tsx
+++ b/ui/web/src/screens/Syncing.test.tsx
@@ -168,7 +168,10 @@ test("the escape hatch does not promise a sync that will finish", () => {
   render(<Syncing status={errorStatus} onLoadAnyway={noop} />);
 
   expect(screen.queryByText(/until syncing finishes/i)).not.toBeInTheDocument();
-  expect(screen.getByText(/need a running node/i)).toBeInTheDocument();
+  expect(screen.getByText(/need it running/i)).toBeInTheDocument();
+  // Addresses are read through the node as well (the next-unused lookup hits the
+  // chain), so the copy must not offer them as something still available here.
+  expect(screen.queryByText(/see its addresses/i)).not.toBeInTheDocument();
 });
 
 // A dead end with no next step is the thing that made this screen feel broken.

--- a/ui/web/src/screens/Syncing.test.tsx
+++ b/ui/web/src/screens/Syncing.test.tsx
@@ -168,10 +168,13 @@ test("the escape hatch does not promise a sync that will finish", () => {
   render(<Syncing status={errorStatus} onLoadAnyway={noop} />);
 
   expect(screen.queryByText(/until syncing finishes/i)).not.toBeInTheDocument();
-  expect(screen.getByText(/need it running/i)).toBeInTheDocument();
   // Addresses are read through the node as well (the next-unused lookup hits the
   // chain), so the copy must not offer them as something still available here.
-  expect(screen.queryByText(/see its addresses/i)).not.toBeInTheDocument();
+  // Asserted positively and in one phrase: rejecting the old wording alone would
+  // pass again the moment new copy offered addresses in different words.
+  expect(
+    screen.getByText(/addresses are all read through the node and need it running/i),
+  ).toBeInTheDocument();
 });
 
 // A dead end with no next step is the thing that made this screen feel broken.

--- a/ui/web/src/screens/Syncing.test.tsx
+++ b/ui/web/src/screens/Syncing.test.tsx
@@ -122,7 +122,7 @@ test("(g) retained bootstrap diagnostics do not override an error state", () => 
       onLoadAnyway={noop}
     />,
   );
-  expect(screen.getByRole("heading", { name: "Sync interrupted" })).toBeInTheDocument();
+  expect(screen.getByRole("heading", { name: "Your node stopped" })).toBeInTheDocument();
   expect(screen.getByRole("alert")).toHaveTextContent("mithril bootstrap: download failed");
   expect(screen.queryByText("40.0%")).not.toBeInTheDocument();
 });
@@ -134,4 +134,54 @@ test("(h) the escape hatch invokes onLoadAnyway", () => {
   );
   fireEvent.click(screen.getByRole("button", { name: /load wallet anyway/i }));
   expect(onLoadAnyway).toHaveBeenCalled();
+});
+
+const errorStatus = {
+  state: "error" as const,
+  tip: 0,
+  caughtUp: false,
+  network: "preview",
+  error: "failed to open listening socket: bind: invalid argument",
+};
+
+// The subtitle used to be the raw error, which the panel below already shows —
+// so the same sentence appeared twice on one screen.
+test("the raw error is shown once, not repeated as the subtitle", () => {
+  render(<Syncing status={errorStatus} onLoadAnyway={noop} />);
+
+  const occurrences = screen.queryAllByText(errorStatus.error);
+  expect(occurrences).toHaveLength(1);
+});
+
+// "Sync interrupted" implied it would resume. This state does not resume on its
+// own, and a title that says otherwise leaves someone waiting on nothing.
+test("the error state does not describe itself as a resumable interruption", () => {
+  render(<Syncing status={errorStatus} onLoadAnyway={noop} />);
+
+  expect(screen.getByRole("heading", { name: /your node stopped/i })).toBeInTheDocument();
+  expect(screen.queryByText(/interrupted/i)).not.toBeInTheDocument();
+});
+
+// The escape hatch promised "until syncing finishes" in every state. In the
+// error state syncing is not going to finish, so it must not say so.
+test("the escape hatch does not promise a sync that will finish", () => {
+  render(<Syncing status={errorStatus} onLoadAnyway={noop} />);
+
+  expect(screen.queryByText(/until syncing finishes/i)).not.toBeInTheDocument();
+  expect(screen.getByText(/need a running node/i)).toBeInTheDocument();
+});
+
+// A dead end with no next step is the thing that made this screen feel broken.
+test("the error state says what to do next", () => {
+  render(<Syncing status={errorStatus} onLoadAnyway={noop} />);
+
+  expect(screen.getByText(/restarting the wallet will try again/i)).toBeInTheDocument();
+  expect(screen.getByText(/keys are in the vault/i)).toBeInTheDocument();
+});
+
+// The syncing state keeps its original promise, which is accurate there.
+test("a syncing node still says balances fill in when the sync finishes", () => {
+  render(<Syncing status={{ state: "syncing", tip: 5, caughtUp: false, network: "preview" }} onLoadAnyway={noop} />);
+
+  expect(screen.getByText(/until syncing finishes/i)).toBeInTheDocument();
 });

--- a/ui/web/src/screens/Syncing.tsx
+++ b/ui/web/src/screens/Syncing.tsx
@@ -255,7 +255,7 @@ export function Syncing({ status, onLoadAnyway }: SyncingProps) {
         </button>
         <p className="helper-text">
           {status.state === "error"
-            ? "You can still open your wallet to see its addresses and settings, but balances and history need a running node."
+            ? "You can still open your wallet and reach its settings, but balances, history and addresses are all read through the node and need it running."
             : "You can open a wallet now, but balances and history stay incomplete until syncing finishes."}
         </p>
       </footer>

--- a/ui/web/src/screens/Syncing.tsx
+++ b/ui/web/src/screens/Syncing.tsx
@@ -198,8 +198,14 @@ export function Syncing({ status, onLoadAnyway }: SyncingProps) {
       subtitle = "Bringing the embedded Cardano node online.";
       break;
     case "error":
-      title = "Sync interrupted";
-      subtitle = status.error || "The node reported an error.";
+      // Not "interrupted": this state does not resume on its own, and a title
+      // that implies it will leaves someone waiting on nothing. The raw error
+      // belongs in the panel below, once — repeating it as the subtitle said
+      // the same sentence twice on one screen.
+      title = "Your node stopped";
+      subtitle =
+        "The embedded Cardano node reported an error and is not running, so " +
+        "balances, history and sending are unavailable until it starts again.";
       break;
     default:
       title = "Preparing";
@@ -216,6 +222,12 @@ export function Syncing({ status, onLoadAnyway }: SyncingProps) {
       <div className="sync-panel">
         <p className="error-text" role="alert">
           {status.error || "The node reported an error."}
+        </p>
+        <p className="helper-text">
+          Restarting the wallet will try again from where it left off — a
+          bootstrap already downloaded is not thrown away. If it keeps failing,
+          the node&rsquo;s own log is the next place to look; your keys are in
+          the vault either way and are not affected by this.
         </p>
       </div>
     );
@@ -242,8 +254,9 @@ export function Syncing({ status, onLoadAnyway }: SyncingProps) {
           Load wallet anyway (read-only)
         </button>
         <p className="helper-text">
-          You can open a wallet now, but balances and history stay incomplete
-          until syncing finishes.
+          {status.state === "error"
+            ? "You can still open your wallet to see its addresses and settings, but balances and history need a running node."
+            : "You can open a wallet now, but balances and history stay incomplete until syncing finishes."}
         </p>
       </footer>
     </div>


### PR DESCRIPTION
## Three things the wallet said badly

Found by driving the built wallet against a real preview node, not by reading
code. Each fix has a test that was confirmed to fail with the fix reverted.

### 1. Upstream issue numbers shown to the user

The delegation card printed this next to someone's own rewards figure:

> rewards are provisional; dingo reward accounting has open issues (#2373-#2376)

Four copies of that string in `internal/wallet/service.go`. A person looking at
their wallet cannot act on a tracker reference in another repository. One shared
constant now says what it means for them; the cause stays in the comment on
`DelegationView`, where the people who *can* act on it will read it. A test
fails if the note ever names dingo or an issue number again.

### 2. The error screen was misleading in three ways at once

It was headed **Sync interrupted** for a state that does not resume on its own,
printed the same raw error twice (as the subtitle, and again in the panel below),
and still offered *"balances and history stay incomplete until syncing finishes"*
when syncing was never going to finish.

Now: it names the state, shows the error once, says what to do next, and keeps
the original promise only where it is accurate. The banner still carries the
error as its status detail — that is its job — so the page shows it twice rather
than three times.

### 3. A disabled Send with no reason

The palette has always explained why Send is off. The button on the balance just
went grey, which leaves someone guessing whether the wallet is broken or merely
waiting. It now shows the same string, hoisted so both surfaces read from one
place instead of drifting into two explanations of the same block. A test asserts
the two agree.

## Verifying

- `vitest` 776 passed · `tsc --noEmit` clean
- `go build` / `go vet` / `go test ./...` clean in the `ui` module
- `eslint` clean (one pre-existing warning in `connectorNotify.ts`, untouched)
- `gofmt` reports `internal/api/api_test.go`, which is pre-existing on main and
  not touched here

One note on my own first attempt: the replacement escape-hatch copy initially
offered "addresses and settings". Addresses are node-gated too, so that was the
same false promise in new words — corrected in the second commit and pinned by a
test.

## Screens

Balance and delegation — the reason under Send, and a rewards note that no
longer cites another repository's issue tracker:

![Portfolio with a reason under the disabled Send button and a plain-language provisional rewards note](https://raw.githubusercontent.com/blinklabs-io/bursa/assets/screenshots/pr-712/polish-portfolio.png)

The error screen:

![The error screen naming the state, showing the error once, and saying what to do next](https://raw.githubusercontent.com/blinklabs-io/bursa/assets/screenshots/pr-712/polish-error-after.png)

A multi-signature wallet whose stored policy will not decode already gets an
alert saying it cannot spend. Before, the generic reason repeated it underneath
the buttons, more vaguely:

![Balance card showing the policy error alert and, below the buttons, a duplicate "Send is unavailable — this wallet cannot spend."](https://raw.githubusercontent.com/blinklabs-io/bursa/assets/screenshots/pr-712/multisig-reason-before.png)

After — the explicit alert stands alone:

![Balance card showing only the policy error alert, with no duplicate reason line](https://raw.githubusercontent.com/blinklabs-io/bursa/assets/screenshots/pr-712/multisig-reason-after.png)

The same wallet at a mobile viewport:

![Portfolio for a multi-signature wallet at 390x844, policy error alert and no duplicate reason](https://raw.githubusercontent.com/blinklabs-io/bursa/assets/screenshots/pr-712/multisig-mobile.png)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three confusing wallet messages so the UI states what the user can do next.

- Rewards note: Replace the upstream tracker string with one shared Go constant that’s user-facing; tests forbid leaking “dingo” or issue numbers.
- Stopped node: Title is “Your node stopped”; subtitle explains impact; raw error appears once; adds restart/log guidance; escape hatch keeps settings reachable and states that balances, history, and addresses need the node. Tests assert the title, single error occurrence, and the exact footer sentence.
- Send disabled: Compute one reason in `App` and pass it to `Portfolio` so the palette and button match; suppress the generic line when a `multiSigError` is already shown. Tests cover agreement and suppression.

<sup>Written for commit 3a36bb16b5af4d9e6227de518b095d39fb60c3dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved explanations when sending is unavailable because the node is still syncing or the wallet lacks the required capability.
  * Updated stopped-node messaging to clearly describe unavailable features and provide restart and log guidance.
  * Clarified that wallet keys remain unaffected when syncing stops.
  * Refined read-only wallet guidance for stopped nodes.
* **Improvements**
  * Simplified provisional rewards and delegation notices by removing external tracker references.
  * Updated normal syncing and recovery messages for greater clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
