### PR TITLE
fix(extension): register provider in main world

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -53,8 +53,10 @@ jobs:
         run: npm run type-check
       - name: test
         run: npm run test
-      - name: build
-        run: npm run build
+      - name: Install Chromium
+        run: npm exec playwright install --with-deps --no-shell chromium
+      - name: restrictive-CSP browser test
+        run: npm run test:e2e
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 https://github.com/actions/upload-artifact/releases/tag/v7.0.1
         with:
           name: bursa-connector-dist

--- a/ui/extension/e2e/README.md
+++ b/ui/extension/e2e/README.md
@@ -1,15 +1,28 @@
-# CIP-30 Extension — Manual E2E Test Harness
+# CIP-30 Extension E2E Tests
 
-This directory contains a static sample dApp (`sample-dapp.html`) for manually
-verifying the end-to-end flow of the Bursa browser extension.  There are no
-automated tests here — the purpose is to confirm that real browser
-extension ↔ Bursa daemon ↔ dApp communication works as expected.
+The automated test loads the unpacked extension in Chromium and opens a page
+whose Content Security Policy blocks all page scripts and requires Trusted
+Types for script sinks. It verifies that the MAIN-world provider is available
+and reports its registration to the isolated-world relay.
+
+```sh
+cd ui/extension
+npm ci
+npm exec playwright install --with-deps --no-shell chromium
+npm run test:e2e
+```
+
+Set `CHROMIUM_PATH` to use an existing Chromium executable instead of the
+Playwright-managed browser.
+
+The static sample dApp (`sample-dapp.html`) remains available for manually
+verifying the complete extension ↔ Bursa daemon ↔ dApp flow.
 
 ---
 
 ## Prerequisites
 
-- Google Chrome (or a Chromium-based browser that supports MV3 extensions)
+- Google Chrome 111 or later (or a compatible Chromium-based browser)
 - Node.js 22 (for building the extension)
 - A running Bursa daemon with the CIP-30 connector enabled
 

--- a/ui/extension/e2e/restrictive-csp.test.mjs
+++ b/ui/extension/e2e/restrictive-csp.test.mjs
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const extensionDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'dist');
+const manifest = JSON.parse(await readFile(join(extensionDir, 'manifest.json'), 'utf8'));
+assert.equal(manifest.minimum_chrome_version, '111');
+assert.deepEqual(
+  manifest.content_scripts.map(({ js, run_at: runAt, world }) => ({ js, runAt, world })),
+  [
+    { js: ['content.js'], runAt: 'document_start', world: 'ISOLATED' },
+    { js: ['injected.js'], runAt: 'document_start', world: 'MAIN' },
+  ],
+);
+assert.equal(manifest.web_accessible_resources, undefined);
+
+const userDataDir = await mkdtemp(join(tmpdir(), 'bursa-extension-e2e-'));
+const server = createServer((_request, response) => {
+  response.writeHead(200, {
+    'Content-Security-Policy':
+      "default-src 'none'; script-src 'none'; object-src 'none'; base-uri 'none'; require-trusted-types-for 'script'",
+    'Content-Type': 'text/html; charset=utf-8',
+  });
+  response.end('<!doctype html><html><head><title>Restrictive CSP</title></head></html>');
+});
+
+await new Promise((resolveListen, rejectListen) => {
+  server.once('error', rejectListen);
+  server.listen(0, '127.0.0.1', resolveListen);
+});
+
+const address = server.address();
+if (!address || typeof address === 'string') {
+  throw new Error('failed to determine restrictive-CSP test server address');
+}
+
+const launchOptions = {
+  headless: true,
+  args: [
+    `--disable-extensions-except=${extensionDir}`,
+    `--load-extension=${extensionDir}`,
+  ],
+};
+if (process.env.CHROMIUM_PATH) {
+  launchOptions.executablePath = process.env.CHROMIUM_PATH;
+} else {
+  launchOptions.channel = 'chromium';
+}
+
+let context;
+try {
+  context = await chromium.launchPersistentContext(userDataDir, launchOptions);
+  await context.addInitScript(() => {
+    window.__bursaProviderStatuses = [];
+    window.addEventListener('message', (event) => {
+      if (event.source === window && event.data?.source === 'bursa-cip30-provider-status') {
+        window.__bursaProviderStatuses.push(event.data);
+      }
+    });
+  });
+
+  const page = await context.newPage();
+  await page.goto(`http://127.0.0.1:${address.port}/`, { waitUntil: 'domcontentloaded' });
+  await page
+    .waitForFunction(
+      () =>
+        (Boolean(window.cardano?.bursa) &&
+          window.__bursaProviderStatuses.some((status) => status.status === 'ready')) ||
+        window.__bursaProviderStatuses.some((status) => status.status === 'error'),
+      undefined,
+      { timeout: 5_000 },
+    )
+    .catch(() => undefined);
+
+  const result = await page.evaluate(() => ({
+    providerAvailable: Boolean(window.cardano?.bursa),
+    registrationReady: window.__bursaProviderStatuses.some(
+      (status) => status.status === 'ready',
+    ),
+    failure: window.__bursaProviderStatuses.find((status) => status.status === 'error'),
+  }));
+
+  assert.ok(
+    result.providerAvailable || result.failure,
+    'provider was not registered and no injection failure was reported',
+  );
+  assert.equal(
+    result.failure,
+    undefined,
+    `provider registration failed: ${result.failure?.error}`,
+  );
+  assert.equal(result.providerAvailable, true);
+  assert.equal(result.registrationReady, true, 'provider registration was not reported ready');
+} finally {
+  await context?.close();
+  await new Promise((resolveClose) => server.close(resolveClose));
+  await rm(userDataDir, { recursive: true, force: true });
+}

