### PR TITLE
feat(ui): read the DRep directory from dingo's dreps list endpoint

### DIFF
--- a/bursa.go
+++ b/bursa.go
@@ -2717,8 +2717,8 @@ func LoadWalletDir(dir string, showSecrets bool) ([]*LoadedKey, error) {
 			continue
 		}
 		n := e.Name()
-		if !(strings.HasSuffix(n, ".vkey")) &&
-			!(strings.HasSuffix(n, ".skey")) {
+		if !strings.HasSuffix(n, ".vkey") &&
+			!strings.HasSuffix(n, ".skey") {
 			continue
 		}
 		p := filepath.Join(dir, n)

--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -111,9 +111,9 @@ type NodeLookup interface {
 	// /pools/extended) for the read-only browse/search screen.
 	Pools(ctx context.Context) ([]chain.PoolInfo, error)
 	DRep(ctx context.Context, drepID string) (chain.DRepInfo, error)
-	// DReps returns the node's full DRep directory (read node-locally from
-	// Dingo's metadata DB) for the read-only browse/search screen.
-	DReps(ctx context.Context) ([]chain.DRepInfo, error)
+	// DReps returns the node's full DRep directory (its paginated
+	// /governance/dreps list) for the read-only browse/search screen.
+	DReps(ctx context.Context) ([]chain.DRepListItem, error)
 	AssetAddresses(ctx context.Context, asset string) ([]chain.AssetAddress, error)
 	// Asset returns on-chain identity/metadata for a native asset (unit =
 	// policy ID + hex asset name). Most assets have no indexed on-chain
@@ -1497,9 +1497,9 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 	}))
 
 	// Read-only DRep directory: browse/search the delegated representatives the
