### PR TITLE
fix(ui): accept same-origin EventSource requests

### DIFF
--- a/ui/internal/api/connector.go
+++ b/ui/internal/api/connector.go
@@ -381,9 +381,8 @@ func handleConnectorPendingPairings(svc *connector.Service, authorizeCode func(p
 // handleConnectorEvents handles GET /connector/events.
 //
 // This is a Server-Sent Events (SSE) stream consumed by the Bursa SPA. It is
-// guarded by strictSameOrigin() and does NOT
-// require the extension bearer token — that is scoped to extension-facing
-// routes only.
+// guarded by sameOrigin() and does NOT require the extension bearer token —
+// that is scoped to extension-facing routes only.
 //
 // On connect:
 //  1. Emits the current pending queue as one authoritative snapshot event.
@@ -393,10 +392,10 @@ func handleConnectorPendingPairings(svc *connector.Service, authorizeCode func(p
 //  4. Returns when the client disconnects (r.Context().Done()).
 func handleConnectorEvents(svc *connector.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// SPA-facing: require a browser same-origin request before opening the
-		// stream. Without this guard local non-browser clients could observe
-		// pending dApp request metadata, including request IDs.
-		if !strictSameOrigin(r) {
+		// EventSource can omit Origin for same-origin GETs. Accept that browser
+		// request shape only over a loopback Host; sameOrigin still rejects an
+		// explicit cross-origin request or a DNS-rebound public Host.
+		if !sameOrigin(r) {
 			writeJSON(w, http.StatusForbidden, map[string]string{"error": "cross-origin request refused"})
 			return
 		}

--- a/ui/internal/api/connector_test.go
+++ b/ui/internal/api/connector_test.go
@@ -569,7 +569,8 @@ func TestConnectorEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}
-	req.Header.Set("Origin", srv.URL)
+	// Browser EventSource can send this same-origin GET without an Origin header.
+	// The loopback Host is the request's same-origin and DNS-rebinding boundary.
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("Do: %v", err)
@@ -645,6 +646,44 @@ func TestConnectorEvents(t *testing.T) {
 		t.Error("did not receive authoritative empty snapshot after decision")
 	}
 	// cancel() (deferred above) ends the SSE stream.
+}
+
+func TestConnectorEventsRejectsCrossOrigin(t *testing.T) {
+	svc := connector.NewService(t.TempDir(), &fakeConnectorBackend{}, nil)
+	handler := handleConnectorEvents(svc)
+
+	tests := []struct {
+		name   string
+		host   string
+		origin string
+	}{
+		{
+			name:   "cross-origin header",
+			host:   "127.0.0.1:8090",
+			origin: "https://evil.example",
+		},
+		{
+			name: "DNS-rebound Host without Origin",
+			host: "evil.example:8090",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/connector/events", nil)
+			req.Host = test.host
+			if test.origin != "" {
+				req.Header.Set("Origin", test.origin)
+			}
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403; body: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
 }
 
 type writeDeadlineRecorder struct {


### PR DESCRIPTION
Same-origin EventSource GETs without Origin are accepted only over loopback. Cross-origin requests and DNS-rebound Hosts remain rejected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the connector events SSE endpoint so browsers using EventSource can open a same-origin stream. The old `strictSameOrigin` check rejected EventSource GETs that omit the Origin header; the new `sameOrigin` check accepts those requests only over a loopback Host and still refuses explicit cross-origin or DNS-rebound public Hosts.

<sup>Written for commit d8c73916501918a42ffd17c6a74cbbaf0b0798c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