--- a/ui/extension/package-lock.json
+++ b/ui/extension/package-lock.json
@@ -13,6 +13,7 @@
         "@vitest/coverage-v8": "^4.1.10",
         "eslint": "^9.0.0",
         "jsdom": "^24.0.0",
+        "playwright": "^1.62.1",
         "typescript": "^5.5.0",
         "typescript-eslint": "^8.0.0",
         "vite": "^8.1.5",
@@ -2977,6 +2978,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/ui/extension/package.json
+++ b/ui/extension/package.json
@@ -7,13 +7,15 @@
     "build": "vite build",
     "lint": "eslint .",
     "type-check": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "npm run build && node e2e/restrictive-csp.test.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
     "@types/chrome": "^0.2.2",
     "eslint": "^9.0.0",
     "jsdom": "^24.0.0",
+    "playwright": "^1.62.1",
     "typescript": "^5.5.0",
     "typescript-eslint": "^8.0.0",
     "vite": "^8.1.5",

--- a/ui/extension/public/manifest.json
+++ b/ui/extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Bursa Connector",
   "version": "0.1.0",
-  "minimum_chrome_version": "92",
+  "minimum_chrome_version": "111",
   "description": "CIP-30 browser wallet connector for Bursa",
   "icons": {
     "16": "icons/icon16.png",
@@ -23,13 +23,14 @@
     {
       "matches": ["<all_urls>"],
       "js": ["content.js"],
-      "run_at": "document_start"
-    }
-  ],
-  "web_accessible_resources": [
+      "run_at": "document_start",
+      "world": "ISOLATED"
+    },
     {
-      "resources": ["injected.js"],
-      "matches": ["<all_urls>"]
+      "matches": ["<all_urls>"],
+      "js": ["injected.js"],
+      "run_at": "document_start",
+      "world": "MAIN"
     }
   ],
   "action": {

--- a/ui/extension/src/content.ts
+++ b/ui/extension/src/content.ts
@@ -10,12 +10,48 @@ function normalizeExactOrigin(origin: string): string | null {
   }
 }
 