-	// node has indexed, to inform vote-delegation. Node-local (read from Dingo's
-	// metadata DB, nothing leaves 127.0.0.1) — so, like the pool directory,
-	// there is deliberately NO external-consent gate. Search (q) and pagination
+	// node has indexed, to inform vote-delegation. Node-local (the embedded
+	// node's own list endpoint over loopback, nothing leaves 127.0.0.1) — so,
+	// like the pool directory, there is deliberately NO external-consent gate. Search (q) and pagination
 	// (page/count) are applied server-side over the node's list.
 	mux.HandleFunc("GET /wallet/dreps", gated(st, func(w http.ResponseWriter, r *http.Request) {
 		if lookup == nil {
@@ -1824,21 +1824,27 @@ func filterAndPagePools(pools []chain.PoolInfo, q, pageStr, countStr string) poo
 // node's DRep directory plus the total number of DReps that matched the search,
 // so the client can page through them.
 type drepDirectoryResponse struct {
-	DReps []chain.DRepInfo `json:"dreps"`
-	Total int              `json:"total"`
-	Page  int              `json:"page"`
-	Count int              `json:"count"`
+	DReps []chain.DRepListItem `json:"dreps"`
+	Total int                  `json:"total"`
+	Page  int                  `json:"page"`
+	Count int                  `json:"count"`
 }
 
 // filterAndPageDReps applies the read-only directory's server-side search and
 // pagination over the node's full DRep list. The search (q) is a
-// case-insensitive substring match against the DRep's bech32 id, hex
-// credential, and metadata anchor URL.
-func filterAndPageDReps(dreps []chain.DRepInfo, q, pageStr, countStr string) drepDirectoryResponse {
-	pageItems, total, page, count := filterAndPage(dreps, q, pageStr, countStr, func(d chain.DRepInfo, needle string) bool {
+// case-insensitive substring match against the DRep's bech32 id, CIP-129 hex
+// payload, and metadata anchor URL. Matching hex as a substring is what lets a
+// bare 28-byte credential — which is only the tail of the 29-byte CIP-129
+// payload the node reports — still find its DRep.
+func filterAndPageDReps(dreps []chain.DRepListItem, q, pageStr, countStr string) drepDirectoryResponse {
+	pageItems, total, page, count := filterAndPage(dreps, q, pageStr, countStr, func(d chain.DRepListItem, needle string) bool {
+		anchorURL := ""
+		if d.Metadata != nil {
+			anchorURL = d.Metadata.URL
+		}
 		return strings.Contains(strings.ToLower(d.DRepID), needle) ||
 			strings.Contains(strings.ToLower(d.Hex), needle) ||
-			strings.Contains(strings.ToLower(d.AnchorURL), needle)
+			strings.Contains(strings.ToLower(anchorURL), needle)
 	})
 	return drepDirectoryResponse{DReps: pageItems, Total: total, Page: page, Count: count}
 }

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -541,7 +542,7 @@ type fakeLookup struct {
 	poolsErr error
 	drep     chain.DRepInfo
 	drepErr  error
-	dreps    []chain.DRepInfo
+	dreps    []chain.DRepListItem
 	drepsErr error
 
 	asset    chain.AssetInfo
@@ -561,7 +562,7 @@ func (f *fakeLookup) DRep(_ context.Context, _ string) (chain.DRepInfo, error) {
 	return f.drep, f.drepErr
 }
 
-func (f *fakeLookup) DReps(_ context.Context) ([]chain.DRepInfo, error) {
+func (f *fakeLookup) DReps(_ context.Context) ([]chain.DRepListItem, error) {
 	return f.dreps, f.drepsErr
 }
 
@@ -686,10 +687,10 @@ func TestGetPoolDirectoryNilLookup(t *testing.T) {
 
 // drepDirectoryResult mirrors the GET /wallet/dreps JSON response for tests.
 type drepDirectoryResult struct {
-	DReps []chain.DRepInfo `json:"dreps"`
-	Total int              `json:"total"`
-	Page  int              `json:"page"`
-	Count int              `json:"count"`
+	DReps []chain.DRepListItem `json:"dreps"`
+	Total int                  `json:"total"`
+	Page  int                  `json:"page"`
+	Count int                  `json:"count"`
 }
 
 func decodeDRepDirectory(t *testing.T, rec *httptest.ResponseRecorder) drepDirectoryResult {
@@ -706,9 +707,14 @@ func drepDirHandler(lookup NodeLookup) http.Handler {
 }
 
 func TestGetDRepDirectory(t *testing.T) {
-	lookup := &fakeLookup{dreps: []chain.DRepInfo{
-		{DRepID: "drep1aaa", Hex: "aa", Amount: "1500000", Active: true, Registered: true, AnchorURL: "https://a.example/d.json"},
-		{DRepID: "drep1bbb", Hex: "bb", Amount: "0", HasScript: true},
+	lookup := &fakeLookup{dreps: []chain.DRepListItem{
+		{
+			DRepID:   "drep1aaa",
+			Hex:      "22aa",
+			Amount:   "1500000",
+			Metadata: &chain.DRepMetadata{URL: "https://a.example/d.json"},
+		},
+		{DRepID: "drep1bbb", Hex: "23bb", Amount: "0", HasScript: true, Retired: true},
 	}}
 	h := drepDirHandler(lookup)
 
@@ -721,15 +727,21 @@ func TestGetDRepDirectory(t *testing.T) {
 	if got.Total != 2 || len(got.DReps) != 2 || got.Page != 1 {
 		t.Fatalf("directory = %+v, want 2 dreps on page 1", got)
 	}
-	if got.DReps[0].DRepID != "drep1aaa" || got.DReps[0].Amount != "1500000" || !got.DReps[0].Active {
-		t.Fatalf("drep[0] = %+v, want drep1aaa with 1500000 voting power, active", got.DReps[0])
+	if got.DReps[0].DRepID != "drep1aaa" || got.DReps[0].Amount != "1500000" || got.DReps[0].Retired {
+		t.Fatalf("drep[0] = %+v, want drep1aaa with 1500000 voting power, not retired", got.DReps[0])
+	}
+	if got.DReps[0].Metadata == nil || got.DReps[0].Metadata.URL != "https://a.example/d.json" {
+		t.Fatalf("drep[0] metadata = %+v, want the anchor url", got.DReps[0].Metadata)
+	}
+	if !got.DReps[1].Retired {
+		t.Fatalf("drep[1] = %+v, want the retired entry", got.DReps[1])
 	}
 }
 
 func TestGetDRepDirectorySearchFilter(t *testing.T) {
-	lookup := &fakeLookup{dreps: []chain.DRepInfo{
-		{DRepID: "drep1aaa", Hex: "aa"},
-		{DRepID: "drep1bbb", Hex: "bb"},
+	lookup := &fakeLookup{dreps: []chain.DRepListItem{
+		{DRepID: "drep1aaa", Hex: "22aa"},
+		{DRepID: "drep1bbb", Hex: "23bb"},
 	}}
 	h := drepDirHandler(lookup)
 
@@ -741,6 +753,48 @@ func TestGetDRepDirectorySearchFilter(t *testing.T) {
 	got := decodeDRepDirectory(t, rec)
 	if got.Total != 1 || len(got.DReps) != 1 || got.DReps[0].DRepID != "drep1bbb" {
 		t.Fatalf("filtered directory = %+v, want only drep1bbb", got)
+	}
+}
+
+// The node's list reports hex as the 29-byte CIP-129 payload (1-byte header +
+// 28-byte credential), so a credential pasted from a tool that prints the bare
+// hash is a suffix of it rather than the whole field. Search must still find
+// both that and a pasted bech32 id.
+func TestGetDRepDirectorySearchMatchesPastedIDs(t *testing.T) {
+	const (
+		credential = "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+		drepID     = "drep1y2s6rgdp5xs6rgdp5xs6rgdp5xs6rgdp5xs6rgdp5xs6rgg68q7a8"
+	)
+	lookup := &fakeLookup{dreps: []chain.DRepListItem{
+		{
+			DRepID:   drepID,
+			Hex:      "22" + credential,
+			Metadata: &chain.DRepMetadata{URL: "https://a.example/drep.json"},
+		},
+		{DRepID: "drep1bbb", Hex: "23bb"},
+	}}
+	h := drepDirHandler(lookup)
+
+	for _, tc := range []struct {
+		name string
+		q    string
+	}{
+		{"bech32 id", drepID},
+		{"bare 28-byte credential hex", credential},
+		{"full cip-129 hex", "22" + credential},
+		{"metadata anchor url", "a.example"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/dreps?q="+url.QueryEscape(tc.q), nil))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("GET /wallet/dreps?q=%s = %d, want 200", tc.q, rec.Code)
+			}
+			got := decodeDRepDirectory(t, rec)
+			if got.Total != 1 || len(got.DReps) != 1 || got.DReps[0].DRepID != drepID {
+				t.Fatalf("search %q = %+v, want the single matching drep", tc.q, got)
+			}
+		})
 	}
 }
 
@@ -759,9 +813,9 @@ func TestGetDRepDirectoryEmpty(t *testing.T) {
 }
 
 func TestGetDRepDirectoryPageOverflow(t *testing.T) {
-	lookup := &fakeLookup{dreps: []chain.DRepInfo{
-		{DRepID: "drep1aaa", Hex: "aa"},
-		{DRepID: "drep1bbb", Hex: "bb"},
+	lookup := &fakeLookup{dreps: []chain.DRepListItem{
+		{DRepID: "drep1aaa", Hex: "22aa"},
+		{DRepID: "drep1bbb", Hex: "23bb"},
 	}}
 	h := drepDirHandler(lookup)
 
@@ -3458,7 +3512,7 @@ func (f *fakeNodeLookup) DRep(_ context.Context, _ string) (chain.DRepInfo, erro
 	return f.drep, f.drepErr
 }
 
-func (f *fakeNodeLookup) DReps(_ context.Context) ([]chain.DRepInfo, error) {
+func (f *fakeNodeLookup) DReps(_ context.Context) ([]chain.DRepListItem, error) {
 	return nil, chain.ErrNotFound
 }
 

--- a/ui/internal/chain/blockfrost.go
+++ b/ui/internal/chain/blockfrost.go
@@ -16,7 +16,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strconv"
 	"sync"
 	"time"
 
@@ -189,12 +188,39 @@ type DRepInfo struct {
 	Amount     string `json:"amount"`
 	Active     bool   `json:"active"`
 	LiveStake  string `json:"live_stake"`
-	// AnchorURL is the DRep's on-chain metadata anchor (a pointer to an
-	// off-chain document), when the node has one indexed. It is populated by
-	// the DReps directory listing (read from Dingo's local metadata DB); the
-	// single-DRep HTTP lookup leaves it empty. The wallet never fetches the
-	// URL — it is displayed as-is, so browsing stays node-local.
-	AnchorURL string `json:"anchor_url,omitempty"`
+}
+
+// DRepListItem is one entry of GET /api/v0/governance/dreps, the node's
+// paginated DRep directory. It is deliberately a separate type from DRepInfo:
+// the list reports CIP-1694 lifecycle status (retired/expired plus the epoch
+// the DRep was last active in) and a resolved CIP-119 anchor document, and it
+// has no registered/active/live_stake fields for DRepInfo to borrow.
+type DRepListItem struct {
+	// DRepID is the CIP-129 bech32 drep1… identifier, encoded by the node. The
+	// predefined targets appear as the literal strings "drep_always_abstain"
+	// and "drep_always_no_confidence", with an empty Hex.
+	DRepID string `json:"drep_id"`
+	// Hex is the CIP-129 payload — the 1-byte header (0x22 key hash, 0x23
+	// script hash) followed by the 28-byte credential — so a pasted bare
+	// credential is a suffix of it, not the whole string.
+	Hex             string        `json:"hex"`
+	Amount          string        `json:"amount"`
+	HasScript       bool          `json:"has_script"`
+	Retired         bool          `json:"retired"`
+	Expired         bool          `json:"expired"`
+	LastActiveEpoch *uint64       `json:"last_active_epoch"`
+	Metadata        *DRepMetadata `json:"metadata"`
+}
+
+// DRepMetadata is the DRep's resolved CIP-119 anchor document as reported by
+// the node's list. Only the anchor's identity is decoded: the directory
+// displays the URL (it never fetches it, so browsing stays node-local) and the
+// hash identifies the document it belongs to. The document body the node also
+// serves (json_metadata/bytes) is deliberately dropped here rather than
+// carried through the wallet's own API for a screen that does not render it.
+type DRepMetadata struct {
+	URL  string `json:"url"`
+	Hash string `json:"hash"`
 }
 
 // Genesis mirrors GET /api/v0/genesis: the network's immutable genesis
@@ -650,159 +676,15 @@ func (c *Client) DRep(ctx context.Context, drepID string) (DRepInfo, error) {
 	return out, err
 }
 
-// DReps returns the delegated representatives the embedded node has indexed, for
-// the read-only DRep-directory browser — the governance analogue of Pools. The
-// list is read directly from Dingo's local metadata DB (the same node-local
-// source AccountDRepID uses), never an external service. Dingo also serves a
-// paginated GET /api/v0/governance/dreps list whose entries carry
-// retired/expired status and resolved CIP-119 anchor metadata this local read
-// cannot derive; moving to it is tracked separately, since it changes the
-// directory's rows and status semantics. Voting power is enriched best-effort
-// from the same DB; if that aggregate (which reads internal account/utxo
-// tables) fails, the directory still lists every DRep with empty amounts rather
-// than failing outright. When no Dingo data dir is configured the directory is
-// empty.
-func (c *Client) DReps(ctx context.Context) ([]DRepInfo, error) {
-	if c.dingoDataDir == "" {
-		return nil, nil
-	}
-	metadataPath := filepath.Join(c.dingoDataDir, "metadata.sqlite")
-	if _, err := os.Stat(metadataPath); errors.Is(err, os.ErrNotExist) {
-		return nil, nil
-	} else if err != nil {
-		return nil, fmt.Errorf("drep directory: %w", err)
-	}
-	db, err := sql.Open("sqlite", sqliteReadOnlyDSN(metadataPath))
-	if err != nil {
-		return nil, fmt.Errorf("open drep directory metadata: %w", err)
-	}
-	defer db.Close()
-	db.SetMaxOpenConns(1)
-	db.SetMaxIdleConns(1)
-
-	// ORDER BY gives a stable row order so the directory's server-side paging
-	// (which slices this list by position) doesn't shift results between
-	// successive page requests.
-	rows, err := db.QueryContext(
-		ctx,
-		`SELECT credential_tag, credential, anchor_url, active FROM drep ORDER BY credential_tag, credential`,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("query drep directory: %w", err)
-	}
-	defer rows.Close()
-
-	var (
-		dreps []DRepInfo
-		keys  []string // power-map key per entry, in lockstep with dreps
-	)
-	for rows.Next() {
-		var (
-			tag    uint8
-			cred   []byte
-			anchor sql.NullString
-			active bool
-		)
-		if err := rows.Scan(&tag, &cred, &anchor, &active); err != nil {
-			return nil, fmt.Errorf("scan drep row: %w", err)
-		}
-		if len(cred) != lcommon.AddressHashSize {
-			continue // skip predefined/malformed credentials
-		}
-		id, err := drepBech32(tag, cred)
-		if err != nil {
-			continue
-		}
-		hexCred := hex.EncodeToString(cred)
-		dreps = append(dreps, DRepInfo{
-			DRepID:     id,
-			Hex:        hexCred,
-			HasScript:  tag == dingoAccountCredentialScript,
-			Registered: active,
-			Active:     active,
-			AnchorURL:  anchor.String,
-		})
-		keys = append(keys, drepPowerKey(tag, hexCred))
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate drep rows: %w", err)
-	}
-
-	// Enrich with voting power (best-effort — see method doc).
-	if powers, perr := drepVotingPowers(ctx, db); perr == nil {
-		for i := range dreps {
-			amount := powers[keys[i]] // absent → "" → "0" below
-			if amount == "" {
-				amount = "0"
-			}
-			dreps[i].Amount = amount
-			dreps[i].LiveStake = amount
-		}
-	}
-	return dreps, nil
-}
-
-// drepVotingPowers sums each DRep's delegated voting power (delegators' UTxO
-// lovelace + rewards) from Dingo's local metadata DB, keyed by drepPowerKey. It
-// mirrors Dingo's own GetDRepVotingPower aggregate but batches every DRep in one
-// pass. Only credential-based DReps (drep_type 0 key / 1 script) have power;
-// the predefined abstain/no-confidence targets are excluded.
-func drepVotingPowers(ctx context.Context, db *sql.DB) (map[string]string, error) {
-	rows, err := db.QueryContext(ctx, `
-		SELECT a.drep_type AS tag, a.drep AS cred,
-		       COALESCE(SUM(COALESCE(u.utxo_sum, 0) + COALESCE(CAST(a.reward AS INTEGER), 0)), 0) AS power
-		FROM account a
-		LEFT JOIN (
-			SELECT credential_tag, staking_key,
-			       COALESCE(SUM(CAST(amount AS INTEGER)), 0) AS utxo_sum
-			FROM utxo
-			WHERE deleted_slot = 0
-			GROUP BY credential_tag, staking_key
-		) u ON u.credential_tag = a.credential_tag AND u.staking_key = a.staking_key
-		WHERE a.active = 1 AND a.drep IS NOT NULL AND a.drep_type IN (0, 1)
-		GROUP BY a.drep, a.drep_type`)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	out := make(map[string]string)
-	for rows.Next() {
-		var (
-			tag   uint8
-			cred  []byte
-			power uint64
-		)
-		if err := rows.Scan(&tag, &cred, &power); err != nil {
-			return nil, err
-		}
-		out[drepPowerKey(tag, hex.EncodeToString(cred))] = strconv.FormatUint(power, 10)
-	}
-	return out, rows.Err()
-}
-
-func drepPowerKey(tag uint8, hexCred string) string {
-	return strconv.Itoa(int(tag)) + ":" + hexCred
-}
-
-// drepBech32 encodes a DRep credential (Dingo's credential_tag plus the 28-byte
-// hash) as a CIP-129 bech32 drep1… identifier. The header byte is produced by
-// gouroboros' Drep.String — the same encoder the delegation builder's
-// lcommon.Drep values use — rather than a local constant, so the directory
-// cannot disagree with the identifiers the wallet builds and the node parses.
-// CIP-129 fixes the high nibble at 0x2 for a DRep and puts the credential type
-// in the low nibble (0x2 key hash, 0x3 script hash), i.e. 0x22 and 0x23; Dingo
-// rejects any other high nibble outright ("invalid DRep voter type").
-func drepBech32(tag uint8, hash []byte) (string, error) {
-	drep := lcommon.Drep{Credential: hash}
-	switch tag {
-	case dingoAccountCredentialKeyHash:
-		drep.Type = lcommon.DrepTypeAddrKeyHash
-	case dingoAccountCredentialScript:
-		drep.Type = lcommon.DrepTypeScriptHash
-	default:
-		return "", fmt.Errorf("drep credential: unknown tag %d", tag)
-	}
-	return drep.String(), nil
+// DReps returns the delegated representatives the node has indexed, for the
+// read-only DRep-directory browser — the governance analogue of Pools. It reads
+// the node's paginated GET /api/v0/governance/dreps list over loopback, the
+// same stable HTTP contract the rest of this client uses, rather than Dingo's
+// private metadata schema. The list is the only source that reports CIP-1694
+// retired/expired status and resolved CIP-119 anchor metadata, so the directory
+// can tell a deregistered DRep from one that merely stopped voting.
+func (c *Client) DReps(ctx context.Context) ([]DRepListItem, error) {
+	return getAllPages[DRepListItem](ctx, c, "/api/v0/governance/dreps")
 }
 
 // Genesis fetches the network's genesis parameters from the embedded node.

--- a/ui/internal/chain/blockfrost_test.go
+++ b/ui/internal/chain/blockfrost_test.go
@@ -1,7 +1,6 @@
 package chain
 
 import (
-	"bytes"
 	"context"
 	"database/sql"
 	"encoding/hex"
@@ -531,145 +530,124 @@ func TestDRepNotFound(t *testing.T) {
 	}
 }
 
-func TestDRepsFromDingoMetadata(t *testing.T) {
-	dir := t.TempDir()
-	db, err := sql.Open("sqlite", filepath.Join(dir, "metadata.sqlite"))
-	if err != nil {
-		t.Fatalf("open sqlite: %v", err)
-	}
-	defer db.Close()
-	for _, ddl := range []string{
-		`CREATE TABLE drep (
-			credential_tag integer NOT NULL,
-			credential blob NOT NULL,
-			anchor_url text,
-			active boolean NOT NULL
-		)`,
-		`CREATE TABLE account (
-			credential_tag integer NOT NULL,
-			staking_key blob NOT NULL,
-			drep blob,
-			drep_type integer,
-			active boolean NOT NULL,
-			reward integer
-		)`,
-		`CREATE TABLE utxo (
-			credential_tag integer NOT NULL,
-			staking_key blob NOT NULL,
-			amount integer NOT NULL,
-			deleted_slot integer NOT NULL
-		)`,
-	} {
-		if _, err := db.Exec(ddl); err != nil {
-			t.Fatalf("create table: %v", err)
+func TestDRepsFromNodeList(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q", r.Method)
 		}
-	}
-
-	credA := make([]byte, lcommon.AddressHashSize) // key-hash DRep with delegators
-	credB := make([]byte, lcommon.AddressHashSize) // script-hash DRep, no delegators
-	for i := range credA {
-		credA[i] = 0xa1
-		credB[i] = 0xb2
-	}
-	if _, err := db.Exec(
-		`INSERT INTO drep (credential_tag, credential, anchor_url, active) VALUES (?, ?, ?, 1), (?, ?, ?, 1)`,
-		dingoAccountCredentialKeyHash, credA, "https://example.com/drep.json",
-		dingoAccountCredentialScript, credB, "",
-	); err != nil {
-		t.Fatalf("insert drep: %v", err)
-	}
-	// A short/malformed credential and an unknown credential_tag must both be
-	// skipped rather than surfaced (or cause an error).
-	if _, err := db.Exec(
-		`INSERT INTO drep (credential_tag, credential, anchor_url, active) VALUES (?, ?, ?, 1), (?, ?, ?, 1)`,
-		dingoAccountCredentialKeyHash, []byte{0xc3, 0xc3}, "",
-		byte(99), bytes.Repeat([]byte{0xc4}, lcommon.AddressHashSize), "",
-	); err != nil {
-		t.Fatalf("insert skip-path drep rows: %v", err)
-	}
-	// One delegator to DRep A: 1_000_000 lovelace of UTxO + 500_000 reward.
-	stakingKey := make([]byte, lcommon.AddressHashSize)
-	for i := range stakingKey {
-		stakingKey[i] = byte(i + 1)
-	}
-	if _, err := db.Exec(
-		`INSERT INTO account (credential_tag, staking_key, drep, drep_type, active, reward) VALUES (?, ?, ?, ?, 1, 500000)`,
-		dingoAccountCredentialKeyHash, stakingKey, credA, dingoDRepTypeAddrKeyHash,
-	); err != nil {
-		t.Fatalf("insert account: %v", err)
-	}
-	if _, err := db.Exec(
-		`INSERT INTO utxo (credential_tag, staking_key, amount, deleted_slot) VALUES (?, ?, 1000000, 0)`,
-		dingoAccountCredentialKeyHash, stakingKey,
-	); err != nil {
-		t.Fatalf("insert utxo: %v", err)
-	}
-
-	c := NewClientURL("http://127.0.0.1:1", WithDingoDataDir(dir))
+		if r.URL.Path != "/api/v0/governance/dreps" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("count"); got != fmt.Sprintf("%d", pageSize) {
+			t.Errorf("count = %q, want %d", got, pageSize)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Shape of dingo's GET /api/v0/governance/dreps list: CIP-129
+		// drep_id, 29-byte hex payload, epoch-based retired/expired status
+		// and a resolved CIP-119 anchor document. Note there is no "active"
+		// or "registered" field — status is derived from retired/expired.
+		_, _ = w.Write([]byte(`[
+			{"drep_id":"drep1aaa","hex":"22aaaa","amount":"1500000","has_script":false,"retired":false,"expired":false,"last_active_epoch":42,"metadata":{"url":"https://example.com/drep.json","hash":"cafe","json_metadata":{"body":{"givenName":"A"}},"bytes":"00"}},
+			{"drep_id":"drep1bbb","hex":"23bbbb","amount":"0","has_script":true,"retired":true,"expired":false,"last_active_epoch":null,"metadata":null},
+			{"drep_id":"drep_always_abstain","hex":"","amount":"7000000","has_script":false,"retired":false,"expired":false,"last_active_epoch":null,"metadata":null}
+		]`))
+	})
 	got, err := c.DReps(context.Background())
 	if err != nil {
 		t.Fatalf("DReps: %v", err)
 	}
-	if len(got) != 2 {
-		t.Fatalf("DReps returned %d dreps, want 2 (the short credential and unknown credential_tag rows must be skipped)", len(got))
-	}
-	byHex := map[string]DRepInfo{}
-	for _, d := range got {
-		byHex[d.Hex] = d
-	}
-	a, ok := byHex[hex.EncodeToString(credA)]
-	if !ok {
-		t.Fatalf("DRep A (%x) missing from %+v", credA, got)
-	}
-	if !strings.HasPrefix(a.DRepID, "drep1") || a.HasScript || !a.Active || !a.Registered {
-		t.Fatalf("DRep A = %+v, want drep1… key-hash, active/registered", a)
-	}
-	if a.Amount != "1500000" || a.LiveStake != "1500000" {
-		t.Fatalf("DRep A voting power = %q, want 1500000", a.Amount)
-	}
-	if a.AnchorURL != "https://example.com/drep.json" {
-		t.Fatalf("DRep A anchor = %q, want the inserted url", a.AnchorURL)
-	}
-	// Pinned literal CIP-129 identifiers, not a round-trip: a round-trip
-	// through this package's own encoder agrees with itself even when the
-	// header byte names the wrong entity. CIP-129 fixes a DRep's high nibble at
-	// 0x2 and puts the credential type in the low nibble (0x2 key hash, 0x3
-	// script hash), so a key DRep's header is 0x22 and a script DRep's is 0x23.
-	// Both strings below are bech32("drep", header || credential) computed from
-	// the CIP-129 header table with a reference bech32 implementation checked
-	// against the CIP's own published vector
-	// (0x22 || 28 zero bytes = drep1ygqqqq…7vlc9n). Dingo rejects any other
-	// high nibble outright ("invalid DRep voter type"), so an id emitted with,
-	// say, 0x33 still decodes as bech32 but fails the node's DRep lookup and
-	// the delegation the directory tells users to paste it into.
-	const (
-		wantDRepAID = "drep1y2s6rgdp5xs6rgdp5xs6rgdp5xs6rgdp5xs6rgdp5xs6rgg68q7a8"
-		wantDRepBID = "drep1ywet9v4jk2et9v4jk2et9v4jk2et9v4jk2et9v4jk2et9vsjgaa4a"
-	)
-	if a.DRepID != wantDRepAID {
-		t.Fatalf("DRep A (key hash) id = %q, want %q (CIP-129 header 0x22)", a.DRepID, wantDRepAID)
+	if len(got) != 3 {
+		t.Fatalf("DReps returned %d dreps, want 3", len(got))
 	}
 
-	b, ok := byHex[hex.EncodeToString(credB)]
-	if !ok {
-		t.Fatalf("DRep B (%x) missing from %+v", credB, got)
+	a := got[0]
+	if a.DRepID != "drep1aaa" || a.Hex != "22aaaa" || a.HasScript {
+		t.Fatalf("drep[0] = %+v, want the key-hash drep1aaa entry", a)
 	}
-	if !b.HasScript || b.Amount != "0" {
-		t.Fatalf("DRep B = %+v, want script-hash with zero voting power", b)
+	if a.Amount != "1500000" {
+		t.Fatalf("drep[0] voting power = %q, want 1500000", a.Amount)
 	}
-	if b.DRepID != wantDRepBID {
-		t.Fatalf("DRep B (script hash) id = %q, want %q (CIP-129 header 0x23, not 0x33)", b.DRepID, wantDRepBID)
+	if a.Retired || a.Expired {
+		t.Fatalf("drep[0] = %+v, want neither retired nor expired", a)
+	}
+	if a.LastActiveEpoch == nil || *a.LastActiveEpoch != 42 {
+		t.Fatalf("drep[0] last active epoch = %v, want 42", a.LastActiveEpoch)
+	}
+	if a.Metadata == nil || a.Metadata.URL != "https://example.com/drep.json" {
+		t.Fatalf("drep[0] metadata = %+v, want the anchor url", a.Metadata)
+	}
+	if a.Metadata.Hash != "cafe" {
+		t.Fatalf("drep[0] metadata hash = %q, want cafe", a.Metadata.Hash)
+	}
+
+	b := got[1]
+	if !b.Retired || !b.HasScript {
+		t.Fatalf("drep[1] = %+v, want a retired script-hash drep", b)
+	}
+	if b.LastActiveEpoch != nil {
+		t.Fatalf("drep[1] last active epoch = %v, want nil", b.LastActiveEpoch)
+	}
+	if b.Metadata != nil {
+		t.Fatalf("drep[1] metadata = %+v, want nil for a drep with no anchor", b.Metadata)
+	}
+
+	// The predefined targets are part of the node's list (interleaved at the
+	// position of their first delegation) and carry real voting power. The
+	// client passes them through; the directory screen decides how to render
+	// them.
+	p := got[2]
+	if p.DRepID != "drep_always_abstain" || p.Hex != "" || p.Amount != "7000000" {
+		t.Fatalf("drep[2] = %+v, want the predefined abstain entry with its voting power", p)
 	}
 }
 
-func TestDRepsNoDataDir(t *testing.T) {
-	c := NewClientURL("http://127.0.0.1:1")
+func TestDRepsPagesThroughNodeList(t *testing.T) {
+	pages := 0
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		pages++
+		if r.URL.Path != "/api/v0/governance/dreps" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		rows := []DRepListItem{{DRepID: "drep1last"}}
+		if r.URL.Query().Get("page") == "1" {
+			rows = make([]DRepListItem, pageSize)
+			for i := range rows {
+				rows[i] = DRepListItem{DRepID: fmt.Sprintf("drep1%03d", i)}
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(rows); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	})
 	got, err := c.DReps(context.Background())
 	if err != nil {
-		t.Fatalf("DReps without data dir: %v", err)
+		t.Fatalf("DReps: %v", err)
 	}
-	if len(got) != 0 {
-		t.Fatalf("DReps without data dir = %+v, want empty", got)
+	if len(got) != pageSize+1 {
+		t.Fatalf("DReps returned %d dreps, want %d across both pages", len(got), pageSize+1)
+	}
+	if got[pageSize].DRepID != "drep1last" {
+		t.Fatalf("last drep = %q, want the page-2 entry", got[pageSize].DRepID)
+	}
+	if pages != 2 {
+		t.Fatalf("requests = %d, want 2", pages)
+	}
+}
+
+// The directory reads the node's HTTP list, so it must work with no Dingo data
+// directory configured — it no longer opens Dingo's private metadata schema.
+func TestDRepsWithoutDingoDataDir(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"drep_id":"drep1aaa","hex":"22aaaa","amount":"1","metadata":null}]`))
+	})
+	got, err := c.DReps(context.Background())
+	if err != nil {
+		t.Fatalf("DReps: %v", err)
+	}
+	if len(got) != 1 || got[0].DRepID != "drep1aaa" {
+		t.Fatalf("DReps = %+v, want the node's single entry without a data dir", got)
 	}
 }
 

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -263,10 +263,9 @@ export interface PoolDirectoryResponse {
   count: number;
 }
 
-// DRepInfo mirrors GET /wallet/drep/{id} and one entry of the GET /wallet/dreps
-// directory: a node-verified DRep readout. amount / live_stake are the DRep's
-// voting power as decimal lovelace strings. anchor_url is the on-chain metadata
-// pointer, present only in the directory listing (the wallet never fetches it).
+// DRepInfo mirrors GET /wallet/drep/{id}: a node-verified readout of a single
+// DRep, used to confirm a pasted id before delegating. amount / live_stake are
+// the DRep's voting power as decimal lovelace strings.
 export interface DRepInfo {
   drep_id: string;
   hex: string;
@@ -275,14 +274,43 @@ export interface DRepInfo {
   amount: string;
   active: boolean;
   live_stake: string;
-  anchor_url?: string;
+}
+
+// DRepMetadata is the DRep's resolved CIP-119 anchor document as reported by
+// the node. Only its identity is carried: the directory displays the URL (it
+// never fetches it) and the hash names the document.
+export interface DRepMetadata {
+  url: string;
+  hash: string;
+}
+
+// DRepListItem is one entry of the GET /wallet/dreps directory, which the
+// wallet reads from the node's own paginated DRep list. It is NOT DRepInfo:
+// there is no single "active" flag here. CIP-1694 status is two independent
+// facts — retired (deregistered) and expired (registered, but silent past the
+// node's DRep inactivity period) — plus the epoch the DRep last acted in.
+//
+// hex is the CIP-129 payload: a 1-byte header (0x22 key hash / 0x23 script
+// hash) followed by the 28-byte credential, so a bare credential is its
+// suffix. The predefined targets ("drep_always_abstain",
+// "drep_always_no_confidence") appear with an empty hex and no metadata.
+export interface DRepListItem {
+  drep_id: string;
+  hex: string;
+  amount: string;
+  has_script: boolean;
+  retired: boolean;
+  expired: boolean;
+  last_active_epoch: number | null;
+  metadata: DRepMetadata | null;
 }
 
 // DRepDirectoryResponse mirrors GET /wallet/dreps: one page of the node's DRep
-// directory (read node-locally from Dingo's metadata DB) plus the total number
-// of DReps matching the search, for the read-only browse/search screen.
+// directory (read node-locally from the embedded node's list endpoint) plus the
+// total number of DReps matching the search, for the read-only browse/search
+// screen.
 export interface DRepDirectoryResponse {
-  dreps: DRepInfo[];
+  dreps: DRepListItem[];
   total: number;
   page: number;
   count: number;

--- a/ui/web/src/screens/DRepDirectory.test.tsx
+++ b/ui/web/src/screens/DRepDirectory.test.tsx
@@ -1,30 +1,58 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { DRepDirectory } from "./DRepDirectory";
 import * as client from "../api/client";
-import type { DRepInfo, DRepDirectoryResponse } from "../api/types";
+import type { DRepListItem, DRepDirectoryResponse } from "../api/types";
 
-const DREP_A: DRepInfo = {
+const DREP_A: DRepListItem = {
   drep_id: "drep1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0001",
-  hex: "aa",
+  hex: "22aa",
   has_script: false,
-  registered: true,
   amount: "1500000000",
-  active: true,
-  live_stake: "1500000000",
-  anchor_url: "https://example.com/drep-a.json",
+  retired: false,
+  expired: false,
+  last_active_epoch: 512,
+  metadata: { url: "https://example.com/drep-a.json", hash: "cafe" },
 };
 
-const DREP_B: DRepInfo = {
+const DREP_B: DRepListItem = {
   drep_id: "drep1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0002",
-  hex: "bb",
+  hex: "23bb",
   has_script: true,
-  registered: false,
   amount: "0",
-  active: false,
-  live_stake: "0",
+  retired: true,
+  expired: false,
+  last_active_epoch: null,
+  metadata: null,
 };
 
-function directory(dreps: DRepInfo[], overrides?: Partial<DRepDirectoryResponse>): DRepDirectoryResponse {
+// Registered, but past the node's DRep inactivity period without voting: the
+// row the old `active` column rendered as "Active".
+const DREP_EXPIRED: DRepListItem = {
+  drep_id: "drep1cccccccccccccccccccccccccccccccccccccccccccccccccc0003",
+  hex: "22cc",
+  has_script: false,
+  amount: "9000000",
+  retired: false,
+  expired: true,
+  last_active_epoch: 480,
+  metadata: null,
+};
+
+// One of the two predefined targets the node interleaves into its list. It has
+// no bech32 id and no credential hex, and is chosen in Staking rather than by
+// pasting an id.
+const DREP_ABSTAIN: DRepListItem = {
+  drep_id: "drep_always_abstain",
+  hex: "",
+  has_script: false,
+  amount: "7000000000",
+  retired: false,
+  expired: false,
+  last_active_epoch: null,
+  metadata: null,
+};
+
+function directory(dreps: DRepListItem[], overrides?: Partial<DRepDirectoryResponse>): DRepDirectoryResponse {
   return { dreps, total: dreps.length, page: 1, count: 50, ...overrides };
 }
 
@@ -37,14 +65,63 @@ test("lists DReps read from the node with formatted voting power and status", as
 
   render(<DRepDirectory network="preview" />);
 
-  // 1500000000 lovelace → 1,500 ADA (grouped); active/inactive statuses shown.
+  // 1500000000 lovelace → 1,500 ADA (grouped).
   expect(await screen.findByText("1,500")).toBeInTheDocument();
-  expect(screen.getByText("Active")).toBeInTheDocument();
-  expect(screen.getByText("Inactive")).toBeInTheDocument();
+  expect(screen.getByText("Registered")).toBeInTheDocument();
+  expect(screen.getByText("Retired")).toBeInTheDocument();
   // Copy affordance carries the full (untruncated) drep id.
   expect(
     screen.getByRole("button", { name: `Copy drep id ${DREP_A.drep_id}` }),
   ).toBeInTheDocument();
+});
+
+test("distinguishes registered, retired and expired DReps", async () => {
+  // The node's list has no single "active" flag: a DRep that registered and
+  // then stopped voting is still registered but expired under CIP-1694, and
+  // must not read the same as one that deregistered.
+  vi.spyOn(client, "getDReps").mockResolvedValue(
+    directory([DREP_A, DREP_B, DREP_EXPIRED]),
+  );
+
+  render(<DRepDirectory network="preview" />);
+
+  expect(await screen.findByText("Registered")).toBeInTheDocument();
+  expect(screen.getByText("Retired")).toBeInTheDocument();
+  const expired = screen.getByText("Expired");
+  expect(expired).toBeInTheDocument();
+  // The epoch it was last active in is what tells an operator how stale it is.
+  expect(expired).toHaveAttribute("title", expect.stringContaining("480"));
+});
+
+test("shows the metadata anchor the node resolved, without fetching it", async () => {
+  vi.spyOn(client, "getDReps").mockResolvedValue(directory([DREP_A, DREP_B]));
+
+  render(<DRepDirectory network="preview" />);
+
+  const anchor = await screen.findByTitle("https://example.com/drep-a.json");
+  expect(anchor).toBeInTheDocument();
+  // It is display-only text, never a link the user can follow from here.
+  expect(anchor.closest("a")).toBeNull();
+  // A DRep with no anchor renders a placeholder rather than an empty cell.
+  expect(screen.getByText("—")).toBeInTheDocument();
+});
+
+test("renders the predefined DReps as targets chosen in Staking", async () => {
+  vi.spyOn(client, "getDReps").mockResolvedValue(directory([DREP_ABSTAIN]));
+
+  render(<DRepDirectory network="preview" />);
+
+  // Listed deliberately: they carry real delegated voting power (7,000 ADA
+  // here), so hiding them would understate what the node indexed.
+  expect(await screen.findByText("drep_always_abstain")).toBeInTheDocument();
+  expect(screen.getByText("7,000")).toBeInTheDocument();
+  expect(screen.getByText("Predefined")).toBeInTheDocument();
+  // They have no on-chain registration to look up and no id worth pasting —
+  // Staking offers them as their own options — so neither affordance is shown.
+  expect(
+    screen.queryByRole("button", { name: /copy drep id/i }),
+  ).not.toBeInTheDocument();
+  expect(screen.queryByRole("link")).not.toBeInTheDocument();
 });
 
 test("search box queries the node server-side with the typed term", async () => {
@@ -53,7 +130,7 @@ test("search box queries the node server-side with the typed term", async () => 
     .mockResolvedValue(directory([DREP_A]));
 
   render(<DRepDirectory network="preview" />);
-  await screen.findByText("Active");
+  await screen.findByText("Registered");
 
   getDReps.mockResolvedValue(directory([DREP_B]));
   fireEvent.change(screen.getByLabelText(/search by drep id/i), {
@@ -111,7 +188,7 @@ test("mentions the Delegate shortcut in the intro copy when it is available", as
   vi.spyOn(client, "getDReps").mockResolvedValue(directory([DREP_A]));
 
   const { container } = render(<DRepDirectory network="preview" />);
-  await screen.findByText("Active");
+  await screen.findByText("Registered");
 
   const helperText = container.querySelector(".helper-text")?.textContent ?? "";
   expect(helperText).toMatch(/or use Delegate\.$/);

--- a/ui/web/src/screens/DRepDirectory.tsx
+++ b/ui/web/src/screens/DRepDirectory.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import type { DRepDirectoryResponse } from "../api/types";
+import type { DRepDirectoryResponse, DRepListItem } from "../api/types";
 import { getDReps } from "../api/client";
 import { Card } from "../components/Card";
 import { Input } from "../components/Input";
@@ -24,6 +24,42 @@ function shortId(id: string): string {
 function power(amount: string): string {
   if (!amount) return "—";
   return formatAda(amount);
+}
+
+// The two predefined voting targets. The node interleaves them into its DRep
+// list at the position of their first delegation, with an empty hex and no
+// metadata. They are real delegation targets carrying real voting power, so
+// the directory lists them — but they have no on-chain registration to look up
+// and no id worth pasting: Staking offers them as their own options.
+const PREDEFINED_DREP_IDS = new Set([
+  "drep_always_abstain",
+  "drep_always_no_confidence",
+]);
+
+// CIP-1694 status. The node reports two independent facts rather than one
+// "active" flag: retired means the DRep deregistered, expired means it is
+// still registered but has not acted within the node's DRep inactivity period.
+// Retired is the terminal one, so it wins when both are set.
+function status(d: DRepListItem): { label: string; title?: string } {
+  if (PREDEFINED_DREP_IDS.has(d.drep_id)) {
+    return {
+      label: "Predefined",
+      title: "A predefined voting target — choose it directly in Staking.",
+    };
+  }
+  if (d.retired) {
+    return { label: "Retired", title: "Deregistered on chain." };
+  }
+  if (d.expired) {
+    return {
+      label: "Expired",
+      title:
+        d.last_active_epoch === null
+          ? "Registered, but inactive past the node's DRep inactivity period."
+          : `Registered, but inactive since epoch ${d.last_active_epoch}.`,
+    };
+  }
+  return { label: "Registered" };
 }
 
 const DREP_COLUMNS = [
@@ -91,33 +127,45 @@ export function DRepDirectory({ network, canDelegate = true }: DRepDirectoryProp
   const hasPrev = page > 1;
   const hasNext = page < pageCount;
 
-  const rows = dreps.map((d) => ({
-    drep: (
-      <span className="pool-id-cell">
-        <code>{shortId(d.drep_id)}</code>
-        <ExplorerLink network={network} kind="drep" id={d.drep_id} />
-      </span>
-    ),
-    power: power(d.amount),
-    status: d.active ? "Active" : "Inactive",
-    metadata: d.anchor_url ? (
-      <span className="muted" title={d.anchor_url}>
-        {shortId(d.anchor_url)}
-      </span>
-    ) : (
-      "—"
-    ),
-    actions: (
-      <span className="pool-id-cell">
-        <CopyButton value={d.drep_id} aria-label={`Copy drep id ${d.drep_id}`} />
-        {canDelegate && (
-          <Button variant="ghost" onClick={() => navigate("staking")}>
-            Delegate
-          </Button>
-        )}
-      </span>
-    ),
-  }));
+  const rows = dreps.map((d) => {
+    const predefined = PREDEFINED_DREP_IDS.has(d.drep_id);
+    const { label, title } = status(d);
+    const anchorURL = d.metadata?.url ?? "";
+    return {
+      drep: (
+        <span className="pool-id-cell">
+          <code>{shortId(d.drep_id)}</code>
+          {/* A predefined target has no on-chain credential, so there is
+              nothing for an explorer to resolve. */}
+          {!predefined && <ExplorerLink network={network} kind="drep" id={d.drep_id} />}
+        </span>
+      ),
+      power: power(d.amount),
+      status: <span title={title}>{label}</span>,
+      metadata: anchorURL ? (
+        <span className="muted" title={anchorURL}>
+          {shortId(anchorURL)}
+        </span>
+      ) : (
+        "—"
+      ),
+      actions: (
+        <span className="pool-id-cell">
+          {/* "drep_always_abstain" is not an id Staking accepts in its DRep
+              field — it is a separate option there — so copying it would hand
+              the user a value that cannot be pasted anywhere. */}
+          {!predefined && (
+            <CopyButton value={d.drep_id} aria-label={`Copy drep id ${d.drep_id}`} />
+          )}
+          {canDelegate && (
+            <Button variant="ghost" onClick={() => navigate("staking")}>
+              Delegate
+            </Button>
+          )}
+        </span>
+      ),
+    };
+  });
 
   return (
     <div className="send-form">


### PR DESCRIPTION
`chain.DReps` read Dingo's private metadata schema directly — the `drep`, `account` and `utxo` tables — and re-implemented the node's voting-power aggregate in ~120 lines of hand-written SQL. Dingo already serves the same data over `GET /api/v0/governance/dreps`, so the directory now reads that list through `getAllPages`, exactly as `Pools()` reads `/pools/extended`. Net −160/+42 lines in the client.

The local read was also wrong about status: it mapped both `Registered` and `Active` from `drep.active`, which only tracks registration. A DRep that registered and then went silent past the node's inactivity period is `active = 1` in that table but expired under CIP-1694, and the directory called it "Active". The node's list reports `retired` and `expired` independently.

## What changed

- **`chain.DRepListItem` / `chain.DRepMetadata`** — a type of its own for the directory, separate from the `DRepInfo` the single-DRep lookup returns. The list has no `registered`/`active`/`live_stake` for `DRepInfo` to borrow, and conflating the two is what produced the wrong status. `DRepInfo.AnchorURL` goes away with it (only the directory ever set it).
- **Status column** now distinguishes Registered / Retired / Expired, and names the last active epoch in the title when a DRep expired.
- **Predefined targets** (`drep_always_abstain`, `drep_always_no_confidence`) are listed deliberately — they carry real delegated voting power — but without an explorer link or a copy button: they have no on-chain credential, and Staking offers them as its own options rather than as an id to paste.
- **`hex`** is now the 29-byte CIP-129 payload (header + credential) rather than the bare 28-byte hash. Search still finds a pasted bare credential because it is a suffix of that payload; a table test pins all four ways a user can paste an id.
- **`anchor_url` → `metadata.url`**, resolved by the node from the CIP-119 anchor. Only `url` and `hash` cross the client boundary; the document body the node also serves is dropped rather than shipped to a screen that does not render it.
- bursa's own CIP-129 bech32 encoder (`drepBech32`) is gone along with `drepVotingPowers`/`drepPowerKey` — the node encodes the identifiers now.

## Screenshots

Every status in one table — Registered, Predefined, Expired, Retired. The predefined rows deliberately carry no explorer link and no copy button.

![DRep Directory listing every status](https://raw.githubusercontent.com/chrisguiney/bursa/6e936fd4e26b87050f29666be196faaa3eb5d949/screenshots/01-dreps-directory.png)

Searching a pasted bare 28-byte credential still finds its DRep, now that `hex` is the 29-byte CIP-129 payload it is only the tail of.

![Search by a pasted bare credential hex](https://raw.githubusercontent.com/chrisguiney/bursa/6e936fd4e26b87050f29666be196faaa3eb5d949/screenshots/02-search-bare-credential.png)

Taken against the real screen driven by `api/client.ts`, with a stub answering `/wallet/dreps` so all four statuses appear together — a real node's page 1 would not show them in one view.

## Acceptance criteria

- [x] `chain.DReps` reads `GET /api/v0/governance/dreps` through `getAllPages`; the `drep`/`account`/`utxo` SQL, `drepVotingPowers`, `drepPowerKey` and `drepBech32` are removed
- [x] Status column distinguishes registered, retired and expired
- [x] Predefined DReps rendered deliberately, with a test
- [x] Directory search still matches a pasted bech32 id and a pasted 28-byte credential hex
- [x] Screenshots for the changed table

## Tests

Written first, confirmed failing, then made to pass.

- `TestDRepsFromNodeList`, `TestDRepsPagesThroughNodeList`, `TestDRepsWithoutDingoDataDir` (the last pins that the directory no longer needs a Dingo data dir)
- `TestGetDRepDirectorySearchMatchesPastedIDs` — bech32 id, bare 28-byte credential, full CIP-129 hex, anchor URL
- `DRepDirectory.test.tsx` — status distinction incl. the expired-epoch title, metadata anchor rendered without a link, predefined row without copy/explorer affordances

Verified: `go test -race` (chain + api) and the full `ui` module green; `npm run test` 803/803 on Node 22 (matching CI — Node 26 breaks jsdom globals on this repo, on main as well); `tsc --noEmit`, `eslint` (0 errors), `npm run build`, `golangci-lint run ./...` on both modules clean.

## Second commit

`style: drop redundant parens gofumpt now flags` touches `bursa.go`, which this change otherwise leaves alone. CI resolves golangci-lint `latest`, which moved to v2.13.0; its gofumpt rejects the parenthesized operands in `LoadWalletDir`'s suffix check. Main is green only because its last lint run predates that release — every PR fails `lint` until this lands. Happy to split it out if you would rather take it separately.

Closes blinklabs-io/bursa#715