### PR TITLE
fix(keys): align pool cold verification key

### DIFF
--- a/bursa.go
+++ b/bursa.go
@@ -147,9 +147,11 @@ func (kf KeyFile) String() string {
 		prefix = "cc_hot_sk"
 	case "CommitteeHotExtendedSigningKeyShelley_ed25519_bip32":
 		prefix = "cc_hot_xsk"
-	case "StakePoolVerificationKeyShelley_ed25519":
+	case "StakePoolVerificationKey_ed25519",
+		"StakePoolVerificationKeyShelley_ed25519":
 		prefix = "pool_vk"
-	case "StakePoolSigningKeyShelley_ed25519":
+	case "StakePoolSigningKey_ed25519",
+		"StakePoolSigningKeyShelley_ed25519":
 		prefix = "pool_sk"
 	case "StakePoolExtendedSigningKeyShelley_ed25519_bip32":
 		prefix = "pool_xsk"
@@ -1098,7 +1100,7 @@ func GetPoolColdVKey(poolColdKey bip32.XPrv) (KeyFile, error) {
 		)
 	}
 	kf := KeyFile{
-		Type:        "StakePoolVerificationKeyShelley_ed25519",
+		Type:        "StakePoolVerificationKey_ed25519",
 		Description: "Stake Pool Cold Verification Key",
 		CborHex:     hex.EncodeToString(keyCbor),
 	}
