### PR TITLE
fix(ui): allow receiving during node bootstrap

### DIFF
--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -1089,8 +1089,19 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 	mux.HandleFunc("GET /wallet/addresses", func(w http.ResponseWriter, r *http.Request) {
 		var v wallet.AddressView
 		var err error
-		if nodeQueryable(st.Status().State) {
+		// A syncing node can answer reads, but its partial ledger view cannot
+		// authoritatively classify an address as unused. Query usage only after the
+		// node reaches the current chain tip; local derivation remains available in
+		// every earlier lifecycle state.
+		if st.Status().State == supervisor.StateReady {
 			v, err = wl.Addresses(r.Context())
+			// Do not publish a classification obtained across a Ready -> syncing
+			// transition. The query result may reflect only the new partial view.
+			if err == nil && st.Status().State != supervisor.StateReady {
+				v.Used = []string{}
+				v.UsageKnown = false
+				v.NextUnused = ""
+			}
 		} else {
 			v, err = wl.LocalAddresses()
 		}

--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -58,6 +58,9 @@ type Wallet interface {
 	// (not necessarily the bound one) — used to summarize each account in the
 	// multi-account listing without rebinding.
 	BalanceForAccount(ctx context.Context, acct *wallet.Account) (wallet.Balance, error)
+	// LocalAddresses returns the derived receive window without consulting the
+	// node, so Receive remains available during startup and bootstrap.
+	LocalAddresses() (wallet.AddressView, error)
 	Addresses(ctx context.Context) (wallet.AddressView, error)
 	Transactions(ctx context.Context) ([]wallet.Tx, error)
 	// TransactionDetail returns the drill-down view (inputs/outputs, every
@@ -1083,10 +1086,16 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 		v, err := wl.Balance(r.Context())
 		serve(w, v, err)
 	}))
-	mux.HandleFunc("GET /wallet/addresses", gated(st, func(w http.ResponseWriter, r *http.Request) {
-		v, err := wl.Addresses(r.Context())
+	mux.HandleFunc("GET /wallet/addresses", func(w http.ResponseWriter, r *http.Request) {
+		var v wallet.AddressView
+		var err error
+		if nodeQueryable(st.Status().State) {
+			v, err = wl.Addresses(r.Context())
+		} else {
+			v, err = wl.LocalAddresses()
+		}
 		serve(w, v, err)
-	}))
+	})
 	mux.HandleFunc("GET /wallet/transactions", gated(st, func(w http.ResponseWriter, r *http.Request) {
 		v, err := wl.Transactions(r.Context())
 		serve(w, v, err)
@@ -2287,7 +2296,7 @@ func resolveNetwork(w http.ResponseWriter, reqNet, nodeNet string) (string, bool
 func gated(st Statuser, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		state := st.Status().State
-		if state != supervisor.StateReady && state != supervisor.StateSyncing {
+		if !nodeQueryable(state) {
 			writeJSON(w, http.StatusServiceUnavailable, map[string]any{
 				"error": "node not ready", "state": state,
 			})
@@ -2295,6 +2304,10 @@ func gated(st Statuser, next http.HandlerFunc) http.HandlerFunc {
 		}
 		next(w, r)
 	}
+}
+
+func nodeQueryable(state supervisor.NodeState) bool {
+	return state == supervisor.StateReady || state == supervisor.StateSyncing
 }
 
 // readyGate blocks spending until the node is fully synced (StateReady). It is

--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -1093,11 +1093,14 @@ func NewHandler(st Statuser, vlt Vault, wl Wallet, sp Spender, settings Settings
 		// authoritatively classify an address as unused. Query usage only after the
 		// node reaches the current chain tip; local derivation remains available in
 		// every earlier lifecycle state.
-		if st.Status().State == supervisor.StateReady {
+		before := st.Status()
+		if before.State == supervisor.StateReady {
 			v, err = wl.Addresses(r.Context())
 			// Do not publish a classification obtained across a Ready -> syncing
 			// transition. The query result may reflect only the new partial view.
-			if err == nil && st.Status().State != supervisor.StateReady {
+			after := st.Status()
+			if err == nil && (after.State != supervisor.StateReady ||
+				after.ReadinessGeneration != before.ReadinessGeneration) {
 				v.Used = []string{}
 				v.UsageKnown = false
 				v.NextUnused = ""

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -59,8 +59,9 @@ type fakeStatuser struct{ s supervisor.Status }
 func (f fakeStatuser) Status() supervisor.Status { return f.s }
 
 type sequenceStatuser struct {
-	states []supervisor.NodeState
-	calls  int
+	states      []supervisor.NodeState
+	generations []uint64
+	calls       int
 }
 
 func (s *sequenceStatuser) Status() supervisor.Status {
@@ -69,7 +70,11 @@ func (s *sequenceStatuser) Status() supervisor.Status {
 		idx = len(s.states) - 1
 	}
 	s.calls++
-	return supervisor.Status{State: s.states[idx]}
+	var generation uint64
+	if idx < len(s.generations) {
+		generation = s.generations[idx]
+	}
+	return supervisor.Status{State: s.states[idx], ReadinessGeneration: generation}
 }
 
 // fakeVault implements the api.Vault interface. It models the layered model in
@@ -1800,6 +1805,35 @@ func TestWalletAddressesDiscardUsageIfNodeLeavesReadyDuringQuery(t *testing.T) {
 	}
 	if fw.addressesCalled != 1 {
 		t.Fatalf("chain address calls = %d, want 1", fw.addressesCalled)
+	}
+}
+
+func TestWalletAddressesDiscardUsageAcrossReadyGeneration(t *testing.T) {
+	st := &sequenceStatuser{
+		states:      []supervisor.NodeState{supervisor.StateReady, supervisor.StateReady},
+		generations: []uint64{4, 5},
+	}
+	fw := &fakeWallet{
+		set: true,
+		addresses: wallet.AddressView{
+			Receive:    []string{"addr_test1used", "addr_test1unused"},
+			Used:       []string{"addr_test1used"},
+			UsageKnown: true,
+			NextUnused: "addr_test1unused",
+		},
+	}
+	h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/addresses", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /wallet/addresses across readiness generation = %d, want 200", rec.Code)
+	}
+	var got wallet.AddressView
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode addresses: %v", err)
+	}
+	if got.UsageKnown || len(got.Used) != 0 || got.NextUnused != "" {
+		t.Fatalf("addresses across readiness generation = %+v, want unknown usage", got)
 	}
 }
 

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -1053,14 +1053,17 @@ func TestStatusReturnsSnapshot(t *testing.T) {
 // fakeWallet is stateful like the real service: queries return wallet.ErrNoWallet
 // until SetAccount has been called (the vault pushes the active account).
 type fakeWallet struct {
-	balance          wallet.Balance
-	set              bool
-	setAccountCalled bool
-	gotNetwork       string
-	gotAccountIndex  uint32
-	txDetail         wallet.TxDetail
-	txDetailErr      error
-	rewards          wallet.RewardHistory
+	balance              wallet.Balance
+	addresses            wallet.AddressView
+	set                  bool
+	setAccountCalled     bool
+	addressesCalled      int
+	localAddressesCalled int
+	gotNetwork           string
+	gotAccountIndex      uint32
+	txDetail             wallet.TxDetail
+	txDetailErr          error
+	rewards              wallet.RewardHistory
 	// balances, when non-nil, gives BalanceForAccount a distinct balance per
 	// account index (keyed by wallet.Account.AccountIndex) — lets tests verify
 	// per-account balance attribution instead of every account echoing the same
@@ -1105,7 +1108,16 @@ func (f *fakeWallet) Addresses(_ context.Context) (wallet.AddressView, error) {
 	if !f.set {
 		return wallet.AddressView{}, wallet.ErrNoWallet
 	}
-	return wallet.AddressView{}, nil
+	f.addressesCalled++
+	return f.addresses, nil
+}
+
+func (f *fakeWallet) LocalAddresses() (wallet.AddressView, error) {
+	if !f.set {
+		return wallet.AddressView{}, wallet.ErrNoWallet
+	}
+	f.localAddressesCalled++
+	return f.addresses, nil
 }
 
 func (f *fakeWallet) Transactions(_ context.Context) ([]wallet.Tx, error) {
@@ -1659,6 +1671,84 @@ func TestWalletGatedWhileBootstrapping(t *testing.T) {
 	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/balance", nil))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("GET /wallet/balance while bootstrapping = %d, want 503", rec.Code)
+	}
+}
+
+func TestWalletAddressesAvailableWithoutQueryableNode(t *testing.T) {
+	for _, state := range []supervisor.NodeState{
+		supervisor.StateStopped,
+		supervisor.StateStarting,
+		supervisor.StateBootstrapping,
+		supervisor.StateError,
+	} {
+		t.Run(string(state), func(t *testing.T) {
+			st := fakeStatuser{s: supervisor.Status{State: state}}
+			fw := &fakeWallet{
+				set: true,
+				addresses: wallet.AddressView{
+					Receive:    []string{"addr_test1derived"},
+					NextUnused: "addr_test1derived",
+				},
+			}
+			h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/addresses", nil))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("GET /wallet/addresses while %s = %d, want 200", state, rec.Code)
+			}
+			var got wallet.AddressView
+			if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+				t.Fatalf("decode addresses: %v", err)
+			}
+			if len(got.Receive) != 1 || got.Receive[0] != "addr_test1derived" || got.NextUnused != "addr_test1derived" {
+				t.Fatalf("addresses while %s = %+v, want locally derived address", state, got)
+			}
+			if fw.localAddressesCalled != 1 || fw.addressesCalled != 0 {
+				t.Fatalf("address calls while %s = local %d, chain %d; want local 1, chain 0", state, fw.localAddressesCalled, fw.addressesCalled)
+			}
+		})
+	}
+}
+
+func TestWalletAddressesIncludeChainUsageWhenQueryable(t *testing.T) {
+	for _, state := range []supervisor.NodeState{supervisor.StateSyncing, supervisor.StateReady} {
+		t.Run(string(state), func(t *testing.T) {
+			st := fakeStatuser{s: supervisor.Status{State: state}}
+			fw := &fakeWallet{
+				set: true,
+				addresses: wallet.AddressView{
+					Receive:    []string{"addr_test1used", "addr_test1unused"},
+					Used:       []string{"addr_test1used"},
+					NextUnused: "addr_test1unused",
+				},
+			}
+			h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/addresses", nil))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("GET /wallet/addresses while %s = %d, want 200", state, rec.Code)
+			}
+			var got wallet.AddressView
+			if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+				t.Fatalf("decode addresses: %v", err)
+			}
+			if len(got.Used) != 1 || got.Used[0] != "addr_test1used" || got.NextUnused != "addr_test1unused" {
+				t.Fatalf("addresses while %s = %+v, want chain usage", state, got)
+			}
+			if fw.addressesCalled != 1 || fw.localAddressesCalled != 0 {
+				t.Fatalf("address calls while %s = chain %d, local %d; want chain 1, local 0", state, fw.addressesCalled, fw.localAddressesCalled)
+			}
+		})
+	}
+}
+
+func TestWalletAddressesWithoutNodeStillRequireActiveWallet(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateBootstrapping}}
+	h := NewHandler(st, &fakeVault{}, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/addresses", nil))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("GET /wallet/addresses without wallet while bootstrapping = %d, want 409", rec.Code)
 	}
 }
 

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -1686,8 +1686,7 @@ func TestWalletAddressesAvailableWithoutQueryableNode(t *testing.T) {
 			fw := &fakeWallet{
 				set: true,
 				addresses: wallet.AddressView{
-					Receive:    []string{"addr_test1derived"},
-					NextUnused: "addr_test1derived",
+					Receive: []string{"addr_test1derived"},
 				},
 			}
 			h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
@@ -1696,12 +1695,20 @@ func TestWalletAddressesAvailableWithoutQueryableNode(t *testing.T) {
 			if rec.Code != http.StatusOK {
 				t.Fatalf("GET /wallet/addresses while %s = %d, want 200", state, rec.Code)
 			}
-			var got wallet.AddressView
+			var got map[string]any
 			if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
 				t.Fatalf("decode addresses: %v", err)
 			}
-			if len(got.Receive) != 1 || got.Receive[0] != "addr_test1derived" || got.NextUnused != "addr_test1derived" {
-				t.Fatalf("addresses while %s = %+v, want locally derived address", state, got)
+			receive, ok := got["receive"].([]any)
+			if !ok || len(receive) != 1 || receive[0] != "addr_test1derived" {
+				t.Fatalf("receive addresses while %s = %#v, want locally derived address", state, got["receive"])
+			}
+			usageKnown, ok := got["usage_known"].(bool)
+			if !ok || usageKnown {
+				t.Fatalf("usage_known while %s = %#v, want explicit false", state, got["usage_known"])
+			}
+			if next, ok := got["next_unused"].(string); !ok || next != "" {
+				t.Fatalf("next_unused while %s = %#v, want empty while usage is unknown", state, got["next_unused"])
 			}
 			if fw.localAddressesCalled != 1 || fw.addressesCalled != 0 {
 				t.Fatalf("address calls while %s = local %d, chain %d; want local 1, chain 0", state, fw.localAddressesCalled, fw.addressesCalled)
@@ -1719,6 +1726,7 @@ func TestWalletAddressesIncludeChainUsageWhenQueryable(t *testing.T) {
 				addresses: wallet.AddressView{
 					Receive:    []string{"addr_test1used", "addr_test1unused"},
 					Used:       []string{"addr_test1used"},
+					UsageKnown: true,
 					NextUnused: "addr_test1unused",
 				},
 			}
@@ -1734,6 +1742,9 @@ func TestWalletAddressesIncludeChainUsageWhenQueryable(t *testing.T) {
 			}
 			if len(got.Used) != 1 || got.Used[0] != "addr_test1used" || got.NextUnused != "addr_test1unused" {
 				t.Fatalf("addresses while %s = %+v, want chain usage", state, got)
+			}
+			if !got.UsageKnown {
+				t.Fatalf("addresses while %s report unknown usage after a chain query", state)
 			}
 			if fw.addressesCalled != 1 || fw.localAddressesCalled != 0 {
 				t.Fatalf("address calls while %s = chain %d, local %d; want chain 1, local 0", state, fw.addressesCalled, fw.localAddressesCalled)

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -58,6 +58,20 @@ type fakeStatuser struct{ s supervisor.Status }
 
 func (f fakeStatuser) Status() supervisor.Status { return f.s }
 
+type sequenceStatuser struct {
+	states []supervisor.NodeState
+	calls  int
+}
+
+func (s *sequenceStatuser) Status() supervisor.Status {
+	idx := s.calls
+	if idx >= len(s.states) {
+		idx = len(s.states) - 1
+	}
+	s.calls++
+	return supervisor.Status{State: s.states[idx]}
+}
+
 // fakeVault implements the api.Vault interface. It models the layered model in
 // memory: Unlock/Lock toggle locked; AddWallet appends and activates; the active
 // wallet drives reads/spends.
@@ -1674,11 +1688,12 @@ func TestWalletGatedWhileBootstrapping(t *testing.T) {
 	}
 }
 
-func TestWalletAddressesAvailableWithoutQueryableNode(t *testing.T) {
+func TestWalletAddressesUseLocalUsageUntilNodeReady(t *testing.T) {
 	for _, state := range []supervisor.NodeState{
 		supervisor.StateStopped,
 		supervisor.StateStarting,
 		supervisor.StateBootstrapping,
+		supervisor.StateSyncing,
 		supervisor.StateError,
 	} {
 		t.Run(string(state), func(t *testing.T) {
@@ -1717,8 +1732,8 @@ func TestWalletAddressesAvailableWithoutQueryableNode(t *testing.T) {
 	}
 }
 
-func TestWalletAddressesIncludeChainUsageWhenQueryable(t *testing.T) {
-	for _, state := range []supervisor.NodeState{supervisor.StateSyncing, supervisor.StateReady} {
+func TestWalletAddressesIncludeChainUsageWhenReady(t *testing.T) {
+	for _, state := range []supervisor.NodeState{supervisor.StateReady} {
 		t.Run(string(state), func(t *testing.T) {
 			st := fakeStatuser{s: supervisor.Status{State: state}}
 			fw := &fakeWallet{
@@ -1750,6 +1765,41 @@ func TestWalletAddressesIncludeChainUsageWhenQueryable(t *testing.T) {
 				t.Fatalf("address calls while %s = chain %d, local %d; want chain 1, local 0", state, fw.addressesCalled, fw.localAddressesCalled)
 			}
 		})
+	}
+}
+
+func TestWalletAddressesDiscardUsageIfNodeLeavesReadyDuringQuery(t *testing.T) {
+	st := &sequenceStatuser{states: []supervisor.NodeState{
+		supervisor.StateReady,
+		supervisor.StateSyncing,
+	}}
+	fw := &fakeWallet{
+		set: true,
+		addresses: wallet.AddressView{
+			Receive:    []string{"addr_test1used", "addr_test1unused"},
+			Used:       []string{"addr_test1used"},
+			UsageKnown: true,
+			NextUnused: "addr_test1unused",
+		},
+	}
+	h := NewHandler(st, &fakeVault{}, fw, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, localReq(http.MethodGet, "/wallet/addresses", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /wallet/addresses across Ready transition = %d, want 200", rec.Code)
+	}
+	var got wallet.AddressView
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode addresses: %v", err)
+	}
+	if got.UsageKnown || len(got.Used) != 0 || got.NextUnused != "" {
+		t.Fatalf("addresses across Ready transition = %+v, want unknown usage", got)
+	}
+	if len(got.Receive) != 2 {
+		t.Fatalf("receive addresses = %#v, want locally derived addresses preserved", got.Receive)
+	}
+	if fw.addressesCalled != 1 {
+		t.Fatalf("chain address calls = %d, want 1", fw.addressesCalled)
 	}
 }
 

--- a/ui/internal/api/connector.go
+++ b/ui/internal/api/connector.go
@@ -470,6 +470,8 @@ func connectorErrorCode(method string, err error) (httpStatus int, code int, inf
 		return http.StatusBadRequest, -1, err.Error()
 	case errors.Is(err, connector.ErrNotGranted), errors.Is(err, connector.ErrRefused):
 		return http.StatusForbidden, -3, err.Error()
+	case errors.Is(err, connector.ErrAddressUsageUnknown):
+		return http.StatusServiceUnavailable, -3, err.Error()
 	case errors.Is(err, connector.ErrTimeout):
 		return http.StatusRequestTimeout, -3, "request timed out"
 	case errors.Is(err, connector.ErrQueueFull):

--- a/ui/internal/api/connector_test.go
+++ b/ui/internal/api/connector_test.go
@@ -235,6 +235,8 @@ func TestConnectorErrorCode(t *testing.T) {
 		{"ErrNotGranted/getBalance", "getBalance", connector.ErrNotGranted, 403, -3, "connector: origin not granted"},
 		// ErrRefused → 403, -3
 		{"ErrRefused/unknown", "unknown", connector.ErrRefused, 403, -3, "connector: refused"},
+		// Unknown address usage is temporarily unavailable but remains a CIP-30 Refused error.
+		{"ErrAddressUsageUnknown", "getUsedAddresses", connector.ErrAddressUsageUnknown, 503, -3, "connector: address usage is unavailable"},
 		// ErrTimeout → 408, -3
 		{"ErrTimeout", "signTx", connector.ErrTimeout, 408, -3, "request timed out"},
 		// ErrQueueFull → 429, -3

--- a/ui/internal/boot/boot.go
+++ b/ui/internal/boot/boot.go
@@ -366,13 +366,19 @@ func Boot(ctx context.Context, cfg Config) (*App, error) {
 
 	var connectorSvc *connector.Service
 	if cfg.ConnectorEnabled {
-		connectorBackend := connector.NewWalletBackend(
+		connectorBackend := connector.NewWalletBackendWithReadiness(
 			walletSvc,
 			spendSvc,
 			nil,
 			cfg.Network,
 			chainClient,
-			func() bool { return sup.Status().State == supervisor.StateReady },
+			func() connector.ReadinessSnapshot {
+				status := sup.Status()
+				return connector.ReadinessSnapshot{
+					Ready:      status.State == supervisor.StateReady,
+					Generation: status.ReadinessGeneration,
+				}
+			},
 		)
 		connectorSvc = connector.NewService(cfg.DataDir, connectorBackend, nil)
 	}

--- a/ui/internal/boot/boot.go
+++ b/ui/internal/boot/boot.go
@@ -372,6 +372,7 @@ func Boot(ctx context.Context, cfg Config) (*App, error) {
 			nil,
 			cfg.Network,
 			chainClient,
+			func() bool { return sup.Status().State == supervisor.StateReady },
 		)
 		connectorSvc = connector.NewService(cfg.DataDir, connectorBackend, nil)
 	}

--- a/ui/internal/connector/backend.go
+++ b/ui/internal/connector/backend.go
@@ -52,6 +52,10 @@ type WalletBackend struct {
 	sp      *spend.Service // reserved for Tasks 12-13
 	chain   chainFetcher
 	network string
+	// usageAuthoritative reports whether the node has a complete chain view.
+	// It is optional at construction for compatibility with non-supervised
+	// callers; production supplies the embedded node's readiness predicate.
+	usageAuthoritative func() bool
 
 	// mu guards walletID/acct, which are rebound whenever the active wallet
 	// changes (unlock/activate/add). dApp request handlers read them
@@ -72,13 +76,19 @@ func NewWalletBackend(
 	acct *wallet.Account,
 	network string,
 	cf chainFetcher,
+	usageAuthoritative ...func() bool,
 ) *WalletBackend {
+	usageReady := func() bool { return true }
+	if len(usageAuthoritative) > 0 && usageAuthoritative[0] != nil {
+		usageReady = usageAuthoritative[0]
+	}
 	return &WalletBackend{
-		wl:      wl,
-		sp:      sp,
-		acct:    acct,
-		chain:   cf,
-		network: network,
+		wl:                 wl,
+		sp:                 sp,
+		acct:               acct,
+		chain:              cf,
+		network:            network,
+		usageAuthoritative: usageReady,
 	}
 }
 
@@ -122,9 +132,35 @@ func (b *WalletBackend) NetworkID() int {
 	return 0
 }
 
+// knownAddressView returns an address view only when its used/unused
+// classification is authoritative. The explicit unavailable error is shared by
+// every CIP-30 address method so an empty Used slice is never mistaken for a
+// definitive answer.
+func (b *WalletBackend) knownAddressView(ctx context.Context) (wallet.AddressView, error) {
+	var (
+		av  wallet.AddressView
+		err error
+	)
+	if b.usageAuthoritative() {
+		av, err = b.wl.Addresses(ctx)
+		if err == nil && !b.usageAuthoritative() {
+			return wallet.AddressView{}, ErrAddressUsageUnknown
+		}
+	} else {
+		av, err = b.wl.LocalAddresses()
+	}
+	if err != nil {
+		return wallet.AddressView{}, err
+	}
+	if !av.UsageKnown {
+		return wallet.AddressView{}, ErrAddressUsageUnknown
+	}
+	return av, nil
+}
+
 // UsedAddresses returns hex-encoded raw address bytes for each chain-seen address.
 func (b *WalletBackend) UsedAddresses(ctx context.Context, paginate *Paginate) ([]string, error) {
-	av, err := b.wl.Addresses(ctx)
+	av, err := b.knownAddressView(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +169,7 @@ func (b *WalletBackend) UsedAddresses(ctx context.Context, paginate *Paginate) (
 
 // UnusedAddresses returns hex-encoded raw bytes for derived addresses not yet on chain.
 func (b *WalletBackend) UnusedAddresses(ctx context.Context) ([]string, error) {
-	av, err := b.wl.Addresses(ctx)
+	av, err := b.knownAddressView(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +191,7 @@ func (b *WalletBackend) UnusedAddresses(ctx context.Context) ([]string, error) {
 // ChangeAddress returns the hex-encoded raw bytes of the first unused receive
 // address (or receive[0] when all are used).
 func (b *WalletBackend) ChangeAddress(ctx context.Context) (string, error) {
-	av, err := b.wl.Addresses(ctx)
+	av, err := b.knownAddressView(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/ui/internal/connector/backend.go
+++ b/ui/internal/connector/backend.go
@@ -55,7 +55,7 @@ type WalletBackend struct {
 	// usageAuthoritative reports whether the node has a complete chain view.
 	// It is optional at construction for compatibility with non-supervised
 	// callers; production supplies the embedded node's readiness predicate.
-	usageAuthoritative func() bool
+	usageReadiness func() ReadinessSnapshot
 
 	// mu guards walletID/acct, which are rebound whenever the active wallet
 	// changes (unlock/activate/add). dApp request handlers read them
@@ -64,6 +64,14 @@ type WalletBackend struct {
 	mu       sync.RWMutex
 	walletID string
 	acct     *wallet.Account
+}
+
+// ReadinessSnapshot identifies the ready interval in which a chain query ran.
+// The generation prevents a Ready -> Syncing -> Ready transition from being
+// mistaken for an uninterrupted authoritative interval.
+type ReadinessSnapshot struct {
+	Ready      bool
+	Generation uint64
 }
 
 // NewWalletBackend constructs a WalletBackend.
@@ -82,13 +90,43 @@ func NewWalletBackend(
 	if len(usageAuthoritative) > 0 && usageAuthoritative[0] != nil {
 		usageReady = usageAuthoritative[0]
 	}
+	return newWalletBackend(wl, sp, acct, network, cf, func() ReadinessSnapshot {
+		return ReadinessSnapshot{Ready: usageReady()}
+	})
+}
+
+// NewWalletBackendWithReadiness constructs a backend using a stable readiness
+// generation supplied by the supervisor. Existing callers may continue using
+// NewWalletBackend with a boolean predicate.
+func NewWalletBackendWithReadiness(
+	wl *wallet.Service,
+	sp *spend.Service,
+	acct *wallet.Account,
+	network string,
+	cf chainFetcher,
+	readiness func() ReadinessSnapshot,
+) *WalletBackend {
+	if readiness == nil {
+		readiness = func() ReadinessSnapshot { return ReadinessSnapshot{Ready: true} }
+	}
+	return newWalletBackend(wl, sp, acct, network, cf, readiness)
+}
+
+func newWalletBackend(
+	wl *wallet.Service,
+	sp *spend.Service,
+	acct *wallet.Account,
+	network string,
+	cf chainFetcher,
+	readiness func() ReadinessSnapshot,
+) *WalletBackend {
 	return &WalletBackend{
-		wl:                 wl,
-		sp:                 sp,
-		acct:               acct,
-		chain:              cf,
-		network:            network,
-		usageAuthoritative: usageReady,
+		wl:             wl,
+		sp:             sp,
+		acct:           acct,
+		chain:          cf,
+		network:        network,
+		usageReadiness: readiness,
 	}
 }
 
@@ -141,9 +179,11 @@ func (b *WalletBackend) knownAddressView(ctx context.Context) (wallet.AddressVie
 		av  wallet.AddressView
 		err error
 	)
-	if b.usageAuthoritative() {
+	before := b.usageReadiness()
+	if before.Ready {
 		av, err = b.wl.Addresses(ctx)
-		if err == nil && !b.usageAuthoritative() {
+		after := b.usageReadiness()
+		if err == nil && (!after.Ready || after.Generation != before.Generation) {
 			return wallet.AddressView{}, ErrAddressUsageUnknown
 		}
 	} else {

--- a/ui/internal/connector/backend_test.go
+++ b/ui/internal/connector/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"encoding/hex"
+	"errors"
 	"math/big"
 	"testing"
 
@@ -31,13 +32,15 @@ const backendTestMnemonic = "abandon abandon abandon abandon abandon abandon aba
 
 // fakeConnectorChain satisfies chainFetcher using a canned map of address UTxOs.
 type fakeConnectorChain struct {
-	addresses  []string // returned by AccountAddresses
-	addressErr error    // error from AccountAddresses (nil = success)
-	utxos      map[string][]chain.UTxO
-	utxoErr    map[string]error
+	addresses    []string // returned by AccountAddresses
+	addressErr   error    // error from AccountAddresses (nil = success)
+	addressCalls int
+	utxos        map[string][]chain.UTxO
+	utxoErr      map[string]error
 }
 
 func (f *fakeConnectorChain) AccountAddresses(_ context.Context, _ string) ([]string, error) {
+	f.addressCalls++
 	if f.addressErr != nil {
 		return nil, f.addressErr
 	}
@@ -368,6 +371,140 @@ func TestWalletBackendAddressesHex(t *testing.T) {
 	wantChange, _ := addrStringToHex(acct.ReceiveAddresses[1])
 	if changeHex != wantChange {
 		t.Errorf("change address = %q, want %q", changeHex, wantChange)
+	}
+}
+
+func assertAddressUsageUnknown(t *testing.T, be *WalletBackend) {
+	t.Helper()
+	methods := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "UsedAddresses",
+			call: func() error {
+				_, err := be.UsedAddresses(context.Background(), nil)
+				return err
+			},
+		},
+		{
+			name: "UnusedAddresses",
+			call: func() error {
+				_, err := be.UnusedAddresses(context.Background())
+				return err
+			},
+		},
+		{
+			name: "ChangeAddress",
+			call: func() error {
+				_, err := be.ChangeAddress(context.Background())
+				return err
+			},
+		},
+	}
+	for _, method := range methods {
+		t.Run(method.name, func(t *testing.T) {
+			if err := method.call(); !errors.Is(err, ErrAddressUsageUnknown) {
+				t.Fatalf("error = %v, want ErrAddressUsageUnknown", err)
+			}
+		})
+	}
+}
+
+func TestWalletBackendAddressUsageUnknownWhileSyncing(t *testing.T) {
+	acct, _ := mustDeriveBackendAccount(t)
+	fc := &fakeConnectorChain{addresses: []string{acct.ReceiveAddresses[0]}}
+	wl := wallet.NewService(&walletChainBridge{f: fc})
+	if _, err := wl.SetWallet(backendTestMnemonic, "preview", 3); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	be := NewWalletBackend(wl, nil, acct, "preview", fc, func() bool { return false })
+
+	assertAddressUsageUnknown(t, be)
+	if fc.addressCalls != 0 {
+		t.Fatalf("AccountAddresses calls = %d, want 0 while syncing", fc.addressCalls)
+	}
+}
+
+func TestWalletBackendAddressUsageUnknownIfNodeLeavesReadyDuringQuery(t *testing.T) {
+	acct, _ := mustDeriveBackendAccount(t)
+	fc := &fakeConnectorChain{addresses: []string{acct.ReceiveAddresses[0]}}
+	wl := wallet.NewService(&walletChainBridge{f: fc})
+	if _, err := wl.SetWallet(backendTestMnemonic, "preview", 3); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	checks := 0
+	be := NewWalletBackend(wl, nil, acct, "preview", fc, func() bool {
+		checks++
+		return checks == 1
+	})
+
+	assertAddressUsageUnknown(t, be)
+	if fc.addressCalls != 1 {
+		t.Fatalf("AccountAddresses calls = %d, want only the in-flight query", fc.addressCalls)
+	}
+}
+
+func TestWalletBackendAddressUsageUnknownForUnregisteredAccount(t *testing.T) {
+	acct, _ := mustDeriveBackendAccount(t)
+	fc := &fakeConnectorChain{addressErr: chain.ErrNotFound}
+	wl := wallet.NewService(&walletChainBridge{f: fc})
+	if _, err := wl.SetWallet(backendTestMnemonic, "preview", 3); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	be := NewWalletBackend(wl, nil, acct, "preview", fc)
+
+	assertAddressUsageUnknown(t, be)
+}
+
+func TestWalletBackendAddressUsageUnknownForScriptAccount(t *testing.T) {
+	fc := &fakeConnectorChain{}
+	wl := wallet.NewService(&walletChainBridge{f: fc})
+	acct := &wallet.Account{ReceiveAddresses: []string{"addr_test1script"}}
+	if err := wl.SetAccount(acct); err != nil {
+		t.Fatalf("SetAccount: %v", err)
+	}
+	be := NewWalletBackend(wl, nil, acct, "preview", fc)
+
+	assertAddressUsageUnknown(t, be)
+	if fc.addressCalls != 0 {
+		t.Fatalf("AccountAddresses calls = %d, want 0 for script account", fc.addressCalls)
+	}
+}
+
+func TestWalletBackendSuccessfulEmptyUsageRemainsAuthoritative(t *testing.T) {
+	acct, _ := mustDeriveBackendAccount(t)
+	fc := &fakeConnectorChain{addresses: []string{}}
+	wl := wallet.NewService(&walletChainBridge{f: fc})
+	if _, err := wl.SetWallet(backendTestMnemonic, "preview", 3); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	be := NewWalletBackend(wl, nil, acct, "preview", fc)
+
+	used, err := be.UsedAddresses(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("UsedAddresses: %v", err)
+	}
+	if used == nil || len(used) != 0 {
+		t.Fatalf("UsedAddresses = %#v, want authoritative empty array", used)
+	}
+	unused, err := be.UnusedAddresses(context.Background())
+	if err != nil {
+		t.Fatalf("UnusedAddresses: %v", err)
+	}
+	if len(unused) != len(acct.ReceiveAddresses) {
+		t.Fatalf("UnusedAddresses count = %d, want %d", len(unused), len(acct.ReceiveAddresses))
+	}
+	change, err := be.ChangeAddress(context.Background())
+	if err != nil {
+		t.Fatalf("ChangeAddress: %v", err)
+	}
+	wantChange, err := addrStringToHex(acct.ReceiveAddresses[0])
+	if err != nil {
+		t.Fatalf("addrStringToHex: %v", err)
+	}
+	if change != wantChange {
+		t.Fatalf("ChangeAddress = %q, want first derived address %q", change, wantChange)
 	}
 }
 

--- a/ui/internal/connector/backend_test.go
+++ b/ui/internal/connector/backend_test.go
@@ -445,6 +445,25 @@ func TestWalletBackendAddressUsageUnknownIfNodeLeavesReadyDuringQuery(t *testing
 	}
 }
 
+func TestWalletBackendAddressUsageUnknownAcrossReadyGeneration(t *testing.T) {
+	acct, _ := mustDeriveBackendAccount(t)
+	fc := &fakeConnectorChain{addresses: []string{acct.ReceiveAddresses[0]}}
+	wl := wallet.NewService(&walletChainBridge{f: fc})
+	if _, err := wl.SetWallet(backendTestMnemonic, "preview", 3); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	checks := 0
+	be := NewWalletBackendWithReadiness(wl, nil, acct, "preview", fc, func() ReadinessSnapshot {
+		checks++
+		return ReadinessSnapshot{Ready: true, Generation: uint64(checks)}
+	})
+
+	assertAddressUsageUnknown(t, be)
+	if fc.addressCalls != 3 {
+		t.Fatalf("AccountAddresses calls = %d, want one per address method", fc.addressCalls)
+	}
+}
+
 func TestWalletBackendAddressUsageUnknownForUnregisteredAccount(t *testing.T) {
 	acct, _ := mustDeriveBackendAccount(t)
 	fc := &fakeConnectorChain{addressErr: chain.ErrNotFound}

--- a/ui/internal/connector/service.go
+++ b/ui/internal/connector/service.go
@@ -18,13 +18,14 @@ import (
 
 // Sentinel errors returned by Service.
 var (
-	ErrRefused          = errors.New("connector: refused")
-	ErrUserDeclined     = errors.New("connector: user declined")
-	ErrNotGranted       = errors.New("connector: origin not granted")
-	ErrPairCodeMismatch = errors.New("connector: pair code mismatch")
-	ErrInvalidParams    = errors.New("connector: invalid request params")
-	ErrInvalidOrigin    = errors.New("connector: invalid origin")
-	ErrTooManyPairings  = errors.New("connector: too many pending pairings")
+	ErrRefused             = errors.New("connector: refused")
+	ErrUserDeclined        = errors.New("connector: user declined")
+	ErrNotGranted          = errors.New("connector: origin not granted")
+	ErrPairCodeMismatch    = errors.New("connector: pair code mismatch")
+	ErrInvalidParams       = errors.New("connector: invalid request params")
+	ErrInvalidOrigin       = errors.New("connector: invalid origin")
+	ErrTooManyPairings     = errors.New("connector: too many pending pairings")
+	ErrAddressUsageUnknown = errors.New("connector: address usage is unavailable")
 	// ErrInvalidExtensionID is defined in token.go.
 )
 

--- a/ui/internal/supervisor/status.go
+++ b/ui/internal/supervisor/status.go
@@ -51,12 +51,17 @@ type BootstrapProgress struct {
 
 // Status is a point-in-time snapshot of the embedded node, serialised by the API.
 type Status struct {
-	State           NodeState          `json:"state"`
-	Tip             uint64             `json:"tip"` // latest block slot known to the node
-	LatestBlockTime *time.Time         `json:"latestBlockTime,omitempty"`
-	CaughtUp        bool               `json:"caughtUp"`
-	Bootstrap       *BootstrapProgress `json:"bootstrap,omitempty"`
-	Err             string             `json:"error,omitempty"`
+	State NodeState `json:"state"`
+	// ReadinessGeneration changes whenever a ready node loses readiness. It is
+	// intentionally internal to the process: consumers use it to reject a
+	// query that crossed a transient syncing interval, even if the node is
+	// ready again by the time the query completes.
+	ReadinessGeneration uint64             `json:"-"`
+	Tip                 uint64             `json:"tip"` // latest block slot known to the node
+	LatestBlockTime     *time.Time         `json:"latestBlockTime,omitempty"`
+	CaughtUp            bool               `json:"caughtUp"`
+	Bootstrap           *BootstrapProgress `json:"bootstrap,omitempty"`
+	Err                 string             `json:"error,omitempty"`
 }
 
 // caughtUp reports whether the latest block is recent enough to consider the

--- a/ui/internal/supervisor/supervisor.go
+++ b/ui/internal/supervisor/supervisor.go
@@ -427,7 +427,7 @@ func (s *Supervisor) stop() <-chan struct{} {
 	// can't race between the unlock and the state write.
 	s.cancel = nil
 	s.runDone = nil
-	s.status.State = StateStopped
+	s.setStateLocked(StateStopped)
 	s.status.Bootstrap = nil // a clean shutdown is not a diagnostic failure
 	s.mu.Unlock()
 	if cancel != nil {
@@ -462,10 +462,17 @@ func (s *Supervisor) setStateForRun(runID uint64, st NodeState) {
 	if !s.activeRunLocked(runID) {
 		return
 	}
-	s.status.State = st
+	s.setStateLocked(st)
 	if st != StateBootstrapping {
 		s.status.Bootstrap = nil
 	}
+}
+
+func (s *Supervisor) setStateLocked(st NodeState) {
+	if s.status.State == StateReady && st != StateReady {
+		s.status.ReadinessGeneration++
+	}
+	s.status.State = st
 }
 
 // Only called from test code; nolint:unused because lint runs with tests:false.
@@ -484,7 +491,7 @@ func (s *Supervisor) setErrorForRun(runID uint64, err error) {
 	cancel := s.cancel
 	s.cancel = nil
 	s.runDone = nil
-	s.status.State = StateError
+	s.setStateLocked(StateError)
 	// Status.Bootstrap is intentionally retained on error so /status shows how
 	// far a bootstrap got before failing (diagnostics).
 	s.status.Err = err.Error()
@@ -524,7 +531,7 @@ func (s *Supervisor) pollLoop(ctx context.Context, runID uint64) {
 			// Don't move off a terminal/stopped state; once Stop sets
 			// StateStopped, a late poll must not revert it to syncing/ready.
 			if s.activeRunLocked(runID) && s.status.State != StateError && s.status.State != StateStopped {
-				s.status.State = deriveState(ok, isCaughtUp)
+				s.setStateLocked(deriveState(ok, isCaughtUp))
 				// CaughtUp must reflect every poll, not just successful ones: a
 				// failed poll yields isCaughtUp=false, so updating it here keeps
 				// the snapshot consistent instead of reporting caughtUp=true

--- a/ui/internal/wallet/service.go
+++ b/ui/internal/wallet/service.go
@@ -144,6 +144,37 @@ func (s *Service) currentAccount() (*Account, error) {
 	return cloneAccount(s.account), nil
 }
 
+func addressView(acct *Account, used []string) AddressView {
+	usedSet := make(map[string]bool, len(used))
+	for _, a := range used {
+		usedSet[a] = true
+	}
+	receive := cloneStringSlice(acct.ReceiveAddresses)
+	next := ""
+	for _, a := range receive {
+		if !usedSet[a] {
+			next = a
+			break
+		}
+	}
+	return AddressView{
+		Receive:    receive,
+		Used:       cloneStringSlice(used),
+		NextUnused: next,
+	}
+}
+
+// LocalAddresses reports the locally derived receive window without querying
+// the node. It is available during startup and bootstrap, before the node can
+// report which addresses have already appeared on chain.
+func (s *Service) LocalAddresses() (AddressView, error) {
+	acct, err := s.currentAccount()
+	if err != nil {
+		return AddressView{}, err
+	}
+	return addressView(acct, nil), nil
+}
+
 // scanAddresses returns the addresses to query for funds and history: the
 // node-reported account addresses (used/change addresses, available once the
 // stake key is registered on chain) unioned with the wallet's derived receive
@@ -234,31 +265,14 @@ func (s *Service) Addresses(ctx context.Context) (AddressView, error) {
 	// address is a malformed request rather than a not-found. Its receive
 	// window is exactly the script address it was created with.
 	if acct.StakeAddress == "" {
-		receive := cloneStringSlice(acct.ReceiveAddresses)
-		next := ""
-		if len(receive) > 0 {
-			next = receive[0]
-		}
-		return AddressView{Receive: receive, NextUnused: next}, nil
+		return addressView(acct, nil), nil
 	}
 	used, err := s.chain.AccountAddresses(ctx, acct.StakeAddress)
 	if err != nil && !errors.Is(err, chain.ErrNotFound) {
 		return AddressView{}, err
 	}
 	// ErrNotFound: no chain-seen addresses yet → used stays empty; NextUnused is receive[0].
-	usedSet := map[string]bool{}
-	for _, a := range used {
-		usedSet[a] = true
-	}
-	receive := cloneStringSlice(acct.ReceiveAddresses)
-	next := ""
-	for _, a := range receive {
-		if !usedSet[a] {
-			next = a
-			break
-		}
-	}
-	return AddressView{Receive: receive, Used: cloneStringSlice(used), NextUnused: next}, nil
+	return addressView(acct, used), nil
 }
 
 // Transactions returns the merged, newest-first history across the account's

--- a/ui/internal/wallet/service.go
+++ b/ui/internal/wallet/service.go
@@ -282,7 +282,12 @@ func (s *Service) Addresses(ctx context.Context) (AddressView, error) {
 	if err != nil && !errors.Is(err, chain.ErrNotFound) {
 		return AddressView{}, err
 	}
-	// ErrNotFound: no chain-seen addresses yet → used stays empty; NextUnused is receive[0].
+	if errors.Is(err, chain.ErrNotFound) {
+		// The account endpoint returns 404 for an unregistered stake credential,
+		// even when one of its derived payment addresses already holds funds. That
+		// response cannot establish that the receive window is unused.
+		return addressView(acct, nil, false), nil
+	}
 	return addressView(acct, used, true), nil
 }
 

--- a/ui/internal/wallet/service.go
+++ b/ui/internal/wallet/service.go
@@ -27,12 +27,15 @@ type chainQuerier interface {
 }
 
 // AddressView is the receive-address view: the derived window, the chain-seen
-// (used) addresses, and the next unused derived address. NextUnused is empty
-// when every address in the derived window is already used on chain (dynamic
-// gap-limit expansion is deferred to a later phase).
+// (used) addresses, and the next unused derived address. UsageKnown is false
+// when the node was not queried; in that state Used and NextUnused must not be
+// interpreted as evidence that an address is unused. When usage is known,
+// NextUnused is empty only if every address in the derived window is already
+// used on chain (dynamic gap-limit expansion is deferred to a later phase).
 type AddressView struct {
 	Receive    []string `json:"receive"`
 	Used       []string `json:"used"`
+	UsageKnown bool     `json:"usage_known"`
 	NextUnused string   `json:"next_unused"`
 }
 
@@ -144,24 +147,31 @@ func (s *Service) currentAccount() (*Account, error) {
 	return cloneAccount(s.account), nil
 }
 
-func addressView(acct *Account, used []string) AddressView {
+func addressView(acct *Account, used []string, usageKnown bool) AddressView {
+	receive := cloneStringSlice(acct.ReceiveAddresses)
+	used = cloneStringSlice(used)
+	if used == nil {
+		used = []string{}
+	}
+	view := AddressView{
+		Receive:    receive,
+		Used:       used,
+		UsageKnown: usageKnown,
+	}
+	if !usageKnown {
+		return view
+	}
 	usedSet := make(map[string]bool, len(used))
 	for _, a := range used {
 		usedSet[a] = true
 	}
-	receive := cloneStringSlice(acct.ReceiveAddresses)
-	next := ""
 	for _, a := range receive {
 		if !usedSet[a] {
-			next = a
+			view.NextUnused = a
 			break
 		}
 	}
-	return AddressView{
-		Receive:    receive,
-		Used:       cloneStringSlice(used),
-		NextUnused: next,
-	}
+	return view
 }
 
 // LocalAddresses reports the locally derived receive window without querying
@@ -172,7 +182,7 @@ func (s *Service) LocalAddresses() (AddressView, error) {
 	if err != nil {
 		return AddressView{}, err
 	}
-	return addressView(acct, nil), nil
+	return addressView(acct, nil, false), nil
 }
 
 // scanAddresses returns the addresses to query for funds and history: the
@@ -262,17 +272,18 @@ func (s *Service) Addresses(ctx context.Context) (AddressView, error) {
 	}
 	// Same reason as scanAddresses: a script (multi-signature) account has no
 	// stake credential, so there is nothing to look up and an empty stake
-	// address is a malformed request rather than a not-found. Its receive
-	// window is exactly the script address it was created with.
+	// address is a malformed request rather than a not-found. Its receive window
+	// is exactly the script address it was created with, but its on-chain usage
+	// remains unknown because this path deliberately makes no chain query.
 	if acct.StakeAddress == "" {
-		return addressView(acct, nil), nil
+		return addressView(acct, nil, false), nil
 	}
 	used, err := s.chain.AccountAddresses(ctx, acct.StakeAddress)
 	if err != nil && !errors.Is(err, chain.ErrNotFound) {
 		return AddressView{}, err
 	}
 	// ErrNotFound: no chain-seen addresses yet → used stays empty; NextUnused is receive[0].
-	return addressView(acct, used), nil
+	return addressView(acct, used, true), nil
 }
 
 // Transactions returns the merged, newest-first history across the account's

--- a/ui/internal/wallet/service_test.go
+++ b/ui/internal/wallet/service_test.go
@@ -124,6 +124,9 @@ func TestServiceBalanceAndAddresses(t *testing.T) {
 	if len(av.Used) != 1 || av.Used[0] != "addr_test1a" {
 		t.Fatalf("used = %v, want [addr_test1a]", av.Used)
 	}
+	if !av.UsageKnown {
+		t.Fatal("UsageKnown false after successful chain query")
+	}
 	if av.NextUnused == "" {
 		t.Fatal("NextUnused empty, want a derived address")
 	}
@@ -180,6 +183,9 @@ func TestServiceEmptyAccount(t *testing.T) {
 	if len(av.Used) != 0 {
 		t.Fatalf("used = %v, want empty", av.Used)
 	}
+	if !av.UsageKnown {
+		t.Fatal("UsageKnown false after definitive chain not-found")
+	}
 	if av.NextUnused != av.Receive[0] {
 		t.Fatalf("NextUnused = %q, want receive[0] %q", av.NextUnused, av.Receive[0])
 	}
@@ -209,11 +215,17 @@ func TestServiceLocalAddressesDoNotQueryChain(t *testing.T) {
 	if fc.addressCalls != 0 {
 		t.Fatalf("AccountAddresses calls = %d, want 0", fc.addressCalls)
 	}
-	if len(got.Receive) != 3 || got.NextUnused != acct.ReceiveAddresses[0] {
-		t.Fatalf("local addresses = %+v, want three derived addresses with receive[0] next", got)
+	if len(got.Receive) != 3 {
+		t.Fatalf("local receive addresses = %v, want three derived addresses", got.Receive)
+	}
+	if got.NextUnused != "" {
+		t.Fatalf("local NextUnused = %q, want empty while chain usage is unknown", got.NextUnused)
 	}
 	if len(got.Used) != 0 {
 		t.Fatalf("local used addresses = %v, want empty", got.Used)
+	}
+	if got.UsageKnown {
+		t.Fatal("local UsageKnown true without a chain query")
 	}
 	got.Receive[0] = "addr_test1mutated"
 	again, err := s.LocalAddresses()
@@ -876,8 +888,11 @@ func TestScriptAccountViewsSkipStakeLookups(t *testing.T) {
 	if len(addrs.Receive) != 1 || addrs.Receive[0] != scriptAddr {
 		t.Fatalf("Addresses receive = %v, want just the script address", addrs.Receive)
 	}
-	if addrs.NextUnused != scriptAddr {
-		t.Fatalf("NextUnused = %q, want the script address", addrs.NextUnused)
+	if addrs.UsageKnown {
+		t.Fatal("UsageKnown true for script account without a chain query")
+	}
+	if addrs.NextUnused != "" {
+		t.Fatalf("NextUnused = %q, want empty while script-address usage is unknown", addrs.NextUnused)
 	}
 
 	del, err := svc.Delegation(context.Background())

--- a/ui/internal/wallet/service_test.go
+++ b/ui/internal/wallet/service_test.go
@@ -162,8 +162,8 @@ func TestServiceBalanceAndAddresses(t *testing.T) {
 
 func TestServiceEmptyAccount(t *testing.T) {
 	// A fresh/unknown stake credential: the node returns 404 (chain.ErrNotFound)
-	// for the account and its addresses. Read-only views must treat this as an
-	// empty wallet, not a hard error.
+	// for the account and its addresses. Read-only views must remain available,
+	// but a 404 cannot prove that the derived payment addresses are unused.
 	fc := &fakeChain{accountErr: chain.ErrNotFound, addressesErr: chain.ErrNotFound}
 	s := NewService(fc)
 	if _, err := s.SetWallet(testMnemonic, "preview", 3); err != nil {
@@ -183,11 +183,11 @@ func TestServiceEmptyAccount(t *testing.T) {
 	if len(av.Used) != 0 {
 		t.Fatalf("used = %v, want empty", av.Used)
 	}
-	if !av.UsageKnown {
-		t.Fatal("UsageKnown false after definitive chain not-found")
+	if av.UsageKnown {
+		t.Fatal("UsageKnown true after account-addresses not-found")
 	}
-	if av.NextUnused != av.Receive[0] {
-		t.Fatalf("NextUnused = %q, want receive[0] %q", av.NextUnused, av.Receive[0])
+	if av.NextUnused != "" {
+		t.Fatalf("NextUnused = %q, want empty while usage is unknown", av.NextUnused)
 	}
 	if _, err := s.Transactions(context.Background()); err != nil {
 		t.Fatalf("Transactions on empty account: %v", err)
@@ -198,6 +198,56 @@ func TestServiceEmptyAccount(t *testing.T) {
 	}
 	if dv.PoolID != nil || dv.Active || dv.RewardsSum != "0" || dv.Withdrawable != "0" {
 		t.Fatalf("delegation on empty account = %+v, want not active / no pool / zero amounts", dv)
+	}
+}
+
+func TestServiceUnregisteredFundedAccountHasUnknownUsage(t *testing.T) {
+	fc := &fakeChain{addressesErr: chain.ErrNotFound}
+	s := NewService(fc)
+	acct, err := s.SetWallet(testMnemonic, "preview", 3)
+	if err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	funded := acct.ReceiveAddresses[0]
+	fc.utxos = map[string][]chain.UTxO{
+		funded: {{Amount: []chain.Amount{{Unit: "lovelace", Quantity: "3000000"}}}},
+	}
+
+	bal, err := s.Balance(context.Background())
+	if err != nil {
+		t.Fatalf("Balance: %v", err)
+	}
+	if bal.Lovelace != "3000000" {
+		t.Fatalf("Balance lovelace = %q, want funded derived address balance", bal.Lovelace)
+	}
+
+	av, err := s.Addresses(context.Background())
+	if err != nil {
+		t.Fatalf("Addresses: %v", err)
+	}
+	if av.UsageKnown {
+		t.Fatal("UsageKnown true for funded account whose stake credential is unregistered")
+	}
+	if len(av.Used) != 0 || av.NextUnused != "" {
+		t.Fatalf("Addresses = %+v, want no used/unused classification", av)
+	}
+}
+
+func TestServiceSuccessfulEmptyAddressQueryIsKnown(t *testing.T) {
+	s := NewService(&fakeChain{addresses: []string{}})
+	if _, err := s.SetWallet(testMnemonic, "preview", 3); err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+
+	av, err := s.Addresses(context.Background())
+	if err != nil {
+		t.Fatalf("Addresses: %v", err)
+	}
+	if !av.UsageKnown {
+		t.Fatal("UsageKnown false after a successful empty chain query")
+	}
+	if len(av.Used) != 0 || av.NextUnused != av.Receive[0] {
+		t.Fatalf("Addresses = %+v, want receive[0] classified as unused", av)
 	}
 }
 

--- a/ui/internal/wallet/service_test.go
+++ b/ui/internal/wallet/service_test.go
@@ -16,6 +16,7 @@ type fakeChain struct {
 	accountErr   error
 	addresses    []string
 	addressesErr error
+	addressCalls int
 	utxos        map[string][]chain.UTxO
 	utxoErrs     map[string]error
 	txs          map[string][]chain.AddressTx
@@ -38,6 +39,7 @@ func (f *fakeChain) Account(_ context.Context, _ string) (chain.AccountInfo, err
 }
 
 func (f *fakeChain) AccountAddresses(_ context.Context, _ string) ([]string, error) {
+	f.addressCalls++
 	return f.addresses, f.addressesErr
 }
 
@@ -190,6 +192,41 @@ func TestServiceEmptyAccount(t *testing.T) {
 	}
 	if dv.PoolID != nil || dv.Active || dv.RewardsSum != "0" || dv.Withdrawable != "0" {
 		t.Fatalf("delegation on empty account = %+v, want not active / no pool / zero amounts", dv)
+	}
+}
+
+func TestServiceLocalAddressesDoNotQueryChain(t *testing.T) {
+	fc := &fakeChain{addressesErr: errors.New("node unavailable")}
+	s := NewService(fc)
+	acct, err := s.SetWallet(testMnemonic, "preview", 3)
+	if err != nil {
+		t.Fatalf("SetWallet: %v", err)
+	}
+	got, err := s.LocalAddresses()
+	if err != nil {
+		t.Fatalf("LocalAddresses: %v", err)
+	}
+	if fc.addressCalls != 0 {
+		t.Fatalf("AccountAddresses calls = %d, want 0", fc.addressCalls)
+	}
+	if len(got.Receive) != 3 || got.NextUnused != acct.ReceiveAddresses[0] {
+		t.Fatalf("local addresses = %+v, want three derived addresses with receive[0] next", got)
+	}
+	if len(got.Used) != 0 {
+		t.Fatalf("local used addresses = %v, want empty", got.Used)
+	}
+	got.Receive[0] = "addr_test1mutated"
+	again, err := s.LocalAddresses()
+	if err != nil {
+		t.Fatalf("LocalAddresses after caller mutation: %v", err)
+	}
+	if again.Receive[0] != acct.ReceiveAddresses[0] {
+		t.Fatalf("receive[0] after caller mutation = %q, want %q", again.Receive[0], acct.ReceiveAddresses[0])
+	}
+
+	empty := NewService(fc)
+	if _, err := empty.LocalAddresses(); !errors.Is(err, ErrNoWallet) {
+		t.Fatalf("LocalAddresses without wallet: err = %v, want ErrNoWallet", err)
 	}
 }
 

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -47,7 +47,7 @@ export interface Balance {
 export interface AddressView {
   receive: string[];
   used: string[];
-  usage_known: boolean;
+  usage_known?: boolean;
   next_unused: string;
 }
 

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -47,6 +47,7 @@ export interface Balance {
 export interface AddressView {
   receive: string[];
   used: string[];
+  usage_known: boolean;
   next_unused: string;
 }
 

--- a/ui/web/src/app.test.tsx
+++ b/ui/web/src/app.test.tsx
@@ -948,7 +948,7 @@ test("the routes the absorbed screens used to own still resolve", async () => {
 test("#/receive opens Receive while the nav still points at Portfolio", async () => {
   // Send and Receive are Portfolio actions, so the highlight is deliberate.
   vi.spyOn(hooks, "useAddresses").mockReturnValue({
-    data: { receive: ["addr_test1abc"], used: [], next_unused: "addr_test1abc" },
+    data: { receive: ["addr_test1abc"], used: [], usage_known: true, next_unused: "addr_test1abc" },
     error: null,
     loading: false,
     refresh: vi.fn(),

--- a/ui/web/src/screens/Receive.qr.test.tsx
+++ b/ui/web/src/screens/Receive.qr.test.tsx
@@ -22,6 +22,7 @@ function mockAddresses() {
     data: {
       receive: [ADDR_A, ADDR_B],
       used: [ADDR_A],
+      usage_known: true,
       next_unused: ADDR_B,
     },
     error: null,
@@ -77,7 +78,7 @@ test("QR regenerates when the next-unused address changes", () => {
   expect(qrCodes[0]).toHaveAttribute("data-qr-value", ADDR_B);
 
   vi.spyOn(hooks, "useAddresses").mockReturnValue({
-    data: { receive: [ADDR_A, ADDR_B], used: [ADDR_A, ADDR_B], next_unused: ADDR_A },
+    data: { receive: [ADDR_A, ADDR_B], used: [ADDR_A, ADDR_B], usage_known: true, next_unused: ADDR_A },
     error: null,
     loading: false,
     refresh: vi.fn(),

--- a/ui/web/src/screens/Receive.test.tsx
+++ b/ui/web/src/screens/Receive.test.tsx
@@ -132,10 +132,9 @@ test("(h) each address gets an external explorer link, scoped to the wallet's ne
   );
   expect(rowLink).toBeDefined();
 });
-// Receive is gated on the node too (the next-unused-address lookup reads the
-// chain), so a user who came in through the read-only escape hatch hits this
-// before anything else. It must explain, not dump a server error.
-test("a node that cannot answer yet is explained, not dumped as an error", () => {
+// Keep the friendly fallback for a transient 503. Ordinary startup and
+// bootstrap requests use locally derived addresses and do not take this path.
+test("a transient 503 is explained, not dumped as an error", () => {
   vi.spyOn(hooks, "useAddresses").mockReturnValue({
     data: null, error: new ApiError(503, "node not ready"), loading: false, refresh: vi.fn(),
   } as never);

--- a/ui/web/src/screens/Receive.test.tsx
+++ b/ui/web/src/screens/Receive.test.tsx
@@ -95,8 +95,39 @@ test("unknown chain usage neither labels addresses unused nor promotes a next-un
 
   expect(screen.queryByRole("heading", { name: /next unused address/i })).not.toBeInTheDocument();
   expect(screen.queryByText("Unused")).not.toBeInTheDocument();
-  expect(screen.getAllByText("Not checked")).toHaveLength(2);
+  expect(screen.getAllByText("Unknown")).toHaveLength(2);
+  expect(screen.getByRole("status")).toHaveTextContent(/on-chain usage is unavailable for this account/i);
+  expect(screen.getByRole("status")).not.toHaveTextContent(/node/i);
   expect(screen.getAllByRole("button", { name: "Copy this receive address" })).toHaveLength(2);
+});
+
+test("a missing usage flag from an older backend is treated as unknown", () => {
+  vi.spyOn(hooks, "useAddresses").mockReturnValue({
+    data: {
+      receive: [ADDR_A],
+      used: [],
+      next_unused: ADDR_A,
+    },
+    error: null,
+    loading: false,
+    refresh: vi.fn(),
+  } as never);
+
+  render(<Receive />);
+
+  expect(screen.queryByRole("heading", { name: /next unused address/i })).not.toBeInTheDocument();
+  expect(screen.queryByText("Unused")).not.toBeInTheDocument();
+  expect(screen.getByText("Unknown")).toBeInTheDocument();
+});
+
+test("script-account copy does not promise usage after node readiness", () => {
+  mockAddresses({ receive: [ADDR_A], used: [], usage_known: false, next_unused: "" });
+  render(<Receive />);
+
+  expect(screen.getByRole("status")).toHaveTextContent(
+    "On-chain usage is unavailable for this account. You can still receive at an address below, but Bursa cannot identify an unused address.",
+  );
+  expect(screen.getByRole("status")).not.toHaveTextContent(/until|node|ready/i);
 });
 
 test("(e) loading state renders a loading indicator", () => {

--- a/ui/web/src/screens/Receive.test.tsx
+++ b/ui/web/src/screens/Receive.test.tsx
@@ -6,11 +6,12 @@ import { ApiError } from "../api/client";
 const ADDR_A = "addr_test1qpfqpgxzsq8d6l5n5qxkdqqvxqqtd2syvxsw0mkzmq2dzn7y2y5a3uqquasklznf6xvxn0tmxy2cjaslt9yq5ygz4dqsv9r4pk";
 const ADDR_B = "addr_test1qqy2j78ks2htj6x5p2xztqpvqxqqtd2syvxsw0mkzmq2dzny0cjaslt9yq5ygz4dqsv9r4pkzuqquasklznf6xvxn0tmxwtest2";
 
-function mockAddresses(overrides?: Partial<{ receive: string[]; used: string[]; next_unused: string }>) {
+function mockAddresses(overrides?: Partial<{ receive: string[]; used: string[]; usage_known: boolean; next_unused: string }>) {
   vi.spyOn(hooks, "useAddresses").mockReturnValue({
     data: {
       receive: [ADDR_A, ADDR_B],
       used: [ADDR_A],
+      usage_known: true,
       next_unused: ADDR_B,
       ...overrides,
     },
@@ -75,6 +76,27 @@ test("(d) unused addresses show an 'Unused' or empty status in the table", () =>
 
   // ADDR_B is not used — there should be an 'Unused' cell in the table.
   expect(screen.getAllByText("Unused").length).toBeGreaterThanOrEqual(1);
+});
+
+test("unknown chain usage neither labels addresses unused nor promotes a next-unused address", () => {
+  vi.spyOn(hooks, "useAddresses").mockReturnValue({
+    data: {
+      receive: [ADDR_A, ADDR_B],
+      used: [],
+      next_unused: ADDR_B,
+      usage_known: false,
+    },
+    error: null,
+    loading: false,
+    refresh: vi.fn(),
+  } as never);
+
+  render(<Receive />);
+
+  expect(screen.queryByRole("heading", { name: /next unused address/i })).not.toBeInTheDocument();
+  expect(screen.queryByText("Unused")).not.toBeInTheDocument();
+  expect(screen.getAllByText("Not checked")).toHaveLength(2);
+  expect(screen.getAllByRole("button", { name: "Copy this receive address" })).toHaveLength(2);
 });
 
 test("(e) loading state renders a loading indicator", () => {

--- a/ui/web/src/screens/Receive.tsx
+++ b/ui/web/src/screens/Receive.tsx
@@ -61,7 +61,10 @@ export function Receive({ network = "preview" }: ReceiveProps = {}) {
   }
 
   const data = addresses.data;
-  const nextUnused = data?.next_unused ?? "";
+  // Missing is treated as unknown too, so a newer UI paired with an older
+  // backend fails closed instead of labelling every address unused.
+  const usageKnown = data?.usage_known === true;
+  const nextUnused = usageKnown ? (data?.next_unused ?? "") : "";
   const receive = data?.receive ?? [];
   const usedSet = new Set(data?.used ?? []);
 
@@ -76,7 +79,7 @@ export function Receive({ network = "preview" }: ReceiveProps = {}) {
     const isExpanded = expandedQr === addr;
     return {
       address: truncateAddr(addr),
-      status: usedSet.has(addr) ? "Used" : "Unused",
+      status: usageKnown ? (usedSet.has(addr) ? "Used" : "Unused") : "Not checked",
       qr: (
         <div className="receive-qr-cell">
           <button
@@ -109,20 +112,27 @@ export function Receive({ network = "preview" }: ReceiveProps = {}) {
 
   return (
     <div className="receive">
-      <Card title="Next Unused Address">
-        <div className="receive-next">
-          {nextUnused && (
-            <AddressQR address={nextUnused} size={QR_SIZE_HERO} title={`QR code for ${nextUnused}`} />
-          )}
-          <div className="receive-next-details">
-            <p className="mono address-full">{nextUnused}</p>
-            <CopyButton value={nextUnused} ariaLabel="Copy next unused address" />
-            {nextUnused && <ExplorerLink network={network} kind="address" id={nextUnused} />}
+      {usageKnown && (
+        <Card title="Next Unused Address">
+          <div className="receive-next">
+            {nextUnused && (
+              <AddressQR address={nextUnused} size={QR_SIZE_HERO} title={`QR code for ${nextUnused}`} />
+            )}
+            <div className="receive-next-details">
+              <p className="mono address-full">{nextUnused}</p>
+              <CopyButton value={nextUnused} ariaLabel="Copy next unused address" />
+              {nextUnused && <ExplorerLink network={network} kind="address" id={nextUnused} />}
+            </div>
           </div>
-        </div>
-      </Card>
+        </Card>
+      )}
 
       <Card title="Receive Addresses">
+        {!usageKnown && receive.length > 0 && (
+          <p className="muted" role="status">
+            On-chain use has not been checked yet. You can receive at an address below, but Bursa cannot identify the next unused address until the node is available.
+          </p>
+        )}
         {receive.length === 0 ? (
           <p className="muted">No addresses available</p>
         ) : (

--- a/ui/web/src/screens/Receive.tsx
+++ b/ui/web/src/screens/Receive.tsx
@@ -79,7 +79,7 @@ export function Receive({ network = "preview" }: ReceiveProps = {}) {
     const isExpanded = expandedQr === addr;
     return {
       address: truncateAddr(addr),
-      status: usageKnown ? (usedSet.has(addr) ? "Used" : "Unused") : "Not checked",
+      status: usageKnown ? (usedSet.has(addr) ? "Used" : "Unused") : "Unknown",
       qr: (
         <div className="receive-qr-cell">
           <button
@@ -130,7 +130,7 @@ export function Receive({ network = "preview" }: ReceiveProps = {}) {
       <Card title="Receive Addresses">
         {!usageKnown && receive.length > 0 && (
           <p className="muted" role="status">
-            On-chain use has not been checked yet. You can receive at an address below, but Bursa cannot identify the next unused address until the node is available.
+            On-chain usage is unavailable for this account. You can still receive at an address below, but Bursa cannot identify an unused address.
           </p>
         )}
         {receive.length === 0 ? (


### PR DESCRIPTION
Fixes #794

- Keep locally derived receive addresses available before node queries work.
- Retain chain usage marking while the node is syncing or ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Receive screen now works before the node is ready—it shows locally derived addresses during startup and bootstrap instead of failing with "node not ready".

**Bug Fixes**
- `/wallet/addresses` returns locally derived addresses when the node is stopped, starting, bootstrapping, syncing, or errored; chain usage marks only appear when the node stays Ready for the whole query, guarded by a new readiness generation.
- Address usage is `usage_known` only for authoritative chain results; script accounts and unregistered stake credentials show "Unknown" instead of "Unused".
- CIP-30 address methods return 503 (`ErrAddressUsageUnknown`) when usage isn't authoritative instead of an empty used list that implied unused.

<sup>Written for commit f2ab0dd6c1c2c234b64fc4c9df465d5602855148. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

