### PR TITLE
ci: pin release workflow actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,12 +96,12 @@ jobs:
       - id: 'auth'
         name: Authenticate with Google Cloud
         if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.os == 'windows' }}
-        uses: 'google-github-actions/auth@v3'
+        uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093' # v3.0.0 https://github.com/google-github-actions/auth/releases/tag/v3.0.0
         with:
           credentials_json: '${{ secrets.CERTIFICATE_SA_CREDENTIALS }}'
       - name: Set up Cloud SDK
         if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.os == 'windows' }}
-        uses: 'google-github-actions/setup-gcloud@v3'
+        uses: 'google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db' # v3.0.1 https://github.com/google-github-actions/setup-gcloud/releases/tag/v3.0.1
       - name: Sign windows binary
         if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.os == 'windows' }}
         run: |
@@ -259,7 +259,7 @@ jobs:
       - name: Set up MSYS2 MinGW64 for Windows amd64 CGO
         if: matrix.os == 'windows' && matrix.arch == 'amd64'
         id: msys2-amd64
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0 https://github.com/msys2/setup-msys2/releases/tag/v2.32.0
         with:
           msystem: MINGW64
           update: true
@@ -268,7 +268,7 @@ jobs:
       - name: Set up MSYS2 clangarm64 for Windows arm64 CGO
         if: matrix.os == 'windows' && matrix.arch == 'arm64'
         id: msys2-arm64
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0 https://github.com/msys2/setup-msys2/releases/tag/v2.32.0
         with:
           msystem: CLANGARM64
           update: true


### PR DESCRIPTION
Pin the remaining Google Cloud and MSYS2 actions in the release workflow to
full upstream commit SHAs while retaining release-version annotations and the
existing job behavior.

Fixes #776


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow reliability by pinning cloud authentication, setup, and Windows environment actions to specific verified versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->