-// Inject the provider script into the page's main world
-const script = document.createElement('script');
-script.src = chrome.runtime.getURL('injected.js');
-script.type = 'module';
-(document.head || document.documentElement).appendChild(script);
-script.onload = () => script.remove();
+const PROVIDER_STATUS_SOURCE = 'bursa-cip30-provider-status';
+const PROVIDER_REGISTRATION_TIMEOUT_MS = 1_000;
+
+function pageTargetOrigin(): string | null {
+  if (window.location.protocol === 'file:' || window.location.origin === 'null') {
+    return '*';
+  }
+  return normalizeExactOrigin(window.location.origin);
+}
+
+function monitorProviderRegistration(): void {
+  const handleProviderStatus = (event: MessageEvent) => {
+    if (event.source !== window) return;
+    if (event.data?.source !== PROVIDER_STATUS_SOURCE) return;
+    if (event.data?.status !== 'ready') return;
+
+    clearTimeout(timeout);
+    window.removeEventListener('message', handleProviderStatus);
+  };
+
+  const timeout = window.setTimeout(() => {
+    window.removeEventListener('message', handleProviderStatus);
+    const error = 'Bursa provider failed to register in the page main world';
+    console.error(error);
+    const targetOrigin = pageTargetOrigin();
+    if (!targetOrigin) return;
+    window.postMessage(
+      {
+        source: PROVIDER_STATUS_SOURCE,
+        status: 'error',
+        error,
+      },
+      targetOrigin,
+    );
+  }, PROVIDER_REGISTRATION_TIMEOUT_MS);
+
+  window.addEventListener('message', handleProviderStatus);
+}
+
+// The manifest runs this isolated-world relay before the MAIN-world provider.
+// The ready handshake makes a missing or failed provider injection observable.
+monitorProviderRegistration();
 
 // Relay page → background
 window.addEventListener('message', (event) => {

--- a/ui/extension/src/injected.ts
+++ b/ui/extension/src/injected.ts
@@ -190,3 +190,15 @@ if (!window.cardano) {
   window.cardano = {};
 }
 window.cardano.bursa = bursaProvider;
+
+const providerStatusTargetOrigin =
+  window.location.protocol === 'file:' || window.location.origin === 'null'
+    ? '*'
+    : window.location.origin;
+window.postMessage(
+  {
+    source: 'bursa-cip30-provider-status',
+    status: 'ready',
+  },
+  providerStatusTargetOrigin,
+);

--- a/ui/extension/tests/content.test.ts
+++ b/ui/extension/tests/content.test.ts
@@ -5,7 +5,6 @@ import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 const sendMessageCallbacks: ((response: unknown) => void)[] = [];
 const chromeMock = {
   runtime: {
-    getURL: vi.fn((path: string) => `chrome-extension://fake-id/${path}`),
     sendMessage: vi.fn((_message: unknown, callback: (response: unknown) => void) => {
       sendMessageCallbacks.push(callback);
     }),
@@ -19,16 +18,27 @@ const jsdomEnv = globalThis as typeof globalThis & {
 };
 
 describe('content script', () => {
-  // Capture injection details before beforeEach clears mocks
-  let injectedSrc: string | undefined;
+  let providerRegistrationFailure: unknown;
 
   beforeAll(async () => {
+    vi.useFakeTimers();
+    const postMessageSpy = vi.spyOn(window, 'postMessage').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
     // Dynamic import so the module runs AFTER chrome mock is installed
     await import('../src/content');
-    // Capture which src was passed to getURL at injection time
-    if (chromeMock.runtime.getURL.mock.calls.length > 0) {
-      injectedSrc = chromeMock.runtime.getURL.mock.calls[0][0] as string;
-    }
+    await vi.advanceTimersByTimeAsync(2_000);
+    providerRegistrationFailure = postMessageSpy.mock.calls
+      .map(([message]) => message)
+      .find(
+        (message) =>
+          typeof message === 'object' &&
+          message !== null &&
+          'source' in message &&
+          message.source === 'bursa-cip30-provider-status' &&
+          'status' in message &&
+          message.status === 'error',
+      );
+    vi.useRealTimers();
   });
 
   beforeEach(() => {
@@ -38,15 +48,12 @@ describe('content script', () => {
     sendMessageCallbacks.length = 0;
   });
 
-  it('injects a script tag with injected.js src', () => {
-    // In jsdom, onload does not fire so the script tag remains in the DOM
-    const scripts = document.querySelectorAll('script');
-    const injectedScript = Array.from(scripts).find((s) =>
-      s.src.includes('injected.js')
-    );
-    expect(injectedScript).toBeDefined();
-    // Also verify getURL was called with 'injected.js' (captured before mock clear)
-    expect(injectedSrc).toBe('injected.js');
+  it('reports when the provider does not register in the page main world', () => {
+    expect(providerRegistrationFailure).toEqual({
+      source: 'bursa-cip30-provider-status',
+      status: 'error',
+      error: 'Bursa provider failed to register in the page main world',
+    });
   });
 
   it('relays bursa-cip30 messages to chrome.runtime.sendMessage', () => {

--- a/ui/extension/vite.config.ts
+++ b/ui/extension/vite.config.ts
@@ -22,5 +22,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    include: ['tests/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
Refs #753

Registers the CIP-30 provider in Chrome's MAIN world and adds a restrictive-CSP browser test.

Closes #762

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers the CIP-30 provider in the page's MAIN world through the manifest instead of injecting a script tag from the isolated world, so the provider loads on pages with restrictive Content Security Policies. The old script-tag injection was blocked by such CSPs; the new approach also removes `web_accessible_resources` but requires Chrome 111 or later.

- Bumps `minimum_chrome_version` from 92 to 111 and adds a postMessage ready/error handshake so provider registration failures are observable and reported.
- Adds a Playwright e2e test that loads the extension on a CSP-restricted page and runs it in CI, with `playwright` added as a dev dependency.
- Closes #762.

<sup>Written for commit cecbb462cbd3b1cefada7cec7ed6c07a6e9766ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

