### PR TITLE
fix(api): bind legacy server to loopback

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ go run ./cmd/bursa api
 
 Access API Swagger documentation: [http://localhost:8080/swagger/index.html](http://localhost:8080/swagger/index.html)
 
+The API listens on `127.0.0.1` by default. Set `API_LISTEN_ADDRESS` to an
+explicit address such as `0.0.0.0` only when remote access is intended and
+protected by appropriate network controls.
+
 For more information about Bursa CLI
 
 ```bash

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -213,7 +213,7 @@ type MetricsConfig struct {
 func defaultConfig() Config {
 	return Config{
 		Api: ApiConfig{
-			ListenAddress: "",
+			ListenAddress: "127.0.0.1",
 			ListenPort:    8080,
 		},
 		Google: GoogleConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -182,6 +182,22 @@ func TestAPIListenAddressDefaultsToLoopback(t *testing.T) {
 
 func TestAPIListenAddressOverrides(t *testing.T) {
 	t.Run("config file", func(t *testing.T) {
+		oldAddress, hadAddress := os.LookupEnv("API_LISTEN_ADDRESS")
+		if err := os.Unsetenv("API_LISTEN_ADDRESS"); err != nil {
+			t.Fatalf("unset API_LISTEN_ADDRESS: %v", err)
+		}
+		t.Cleanup(func() {
+			var err error
+			if hadAddress {
+				err = os.Setenv("API_LISTEN_ADDRESS", oldAddress)
+			} else {
+				err = os.Unsetenv("API_LISTEN_ADDRESS")
+			}
+			if err != nil {
+				t.Errorf("restore API_LISTEN_ADDRESS: %v", err)
+			}
+		})
+
 		dir := t.TempDir()
 		configFile := filepath.Join(dir, "bursa.yml")
 		if err := os.WriteFile(

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -170,6 +170,56 @@ func TestLoadConfigFile_EmptyPath(t *testing.T) {
 	}
 }
 
+func TestAPIListenAddressDefaultsToLoopback(t *testing.T) {
+	cfg := defaultConfig()
+	if cfg.Api.ListenAddress != "127.0.0.1" {
+		t.Fatalf(
+			"default API listen address: got %q, want 127.0.0.1",
+			cfg.Api.ListenAddress,
+		)
+	}
+}
+
+func TestAPIListenAddressOverrides(t *testing.T) {
+	t.Run("config file", func(t *testing.T) {
+		dir := t.TempDir()
+		configFile := filepath.Join(dir, "bursa.yml")
+		if err := os.WriteFile(
+			configFile,
+			[]byte("api:\n  address: 0.0.0.0\n"),
+			0o600,
+		); err != nil {
+			t.Fatalf("write config file: %v", err)
+		}
+		globalConfig = defaultConfig()
+		cfg, err := LoadConfigFile(configFile)
+		if err != nil {
+			t.Fatalf("LoadConfigFile: %v", err)
+		}
+		if cfg.Api.ListenAddress != "0.0.0.0" {
+			t.Fatalf(
+				"config API listen address: got %q, want 0.0.0.0",
+				cfg.Api.ListenAddress,
+			)
+		}
+	})
+
+	t.Run("environment", func(t *testing.T) {
+		t.Setenv("API_LISTEN_ADDRESS", "192.0.2.1")
+		globalConfig = defaultConfig()
+		cfg, err := LoadConfigFile("")
+		if err != nil {
+			t.Fatalf("LoadConfigFile with environment override: %v", err)
+		}
+		if cfg.Api.ListenAddress != "192.0.2.1" {
+			t.Fatalf(
+				"environment API listen address: got %q, want 192.0.2.1",
+				cfg.Api.ListenAddress,
+			)
+		}
+	})
+}
+
 func TestKESAgentConfig_SocketModeDefaults(t *testing.T) {
 	globalConfig = defaultConfig()
 	cfg, err := LoadConfigFile("")


### PR DESCRIPTION
## Summary

- bind the legacy API to `127.0.0.1` by default
- preserve explicit YAML and environment listen-address overrides
- document how to opt into remote exposure

## Testing

- `go test -race ./...`
- `go vet ./internal/config`
- environment-independent default regression test
- YAML and environment override tests
- `git diff --check`

Fixes #742.
