### PR TITLE
fix(kesagent): lock memory through x/sys/unix, not syscall

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -26,3 +26,37 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: go-test
         run: go test ./...
+
+  # Cross-compile every platform the release builds. `go test` above runs on
+  # ubuntu only, so before this job the first thing that ever tried a non-linux
+  # target was the publish workflow — after the merge had already landed. Builds
+  # ./cmd/bursa, the same package `make build` produces in the release job, so
+  # this fails exactly when a release would.
+  cross-build:
+    name: cross-build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: darwin
+            arch: arm64
+          - os: freebsd
+            arch: amd64
+          - os: freebsd
+            arch: arm64
+          - os: linux
+            arch: amd64
+          - os: linux
+            arch: arm64
+          - os: windows
+            arch: amd64
+          - os: windows
+            arch: arm64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
+        with:
+          go-version: 1.26.x
+      - name: cross-build
+        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o /dev/null ./cmd/bursa

--- a/internal/kesagent/securemem/mlock_unix.go
+++ b/internal/kesagent/securemem/mlock_unix.go
@@ -16,7 +16,12 @@
 
 package securemem
 
-import "syscall"
+// golang.org/x/sys/unix rather than syscall: the stdlib only defines
+// Mlock/Munlock on linux and darwin, so building this file for the BSDs in the
+// constraint above failed to compile at all (it broke every release build on
+// freebsd). x/sys/unix defines them for all six, and is pure Go, so the root
+// module stays CGO-free.
+import "golang.org/x/sys/unix"
 
-func lockMemory(b []byte) error   { return syscall.Mlock(b) }
-func unlockMemory(b []byte) error { return syscall.Munlock(b) }
+func lockMemory(b []byte) error   { return unix.Mlock(b) }
+func unlockMemory(b []byte) error { return unix.Munlock(b) }


### PR DESCRIPTION
Every `publish` run on `main` has failed since the KES agent landed. This fixes
the cause, and adds the check that would have caught it before merge.

## The break

`build-binaries (freebsd, amd64)` and `(freebsd, arm64)` fail at **Build binary**:

```
internal/kesagent/securemem/mlock_unix.go:21:52: undefined: syscall.Mlock
internal/kesagent/securemem/mlock_unix.go:22:52: undefined: syscall.Munlock
```

Identical across runs 32274813456, 32298779875, 32369125363, 32390906318,
32393788888 and 32396638354 — one cause, not several. `finalize-release` needs
`build-binaries`, so the draft release is never published.

`mlock_unix.go` is built for six platforms, but the stdlib only defines those two
symbols on two of them:

| GOOS | `syscall.Mlock` | `unix.Mlock` |
|---|---|---|
| linux | yes | yes |
| darwin | yes | yes |
| freebsd | **no** | yes |
| netbsd | **no** | yes |
| openbsd | **no** | yes |
| dragonfly | **no** | yes |

So the import moves to `golang.org/x/sys/unix`, already a direct dependency and
pure Go — the root module stays CGO-free. Narrowing the constraint to
`linux || darwin` would also compile, but it would quietly drop mlock protection
for KES signing key material on the BSDs, so the constraint stays as-is.

## Why pull-request CI was green

`go-test.yml` runs `go test ./...` on `ubuntu-latest` only. Nothing
cross-compiles, so the first thing that ever tried `GOOS=freebsd` was `publish`,
after the merge. The second commit adds a `cross-build` matrix that builds
`./cmd/bursa` — the package `make build` produces in the release job — for all
seven release targets. No tests, no CGO, and a matrix row names the target that
failed.

## Verified

- `GOOS=freebsd GOARCH=amd64 make build` and `arm64`: both succeed. This is the
  exact command the failing job runs.
- `go build ./internal/kesagent/securemem/` for linux, darwin, freebsd, netbsd,
  openbsd, dragonfly — all six compile. windows and plan9 still compile through
  `mlock_other.go`.
- Reverted the import and re-ran the new guard's own command: freebsd fails with
  the original error while `linux/amd64` stays green — so the guard catches this
  class of break, and confirms an ubuntu-only run cannot.
- Root module: `CGO_ENABLED=0 go build ./...`, `go vet ./...`, `go test ./...`
  all clean. `go test ./internal/kesagent/...` passes.
- `gofmt` clean; the workflow YAML parses.

Not verified: the workflow run itself, which needs a tag push.

Closes #729
Closes #734


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore BSD builds by using `golang.org/x/sys/unix` for memory locking instead of `syscall`, and add a cross-build CI guard to catch non-Linux breaks before merge. Previously `syscall.Mlock/Munlock` were undefined on BSD and broke release builds; now `unix.Mlock/Munlock` compile on all Unix targets without adding CGO.

- Replace `syscall` with `golang.org/x/sys/unix` in `internal/kesagent/securemem/mlock_unix.go` to keep mlock protection on linux, darwin, and the BSDs.
- Add a `cross-build` job in `.github/workflows/go-test.yml` that builds `./cmd/bursa` for darwin arm64, freebsd amd64/arm64, linux amd64/arm64, and windows amd64/arm64 to fail early on target-specific build issues.

<sup>Written for commit e27abe34e2cac6622e37c0c01b47180c54e1b708. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

