### PR TITLE
fix(ui): restore the dist/index.html pre-build placeholder

### DIFF
--- a/ui/internal/webui/dist/index.html
+++ b/ui/internal/webui/dist/index.html
@@ -1,7 +1,39 @@
 <!doctype html>
 <html lang="en">
-  <head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Bursa Wallet</title>  <script type="module" crossorigin src="/assets/index-UN2v5GwE.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-D8T3krv9.css">
-</head>
-  <body><div id="root"></div></body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Bursa Wallet</title>
+  </head>
+  <body>
+    <!--
+      Pre-build placeholder.
+
+      This file is the only thing under ui/internal/webui/dist/ that is tracked
+      in git (the hashed JS/CSS bundles are .gitignore'd build output). It exists
+      so `//go:embed dist` compiles from a clean checkout, and it is served as-is
+      if the binary is run before the web UI has been built — hence the message
+      below. `npm run build` (vite, emptyOutDir) overwrites this with the real
+      compiled index.html and its assets; do not commit that build output.
+
+      No inline CSS/JS on purpose: the server sends Content-Security-Policy
+      `default-src 'self'`, which blocks inline styles and scripts, so this page
+      stays intentionally plain.
+    -->
+    <h1>Bursa Wallet — web UI not built yet</h1>
+    <p>
+      The single-page app that ships embedded in <code>bursa-wallet</code> has
+      not been built. You are seeing the placeholder that is committed in its
+      place.
+    </p>
+    <p>To build the web UI, run:</p>
+    <pre>cd ui/web
+npm install
+npm run build</pre>
+    <p>
+      That compiles the app into <code>ui/internal/webui/dist/</code> (replacing
+      this file). Rebuild the <code>bursa-wallet</code> binary afterwards so the
+      embedded assets are picked up.
+    </p>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
Restores the tracked `ui/internal/webui/dist/index.html` to its intended **pre-build placeholder** (from #530). It had been overwritten by committed `npm run build` output.

## Why
`dist/index.html` is the only thing under `ui/internal/webui/dist/` that is tracked — it exists so `//go:embed dist` compiles from a clean checkout; the hashed JS/CSS bundles are `.gitignore`d build output (`ui/internal/webui/.gitignore`: `dist/*`). Real `npm run build` output was being committed over the placeholder, and since each build emits different hashed asset references (`/assets/index-<hash>.js`), every UI PR that did so conflicted with every other on this file.

This restores the stable placeholder (which also carries the comment documenting the policy: the real `index.html` is produced by the web build at binary-build time and must not be committed).

Verified: `go build ./internal/webui/... ./cmd/...` still compiles (the placeholder is valid HTML the embed is happy with).

## Follow-up (not in this PR)
Recurrence prevention — point Vite's `outDir` at a gitignored dir and have the Makefile/CI copy the real build into `dist/` only at binary-build time — so `npm run build` can't dirty the tracked placeholder and no UI PR conflicts on `dist/` again. Happy to do that separately.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `ui/internal/webui/dist/index.html` to a stable pre-build placeholder to avoid committing `vite` build output with hashed assets. Previously the built file was committed, causing frequent merge conflicts; now only the placeholder is tracked so `//go:embed dist` works from a clean checkout.

- Runtime behavior: unchanged when the web UI is built; if the binary runs without a web build, the placeholder page is served.
- Review focus: HTML content is plain and carries the policy comment; no backend or build tooling changes.
- Migration for contributors: do not commit `npm run build` output in `ui/internal/webui/dist/`. Build locally with `npm install && npm run build`, then rebuild the binary to embed assets. If you see the placeholder at runtime, the web UI hasn’t been built.

<sup>Written for commit 25a5310111adb4d6c8156148e87891c4648328b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

