### PR TITLE
fix(deps): override protobufjs and uuid to clear ui/web advisories

### DIFF
--- a/ui/web/package-lock.json
+++ b/ui/web/package-lock.json
@@ -16,6 +16,7 @@
         "@zxing/browser": "^0.1.5",
         "@zxing/library": "^0.21.0",
         "bech32": "^1.1.4",
+        "buffer": "^6.0.3",
         "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -1686,12 +1687,6 @@
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
@@ -3354,30 +3349,6 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@trezor/blockchain-link-utils/node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@trezor/connect": {
       "version": "9.7.3",
       "resolved": "https://registry.npmjs.org/@trezor/connect/-/connect-9.7.3.tgz",
@@ -3497,30 +3468,6 @@
       },
       "peerDependencies": {
         "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@trezor/device-authenticity/node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/@trezor/device-utils": {
@@ -7658,28 +7605,33 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
@@ -8832,13 +8784,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/varuint-bitcoin": {
@@ -8962,21 +8917,6 @@
       },
       "peerDependencies": {
         "vite": ">=2.8"
-      }
-    },
-    "node_modules/vite-plugin-top-level-await/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite-plugin-wasm": {

--- a/ui/web/package.json
+++ b/ui/web/package.json
@@ -27,6 +27,10 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
+  "overrides": {
+    "protobufjs": "^7.6.5",
+    "uuid": "^11.1.1"
+  },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",
     "@testing-library/react": "^16.0.0",


### PR DESCRIPTION
## What changed

Added an npm `overrides` block to `ui/web/package.json` pinning two transitive
dependencies, and refreshed `ui/web/package-lock.json`:

```json
"overrides": {
  "protobufjs": "^7.6.5",
  "uuid": "^11.1.1"
}
```

No source code changes.

## Why an override rather than a dependency bump

The advisories arrive transitively through the Trezor hardware-wallet
integration, and a bump cannot reach them:

- `@trezor/connect-web@9.7.3` is already the newest stable release. The only
  later versions on the registry are `10.0.0-alpha.1` and `10.0.0-beta.1`,
  which are not appropriate to ship.
- `@trezor/protobuf@1.5.3` declares `"protobufjs": "7.5.5"` as an **exact**
  version, not a range. Even the newest Trezor release therefore cannot resolve
  a patched protobufjs.
- `npm audit` reported `fixAvailable` as a *downgrade* to `@trezor/connect-web@9.1.1`,
  which is older and does not actually resolve the protobufjs findings.
- The `uuid` finding comes from `@keystonehq/*`, which pin `uuid: "^8.3.2"`;
  `npm audit` reported `fixAvailable: false` for it.

The override also collapses three separate protobufjs copies in the tree
(`7.4.0` under `@trezor/blockchain-link-utils`, `7.4.0` under
`@trezor/device-authenticity`, and `7.5.5` hoisted) down to a single deduped
`7.6.5`, which is why the lockfile diff removes more lines than it adds.

## `npm audit --omit=dev` before and after

| Severity | Before | After |
|----------|--------|-------|
| Critical | 1      | **0** |
| High     | 7      | **0** |
| Moderate | 3      | **0** |
| Low      | 7      | 10    |
| **Total**| **18** | **10**|

The critical (`Arbitrary code execution in protobufjs`), all seven highs, and
all three moderates are cleared. The low count rises from 7 to 10 only because
`@trezor/blockchain-link`, `@trezor/connect` and `@trezor/connect-web` had been
reported at high severity for the protobufjs chain; with that chain fixed they
are re-reported at the low severity they still carry from the `elliptic` chain.
No new package became vulnerable.

Resolved versions:

```
$ npm ls protobufjs --all
    │   └── protobufjs@7.6.5 deduped
    │   └── protobufjs@7.6.5 deduped
      └── protobufjs@7.6.5 overridden

$ npm ls uuid --all
│ └── uuid@11.1.1 overridden
│ └── uuid@11.1.1 deduped
  └── uuid@11.1.1 deduped
```

## Advisories that remain, and why

All 10 remaining runtime findings are low severity and every one of them roots
in **`elliptic`** (`Elliptic Uses a Cryptographic Primitive with a Risky
Implementation`, vulnerable range `*`). `elliptic` has **no patched version
available** — there is nothing to upgrade to, so this PR does not attempt to
fix it and does not claim it is fixed. The chain is:

```
elliptic  ->  browserify-sign, create-ecdh, tiny-secp256k1
          ->  crypto-browserify, @trezor/utxo-lib
          ->  @trezor/blockchain-link-types, @trezor/blockchain-link
          ->  @trezor/connect  ->  @trezor/connect-web
```

Separately, `npm audit` without `--omit=dev` still reports one high in
`nanoid` (`GHSA-2v37-7h3g-55p8`), reached only through the dev-only Vite
toolchain. It pre-dates this change (dev-scope counts were unchanged: 20 total
before, 11 after) and is out of scope here, since it is not part of any shipped
runtime bundle.

## Compatibility

`protobufjs` is held inside the `7.x` major that `@trezor/protobuf` is written
against — `7.6.5` is the head of the `latest-7` dist-tag. `@trezor/protobuf`
imports only `protobufjs/light` and uses just three symbols from it:
`configure()`, `Root.fromJSON()` and `util.Long`.

Because the unit tests mock `@trezor/connect-web`, they do not exercise
protobufjs at all, so the real codec was driven directly against the shipped
Trezor message descriptor on `7.6.5`:

- `parseConfigure(@trezor/protobuf/messages.json)` parses, yielding **368
  message types**.
- Encode/decode round-trips succeed for `GetPublicKey`, `CardanoGetPublicKey`,
  `CardanoGetAddress`, `CardanoSignTxInit` and `CardanoTxInput`, with correct
  wire message-type numbers (11, 305, 307, 320, 321).
- Enum fields resolve to names (`ICARUS`, `BASE`, `ORDINARY_TRANSACTION`),
  `bytes` fields round-trip as hex, and the `uint64` `fee` field round-trips
  through the `long` implementation that `@trezor/protobuf` installs into
  `protobuf.util.Long`.

For `uuid`, the only APIs any dependency actually uses are the named exports
`parse` (by `@keystonehq/bc-ur-registry-cardano` and `@keystonehq/hw-app-ada`,
via both the ESM `import { parse } from 'uuid'` and the CJS `require('uuid')`
builds) and `v5` (by the dev-only `vite-plugin-top-level-await`). Both are
present as named ESM and CJS exports in `11.1.1`, and both were verified at
runtime, including the exact `Buffer.from(parse(s))` 16-byte request-id
construction Keystone performs. No dependency uses the v8-era default export
or deep `uuid/v4` imports, which are the breaking changes in the v8 to v11
range.

Residual risk worth stating plainly: several of the protobufjs fixes between
`7.5.5` and `7.6.5` are hardening changes (recursion depth limits, restrictions
on schema-derived names that could shadow runtime properties, stricter option
parsing). The round-trips above show the Trezor descriptor and the Cardano
message set are unaffected, but this was verified against the descriptor and
codec rather than against a physical device — no Trezor was connected. An
on-device signing check is worth doing before release if one is available.

## Verification

All run in `ui/web` after `npm install`:

| Check | Result |
|-------|--------|
| `npm run type-check` (`tsc --noEmit`) | pass, exit 0, no output |
| `npx vitest run` | **67 files / 812 tests passed**, 0 failed |
| `npx vitest run src/hw` | **12 files / 148 tests passed**, incl. `trezor.test.ts` 15/15 and `keystone.test.ts` 29/29 |
| `npx eslint src` | exit 0 — 0 errors, 1 warning |
| `npm run build` | pass, exit 0, built in 33.42s |

The single eslint warning is the pre-existing unused-eslint-disable directive in
`src/connectorNotify.ts:56` and is untouched by this change.

The build wrote to the gitignored `ui/web/dist`, so the tracked
`ui/internal/webui/dist/index.html` placeholder was left unmodified — this PR
changes only `ui/web/package.json` and `ui/web/package-lock.json`.

Closes #732


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Overrides transitive `protobufjs` to `^7.6.5` and `uuid` to `^11.1.1` in `ui/web` to clear runtime advisories. Before: `npm audit --omit=dev` had 1 critical, 7 high, 3 moderate; after: only 10 low remain (all from `elliptic`, no patched version available).

- Adds `overrides` to `ui/web/package.json` and refreshes `package-lock.json`; no source code changes.
- Normal bumps can’t reach fixes (`@trezor/protobuf` pins `protobufjs@7.5.5`; `@trezor/connect-web@9.7.3` is latest stable; `@keystonehq/*` pins `uuid@^8`).
- Dedupe effect: consolidates multiple `protobufjs` copies to a single `7.6.5`.
- Compatibility: stays within `protobufjs 7.x` APIs used by `@trezor/protobuf`; `uuid` named exports (`parse`, `v5`) remain.
- Rollout: consider an on-device Trezor signing check before release; build and tests pass.

<sup>Written for commit 7c2c3f8681f25e3ff64f3c52ef714c9000afa2dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

