### PR TITLE
build(ui): stop committing the embedded dist; restore placeholder

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -77,6 +77,8 @@ jobs:
       # production SPA before gomobile compiles the binding.
       - name: Build web bundle
         run: cd ui/web && npm ci && npm run build
+      - name: Embed the web bundle into the //go:embed dist target
+        run: make webui-embed
       - name: Install gomobile
         run: |
           go install "golang.org/x/mobile/cmd/gomobile@${GOMOBILE_VERSION}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -396,8 +396,20 @@ jobs:
           & $env:CC --version
           # Vite builds into ui\web\dist (gitignored); copy it into the
           # //go:embed dist target so the exe embeds the real SPA, not the placeholder.
-          Remove-Item -Recurse -Force ui\internal\webui\dist\assets -ErrorAction SilentlyContinue
-          Copy-Item -Recurse -Force ui\web\dist\* ui\internal\webui\dist\
+          # Every step is terminating: PowerShell continues past a failed
+          # Copy-Item by default, which would embed the tracked placeholder in a
+          # release exe and report success. Checking that the destination
+          # index.html merely exists is not enough, because the placeholder is
+          # already there -- so verify the copied bundle is not the placeholder.
+          if (-not (Test-Path ui\web\dist\index.html)) {
+            Write-Error "web bundle missing: ui\web\dist\index.html"; exit 1
+          }
+          Remove-Item -Recurse -Force ui\internal\webui\dist\* -ErrorAction Stop
+          Copy-Item -Recurse -Force ui\web\dist\* ui\internal\webui\dist\ -ErrorAction Stop
+          if (Select-String -Path ui\internal\webui\dist\index.html `
+                -Pattern 'Pre-build placeholder' -Quiet) {
+            Write-Error "embed dir still holds the placeholder after copy"; exit 1
+          }
           Push-Location ui
           go build -tags webview -ldflags "-s -w -H=windowsgui" -o "$env:GITHUB_WORKSPACE\bursa-wallet.exe" ./cmd/bursa-wallet
           if ($LASTEXITCODE -ne 0) { Write-Error "webview exe build failed"; exit 1 }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -394,6 +394,10 @@ jobs:
             $env:CXX = "$msys2Loc\clangarm64\bin\clang++.exe"
           }
           & $env:CC --version
+          # Vite builds into ui\web\dist (gitignored); copy it into the
+          # //go:embed dist target so the exe embeds the real SPA, not the placeholder.
+          Remove-Item -Recurse -Force ui\internal\webui\dist\assets -ErrorAction SilentlyContinue
+          Copy-Item -Recurse -Force ui\web\dist\* ui\internal\webui\dist\
           Push-Location ui
           go build -tags webview -ldflags "-s -w -H=windowsgui" -o "$env:GITHUB_WORKSPACE\bursa-wallet.exe" ./cmd/bursa-wallet
           if ($LASTEXITCODE -ne 0) { Write-Error "webview exe build failed"; exit 1 }

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ UI_WEBVIEW_LDFLAGS=-ldflags "$(UI_LDFLAGS_CONTENT)$(if $(filter windows,$(GOOS))
 # exist, which is the case on every target that needs no shim.
 WEBVIEW_PKG_CONFIG_DIR=$(ROOT_DIR)/.pkgconfig
 
-.PHONY: build wallet wallet-binary wallet-webview wallet-binary-webview webui-embed webkit-shim bundle-macos pkg-macos pkg-macos-adhoc mod-tidy clean test
+.PHONY: build wallet wallet-binary wallet-webview wallet-binary-webview webui-embed webui-embed-restore webkit-shim bundle-macos pkg-macos pkg-macos-adhoc mod-tidy clean test
 
 # Alias for building program binary
 build: $(BINARIES)
@@ -47,11 +47,26 @@ build: $(BINARIES)
 # time. No-ops (keeping the placeholder) when the web bundle has not been built.
 webui-embed:
 	@if [ -f ui/web/dist/index.html ]; then \
-		rm -rf ui/internal/webui/dist/assets; \
-		cp -R ui/web/dist/. ui/internal/webui/dist/; \
-		echo "webui-embed: copied ui/web/dist -> ui/internal/webui/dist"; \
+		rm -rf ui/internal/webui/dist/* \
+		&& cp -R ui/web/dist/. ui/internal/webui/dist/ \
+		&& [ -f ui/internal/webui/dist/index.html ] \
+		&& echo "webui-embed: copied ui/web/dist -> ui/internal/webui/dist" \
+		|| { echo "webui-embed: FAILED to embed ui/web/dist" >&2; exit 1; }; \
 	else \
 		echo "webui-embed: ui/web/dist not built; keeping placeholder"; \
+	fi
+
+# Put the tracked placeholder back and drop the generated bundle, so building a
+# binary does not leave ui/internal/webui/dist/index.html modified in the work
+# tree. Restored from git because the placeholder has no other pristine copy;
+# outside a work tree (a release tarball) there is nothing to restore and
+# nothing that needs it, so this is a no-op rather than an error.
+webui-embed-restore:
+	@if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
+		rm -rf ui/internal/webui/dist/* \
+		&& git checkout -- ui/internal/webui/dist/index.html \
+		|| { echo "webui-embed-restore: FAILED to restore placeholder" >&2; \
+			exit 1; }; \
 	fi
 
 # Build the embedded-SPA wallet binary from the nested ui/ module. The web
@@ -66,10 +81,13 @@ wallet:
 # release cross-build matrix; the default build is pure Go and cross-compiles
 # without CGO. The webview variant is intentionally NOT built here.
 wallet-binary: webui-embed
-	cd ui && go build \
+	@cd ui && go build \
 		$(UI_GO_LDFLAGS) \
 		-o bursa-wallet \
-		./cmd/bursa-wallet
+		./cmd/bursa-wallet; \
+	status=$$?; \
+	$(MAKE) -C .. webui-embed-restore; \
+	exit $$status
 
 # Build the webview desktop wallet: the web bundle first, then the CGO +
 # `-tags webview` variant (native system webview: WKWebView/mac, WebView2/win,
@@ -82,13 +100,16 @@ wallet-webview:
 # Compile only the webview bursa-wallet binary, assuming the web bundle has
 # already been built into the //go:embed dist target. Honors GOOS/GOARCH.
 wallet-binary-webview: webkit-shim webui-embed
-	cd ui && CGO_ENABLED=1 \
+	@cd ui && CGO_ENABLED=1 \
 		PKG_CONFIG_PATH="$(WEBVIEW_PKG_CONFIG_DIR)$(if $(PKG_CONFIG_PATH),:$(PKG_CONFIG_PATH),)" \
 		go build \
 		$(UI_WEBVIEW_LDFLAGS) \
 		-tags webview \
 		-o bursa-wallet$(if $(filter windows,$(GOOS)),.exe,) \
-		./cmd/bursa-wallet
+		./cmd/bursa-wallet; \
+	status=$$?; \
+	$(MAKE) -C .. webui-embed-restore; \
+	exit $$status
 
 # github.com/webview/webview_go hardcodes `pkg-config: gtk+-3.0 webkit2gtk-4.0`
 # and offers no 4.1 build tag; the pinned commit is also upstream's latest, so

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,24 @@ UI_WEBVIEW_LDFLAGS=-ldflags "$(UI_LDFLAGS_CONTENT)$(if $(filter windows,$(GOOS))
 # exist, which is the case on every target that needs no shim.
 WEBVIEW_PKG_CONFIG_DIR=$(ROOT_DIR)/.pkgconfig
 
-.PHONY: build wallet wallet-binary wallet-webview wallet-binary-webview webkit-shim bundle-macos pkg-macos pkg-macos-adhoc mod-tidy clean test
+.PHONY: build wallet wallet-binary wallet-webview wallet-binary-webview webui-embed webkit-shim bundle-macos pkg-macos pkg-macos-adhoc mod-tidy clean test
 
 # Alias for building program binary
 build: $(BINARIES)
+
+# Copy the built SPA (ui/web/dist, gitignored) into the //go:embed dist target
+# so the wallet binaries embed the real UI. Vite builds into ui/web/dist, so
+# `npm run build` never overwrites the tracked ui/internal/webui/dist/index.html
+# placeholder; the real bundle lands in the embed dir only here, at binary-build
+# time. No-ops (keeping the placeholder) when the web bundle has not been built.
+webui-embed:
+	@if [ -f ui/web/dist/index.html ]; then \
+		rm -rf ui/internal/webui/dist/assets; \
+		cp -R ui/web/dist/. ui/internal/webui/dist/; \
+		echo "webui-embed: copied ui/web/dist -> ui/internal/webui/dist"; \
+	else \
+		echo "webui-embed: ui/web/dist not built; keeping placeholder"; \
+	fi
 
 # Build the embedded-SPA wallet binary from the nested ui/ module. The web
 # bundle is built first so the //go:embed dist target is populated, then the
@@ -51,7 +65,7 @@ wallet:
 # been built into the //go:embed dist target. Honors GOOS/GOARCH for the
 # release cross-build matrix; the default build is pure Go and cross-compiles
 # without CGO. The webview variant is intentionally NOT built here.
-wallet-binary:
+wallet-binary: webui-embed
 	cd ui && go build \
 		$(UI_GO_LDFLAGS) \
 		-o bursa-wallet \
@@ -67,7 +81,7 @@ wallet-webview:
 
 # Compile only the webview bursa-wallet binary, assuming the web bundle has
 # already been built into the //go:embed dist target. Honors GOOS/GOARCH.
-wallet-binary-webview: webkit-shim
+wallet-binary-webview: webkit-shim webui-embed
 	cd ui && CGO_ENABLED=1 \
 		PKG_CONFIG_PATH="$(WEBVIEW_PKG_CONFIG_DIR)$(if $(PKG_CONFIG_PATH),:$(PKG_CONFIG_PATH),)" \
 		go build \

--- a/packaging/macos/build-pkg.sh
+++ b/packaging/macos/build-pkg.sh
@@ -128,6 +128,11 @@ build_binary() {
         ( cd "${UI_DIR}/web" && npm ci && npm run build )
     fi
 
+    # Vite builds into ui/web/dist (gitignored); copy it into the //go:embed
+    # dist target so the Go build embeds the real SPA rather than the placeholder.
+    log "Embedding web bundle into ui/internal/webui/dist"
+    make -C "${REPO_ROOT}" webui-embed
+
     # Mirror the Makefile's UI version-ldflags pattern.
     local ldflags="-s -w \
 -X '${UI_GOMODULE}/internal/version.Version=${VERSION}' \

--- a/packaging/macos/build-pkg.sh
+++ b/packaging/macos/build-pkg.sh
@@ -99,9 +99,11 @@ UNSIGNED_PKG="${BUILD_DIR}/bursa-unsigned.pkg"
 # Icon source (already present in the repo).
 ICON_SRC="${ICON_SRC:-${REPO_ROOT}/.github/assets/Bursa.icns}"
 
-# Set SKIP_WEB_BUILD=1 to reuse an already-built web bundle
-# (ui/internal/webui/dist) instead of re-running the npm build. CI builds the
-# bundle once in an earlier step.
+# Set SKIP_WEB_BUILD=1 to reuse an already-built web bundle (ui/web/dist, the
+# Vite outDir) instead of re-running the npm build. CI builds the bundle once in
+# an earlier step. Note this is the Vite output directory, not the //go:embed
+# target ui/internal/webui/dist that webui-embed copies it into: a bundle left
+# only in the embed dir is not a reusable build, and webui-embed would no-op.
 SKIP_WEB_BUILD="${SKIP_WEB_BUILD:-0}"
 
 # ---------------------------------------------------------------------------
@@ -122,6 +124,13 @@ build_binary() {
     # Build the web bundle first so the //go:embed dist target
     # (ui/internal/webui/dist) is populated before the Go build.
     if [ "${SKIP_WEB_BUILD}" = "1" ] || [ "${SKIP_WEB_BUILD}" = "true" ]; then
+        # Fail loudly rather than let webui-embed no-op and ship a pkg whose
+        # binary serves the placeholder page.
+        if [ ! -f "${UI_DIR}/web/dist/index.html" ]; then
+            echo "SKIP_WEB_BUILD set but ${UI_DIR}/web/dist/index.html is" \
+                "missing; build the web bundle or unset SKIP_WEB_BUILD" >&2
+            exit 1
+        fi
         log "SKIP_WEB_BUILD set - reusing existing web bundle"
     else
         log "Building web bundle (npm ci && npm run build)"
@@ -132,6 +141,14 @@ build_binary() {
     # dist target so the Go build embeds the real SPA rather than the placeholder.
     log "Embedding web bundle into ui/internal/webui/dist"
     make -C "${REPO_ROOT}" webui-embed
+    # webui-embed keeps the placeholder when the bundle is absent, and exits
+    # zero doing so. A release pkg must never carry that, so check rather than
+    # assume.
+    if grep -q "Pre-build placeholder" \
+        "${UI_DIR}/internal/webui/dist/index.html"; then
+        echo "embed dir still holds the placeholder; refusing to package" >&2
+        exit 1
+    fi
 
     # Mirror the Makefile's UI version-ldflags pattern.
     local ldflags="-s -w \

--- a/ui/internal/webui/dist/index.html
+++ b/ui/internal/webui/dist/index.html
@@ -1,7 +1,39 @@
 <!doctype html>
 <html lang="en">
-  <head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Bursa Wallet</title>  <script type="module" crossorigin src="/assets/index-UN2v5GwE.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-D8T3krv9.css">
-</head>
-  <body><div id="root"></div></body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Bursa Wallet</title>
+  </head>
+  <body>
+    <!--
+      Pre-build placeholder.
+
+      This file is the only thing under ui/internal/webui/dist/ that is tracked
+      in git (the hashed JS/CSS bundles are .gitignore'd build output). It exists
+      so `//go:embed dist` compiles from a clean checkout, and it is served as-is
+      if the binary is run before the web UI has been built — hence the message
+      below. `npm run build` (vite, emptyOutDir) overwrites this with the real
+      compiled index.html and its assets; do not commit that build output.
+
+      No inline CSS/JS on purpose: the server sends Content-Security-Policy
+      `default-src 'self'`, which blocks inline styles and scripts, so this page
+      stays intentionally plain.
+    -->
+    <h1>Bursa Wallet — web UI not built yet</h1>
+    <p>
+      The single-page app that ships embedded in <code>bursa-wallet</code> has
+      not been built. You are seeing the placeholder that is committed in its
+      place.
+    </p>
+    <p>To build the web UI, run:</p>
+    <pre>cd ui/web
+npm install
+npm run build</pre>
+    <p>
+      That compiles the app into <code>ui/internal/webui/dist/</code> (replacing
+      this file). Rebuild the <code>bursa-wallet</code> binary afterwards so the
+      embedded assets are picked up.
+    </p>
+  </body>
 </html>

--- a/ui/internal/webui/dist/index.html
+++ b/ui/internal/webui/dist/index.html
@@ -13,8 +13,10 @@
       in git (the hashed JS/CSS bundles are .gitignore'd build output). It exists
       so `//go:embed dist` compiles from a clean checkout, and it is served as-is
       if the binary is run before the web UI has been built — hence the message
-      below. `npm run build` (vite, emptyOutDir) overwrites this with the real
-      compiled index.html and its assets; do not commit that build output.
+      below. `npm run build` (vite) no longer touches this file: it builds into
+      ui/web/dist, and `make webui-embed` copies that over this directory only
+      at binary-build time, restoring this placeholder afterwards. Do not commit
+      that build output.
 
       No inline CSS/JS on purpose: the server sends Content-Security-Policy
       `default-src 'self'`, which blocks inline styles and scripts, so this page

--- a/ui/web/vite.config.ts
+++ b/ui/web/vite.config.ts
@@ -8,7 +8,13 @@ export default defineConfig({
   // SDK load its WebAssembly serialization lib. They only affect that async
   // chunk; the initial bundle is unaffected.
   plugins: [react(), wasm(), topLevelAwait()],
-  build: { outDir: "../internal/webui/dist", emptyOutDir: true },
+  // Build into ui/web/dist (gitignored) rather than straight into the embedded
+  // ui/internal/webui/dist. That keeps `npm run build` from overwriting the
+  // tracked dist/index.html placeholder (whose per-build hashed asset refs
+  // otherwise get committed and conflict across UI PRs). The Makefile's
+  // webui-embed step copies this output into the //go:embed dist target only at
+  // binary-build time.
+  build: { outDir: "dist", emptyOutDir: true },
   server: {
     proxy: {
       "/status": "http://127.0.0.1:8090",


### PR DESCRIPTION
## Summary
Stops committed build artifacts (`ui/internal/webui/dist/index.html`) from recurring, and restores the placeholder.

**Root cause:** Vite's `outDir` was `../internal/webui/dist`, so every `npm run build` overwrote the tracked `dist/index.html` placeholder with hashed-asset output. Since the file is force-tracked (`.gitignore`: `dist/*` + `!dist/index.html`), a broad `git add` then re-committed it — and each build's different asset hashes conflicted across UI PRs.

## Changes
- **Vite `outDir` → `dist`** (`ui/web/dist`, already gitignored). `npm run build` no longer touches the embedded dir.
- **Restore** the pre-build `dist/index.html` placeholder (from #530).
- **Makefile `webui-embed`** target — copies `ui/web/dist` into the `//go:embed dist` target; wired as a prereq of `wallet-binary` / `wallet-binary-webview`, so it runs only at binary-build time.
- **Direct-build release paths** that bypass `make` now run the copy too: mobile (`make webui-embed`), macOS `build-pkg.sh` (`make -C … webui-embed`), Windows `publish.yml` (PowerShell copy).

## Verified locally
- `npm run build` → outputs to `ui/web/dist` (gitignored); the tracked placeholder is untouched.
- `make webui-embed` → copies the real bundle (index + 18 assets) into the embed dir.
- `go build ./internal/webui/... ./cmd/bursa-wallet/...` embeds it (exit 0).
- `go test ./internal/webui/...` passes against the placeholder (its assertions only need the "Bursa Wallet" title, which the placeholder has).
- YAML + `bash -n` clean on the touched workflows/script.

Result: `npm run build` can no longer dirty the tracked placeholder, and no UI PR conflicts on `dist/` again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops npm run build from overwriting the embedded placeholder and removes UI PR churn from hashed assets. Previously Vite built into `ui/internal/webui/dist` (tracked); now it builds into `ui/web/dist` (gitignored), and an embed step copies the bundle into the `//go:embed dist` target only during binary builds, failing if the placeholder would ship.

- Vite `outDir` → `ui/web/dist`; restored and clarified the placeholder at `ui/internal/webui/dist/index.html`.
- Added `make webui-embed` (copy) and `webui-embed-restore` (put placeholder back). `wallet-binary` and `wallet-binary-webview` depend on them to embed at build time and leave the tree clean.
- Embedding now terminates on errors, clears the embed dir, and verifies the result is not the placeholder. Windows publish, macOS packaging, and the mobile workflow run the embed step and enforce the same checks; PowerShell paths are now error-terminating.

Migration:
- Outside the provided make targets, run `npm run build` then `make webui-embed`. On macOS packaging, set `SKIP_WEB_BUILD=1` only if `ui/web/dist/index.html` exists. Do not commit files under `ui/internal/webui/dist` beyond the placeholder.

<sup>Written for commit 6e87cb16d81564092dfc321096fd34914a05f456. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Packaged desktop and mobile builds now include the latest web interface instead of placeholder content.
  * Web assets are consistently embedded during Windows, macOS, iOS, and standard binary builds.

* **Build Improvements**
  * Added automatic handling for copying the production web bundle into packaged applications.
  * Updated web builds to use a dedicated output directory before embedding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->