### PR TITLE
fix(wallet): reuse account stake key for addresses

### DIFF
--- a/bursa.go
+++ b/bursa.go
@@ -2212,6 +2212,8 @@ func validateScriptInvalidBefore(
 	return slot >= script.Slot
 }
 
+// GetAddress derives a base address using payment key index num and the
+// account's default stake key at index 0.
 func GetAddress(
 	accountKey bip32.XPrv,
 	networkName string,
@@ -2231,7 +2233,7 @@ func GetAddress(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get payment key: %w", err)
 	}
-	stakeKey, err := GetStakeKey(accountKey, num)
+	stakeKey, err := GetStakeKey(accountKey, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get stake key: %w", err)
 	}

--- a/bursa_capability_test.go
+++ b/bursa_capability_test.go
@@ -490,6 +490,25 @@ func TestGetAddressBech32(t *testing.T) {
 	assert.NotEqual(t, mainnet.String(), testnet.String())
 }
 
+func TestGetAddressUsesAccountStakeKey(t *testing.T) {
+	accountKey := capabilityAccountKey(t)
+	stakeKey, err := GetStakeKey(accountKey, 0)
+	require.NoError(t, err)
+	wantStakeHash := stakeKey.Public().PublicKey().Hash()
+
+	address0, err := GetAddress(accountKey, "mainnet", 0)
+	require.NoError(t, err)
+	address1, err := GetAddress(accountKey, "mainnet", 1)
+	require.NoError(t, err)
+
+	require.NotEqual(t, address0.PaymentKeyHash(), address1.PaymentKeyHash(),
+		"different address indexes must use different payment keys")
+	require.Equal(t, lcommon.Blake2b224(wantStakeHash), address0.StakeKeyHash(),
+		"address index 0 must use the account stake key at index 0")
+	require.Equal(t, lcommon.Blake2b224(wantStakeHash), address1.StakeKeyHash(),
+		"address index 1 must use the account stake key at index 0")
+}
+
 func TestGetRewardAddressBech32(t *testing.T) {
 	accountKey := capabilityAccountKey(t)
 	stakeKey, err := GetStakeKey(accountKey, 0)


### PR DESCRIPTION
- Reuse stake index 0 across payment address indexes.
- Cover multiple payment indexes with a regression test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected address generation so all payment address indexes consistently use the account’s stake key.
  - Ensured addresses at different payment indexes retain distinct payment keys while sharing the correct stake key.

- **Tests**
  - Added coverage verifying stake key consistency and payment key uniqueness across address indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->