### PR TITLE
fix(wallet): derive addresses from selected keys

### DIFF
--- a/bursa.go
+++ b/bursa.go
@@ -229,7 +229,11 @@ type WalletConfig struct {
 	CommitteeColdID uint32 // Committee cold key derivation index (CIP-105)
 	CommitteeHotID  uint32 // Committee hot key derivation index (CIP-105)
 	PoolColdID      uint32 // Pool cold key derivation index (CIP-1853)
-	AddressID       uint32 // Address derivation index
+	// AddressID is a compatibility alias for PaymentID and StakeID.
+	// Deprecated: configure PaymentID and StakeID independently instead.
+	AddressID    uint32
+	paymentIDSet bool
+	stakeIDSet   bool
 }
 
 // WalletOption is a functional option for configuring wallet creation
@@ -268,6 +272,7 @@ func WithAccountID(id uint32) WalletOption {
 func WithPaymentID(id uint32) WalletOption {
 	return func(c *WalletConfig) {
 		c.PaymentID = id
+		c.paymentIDSet = true
 	}
 }
 
@@ -277,6 +282,7 @@ func WithPaymentID(id uint32) WalletOption {
 func WithStakeID(id uint32) WalletOption {
 	return func(c *WalletConfig) {
 		c.StakeID = id
+		c.stakeIDSet = true
 	}
 }
 
@@ -316,12 +322,20 @@ func WithPoolColdID(id uint32) WalletOption {
 	}
 }
 
-// WithAddressID sets the address derivation index.
+// WithAddressID sets the payment and stake derivation indices when their
+// dedicated options have not been provided.
 // Must be less than 2^31 for BIP32 compatibility.
 // Default: 0
+// New code should use WithPaymentID and WithStakeID instead.
 func WithAddressID(id uint32) WalletOption {
 	return func(c *WalletConfig) {
 		c.AddressID = id
+		if !c.paymentIDSet {
+			c.PaymentID = id
+		}
+		if !c.stakeIDSet {
+			c.StakeID = id
+		}
 	}
 }
 
@@ -433,7 +447,11 @@ func NewWallet(mnemonic string, opts ...WalletOption) (*Wallet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pool cold key: %w", err)
 	}
-	addr, err := GetAddress(accountKey, cfg.Network, cfg.AddressID)
+	network, ok := ouroboros.NetworkByName(cfg.Network)
+	if !ok {
+		return nil, fmt.Errorf("unable to get address: %w", ErrInvalidNetwork)
+	}
+	addr, err := newAddressFromKeys(paymentKey, stakeKey, network.Id)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get address: %w", err)
 	}
@@ -2207,15 +2225,23 @@ func GetAddress(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get payment key: %w", err)
 	}
-	paymentKeyPublicHash := paymentKey.Public().PublicKey().Hash()
 	stakeKey, err := GetStakeKey(accountKey, num)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get stake key: %w", err)
 	}
+	return newAddressFromKeys(paymentKey, stakeKey, network.Id)
+}
+
+func newAddressFromKeys(
+	paymentKey bip32.XPrv,
+	stakeKey bip32.XPrv,
+	networkID uint8,
+) (*lcommon.Address, error) {
+	paymentKeyPublicHash := paymentKey.Public().PublicKey().Hash()
 	stakeKeyPublicHash := stakeKey.Public().PublicKey().Hash()
 	addr, err := lcommon.NewAddressFromParts(
 		lcommon.AddressTypeKeyKey,
-		network.Id,
+		networkID,
 		paymentKeyPublicHash[:],
 		stakeKeyPublicHash[:],
 	)

--- a/bursa_test.go
+++ b/bursa_test.go
@@ -413,6 +413,57 @@ func TestNewWalletInvalidIndices(t *testing.T) {
 	assert.Contains(t, err.Error(), "derivation indices must be less than 2^31")
 }
 
+func TestNewWalletAddressMatchesExportedCredentials(t *testing.T) {
+	const mnemonic = "abandon abandon abandon abandon abandon abandon " +
+		"abandon abandon abandon abandon abandon about"
+	const (
+		paymentID = uint32(1)
+		stakeID   = uint32(2)
+		addressID = uint32(3)
+	)
+
+	wallet, err := NewWallet(
+		mnemonic,
+		WithPaymentID(paymentID),
+		WithStakeID(stakeID),
+		WithAddressID(addressID),
+	)
+	require.NoError(t, err)
+
+	address, err := lcommon.NewAddress(wallet.PaymentAddress)
+	require.NoError(t, err)
+	paymentVKey := decodeCborBytes(t, wallet.PaymentVKey.CborHex)
+	stakeVKey := decodeCborBytes(t, wallet.StakeVKey.CborHex)
+	assert.Equal(
+		t,
+		lcommon.Blake2b224Hash(paymentVKey),
+		address.PaymentKeyHash(),
+	)
+	assert.Equal(t, lcommon.Blake2b224Hash(stakeVKey), address.StakeKeyHash())
+
+	rootKey, err := GetRootKeyFromMnemonic(mnemonic, "")
+	require.NoError(t, err)
+	accountKey, err := GetAccountKey(rootKey, 0)
+	require.NoError(t, err)
+	paymentKey, err := GetPaymentKey(accountKey, paymentID)
+	require.NoError(t, err)
+	stakeKey, err := GetStakeKey(accountKey, stakeID)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(paymentKey.Public().PublicKey()), paymentVKey)
+	assert.Equal(t, []byte(stakeKey.Public().PublicKey()), stakeVKey)
+}
+
+func TestWithAddressIDSetsCredentialFallbacks(t *testing.T) {
+	const addressID = uint32(3)
+	cfg := defaultWalletConfig()
+
+	WithAddressID(addressID)(cfg)
+
+	assert.Equal(t, addressID, cfg.AddressID)
+	assert.Equal(t, addressID, cfg.PaymentID)
+	assert.Equal(t, addressID, cfg.StakeID)
+}
+
 func TestGenerateMnemonic(t *testing.T) {
 	mnemonic, err := GenerateMnemonic()
 	assert.NoError(t, err)


### PR DESCRIPTION
`NewWallet` now builds `PaymentAddress` directly from the payment and stake keys selected by `WithPaymentID` and `WithStakeID`.

`WithAddressID` remains a compatibility alias for both credential indices when dedicated options are absent. Explicit credential options take precedence regardless of option order.

Regression coverage verifies the address payment and stake hashes against the exported verification keys and preserves the compatibility alias behavior.

Closes #763
