### PR TITLE
refactor: single opcert decoder shared by key loading and the KES agent

### DIFF
--- a/bursa.go
+++ b/bursa.go
@@ -2410,129 +2410,6 @@ func decodeKESSKey(skeyBytes []byte) ([]byte, []byte, error) {
 	return keyBytes, pubKey, nil
 }
 
-// decodeOpCert decodes an operational certificate from CBOR.
-// OpCert CBOR format: [[kes_vkey, issue_number, kes_period, signature], cold_vkey]
-// The outer array has 2 elements:
-//   - Inner 4-element array with the certificate data
-//   - Cold verification key (32 bytes)
-//
-// Returns: kesVkey, issueNumber, kesPeriod, signature, coldVkey, error
-func decodeOpCert(
-	certBytes []byte,
-) ([]byte, uint64, uint64, []byte, []byte, error) {
-	var outerData []any
-	if _, err := cbor.Decode(certBytes, &outerData); err != nil {
-		return nil, 0, 0, nil, nil, fmt.Errorf(
-			"failed to unmarshal OpCert CBOR: %w",
-			err,
-		)
-	}
-	if len(outerData) != 2 {
-		return nil, 0, 0, nil, nil, fmt.Errorf(
-			"invalid OpCert: expected 2-element outer array, got %d",
-			len(outerData),
-		)
-	}
-
-	// Extract inner certificate array
-	certData, ok := outerData[0].([]any)
-	if !ok {
-		return nil, 0, 0, nil, nil, errors.New(
-			"invalid OpCert: first element is not an array",
-		)
-	}
-	if len(certData) != 4 {
-		return nil, 0, 0, nil, nil, fmt.Errorf(
-			"invalid OpCert: expected 4-element cert array, got %d",
-			len(certData),
-		)
-	}
-
-	// Extract cold vkey
-	coldVkey, ok := outerData[1].([]byte)
-	if !ok {
-		return nil, 0, 0, nil, nil, errors.New(
-			"invalid OpCert: cold_vkey is not bytes",
-		)
-	}
-	if len(coldVkey) != 32 {
-		return nil, 0, 0, nil, nil, fmt.Errorf(
-			"invalid OpCert: cold_vkey expected 32 bytes, got %d",
-			len(coldVkey),
-		)
-	}
-
-	// Extract KES vkey from inner array
-	kesVkey, ok := certData[0].([]byte)
-	if !ok {
-		return nil, 0, 0, nil, nil, errors.New(
-			"invalid OpCert: kes_vkey is not bytes",
-		)
-	}
-	if len(kesVkey) != 32 {
-		return nil, 0, 0, nil, nil, fmt.Errorf(
-			"invalid OpCert: kes_vkey expected 32 bytes, got %d",
-			len(kesVkey),
-		)
-	}
-
-	// Extract issue number (can be uint64 or int64 depending on CBOR encoding)
-	var issueNumber uint64
-	switch v := certData[1].(type) {
-	case uint64:
-		issueNumber = v
-	case int64:
-		if v < 0 {
-			return nil, 0, 0, nil, nil, fmt.Errorf(
-				"invalid OpCert: issue_number cannot be negative, got %d",
-				v,
-			)
-		}
-		issueNumber = uint64(v) // #nosec G115
-	default:
-		return nil, 0, 0, nil, nil, fmt.Errorf(
-			"invalid OpCert: issue_number has unexpected type %T",
-			certData[1],
-		)
-	}
-
-	// Extract KES period
-	var kesPeriod uint64
-	switch v := certData[2].(type) {
-	case uint64:
-		kesPeriod = v
-	case int64:
-		if v < 0 {
-			return nil, 0, 0, nil, nil, fmt.Errorf(
-				"invalid OpCert: kes_period cannot be negative, got %d",
-				v,
-			)
-		}
-		kesPeriod = uint64(v) // #nosec G115
-	default:
-		return nil, 0, 0, nil, nil, fmt.Errorf(
-			"invalid OpCert: kes_period has unexpected type %T",
-			certData[2],
-		)
-	}
-
-	// Extract cold signature
-	signature, ok := certData[3].([]byte)
-	if !ok {
-		return nil, 0, 0, nil, nil, errors.New(
-			"invalid OpCert: cold_signature is not bytes",
-		)
-	}
-	if len(signature) != 64 {
-		return nil, 0, 0, nil, nil, fmt.Errorf(
-			"invalid OpCert: cold_signature expected 64 bytes, got %d",
-			len(signature),
-		)
-	}
-
-	return kesVkey, issueNumber, kesPeriod, signature, coldVkey, nil
-}
-
 func parseKeyEnvelope(fileBytes []byte) (*LoadedKey, error) {
 	var env KeyFile
 	if err := json.Unmarshal(fileBytes, &env); err != nil {
@@ -2635,17 +2512,15 @@ func parseKeyEnvelope(fileBytes []byte) (*LoadedKey, error) {
 		return lk, nil
 	// Operational Certificate
 	case "NodeOperationalCertificate":
-		kesVkey, issueNumber, kesPeriod, signature, coldVkey, err := decodeOpCert(
-			cborData,
-		)
+		dec, err := DecodeOpCert(cborData)
 		if err != nil {
 			return nil, err
 		}
-		lk.VKey = kesVkey
-		lk.OpCertIssueNumber = issueNumber
-		lk.OpCertKesPeriod = kesPeriod
-		lk.OpCertSignature = signature
-		lk.OpCertColdVKey = coldVkey
+		lk.VKey = dec.KESVKey
+		lk.OpCertIssueNumber = dec.IssueNumber
+		lk.OpCertKesPeriod = dec.KESPeriod
+		lk.OpCertSignature = dec.ColdSig
+		lk.OpCertColdVKey = dec.ColdVKey
 		return lk, nil
 	default:
 		return nil, fmt.Errorf("unknown key type: %s", env.Type)

--- a/internal/kesagent/agent.go
+++ b/internal/kesagent/agent.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/bursa/internal/kesagent/securemem"
 	"github.com/blinklabs-io/gouroboros/kes"
 	"github.com/blinklabs-io/gouroboros/ledger"
@@ -240,7 +241,7 @@ func (a *Agent) GenStagedKey() ([]byte, error) {
 // evolves it to the current period, and (serve-key mode) pushes it. It returns
 // the resulting agent info.
 func (a *Agent) InstallKey(opcertBytes []byte) (*AgentInfo, error) {
-	dec, err := decodeOpCert(opcertBytes)
+	dec, err := bursa.DecodeOpCert(opcertBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -252,30 +253,30 @@ func (a *Agent) InstallKey(opcertBytes []byte) (*AgentInfo, error) {
 		return nil, ErrNoStagedKey
 	}
 	// The agent holds only the cold vkey; the opcert must carry the same one.
-	if !bytes.Equal(dec.coldVkey, a.cfg.ColdVKey) {
+	if !bytes.Equal(dec.ColdVKey, a.cfg.ColdVKey) {
 		return nil, ErrOpCertColdVK
 	}
 	// Verify the cold-key signature over the OCertSignable representation.
-	if err := ledger.VerifyOpCertSignature(dec.ledgerOpCert(), a.cfg.ColdVKey); err != nil {
+	if err := ledger.VerifyOpCertSignature(dec.LedgerOpCert(), a.cfg.ColdVKey); err != nil {
 		return nil, fmt.Errorf("kesagent: opcert signature invalid: %w", err)
 	}
 	// The opcert must commit to the staged KES vkey.
-	if !bytes.Equal(dec.kesVkey, a.staged.vkey) {
+	if !bytes.Equal(dec.KESVKey, a.staged.vkey) {
 		return nil, ErrOpCertKESVK
 	}
 	// Period sanity: not from the future, and not already expired.
 	cur := a.currentKESPeriod()
-	if dec.kesPeriod > cur {
+	if dec.KESPeriod > cur {
 		return nil, fmt.Errorf(
 			"kesagent: opcert KES period %d is in the future (current %d)",
-			dec.kesPeriod, cur,
+			dec.KESPeriod, cur,
 		)
 	}
 	maxEvol := a.maxEvolutions()
-	if cur-dec.kesPeriod >= maxEvol {
+	if cur-dec.KESPeriod >= maxEvol {
 		return nil, fmt.Errorf(
 			"kesagent: opcert expired: %d evolutions since period %d >= max %d",
-			cur-dec.kesPeriod, dec.kesPeriod, maxEvol,
+			cur-dec.KESPeriod, dec.KESPeriod, maxEvol,
 		)
 	}
 
@@ -285,10 +286,10 @@ func (a *Agent) InstallKey(opcertBytes []byte) (*AgentInfo, error) {
 	oldActive := a.active
 	ks := a.staged
 	a.staged = nil
-	ks.startPeriod = dec.kesPeriod
+	ks.startPeriod = dec.KESPeriod
 	ks.maxEvol = maxEvol
 	ks.opcert = append([]byte(nil), opcertBytes...)
-	ks.issueNumber = dec.issueNumber
+	ks.issueNumber = dec.IssueNumber
 	ks.exhausted = false
 	a.active = ks
 

--- a/internal/kesagent/helpers_test.go
+++ b/internal/kesagent/helpers_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
 )
@@ -99,13 +100,13 @@ func makeOpCert(t *testing.T, kesVkey []byte, issue, period uint64, cold coldKey
 // then no longer matches, so VerifyOpCertSignature fails.
 func tamperOpCertKESVkey(t *testing.T, opcert, newVkey []byte) []byte {
 	t.Helper()
-	dec, err := decodeOpCert(opcert)
+	dec, err := bursa.DecodeOpCert(opcert)
 	if err != nil {
 		t.Fatalf("decode for tamper: %v", err)
 	}
 	env := []any{
-		[]any{newVkey, dec.issueNumber, dec.kesPeriod, dec.coldSig},
-		dec.coldVkey,
+		[]any{newVkey, dec.IssueNumber, dec.KESPeriod, dec.ColdSig},
+		dec.ColdVKey,
 	}
 	b, err := cbor.Encode(env)
 	if err != nil {

--- a/opcert.go
+++ b/opcert.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package kesagent
+package bursa
 
 import (
 	"crypto/ed25519"
@@ -24,25 +24,28 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger"
 )
 
-// decodedOpCert holds the fields decoded from a canonical node operational
-// certificate CBOR envelope.
-type decodedOpCert struct {
-	kesVkey     []byte
-	issueNumber uint64
-	kesPeriod   uint64
-	coldSig     []byte
-	coldVkey    []byte
+// DecodedOpCert holds the fields decoded from a node operational certificate
+// CBOR envelope.
+type DecodedOpCert struct {
+	KESVKey     []byte
+	IssueNumber uint64
+	KESPeriod   uint64
+	ColdSig     []byte
+	ColdVKey    []byte
 }
 
-// decodeOpCert decodes a node operational certificate from CBOR.
+// DecodeOpCert decodes a node operational certificate from CBOR.
 //
-// Wire format (matches bursa / cardano-node):
+// Wire format (matches cardano-node / cardano-cli):
 //
 //	[[kes_vkey, issue_number, kes_period, cold_signature], cold_vkey]
 //
-// This mirrors bursa's own decodeOpCert; it is duplicated here to keep the
-// agent package self-contained (the root helper is unexported).
-func decodeOpCert(certBytes []byte) (*decodedOpCert, error) {
+// The outer array has two elements: the 4-element inner certificate array and
+// the 32-byte cold verification key. All six validation rules (outer/inner
+// arity, cold-vkey and kes-vkey types + lengths, non-negative counters, and the
+// cold-signature type + length) are enforced here so this is the single trusted
+// parser for opcerts across the module (both key loading and the KES agent).
+func DecodeOpCert(certBytes []byte) (*DecodedOpCert, error) {
 	var outer []any
 	if _, err := cbor.Decode(certBytes, &outer); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal OpCert CBOR: %w", err)
@@ -83,11 +86,11 @@ func decodeOpCert(certBytes []byte) (*decodedOpCert, error) {
 			kes.PublicKeySize, len(kesVkey),
 		)
 	}
-	issueNumber, err := asUint64(cert[1], "issue_number")
+	issueNumber, err := opCertUint64(cert[1], "issue_number")
 	if err != nil {
 		return nil, err
 	}
-	kesPeriod, err := asUint64(cert[2], "kes_period")
+	kesPeriod, err := opCertUint64(cert[2], "kes_period")
 	if err != nil {
 		return nil, err
 	}
@@ -101,16 +104,28 @@ func decodeOpCert(certBytes []byte) (*decodedOpCert, error) {
 			ed25519.SignatureSize, len(coldSig),
 		)
 	}
-	return &decodedOpCert{
-		kesVkey:     kesVkey,
-		issueNumber: issueNumber,
-		kesPeriod:   kesPeriod,
-		coldSig:     coldSig,
-		coldVkey:    coldVkey,
+	return &DecodedOpCert{
+		KESVKey:     kesVkey,
+		IssueNumber: issueNumber,
+		KESPeriod:   kesPeriod,
+		ColdSig:     coldSig,
+		ColdVKey:    coldVkey,
 	}, nil
 }
 
-func asUint64(v any, field string) (uint64, error) {
+// LedgerOpCert converts to the gouroboros ledger.OpCert for signature checks.
+func (d *DecodedOpCert) LedgerOpCert() *ledger.OpCert {
+	return &ledger.OpCert{
+		KesVkey:       d.KESVKey,
+		IssueNumber:   d.IssueNumber,
+		KesPeriod:     d.KESPeriod,
+		ColdSignature: d.ColdSig,
+	}
+}
+
+// opCertUint64 accepts the uint64/int64 forms CBOR may decode a non-negative
+// integer into, rejecting negatives and other types.
+func opCertUint64(v any, field string) (uint64, error) {
 	switch n := v.(type) {
 	case uint64:
 		return n, nil
@@ -118,18 +133,8 @@ func asUint64(v any, field string) (uint64, error) {
 		if n < 0 {
 			return 0, fmt.Errorf("invalid OpCert: %s cannot be negative, got %d", field, n)
 		}
-		return uint64(n), nil
+		return uint64(n), nil // #nosec G115 -- negative rejected above
 	default:
 		return 0, fmt.Errorf("invalid OpCert: %s has unexpected type %T", field, v)
-	}
-}
-
-// ledgerOpCert converts to the gouroboros ledger.OpCert for signature checks.
-func (d *decodedOpCert) ledgerOpCert() *ledger.OpCert {
-	return &ledger.OpCert{
-		KesVkey:       d.kesVkey,
-		IssueNumber:   d.issueNumber,
-		KesPeriod:     d.kesPeriod,
-		ColdSignature: d.coldSig,
 	}
 }


### PR DESCRIPTION
Closes #709 

## Summary
Removes a duplicated operational-certificate CBOR decoder. The KES agent (`internal/kesagent`) reimplemented the same six-rule opcert parser the key-loading path already had in `bursa.go`, so a future hardening fix (canonical CBOR, indefinite-length rejection, etc.) could land in one and silently miss the other.

## Change
- Promote the struct-based decoder to an exported **`bursa.DecodeOpCert(certBytes) (*DecodedOpCert, error)`** (with a `LedgerOpCert()` helper) in the root package.
- Route both consumers through it: `LoadKeyFromFile`/`parseKeyEnvelope`'s `NodeOperationalCertificate` case, and the KES agent's `InstallKey`.
- Delete the duplicate parser (`internal/kesagent/opcert.go`).

Net **−118 lines**, single source of truth for opcert parsing.

## Validation
- `go build ./...` (linux) and `GOOS=windows go build ./...` — clean.
- `go test` root package (opcert/key-loading) + `go test -race ./internal/kesagent/...` — pass.
- `go vet ./...`, nilaway — clean.

No behavioral change: the promoted decoder is the stricter of the two (validates the 64-byte cold signature), which the key-loading path now also benefits from.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates operational-certificate CBOR decoding by exporting `bursa.DecodeOpCert` and using it in both key loading and the KES agent. This centralizes validation and removes drift; key loading now also enforces the 64-byte cold signature.

- Exposes `bursa.DecodeOpCert([]byte) (*DecodedOpCert, error)` with `DecodedOpCert.LedgerOpCert()`.
- Routes `LoadKeyFromFile`/`parseKeyEnvelope` (NodeOperationalCertificate) and `internal/kesagent.Agent.InstallKey` through the shared decoder.
- Removes the duplicate decoder from `internal/kesagent/opcert.go` (net −118 LOC).
- Behavior: no intended change; stricter signature check now applies to key loading as well.
- Review notes: imports in `internal/kesagent` now use `github.com/blinklabs-io/bursa`; updated field names (`KESVKey`, `KESPeriod`, etc.).
- No migration required; downstreams may optionally use `bursa.DecodeOpCert` directly.

<sup>Written for commit 137f8e8c2f803e99085c4787db231290e05308b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated operational-certificate decoding into a shared, reusable implementation.
  * Standardized certificate field access and conversion for improved consistency across certificate validation and key installation workflows.
  * Preserved existing certificate checks, signature verification, staged-key matching, period validation, and rollback behavior.
* **Developer Experience**
  * Exposed operational-certificate decoding and ledger conversion APIs for use by other components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->