### PR TITLE
fix(extension): implement CIP-30 extension negotiation

### DIFF
--- a/ui/extension/e2e/README.md
+++ b/ui/extension/e2e/README.md
@@ -89,7 +89,8 @@ Work through the buttons top-to-bottom:
 | Button | Expected behaviour |
 |--------|--------------------|
 | `isEnabled()` | Returns `false` (not yet approved) |
-| `enable()` | Bursa shows an **Approve Connection** prompt; accept it. Returns the CIP-30 API object. |
+| `enable()` | Requests CIP-95. Bursa shows an **Approve Connection** prompt; accept it. Returns the CIP-30 API object. |
+| `getExtensions()` | Returns `[{ "cip": 95 }]` |
 | `getNetworkId()` | Returns `0` (testnet) or `1` (mainnet) |
 | `getBalance()` | Returns a CBOR-hex encoded `Value` |
 | `getUsedAddresses()` | Returns an array of bech32 addresses (may be empty) |

--- a/ui/extension/e2e/sample-dapp.html
+++ b/ui/extension/e2e/sample-dapp.html
@@ -67,6 +67,7 @@
 
   <h2>CIP-30 API</h2>
   <div class="btn-group">
+    <button id="btn-extensions" disabled>getExtensions()</button>
     <button id="btn-network-id" disabled>getNetworkId()</button>
     <button id="btn-balance" disabled>getBalance()</button>
     <button id="btn-used-addrs" disabled>getUsedAddresses()</button>
@@ -186,10 +187,10 @@
     // ---------------------------------------------------------------------------
 
     document.getElementById('btn-enable').onclick = async () => {
-      section('enable()');
+      section('enable({ extensions: [{ cip: 95 }] })');
       try {
         const bursa = getBursa();
-        api = await bursa.enable();
+        api = await bursa.enable({ extensions: [{ cip: 95 }] });
         setEnabled(true);
         ok('API object obtained');
       } catch (e) { err(e); }
@@ -201,6 +202,11 @@
         const result = await getBursa().isEnabled();
         ok(result);
       } catch (e) { err(e); }
