### PR TITLE
fix: use language-aware script hashes

### DIFF
--- a/bursa.go
+++ b/bursa.go
@@ -1907,14 +1907,8 @@ func GetScriptHash(script Script) ([]byte, error) {
 	if script == nil {
 		return nil, errors.New("script cannot be nil")
 	}
-	scriptCBOR := script.RawScriptBytes()
-	hasher, err := blake2b.New(28, nil)
-	if err != nil {
-		// This should never happen with valid parameters
-		return nil, fmt.Errorf("failed to create blake2b hasher: %w", err)
-	}
-	hasher.Write(scriptCBOR)
-	return hasher.Sum(nil), nil
+	scriptHash := script.Hash()
+	return scriptHash.Bytes(), nil
 }
 
 // GetScriptAddress creates an address from a script

--- a/bursa_test.go
+++ b/bursa_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/blinklabs-io/bursa/bip32"
 	bip39 "github.com/blinklabs-io/go-bip39"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1142,15 +1143,84 @@ func TestScriptTypes(t *testing.T) {
 	assert.NotEmpty(t, cbor)
 }
 
-func TestGetScriptHash(t *testing.T) {
-	// Use proper 28-byte key hash (Blake2b-224)
-	keyHash := testKeyHash()
-	script, err := NewScriptSig(keyHash)
-	assert.NoError(t, err)
-	assert.NotNil(t, script)
-	hash, err := GetScriptHash(script)
-	assert.NoError(t, err)
-	assert.Len(t, hash, 28)
+func TestGetScriptHashAndAddressVectors(t *testing.T) {
+	// These fixed outputs were generated with cardano-cli 10.14.0.0. Using
+	// the same script bytes for each Plutus language verifies that the language
+	// tag is part of the credential.
+	nativeScriptBytes, err := hex.DecodeString(
+		"830302838200581c32000809732f4d5b9a53e2eec996e7c79a249630" +
+			"68ffbf3565318e9a8200581caaaaaaaa111122223333444455556666" +
+			"77778888999900001111aaaa8200581cbbbbbbbb1111222233334444" +
+			"5555666677778888999900001111bbbb",
+	)
+	require.NoError(t, err)
+	var nativeScript NativeScript
+	require.NoError(t, nativeScript.UnmarshalCBOR(nativeScriptBytes))
+
+	plutusScriptBytes, err := hex.DecodeString(
+		"587f01010032323232323225333002323232323253330073370e900118" +
+			"041baa0011323232533300a3370e900018059baa00513232533300f301" +
+			"100214a22c6eb8c03c004c030dd50028b18069807001180600098049b" +
+			"aa00116300a300b0023009001300900230070013004375400229309b2" +
+			"b2b9a5573aaae7955cfaba157441",
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name                   string
+		script                 Script
+		expectedHash           string
+		expectedMainnetAddress string
+		expectedTestnetAddress string
+	}{
+		{
+			name:                   "native",
+			script:                 &nativeScript,
+			expectedHash:           "97e609874ba758c9cfaf7b03d0223402d4d91405e9b7fe503a9977fa",
+			expectedMainnetAddress: "addr1wxt7vzv8fwn43jw04aas85pzxspdfkg5qh5m0ljs82vh07s9fhjmu",
+			expectedTestnetAddress: "addr_test1wzt7vzv8fwn43jw04aas85pzxspdfkg5qh5m0ljs82vh07s7prw5e",
+		},
+		{
+			name:                   "Plutus V1",
+			script:                 lcommon.PlutusV1Script(plutusScriptBytes),
+			expectedHash:           "29faed158eeb221d7c5b3804cb00f590e38dc9846259a5c0128d6c42",
+			expectedMainnetAddress: "addr1wy5l4mg43m4jy8tutvuqfjcq7kgw8rwfs339nfwqz2xkcssxage2k",
+			expectedTestnetAddress: "addr_test1wq5l4mg43m4jy8tutvuqfjcq7kgw8rwfs339nfwqz2xkcssa4u99n",
+		},
+		{
+			name:                   "Plutus V2",
+			script:                 lcommon.PlutusV2Script(plutusScriptBytes),
+			expectedHash:           "372f2611534456c5f249429d87d088ba64c97205c2ce1cf779eab108",
+			expectedMainnetAddress: "addr1wymj7fs32dz9d30jf9pfmp7s3zaxfjtjqhpvu88h084tzzqyjkg4u",
+			expectedTestnetAddress: "addr_test1wqmj7fs32dz9d30jf9pfmp7s3zaxfjtjqhpvu88h084tzzql6z56e",
+		},
+		{
+			name:                   "Plutus V3",
+			script:                 lcommon.PlutusV3Script(plutusScriptBytes),
+			expectedHash:           "2909c3d0441e76cd6ae1fc09664bb209868902e191c2b8c30b82d331",
+			expectedMainnetAddress: "addr1wy5sns7sgs08dnt2u87qjejtkgycdzgzuxgu9wxrpwpdxvgv04xjl",
+			expectedTestnetAddress: "addr_test1wq5sns7sgs08dnt2u87qjejtkgycdzgzuxgu9wxrpwpdxvgh8p6a6",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			hash, err := GetScriptHash(test.script)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedHash, hex.EncodeToString(hash))
+
+			for network, expectedAddress := range map[string]string{
+				"mainnet": test.expectedMainnetAddress,
+				"preview": test.expectedTestnetAddress,
+			} {
+				t.Run(network, func(t *testing.T) {
+					address, err := GetScriptAddress(test.script, network)
+					require.NoError(t, err)
+					assert.Equal(t, expectedAddress, address)
+				})
+			}
+		})
+	}
 }
 
 func TestGetScriptAddress(t *testing.T) {


### PR DESCRIPTION
Derives script credentials through the language-aware `Script.Hash` contract.

Adds fixed native and Plutus V1-V3 hash and address vectors for mainnet and test networks.

Fixes #739
