### PR TITLE
fix(ui): derive DRep registration from retired, not a stale field

### DIFF
--- a/ui/internal/chain/blockfrost.go
+++ b/ui/internal/chain/blockfrost.go
@@ -181,23 +181,25 @@ type ProtocolParams struct {
 
 // DRepInfo describes a delegated representative as returned by
 // GET /api/v0/governance/dreps/{drep_id}. It confirms the DRep exists on chain
-// (the node 404s an unknown DRep, surfaced as ErrNotFound) and reports whether
-// it is currently registered/active.
+// (the node 404s an unknown DRep, surfaced as ErrNotFound). There is no
+// "registered" field on the wire; callers derive registration as !Retired,
+// same as DRepListItem below.
 type DRepInfo struct {
-	DRepID     string `json:"drep_id"`
-	Hex        string `json:"hex"`
-	HasScript  bool   `json:"has_script"`
-	Registered bool   `json:"registered"`
-	Amount     string `json:"amount"`
-	Active     bool   `json:"active"`
-	LiveStake  string `json:"live_stake"`
+	DRepID          string  `json:"drep_id"`
+	Hex             string  `json:"hex"`
+	HasScript       bool    `json:"has_script"`
+	Amount          string  `json:"amount"`
+	Active          bool    `json:"active"`
+	ActiveEpoch     *uint64 `json:"active_epoch"`
+	Retired         bool    `json:"retired"`
+	Expired         bool    `json:"expired"`
+	LastActiveEpoch *uint64 `json:"last_active_epoch"`
 }
 
 // DRepListItem is one entry of GET /api/v0/governance/dreps, the node's
 // paginated DRep directory. It is deliberately a separate type from DRepInfo:
-// the list reports CIP-1694 lifecycle status (retired/expired plus the epoch
-// the DRep was last active in) and a resolved CIP-119 anchor document, and it
-// has no registered/active/live_stake fields for DRepInfo to borrow.
+// the list also resolves a CIP-119 anchor document, which the single-DRep
+// lookup does not.
 type DRepListItem struct {
 	// DRepID is the CIP-129 bech32 drep1… identifier, encoded by the node. The
 	// predefined targets appear as the literal strings "drep_always_abstain"

--- a/ui/internal/chain/blockfrost_test.go
+++ b/ui/internal/chain/blockfrost_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	dingoblockfrost "github.com/blinklabs-io/dingo/api/blockfrost"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
@@ -495,24 +496,61 @@ func TestPoolsReturnsFullList(t *testing.T) {
 	}
 }
 
+// TestDRep marshals dingo's own DRepResponse type as the fixture (rather than
+// hand-writing the JSON body) so a future wire-shape change fails this test
+// instead of silently decoding to zero values, as it did in #720.
 func TestDRep(t *testing.T) {
-	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			t.Errorf("method = %q", r.Method)
-		}
-		if r.URL.Path != "/api/v0/governance/dreps/drep1abc" {
-			t.Errorf("path = %q", r.URL.Path)
-		}
+	drepResp := func(w http.ResponseWriter, resp dingoblockfrost.DRepResponse) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"drep_id":"drep1abc","hex":"abc","has_script":false,"registered":true,"amount":"123","active":true,"live_stake":"123"}`))
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode fixture: %v", err)
+		}
+	}
+
+	t.Run("active, not retired", func(t *testing.T) {
+		c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				t.Errorf("method = %q", r.Method)
+			}
+			if r.URL.Path != "/api/v0/governance/dreps/drep1abc" {
+				t.Errorf("path = %q", r.URL.Path)
+			}
+			drepResp(w, dingoblockfrost.DRepResponse{
+				DRepID:    "drep1abc",
+				Hex:       "abc",
+				HasScript: false,
+				Amount:    "123",
+				Active:    true,
+				Retired:   false,
+			})
+		})
+		got, err := c.DRep(context.Background(), "drep1abc")
+		if err != nil {
+			t.Fatalf("DRep: %v", err)
+		}
+		if got.DRepID != "drep1abc" || got.Retired || !got.Active {
+			t.Fatalf("unexpected drep: %+v", got)
+		}
 	})
-	got, err := c.DRep(context.Background(), "drep1abc")
-	if err != nil {
-		t.Fatalf("DRep: %v", err)
-	}
-	if got.DRepID != "drep1abc" || !got.Registered || !got.Active {
-		t.Fatalf("unexpected drep: %+v", got)
-	}
+
+	t.Run("retired drep decodes Retired", func(t *testing.T) {
+		c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			drepResp(w, dingoblockfrost.DRepResponse{
+				DRepID:  "drep1retired",
+				Hex:     "def",
+				Amount:  "0",
+				Active:  false,
+				Retired: true,
+			})
+		})
+		got, err := c.DRep(context.Background(), "drep1retired")
+		if err != nil {
+			t.Fatalf("DRep: %v", err)
+		}
+		if !got.Retired {
+			t.Fatalf("expected Retired to decode true: %+v", got)
+		}
+	})
 }
 
 func TestDRepNotFound(t *testing.T) {

--- a/ui/internal/spend/delegation.go
+++ b/ui/internal/spend/delegation.go
@@ -521,7 +521,7 @@ func (s *Service) ownDRepRegistered(ctx context.Context, q chainQuerier, own lco
 			}
 			continue
 		}
-		return info.Registered, nil
+		return !info.Retired, nil
 	}
 	if firstErr != nil {
 		return false, fmt.Errorf("verify own DRep: %w", firstErr)

--- a/ui/internal/spend/delegation_test.go
+++ b/ui/internal/spend/delegation_test.go
@@ -337,7 +337,7 @@ func newFakeQuerier() *fakeQuerier {
 	return &fakeQuerier{
 		account: chain.AccountInfo{Active: false, WithdrawableAmount: "0"},
 		pool:    chain.PoolInfo{PoolID: "pool1abc"},
-		drep:    chain.DRepInfo{DRepID: "drep1abc", Registered: true},
+		drep:    chain.DRepInfo{DRepID: "drep1abc", Retired: false},
 		params:  chain.ProtocolParams{KeyDeposit: "2000000", PoolDeposit: "500000000", DRepDeposit: &dd},
 	}
 }
@@ -483,7 +483,7 @@ func TestBuildDelegationRegisterSelfNoChange(t *testing.T) {
 	q := newFakeQuerier()
 	q.account = chain.AccountInfo{Registered: true, Active: true, WithdrawableAmount: "0"}
 	q.accountDRepID = strptr(own.String())
-	q.drep = chain.DRepInfo{DRepID: own.String(), Registered: true}
+	q.drep = chain.DRepInfo{DRepID: own.String(), Retired: false}
 	s.SetChainQuerier(q)
 
 	_, err = s.BuildDelegation(context.Background(), DelegationRequest{Vote: &Vote{Type: VoteRegisterSelf}})
@@ -506,7 +506,7 @@ func TestBuildDelegationRegisterSelfAlreadyRegisteredVoteOnly(t *testing.T) {
 	q := newFakeQuerier()
 	q.account = chain.AccountInfo{Registered: true, Active: true, WithdrawableAmount: "0"}
 	q.accountDRepID = strptr("drep_abstain")
-	q.drep = chain.DRepInfo{DRepID: own.String(), Registered: true}
+	q.drep = chain.DRepInfo{DRepID: own.String(), Retired: false}
 	s.SetChainQuerier(q)
 
 	pv, err := s.BuildDelegation(context.Background(), DelegationRequest{Vote: &Vote{Type: VoteRegisterSelf}})

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -295,16 +295,15 @@ export interface GovernanceActionsResponse {
 }
 
 // DRepInfo mirrors GET /wallet/drep/{id}: a node-verified readout of a single
-// DRep, used to confirm a pasted id before delegating. amount / live_stake are
-// the DRep's voting power as decimal lovelace strings.
+// DRep, used to confirm a pasted id before delegating. amount is the DRep's
+// voting power as a decimal lovelace string.
 export interface DRepInfo {
   drep_id: string;
   hex: string;
   has_script: boolean;
-  registered: boolean;
   amount: string;
   active: boolean;
-  live_stake: string;
+  retired: boolean;
 }
 
 // DRepMetadata is the DRep's resolved CIP-119 anchor document as reported by

--- a/ui/web/src/screens/Staking.test.tsx
+++ b/ui/web/src/screens/Staking.test.tsx
@@ -34,10 +34,9 @@ const MOCK_DREP: DRepInfo = {
   drep_id: "drep1abc",
   hex: "abc",
   has_script: false,
-  registered: true,
   amount: "500000000",
   active: true,
-  live_stake: "4200000000",
+  retired: false,
 };
 
 const MOCK_PREVIEW: DelegationPreview = {

--- a/ui/web/src/screens/Staking.tsx
+++ b/ui/web/src/screens/Staking.tsx
@@ -337,7 +337,7 @@ function Compose(props: ComposeProps) {
                     {drep && (
                       <p className="verified-readout">
                         <span className="verified-tick">✓ Verified by your node</span>
-                        {drep.registered ? " · registered" : " · not registered"}
+                        {!drep.retired ? " · registered" : " · not registered"}
                         <ExplorerLink network={network} kind="drep" id={drep.drep_id} />
                       </p>
                     )}


### PR DESCRIPTION
## Summary

dingo dropped the `registered`/`live_stake` fields from its DRep response in v0.68. `DRepInfo` still decoded them, so `Registered` silently zero-valued to `false` on every call — no decode error, since Go leaves unmatched JSON keys at their zero value.

Two user-visible consequences on `main`:
- **Staking** reported any registered DRep as "not registered" (`drep.registered` was always false).
- **Self-delegation** planned a duplicate `CertDRepRegistration` (and a second 500 ADA `drep_deposit`) for an already-registered DRep, since `ownDRepRegistered` returned `info.Registered`, which was always false. The ledger rejects the resulting tx; no funds are lost, but the flow is blocked and the deposit preview is wrong.

## Changes by file

- **`ui/internal/chain/blockfrost.go`** — `DRepInfo` now mirrors dingo's actual `DRepResponse` wire shape: added `ActiveEpoch`, `Retired`, `Expired`, `LastActiveEpoch`; dropped `Registered` and the dead `LiveStake` (never populated, no consumer). `Client.DRep` goes back to a plain decode — no more field to derive.
- **`ui/internal/spend/delegation.go`** — `ownDRepRegistered` now returns `!info.Retired` directly instead of the removed `info.Registered`.
- **`ui/web/src/screens/Staking.tsx`** — the DRep verification readout checks `!drep.retired` instead of `drep.registered`.
- **`ui/web/src/api/types.ts`** — `DRepInfo` interface drops `registered`/`live_stake`, adds `retired: boolean`, matching the shape `DRepListItem` already uses (from #718). Updated a stale doc comment that still referenced `live_stake`.

This mirrors the pattern #718 already established for `DRepListItem`/`DRepDirectory.tsx`: no derived `registered` field anywhere, callers read `retired` directly.

## Tests modified

- **`ui/internal/chain/blockfrost_test.go`** — `TestDRep` now marshals dingo's own `dingoblockfrost.DRepResponse` type as its fixture instead of a hand-written JSON literal, so a future wire-shape rename fails the test instead of silently zeroing a bool. Split into two subtests: an active/not-retired DRep, and a retired DRep (asserting `Retired` decodes correctly).
- **`ui/internal/spend/delegation_test.go`** — the three `chain.DRepInfo{..., Registered: true}` fixtures (in `newFakeQuerier` and two `BuildDelegation` tests) now use `Retired: false`, matching the new field.
- **`ui/web/src/screens/Staking.test.tsx`** — `MOCK_DREP` drops `registered`/`live_stake`, adds `retired: false`.

## Validation

- `go build ./...`, `go vet ./...`, `gofmt -l .` — clean
- `go test ./internal/chain/... ./internal/spend/... ./internal/api/...` — pass
- `golangci-lint run` on the changed packages — 0 issues
- `npx tsc --noEmit` — clean
- `npx vitest run` — 822/822 tests pass

## Scope note

Verified at the decode, plan-construction, and unit-test level (as above). Neither original consequence was exercised end-to-end against a synced node — no devnet or preview node was available in this environment.


Closes #720 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Improved DRep lifecycle tracking with active, retired, and expired status information.
  * Updated staking screens to accurately show whether a DRep is registered based on retirement status.
  * Removed outdated registration and live-stake details from DRep information.
* **Bug Fixes**
  * Corrected handling and display of active and retired DReps.
  * Unknown DReps continue to return a not-found result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->