+    };
+
+    document.getElementById('btn-extensions').onclick = async () => {
+      section('getExtensions()');
+      try { ok(await api.getExtensions()); } catch (e) { err(e); }
     };
 
     document.getElementById('btn-network-id').onclick = async () => {

--- a/ui/extension/src/injected.ts
+++ b/ui/extension/src/injected.ts
@@ -5,8 +5,16 @@ export {};
 
 declare global {
   interface Window {
-    cardano?: Record<string, unknown>;
+    cardano?: Record<string, unknown> & { bursa?: CIP30Provider };
   }
+}
+
+interface Extension {
+  cip: number;
+}
+
+interface EnableOptions {
+  extensions?: Extension[];
 }
 
 interface Paginate {
@@ -19,7 +27,14 @@ interface CIP30Error {
   info: string;
 }
 
+interface CIP95API {
+  getPubDRepKey(): Promise<string>;
+  getRegisteredPubStakeKeys(): Promise<string[]>;
+  getUnregisteredPubStakeKeys(): Promise<string[]>;
+}
+
 interface CIP30API {
+  getExtensions(): Promise<Extension[]>;
   getNetworkId(): Promise<number>;
   getUtxos(amount?: string, paginate?: Paginate): Promise<string[] | null>;
   getBalance(): Promise<string>;
@@ -31,12 +46,19 @@ interface CIP30API {
   signTx(tx: string, partialSign?: boolean): Promise<string>;
   signData(addr: string, payload: string): Promise<{ signature: string; key: string }>;
   submitTx(tx: string): Promise<string>;
-  cip95: {
-    getPubDRepKey(): Promise<string>;
-    getRegisteredPubStakeKeys(): Promise<string[]>;
-    getUnregisteredPubStakeKeys(): Promise<string[]>;
-  };
+  cip95?: CIP95API;
 }
+
+interface CIP30Provider {
+  apiVersion: string;
+  name: string;
+  icon: string;
+  supportedExtensions: Extension[];
+  isEnabled(): Promise<boolean>;
+  enable(options?: EnableOptions): Promise<CIP30API>;
+}
+
+const SUPPORTED_EXTENSIONS: readonly Extension[] = [{ cip: 95 }];
 
 // Slightly longer than the background's 125s fetch timeout so a real (slow)
 // reply is preferred over our local timeout when both are in flight.
@@ -111,8 +133,36 @@ async function safeRequest(method: string, params?: unknown): Promise<unknown> {
   }
 }
 
-function buildCIP30API(): CIP30API {
+function copyExtensions(extensions: readonly Extension[]): Extension[] {
+  return extensions.map(({ cip }) => ({ cip }));
+}
+
+function negotiateExtensions(requestedExtensions: readonly Extension[]): Extension[] {
+  const requestedCIPs = new Set(requestedExtensions.map(({ cip }) => cip));
+  return copyExtensions(
+    SUPPORTED_EXTENSIONS.filter(({ cip }) => requestedCIPs.has(cip))
+  );
+}
+
+function buildCIP95API(): CIP95API {
   return {
+    async getPubDRepKey(): Promise<string> {
+      return safeRequest('cip95.getPubDRepKey') as Promise<string>;
+    },
+    async getRegisteredPubStakeKeys(): Promise<string[]> {
+      return safeRequest('cip95.getRegisteredPubStakeKeys') as Promise<string[]>;
+    },
+    async getUnregisteredPubStakeKeys(): Promise<string[]> {
+      return safeRequest('cip95.getUnregisteredPubStakeKeys') as Promise<string[]>;
+    },
+  };
+}
+
+function buildCIP30API(enabledExtensions: readonly Extension[]): CIP30API {
+  const api: CIP30API = {
+    async getExtensions(): Promise<Extension[]> {
+      return copyExtensions(enabledExtensions);
+    },
     async getNetworkId(): Promise<number> {
       return safeRequest('getNetworkId') as Promise<number>;
     },
@@ -146,25 +196,19 @@ function buildCIP30API(): CIP30API {
     async submitTx(tx: string): Promise<string> {
       return safeRequest('submitTx', { tx }) as Promise<string>;
     },
-    cip95: {
-      async getPubDRepKey(): Promise<string> {
-        return safeRequest('cip95.getPubDRepKey') as Promise<string>;
-      },
-      async getRegisteredPubStakeKeys(): Promise<string[]> {
-        return safeRequest('cip95.getRegisteredPubStakeKeys') as Promise<string[]>;
-      },
-      async getUnregisteredPubStakeKeys(): Promise<string[]> {
-        return safeRequest('cip95.getUnregisteredPubStakeKeys') as Promise<string[]>;
-      },
-    },
   };
+
+  if (enabledExtensions.some(({ cip }) => cip === 95)) {
+    api.cip95 = buildCIP95API();
+  }
+  return api;
 }
 
-const bursaProvider = {
-  apiVersion: '0.1.0',
+const bursaProvider: CIP30Provider = {
+  apiVersion: '1',
   name: 'Bursa',
   icon: 'data:image/svg+xml,%3Csvg xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22 width%3D%221%22 height%3D%221%22%2F%3E',
-  supportedExtensions: [{ cip: 95 }],
+  supportedExtensions: copyExtensions(SUPPORTED_EXTENSIONS),
 
   async isEnabled(): Promise<boolean> {
     // Use safeRequest for parity with enable(): rejections become CIP-30
@@ -174,12 +218,19 @@ const bursaProvider = {
     return safeRequest('isEnabled') as Promise<boolean>;
   },
 
-  async enable(): Promise<CIP30API> {
+  async enable({ extensions = [] }: EnableOptions = {}): Promise<CIP30API> {
     try {
+      const requestedExtensions = copyExtensions(extensions);
+      const enabledExtensions = negotiateExtensions(requestedExtensions);
       // See isEnabled: the origin is derived from the sender by the background
       // worker, so we deliberately do not pass a page-controlled origin.
-      await sendRequest('enable');
-      return buildCIP30API();
+      await sendRequest(
+        'enable',
+        requestedExtensions.length > 0
+          ? { extensions: requestedExtensions }
+          : undefined
+      );
+      return buildCIP30API(enabledExtensions);
     } catch (err) {
       throw wrapError(err);
     }

--- a/ui/extension/tests/injected.test.ts
+++ b/ui/extension/tests/injected.test.ts
@@ -9,6 +9,24 @@ const jsdomEnv = globalThis as typeof globalThis & {
   };
 };
 
+interface TestExtension {
+  cip: number;
+}
+
+interface TestCIP30API {
+  getExtensions(): Promise<TestExtension[]>;
+  getNetworkId(): Promise<number>;
+  cip95?: {
+    getPubDRepKey(): Promise<string>;
+  };
+}
+
+interface TestProvider {
+  apiVersion: string;
+  supportedExtensions: TestExtension[];
+  enable(options?: { extensions?: TestExtension[] }): Promise<TestCIP30API>;
+}
+
 describe('injected provider', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -19,6 +37,66 @@ describe('injected provider', () => {
     expect(window.cardano?.bursa).toBeDefined();
     const provider = window.cardano?.bursa as { name: string };
     expect(provider.name).toBe('Bursa');
+  });
+
+  it('publishes the CIP-30 v1 provider metadata', () => {
+    const provider = window.cardano?.bursa as TestProvider;
+
+    expect(provider.apiVersion).toBe('1');
+    expect(provider.supportedExtensions).toEqual([{ cip: 95 }]);
+  });
+
+  it('negotiates requested extensions and exposes their API surface', async () => {
+    const postMessageSpy = vi.spyOn(window, 'postMessage');
+    const provider = window.cardano?.bursa as TestProvider;
+    const requestedExtensions = [{ cip: 95 }, { cip: 142 }, { cip: 95 }];
+
+    const enablePromise = provider.enable({ extensions: requestedExtensions });
+    const enableCall = postMessageSpy.mock.calls[0][0] as {
+      id: string;
+      method: string;
+      params: unknown;
+    };
+    expect(enableCall.method).toBe('enable');
+    expect(enableCall.params).toEqual({ extensions: requestedExtensions });
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { source: 'bursa-cip30-reply', id: enableCall.id, result: true },
+        source: window,
+      })
+    );
+
+    const api = await enablePromise;
+    await expect(api.getExtensions()).resolves.toEqual([{ cip: 95 }]);
+    expect(api.cip95?.getPubDRepKey).toBeTypeOf('function');
+
+    const returnedExtensions = await api.getExtensions();
+    returnedExtensions.push({ cip: 142 });
+    await expect(api.getExtensions()).resolves.toEqual([{ cip: 95 }]);
+  });
+
+  it('returns the base API when no extensions are requested', async () => {
+    const postMessageSpy = vi.spyOn(window, 'postMessage');
+    const provider = window.cardano?.bursa as TestProvider;
+
+    const enablePromise = provider.enable();
+    const enableCall = postMessageSpy.mock.calls[0][0] as {
+      id: string;
+      params: unknown;
+    };
+    expect(enableCall.params).toBeUndefined();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { source: 'bursa-cip30-reply', id: enableCall.id, result: true },
+        source: window,
+      })
+    );
+
+    const api = await enablePromise;
+    await expect(api.getExtensions()).resolves.toEqual([]);
+    expect(api.cip95).toBeUndefined();
   });
 
   it('postMessage shape: getNetworkId posts correct message', async () => {


### PR DESCRIPTION
Fixes #761; Refs #753

Provider API v1 negotiates requested extensions and reports enabled extensions.

CIP-95 is exposed only when enabled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements CIP-30 extension negotiation so Bursa only exposes CIP-95 when a dapp requests it. Previously `enable()` always returned the full API including `cip95`.

- `enable({ extensions })` negotiates the requested extensions against the supported `{ cip: 95 }` and forwards them to the background worker.
- `getExtensions()` reports the negotiated extensions, and `cip95` is only attached when CIP-95 is enabled.
- Provider `apiVersion` changes from `0.1.0` to `1`.

<sup>Written for commit 2d29c1ffffce6f6c1117263123587ca1cdaad9e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

