### PR TITLE
style: satisfy gofumpt in loadKeysFromDir

### DIFF
--- a/bursa.go
+++ b/bursa.go
@@ -2717,8 +2717,8 @@ func LoadWalletDir(dir string, showSecrets bool) ([]*LoadedKey, error) {
 			continue
 		}
 		n := e.Name()
-		if !(strings.HasSuffix(n, ".vkey")) &&
-			!(strings.HasSuffix(n, ".skey")) {
+		if !strings.HasSuffix(n, ".vkey") &&
+			!strings.HasSuffix(n, ".skey") {
 			continue
 		}
 		p := filepath.Join(dir, n)


### PR DESCRIPTION
## Problem

The `lint` job fails on #717, which touches only workflows, the Makefile, a
packaging script, and `vite.config.ts` — no Go code:

```
bursa.go:2720:1: File is not properly formatted (gofumpt)
```

## Cause

`golangci-lint-action` is pinned by SHA but takes no `version` input, so it
installs the latest release — currently v2.13.0. The gofumpt bundled with
v2.13.0 rejects the redundant parentheses in `loadKeysFromDir`:

```go
if !(strings.HasSuffix(n, ".vkey")) &&
    !(strings.HasSuffix(n, ".skey")) {
```

That code has been unchanged since #335 (2025-11-10). The failure is a
toolchain change, not a regression in any open PR, so it now fails every
bursa pull request whose branch contains this line. #718 passes only because
it predates the line.

`run.tests: false` in `.golangci.yml` is why the 18 `_test.go` files gofumpt
v2.13.0 also flags are not reported. Those remain unaddressed here.

## Verification

Root module, with the version CI installs:

| Revision | `golangci-lint v2.13.0 run ./...` |
| --- | --- |
| `origin/main` | `bursa.go:2720:1: File is not properly formatted (gofumpt)` |
| this branch | `0 issues.` (exit 0) |

Unblocks #717.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes redundant parentheses in LoadWalletDir’s key filter to satisfy gofumpt v2.13.0, restoring green lint in CI. Previously CI failed with “File is not properly formatted (gofumpt)”; after this formatting-only change, lint passes and runtime behavior is unchanged, unblocking #717.

<sup>Written for commit 5987460d3c4eaab2790c141226685313f17e12a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified wallet file type detection while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->