@@ -1110,7 +1112,7 @@ func GetPoolColdVKey(poolColdKey bip32.XPrv) (KeyFile, error) {
 func GetPoolColdSKey(poolColdKey bip32.XPrv) (KeyFile, error) {
 	return getSigningKeyFile(
 		poolColdKey,
-		"StakePoolSigningKeyShelley_ed25519",
+		"StakePoolSigningKey_ed25519",
 		"Stake Pool Cold Signing Key",
 	)
 }
@@ -2440,6 +2442,7 @@ func parseKeyEnvelope(fileBytes []byte) (*LoadedKey, error) {
 		"DRepVerificationKeyShelley_ed25519",
 		"CommitteeColdVerificationKeyShelley_ed25519",
 		"CommitteeHotVerificationKeyShelley_ed25519",
+		"StakePoolVerificationKey_ed25519",
 		"StakePoolVerificationKeyShelley_ed25519",
 		"PolicyVerificationKeyShelley_ed25519":
 		vk, err := decodeVerificationKey(cborData)
@@ -2453,6 +2456,7 @@ func parseKeyEnvelope(fileBytes []byte) (*LoadedKey, error) {
 		"DRepSigningKeyShelley_ed25519",
 		"CommitteeColdSigningKeyShelley_ed25519",
 		"CommitteeHotSigningKeyShelley_ed25519",
+		"StakePoolSigningKey_ed25519",
 		"StakePoolSigningKeyShelley_ed25519",
 		"PolicySigningKeyShelley_ed25519":
 		sk, vk, err := decodeNonExtendedCborKey(cborData)

--- a/bursa.go
+++ b/bursa.go
@@ -1085,8 +1085,12 @@ func GetPoolColdKey(
 
 // GetPoolColdVKey creates a stake pool cold verification key file
 func GetPoolColdVKey(poolColdKey bip32.XPrv) (KeyFile, error) {
-	// Encode just the raw public key bytes (cardano-cli compatible format)
-	keyCbor, err := cbor.Encode(poolColdKey.Public().PublicKey())
+	// Pool cold signing uses standard Ed25519 seeded from k_L, rather than the
+	// BIP32 extended public key derived from k_L. Export the matching public key
+	// so pool registration and operational certificates use the same key.
+	seed := poolColdKey.PrivateKey()[:ed25519.SeedSize]
+	vkey := ed25519.NewKeyFromSeed(seed).Public().(ed25519.PublicKey)
+	keyCbor, err := cbor.Encode(vkey)
 	if err != nil {
 		return KeyFile{}, fmt.Errorf(
 			"failed to encode pool cold verification key CBOR: %w",

--- a/bursa_test.go
+++ b/bursa_test.go
@@ -2310,14 +2310,14 @@ func TestCIP1853KeyFileGeneration(t *testing.T) {
 	// Test verification key generation
 	vkey, err := GetPoolColdVKey(poolColdKey)
 	assert.NoError(t, err)
-	assert.Equal(t, "StakePoolVerificationKeyShelley_ed25519", vkey.Type)
+	assert.Equal(t, "StakePoolVerificationKey_ed25519", vkey.Type)
 	assert.Equal(t, "Stake Pool Cold Verification Key", vkey.Description)
 	assert.NotEmpty(t, vkey.CborHex)
 
 	// Test signing key generation
 	skey, err := GetPoolColdSKey(poolColdKey)
 	assert.NoError(t, err)
-	assert.Equal(t, "StakePoolSigningKeyShelley_ed25519", skey.Type)
+	assert.Equal(t, "StakePoolSigningKey_ed25519", skey.Type)
 	assert.Equal(t, "Stake Pool Cold Signing Key", skey.Description)
 	assert.NotEmpty(t, skey.CborHex)
 
@@ -2373,6 +2373,71 @@ func TestCIP1853KeyFileGeneration(t *testing.T) {
 	assert.NotEmpty(t, extendedSkeyCbor)
 }
 
+func TestPoolColdKeyEnvelopeCompatibility(t *testing.T) {
+	rootKey, err := GetRootKeyFromMnemonic(
+		"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+		"",
+	)
+	require.NoError(t, err)
+	poolColdKey, err := GetPoolColdKey(rootKey, 0, 0)
+	require.NoError(t, err)
+	vkey, err := GetPoolColdVKey(poolColdKey)
+	require.NoError(t, err)
+	skey, err := GetPoolColdSKey(poolColdKey)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name  string
+		key   KeyFile
+		type_ string
+		want  int
+	}{
+		{
+			name:  "canonical verification key",
+			key:   vkey,
+			type_: "StakePoolVerificationKey_ed25519",
+			want:  ed25519.PublicKeySize,
+		},
+		{
+			name:  "legacy verification key",
+			key:   vkey,
+			type_: "StakePoolVerificationKeyShelley_ed25519",
+			want:  ed25519.PublicKeySize,
+		},
+		{
+			name:  "canonical signing key",
+			key:   skey,
+			type_: "StakePoolSigningKey_ed25519",
+			want:  ed25519.PrivateKeySize,
+		},
+		{
+			name:  "legacy signing key",
+			key:   skey,
+			type_: "StakePoolSigningKeyShelley_ed25519",
+			want:  ed25519.PrivateKeySize,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			envelope := KeyFile{
+				Type:    tc.type_,
+				CborHex: tc.key.CborHex,
+			}
+			data, err := json.Marshal(envelope)
+			require.NoError(t, err)
+			loaded, err := LoadKeyFromBytes(data)
+			require.NoError(t, err)
+			assert.Equal(t, tc.type_, loaded.Type)
+			if strings.Contains(tc.type_, "Verification") {
+				assert.Len(t, loaded.VKey, tc.want)
+			} else {
+				assert.Len(t, loaded.SKey, tc.want)
+			}
+		})
+	}
+}
+
 // TestCIP1853WalletIntegration validates pool cold key integration in Wallet struct
 func TestCIP1853WalletIntegration(t *testing.T) {
 	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
@@ -2401,12 +2466,12 @@ func TestCIP1853WalletIntegration(t *testing.T) {
 	// Verify key types
 	assert.Equal(
 		t,
-		"StakePoolVerificationKeyShelley_ed25519",
+		"StakePoolVerificationKey_ed25519",
 		wallet.PoolColdVKey.Type,
 	)
 	assert.Equal(
 		t,
-		"StakePoolSigningKeyShelley_ed25519",
+		"StakePoolSigningKey_ed25519",
 		wallet.PoolColdSKey.Type,
 	)
 	assert.Equal(

--- a/bursa_test.go
+++ b/bursa_test.go
@@ -2321,6 +2321,29 @@ func TestCIP1853KeyFileGeneration(t *testing.T) {
 	assert.Equal(t, "Stake Pool Cold Signing Key", skey.Description)
 	assert.NotEmpty(t, skey.CborHex)
 
+	// The exported cold vkey must match the standard Ed25519 key used to
+	// sign operational certificates from the pool cold signing key seed.
+	coldSeed := decodeCborBytes(t, skey.CborHex)
+	expectedColdVKey := ed25519.NewKeyFromSeed(coldSeed).
+		Public().(ed25519.PublicKey)
+	actualColdVKey := decodeCborBytes(t, vkey.CborHex)
+	assert.Equal(t, []byte(expectedColdVKey), actualColdVKey)
+
+	kesVkey := make([]byte, 32)
+	opCert, err := CreateOperationalCertificate(
+		kesVkey,
+		0,
+		100,
+		coldSeed,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, opCert.ColdVkey, actualColdVKey)
+	require.True(t, ed25519.Verify(
+		actualColdVKey,
+		lcommon.OpCertSignableBytes(kesVkey, 0, 100),
+		opCert.ColdSignature,
+	))
+
 	// Test extended signing key generation
 	extendedSkey, err := GetPoolColdExtendedSKey(poolColdKey)
 	assert.NoError(t, err)

--- a/internal/cli/cardano_cli_compat_test.go
+++ b/internal/cli/cardano_cli_compat_test.go
@@ -16,6 +16,11 @@ package cli
 
 import (
 	"encoding/hex"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/blinklabs-io/bursa"
@@ -24,6 +29,55 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPoolColdKeyFilesAcceptedByCardanoCLI(t *testing.T) {
+	cardanoCLI, err := exec.LookPath("cardano-cli")
+	if err != nil {
+		t.Skip("cardano-cli is not installed")
+	}
+
+	wallet, err := bursa.NewWallet(testMnemonic)
+	require.NoError(t, err)
+	tmpDir := t.TempDir()
+	vkeyFile := filepath.Join(tmpDir, "pool-cold.vkey")
+	skeyFile := filepath.Join(tmpDir, "pool-cold.skey")
+	derivedVKeyFile := filepath.Join(tmpDir, "derived.vkey")
+
+	for path, key := range map[string]bursa.KeyFile{
+		vkeyFile: wallet.PoolColdVKey,
+		skeyFile: wallet.PoolColdSKey,
+	} {
+		data, err := json.Marshal(key)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(path, data, 0o600))
+	}
+
+	cmd := exec.Command(
+		cardanoCLI,
+		"conway", "stake-pool", "id",
+		"--cold-verification-key-file", vkeyFile,
+		"--output-hex",
+	)
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "cardano-cli stake-pool id failed: %s", output)
+	poolID, err := hex.DecodeString(strings.TrimSpace(string(output)))
+	require.NoError(t, err)
+	assert.Len(t, poolID, 28)
+
+	cmd = exec.Command(
+		cardanoCLI,
+		"key", "verification-key",
+		"--signing-key-file", skeyFile,
+		"--verification-key-file", derivedVKeyFile,
+	)
+	output, err = cmd.CombinedOutput()
+	require.NoErrorf(t, err, "cardano-cli key verification-key failed: %s", output)
+	derived, err := os.ReadFile(derivedVKeyFile)
+	require.NoError(t, err)
+	var derivedEnvelope bursa.KeyFile
+	require.NoError(t, json.Unmarshal(derived, &derivedEnvelope))
+	assert.Equal(t, "StakePoolVerificationKey_ed25519", derivedEnvelope.Type)
+}
 
 // Test mnemonic - CIP-1852 test vector (DO NOT USE FOR REAL FUNDS)
 const testMnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"

--- a/internal/cli/key_file_output_test.go
+++ b/internal/cli/key_file_output_test.go
@@ -36,8 +36,8 @@ func TestKeyFileOutput(t *testing.T) {
 		{
 			name:             "pool cold key",
 			runFunc:          func(skey, vkey string) error { return RunKeyPoolCold(testMnemonic, "", "", skey, vkey, 0) },
-			expectedVKeyType: "StakePoolVerificationKeyShelley_ed25519",
-			expectedSKeyType: "StakePoolSigningKeyShelley_ed25519",
+			expectedVKeyType: "StakePoolVerificationKey_ed25519",
+			expectedSKeyType: "StakePoolSigningKey_ed25519",
 		},
 		{
 			name:             "policy key",

--- a/internal/signer/setup_test.go
+++ b/internal/signer/setup_test.go
@@ -41,6 +41,7 @@ func TestKeyTypeFromEnvelope(t *testing.T) {
 		{"StakeSigningKeyShelley_ed25519", backend.KeyTypeStake},
 		// StakePool signing key (was previously shadowed by the Stake case)
 		{"StakePoolSigningKeyShelley_ed25519", backend.KeyTypePool},
+		{"StakePoolSigningKey_ed25519", backend.KeyTypePool},
 		// Governance / committee keys
 		{"DRepSigningKeyShelley_ed25519", backend.KeyTypeDRep},
 		{"CommitteeHotSigningKeyShelley_ed25519", backend.KeyTypeCCHot},


### PR DESCRIPTION
## Summary

- derive the exported pool cold verification key from the standard Ed25519 signing seed
- emit canonical `cardano-cli` pool cold key envelope type values
- preserve loading of legacy Shelley-suffixed pool key envelopes
- align pool registration identity with Bursa-issued operational certificates

## Testing

- `go test -race ./...`
- `go vet ./...`
- `go test -race . -run '^TestCIP1853KeyFileGeneration$' -count=1`
- cardano-cli acceptance coverage for exported pool cold vkey and skey envelopes
- pool cold key and operational-certificate identity regression tests
- OpenAPI and UI pool-operations tests
- supported-platform cross-build matrix
- `git diff --check`

Fixes #740.
