### PR TITLE
fix(hw): match air-gapped signer replies to the active request

### DIFF
--- a/ui/web/src/hw/keystone.test.ts
+++ b/ui/web/src/hw/keystone.test.ts
@@ -15,6 +15,19 @@ import {
 // keystone.ts's ensureBuffer() does in the browser, where no global exists.
 (globalThis as unknown as { Buffer: unknown }).Buffer = URBuffer;
 
+// connectKeystoneQR generates its own request id internally (not observable
+// from outside); pin it to a fixed, valid UUID so it matches the request id
+// every fixture below stamps on its reply, without reaching into
+// crypto.randomUUID.
+const { MOCK_REQUEST_ID } = vi.hoisted(() => ({
+  MOCK_REQUEST_ID: "11111111-1111-4111-8111-111111111111",
+}));
+
+vi.mock("./requestId", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./requestId")>();
+  return { ...actual, newRequestId: () => MOCK_REQUEST_ID };
+});
+
 // ── USB transport + app mocks (no real WebUSB in CI) ──────────────────────────
 const { mockRequestPermission, mockConnect, mockClose, mockGetAppConfig, mockGetXpubs, mockSignTx } =
   vi.hoisted(() => ({
@@ -132,9 +145,22 @@ function witnessSetHex(pubHex: string, sigHex: string): string {
   return "a10081" + "82" + "5820" + pubHex + "5840" + sigHex;
 }
 
-// A cardano-signature UR wrapping the witness set.
-function signatureCborHex(pubHex: string, sigHex: string): string {
-  const sig = new CardanoSignature(buf(witnessSetHex(pubHex, sigHex)));
+function uuidToBuffer(uuidStr: string): Buffer {
+  return URBuffer.from(uuidStr.replace(/-/g, ""), "hex") as unknown as Buffer;
+}
+
+// A cardano-signature UR wrapping the witness set. `requestId` defaults to the
+// mocked id every connectKeystoneQR call in this file sends (MOCK_REQUEST_ID);
+// pass `null` to omit it, or a different UUID to build a stale-scan fixture.
+function signatureCborHex(
+  pubHex: string,
+  sigHex: string,
+  requestId: string | null = MOCK_REQUEST_ID,
+): string {
+  const sig = new CardanoSignature(
+    buf(witnessSetHex(pubHex, sigHex)),
+    requestId ? uuidToBuffer(requestId) : undefined,
+  );
   return Buffer.from(sig.toUR().cbor).toString("hex");
 }
 
@@ -258,6 +284,52 @@ describe("connectKeystoneQR", () => {
     });
     const session = await connectKeystoneQR({ transport: "qr", bridge, xfp: "52744703" });
     await expect(session.signTx(NEUTRAL_REQ)).rejects.toThrow(/cardano-signature/i);
+    expect(bridge.close).toHaveBeenCalled();
+  });
+
+  // ── request-identifier matching (issue: reject a reply that doesn't answer
+  // the active request — a stale scan, or one with no/garbled identifier) ──────
+
+  test("signTx rejects a reply carrying a different (stale) request id", async () => {
+    // A signature left over from an EARLIER sign request must not be attached
+    // to the current operation just because it is otherwise well-formed.
+    const bridge = makeBridge();
+    bridge.scanResponse.mockResolvedValue({
+      type: "cardano-signature",
+      cborHex: signatureCborHex(
+        TEST_PUB_KEY_HEX,
+        TEST_SIG_HEX,
+        "22222222-2222-4222-8222-222222222222",
+      ),
+    });
+    const session = await connectKeystoneQR({ transport: "qr", bridge, xfp: "52744703" });
+    await expect(session.signTx(NEUTRAL_REQ)).rejects.toThrow(/does not match the active request/i);
+    expect(bridge.close).toHaveBeenCalled();
+  });
+
+  test("signTx rejects a reply with no request id", async () => {
+    const bridge = makeBridge();
+    bridge.scanResponse.mockResolvedValue({
+      type: "cardano-signature",
+      cborHex: signatureCborHex(TEST_PUB_KEY_HEX, TEST_SIG_HEX, null),
+    });
+    const session = await connectKeystoneQR({ transport: "qr", bridge, xfp: "52744703" });
+    await expect(session.signTx(NEUTRAL_REQ)).rejects.toThrow(/no request identifier/i);
+    expect(bridge.close).toHaveBeenCalled();
+  });
+
+  test("signTx rejects a reply whose request id is a malformed length", async () => {
+    const bridge = makeBridge();
+    const sig = new CardanoSignature(
+      buf(witnessSetHex(TEST_PUB_KEY_HEX, TEST_SIG_HEX)),
+      URBuffer.from("aabbccdd", "hex") as unknown as Buffer, // 4 bytes, not a 16-byte UUID
+    );
+    bridge.scanResponse.mockResolvedValue({
+      type: "cardano-signature",
+      cborHex: Buffer.from(sig.toUR().cbor).toString("hex"),
+    });
+    const session = await connectKeystoneQR({ transport: "qr", bridge, xfp: "52744703" });
+    await expect(session.signTx(NEUTRAL_REQ)).rejects.toThrow(/malformed request identifier/i);
     expect(bridge.close).toHaveBeenCalled();
   });
 

--- a/ui/web/src/hw/keystone.ts
+++ b/ui/web/src/hw/keystone.ts
@@ -34,6 +34,7 @@ import { encodeWitnessArray } from "./witness";
 import { decodeCbor, type CborValue } from "./qr/cbor";
 import { ensureBuffer, encodeUR } from "./qr/ur";
 import { isValidXfp } from "./qr/xfp";
+import { newRequestId, assertUuidRequestIdMatches } from "./requestId";
 
 // signMessage is not yet implemented for Keystone: CIP-8 over the air-gapped QR
 // transport needs the shared QR modal that lands with the SeedSigner work. The
@@ -304,14 +305,6 @@ export function buildKeystoneUtxos(req: HardwareSignResponse, xfp: string): Keys
   return utxos;
 }
 
-// A random-enough request id; the device echoes it back on the signature so a
-// stale scan can be detected. crypto.randomUUID is available in every target
-// (secure-context browsers); fall back to a fixed nil UUID if it is missing.
-function newRequestId(): string {
-  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
-  return c?.randomUUID ? c.randomUUID() : "00000000-0000-0000-0000-000000000000";
-}
-
 // ── Public API ───────────────────────────────────────────────────────────────
 
 /**
@@ -377,11 +370,15 @@ export async function connectKeystoneQR(
       const signData = B.from(req.unsigned_tx_cbor, "hex") as unknown as Buffer;
       const utxos = buildKeystoneUtxos(req, xfp);
 
+      // Retained so the reply's echoed identifier can be checked against THIS
+      // request below — a stale scan (an earlier reply still on-screen) must
+      // not be accepted as the answer to it.
+      const requestId = newRequestId();
       const signRequest = CardanoSignRequest.constructCardanoSignRequest(
         signData,
         utxos,
         [],
-        newRequestId(),
+        requestId,
         "bursa-wallet",
       );
 
@@ -404,6 +401,12 @@ export async function connectKeystoneQR(
         }
         const signature = CardanoSignature.fromCBOR(
           B.from(scanned.cborHex, "hex") as unknown as Buffer,
+        );
+        const receivedId = signature.getRequestId();
+        assertUuidRequestIdMatches(
+          requestId,
+          receivedId ? new Uint8Array(receivedId) : undefined,
+          "Keystone signature reply",
         );
         const witnessSet = new Uint8Array(signature.getWitnessSet());
         return encodeWitnessArray(witnessSetToPairs(witnessSet));

--- a/ui/web/src/hw/requestId.test.ts
+++ b/ui/web/src/hw/requestId.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, afterEach, vi } from "vitest";
 import {
   newRequestId,
   assertStringRequestIdMatches,
@@ -6,6 +6,10 @@ import {
 } from "./requestId";
 
 describe("newRequestId", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   test("returns a well-formed RFC-4122 UUID string", () => {
     const id = newRequestId();
     expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
@@ -13,6 +17,14 @@ describe("newRequestId", () => {
 
   test("returns a fresh id on each call", () => {
     expect(newRequestId()).not.toBe(newRequestId());
+  });
+
+  test("fails closed (throws) rather than falling back to a predictable id when crypto.randomUUID is unavailable", () => {
+    // A fixed fallback (e.g. a nil UUID) would defeat the whole point of this
+    // id: every request would carry the same value, so a captured old reply
+    // would pass the active-request match check.
+    vi.stubGlobal("crypto", {});
+    expect(() => newRequestId()).toThrow(/crypto\.randomUUID/i);
   });
 });
 

--- a/ui/web/src/hw/requestId.test.ts
+++ b/ui/web/src/hw/requestId.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect } from "vitest";
+import {
+  newRequestId,
+  assertStringRequestIdMatches,
+  assertUuidRequestIdMatches,
+} from "./requestId";
+
+describe("newRequestId", () => {
+  test("returns a well-formed RFC-4122 UUID string", () => {
+    const id = newRequestId();
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+  });
+
+  test("returns a fresh id on each call", () => {
+    expect(newRequestId()).not.toBe(newRequestId());
+  });
+});
+
+describe("assertStringRequestIdMatches (SeedSigner's plain-string dialect)", () => {
+  test("accepts a matching id", () => {
+    expect(() => assertStringRequestIdMatches("id", "id", "ctx")).not.toThrow();
+  });
+
+  test("rejects a missing id", () => {
+    expect(() => assertStringRequestIdMatches("id", undefined, "ctx")).toThrow(
+      /ctx has no request identifier/i,
+    );
+  });
+
+  test("rejects a non-string id (malformed)", () => {
+    expect(() => assertStringRequestIdMatches("id", 42, "ctx")).toThrow(
+      /ctx has a malformed request identifier/i,
+    );
+  });
+
+  test("rejects a different (stale) id", () => {
+    expect(() => assertStringRequestIdMatches("id", "earlier-request", "ctx")).toThrow(
+      /ctx request identifier does not match the active request/i,
+    );
+  });
+});
+
+describe("assertUuidRequestIdMatches (Keystone's tagged-UUID dialect)", () => {
+  const EXPECTED = "11111111-1111-4111-8111-111111111111";
+  const expectedBytes = Uint8Array.from(Buffer.from(EXPECTED.replace(/-/g, ""), "hex"));
+
+  test("accepts a matching 16-byte id, case-insensitively", () => {
+    expect(() => assertUuidRequestIdMatches(EXPECTED, expectedBytes, "ctx")).not.toThrow();
+    expect(() =>
+      assertUuidRequestIdMatches(EXPECTED.toUpperCase(), expectedBytes, "ctx"),
+    ).not.toThrow();
+  });
+
+  test("rejects a missing id", () => {
+    expect(() => assertUuidRequestIdMatches(EXPECTED, undefined, "ctx")).toThrow(
+      /ctx has no request identifier/i,
+    );
+  });
+
+  test("rejects a wrong-length id (malformed)", () => {
+    const short = Uint8Array.from(Buffer.from("aabbccdd", "hex"));
+    expect(() => assertUuidRequestIdMatches(EXPECTED, short, "ctx")).toThrow(
+      /ctx has a malformed request identifier/i,
+    );
+  });
+
+  test("rejects a different (stale) id of the correct length", () => {
+    const other = Uint8Array.from(
+      Buffer.from("22222222" + "2222" + "4222" + "8222" + "222222222222", "hex"),
+    );
+    expect(other.length).toBe(16);
+    expect(() => assertUuidRequestIdMatches(EXPECTED, other, "ctx")).toThrow(
+      /ctx request identifier does not match the active request/i,
+    );
+  });
+});

--- a/ui/web/src/hw/requestId.ts
+++ b/ui/web/src/hw/requestId.ts
@@ -11,12 +11,24 @@
  */
 
 /**
- * A fresh RFC-4122 UUID string. crypto.randomUUID is available in every target
- * (secure-context browsers); fall back to a fixed nil UUID if it is missing.
+ * A fresh RFC-4122 UUID string. This id is the whole security control against a
+ * stale/replayed reply, so it MUST be unpredictable — never fall back to a fixed
+ * value (e.g. a nil UUID) when crypto.randomUUID is unavailable: every request
+ * would then carry the same id, and a captured old reply would pass the match
+ * check. Fail closed instead.
+ *
+ * @throws Error — crypto.randomUUID is missing (non-secure context or an
+ *   unsupported browser).
  */
 export function newRequestId(): string {
   const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
-  return c?.randomUUID ? c.randomUUID() : "00000000-0000-0000-0000-000000000000";
+  if (!c?.randomUUID) {
+    throw new Error(
+      "This browser has no crypto.randomUUID (requires a secure context) — cannot generate " +
+        "an unpredictable request identifier for the air-gapped QR round-trip.",
+    );
+  }
+  return c.randomUUID();
 }
 
 /**

--- a/ui/web/src/hw/requestId.ts
+++ b/ui/web/src/hw/requestId.ts
@@ -1,0 +1,73 @@
+/**
+ * hw/requestId.ts — the "active request" identifier shared by every air-gapped
+ * QR round-trip (Keystone sign, SeedSigner account import, SeedSigner tx sign).
+ *
+ * Each of those exchanges stamps a fresh identifier on the request it displays
+ * and expects the device to echo it back on the reply. A response is only the
+ * answer to the request THIS call made if that identifier matches: without the
+ * check, a stale scan (an earlier reply, still showing on a phone or in a
+ * screenshot) or a reply meant for an unrelated request would be silently
+ * accepted and its signature attached to the current operation.
+ */
+
+/**
+ * A fresh RFC-4122 UUID string. crypto.randomUUID is available in every target
+ * (secure-context browsers); fall back to a fixed nil UUID if it is missing.
+ */
+export function newRequestId(): string {
+  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  return c?.randomUUID ? c.randomUUID() : "00000000-0000-0000-0000-000000000000";
+}
+
+/**
+ * Validate a request identifier carried as a plain UTF-8 string in a bespoke
+ * CBOR payload (SeedSigner's dialect) against the id the active request sent.
+ */
+export function assertStringRequestIdMatches(
+  expected: string,
+  actual: unknown,
+  context: string,
+): void {
+  if (actual === undefined) {
+    throw new Error(
+      `${context} has no request identifier — cannot confirm it answers the active request (possible stale scan).`,
+    );
+  }
+  if (typeof actual !== "string") {
+    throw new Error(`${context} has a malformed request identifier (not a text string).`);
+  }
+  if (actual !== expected) {
+    throw new Error(
+      `${context} request identifier does not match the active request — this looks like a stale or unrelated scan.`,
+    );
+  }
+}
+
+/**
+ * Validate a request identifier carried as a raw 16-byte UUID (Keystone's UR
+ * registry, tagged UUID) against the RFC-4122 string id the active request sent.
+ */
+export function assertUuidRequestIdMatches(
+  expectedUuid: string,
+  actual: Uint8Array | undefined,
+  context: string,
+): void {
+  if (actual === undefined) {
+    throw new Error(
+      `${context} has no request identifier — cannot confirm it answers the active request (possible stale scan).`,
+    );
+  }
+  if (actual.length !== 16) {
+    throw new Error(
+      `${context} has a malformed request identifier (expected a 16-byte UUID, got ${actual.length} bytes).`,
+    );
+  }
+  const expectedHex = expectedUuid.replace(/-/g, "").toLowerCase();
+  let actualHex = "";
+  for (const b of actual) actualHex += b.toString(16).padStart(2, "0");
+  if (actualHex !== expectedHex) {
+    throw new Error(
+      `${context} request identifier does not match the active request — this looks like a stale or unrelated scan.`,
+    );
+  }
+}

--- a/ui/web/src/hw/seedsigner.test.ts
+++ b/ui/web/src/hw/seedsigner.test.ts
@@ -17,6 +17,14 @@ import { bytesToHex, hexToBytes } from "./hex";
 import type { SeedSignerQRBridge, SeedSignerScannedUR } from "./types";
 import type { HardwareSignResponse } from "../api/types";
 
+// connectSeedSigner generates its own request id internally (not observable from
+// outside); pin it to "id" so it matches the fixed request id ("id") every
+// fixture below stamps on its reply, without reaching into crypto.randomUUID.
+vi.mock("./requestId", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./requestId")>();
+  return { ...actual, newRequestId: () => "id" };
+});
+
 // Shared parity vector — identical key material to the Ledger/Trezor/Keystone
 // canonical vectors, so SeedSigner MUST produce the same bech32 xpub and, for the
 // same pubkey/sig, the same witness-array CBOR.
@@ -52,20 +60,32 @@ const NEUTRAL_REQ: HardwareSignResponse = {
 
 const ht = (s: string): string => bytesToHex([...new TextEncoder().encode(s)]);
 
+// CBOR text-string encoding for a short (<24-byte) string: a single-byte
+// major-type-3 header (0x60 + length) followed by the UTF-8 bytes.
+function cborTextHex(s: string): string {
+  const len = new TextEncoder().encode(s).length;
+  if (len >= 24) throw new Error("cborTextHex: string too long for a single-byte header");
+  return (0x60 + len).toString(16).padStart(2, "0") + ht(s);
+}
+
 // A `cardano-account` reply carrying one account record + the master fingerprint.
+// `requestId` defaults to "id" — the fixed id every connectSeedSigner call in
+// this file sends (newRequestId is mocked above) — so callers only need to
+// override it to build a stale/mismatched-id fixture.
 function accountCborHex(
   account: number,
   pubHex: string,
   ccHex: string,
   xfpHex: string,
   label = "SeedSigner",
+  requestId = "id",
 ): string {
   const rec = new Map<number, unknown>();
   rec.set(1, account);
   rec.set(2, hexToBytes(pubHex + ccHex));
   rec.set(3, `1852'/1815'/${account}'`);
   const m = new Map<number, unknown>();
-  m.set(1, "id");
+  m.set(1, requestId);
   m.set(2, hexToBytes(xfpHex));
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   m.set(3, [rec] as any);
@@ -76,9 +96,10 @@ function accountCborHex(
 
 // A `cardano-tx-sig-res` reply: {1:request_id, 2: tag258([[pub,sig]])}. The set
 // tag (d90102) is written by hand since the shared encoder emits no tags.
-function txSigResCborHex(pubHex: string, sigHex: string): string {
+// `requestId` defaults to "id" for the same reason as accountCborHex above.
+function txSigResCborHex(pubHex: string, sigHex: string, requestId = "id"): string {
   const witnessSet = "d90102" + "81" + "82" + "5820" + pubHex + "5840" + sigHex;
-  return "a2" + "01" + "62" + ht("id") + "02" + witnessSet;
+  return "a2" + "01" + cborTextHex(requestId) + "02" + witnessSet;
 }
 
 function makeBridge(): SeedSignerQRBridge & {
@@ -202,7 +223,7 @@ describe("parseAccountResponse", () => {
       type: "cardano-account",
       cborHex: accountCborHex(0, TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, TEST_XFP),
     };
-    const acct = parseAccountResponse(scanned, 0);
+    const acct = parseAccountResponse(scanned, 0, "id");
     expect(acct.xpub).toBe(TEST_XPUB_BECH32);
     expect(acct.xfp).toBe(TEST_XFP);
     expect(acct.account).toBe(0);
@@ -210,7 +231,7 @@ describe("parseAccountResponse", () => {
 
   test("rejects a non-account UR", () => {
     expect(() =>
-      parseAccountResponse({ type: "cardano-tx-sig-res", cborHex: "a0" }, 0),
+      parseAccountResponse({ type: "cardano-tx-sig-res", cborHex: "a0" }, 0, "id"),
     ).toThrow(/cardano-account/i);
   });
 
@@ -219,7 +240,7 @@ describe("parseAccountResponse", () => {
       type: "cardano-account",
       cborHex: accountCborHex(0, TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, TEST_XFP),
     };
-    expect(() => parseAccountResponse(scanned, 5)).toThrow(/does not contain account 5/i);
+    expect(() => parseAccountResponse(scanned, 5, "id")).toThrow(/does not contain account 5/i);
   });
 
   test("rejects a malformed (non-8-hex) fingerprint", () => {
@@ -228,7 +249,43 @@ describe("parseAccountResponse", () => {
       type: "cardano-account",
       cborHex: accountCborHex(0, TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, "aabbcc"),
     };
-    expect(() => parseAccountResponse(scanned, 0)).toThrow(/malformed master fingerprint/i);
+    expect(() => parseAccountResponse(scanned, 0, "id")).toThrow(/malformed master fingerprint/i);
+  });
+
+  // ── request-identifier matching (issue: reject a reply that doesn't answer
+  // the active request — a stale scan, or one with no/garbled identifier) ──────
+
+  test("rejects a reply whose request id does not match the active request (stale scan)", () => {
+    const scanned: SeedSignerScannedUR = {
+      type: "cardano-account",
+      cborHex: accountCborHex(0, TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, TEST_XFP, "SeedSigner", "earlier-request"),
+    };
+    expect(() => parseAccountResponse(scanned, 0, "id")).toThrow(/does not match the active request/i);
+  });
+
+  test("rejects a reply with no request id", () => {
+    const m = new Map<number, unknown>();
+    m.set(2, hexToBytes(TEST_XFP));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    m.set(3, [] as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cborHex = bytesToHex([...encodeCbor(m as any)]);
+    expect(() => parseAccountResponse({ type: "cardano-account", cborHex }, 0, "id")).toThrow(
+      /no request identifier/i,
+    );
+  });
+
+  test("rejects a reply whose request id is not a text string (malformed)", () => {
+    const m = new Map<number, unknown>();
+    m.set(1, 42); // request id must be a string, not an integer
+    m.set(2, hexToBytes(TEST_XFP));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    m.set(3, [] as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cborHex = bytesToHex([...encodeCbor(m as any)]);
+    expect(() => parseAccountResponse({ type: "cardano-account", cborHex }, 0, "id")).toThrow(
+      /malformed request identifier/i,
+    );
   });
 });
 
@@ -238,7 +295,15 @@ describe("parseAccountXfp", () => {
       type: "cardano-account",
       cborHex: accountCborHex(3, TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, TEST_XFP),
     };
-    expect(parseAccountXfp(scanned)).toBe(TEST_XFP);
+    expect(parseAccountXfp(scanned, "id")).toBe(TEST_XFP);
+  });
+
+  test("rejects a reply whose request id does not match the active request", () => {
+    const scanned: SeedSignerScannedUR = {
+      type: "cardano-account",
+      cborHex: accountCborHex(3, TEST_PUB_KEY_HEX, TEST_CHAIN_CODE_HEX, TEST_XFP, "SeedSigner", "other-request"),
+    };
+    expect(() => parseAccountXfp(scanned, "id")).toThrow(/does not match the active request/i);
   });
 });
 
@@ -250,7 +315,7 @@ describe("parseTxSigResponse", () => {
       type: "cardano-tx-sig-res",
       cborHex: txSigResCborHex(TEST_PUB_KEY_HEX, TEST_SIG_HEX),
     };
-    const result = parseTxSigResponse(scanned);
+    const result = parseTxSigResponse(scanned, "id");
     expect(result).toBe(encodeWitnessArray([{ pubKeyHex: TEST_PUB_KEY_HEX, sigHex: TEST_SIG_HEX }]));
     expect(result.startsWith("8182")).toBe(true);
     expect(result).toContain(TEST_PUB_KEY_HEX);
@@ -258,17 +323,43 @@ describe("parseTxSigResponse", () => {
   });
 
   test("rejects a non-signature UR", () => {
-    expect(() => parseTxSigResponse({ type: "cardano-account", cborHex: "a0" })).toThrow(
-      /cardano-tx-sig-res/i,
-    );
+    expect(() =>
+      parseTxSigResponse({ type: "cardano-account", cborHex: "a0" }, "id"),
+    ).toThrow(/cardano-tx-sig-res/i);
   });
 
   test("trims an extended (pubkey||chaincode) vkey to the 32-byte public key", () => {
     const extended = TEST_PUB_KEY_HEX + TEST_CHAIN_CODE_HEX;
     const witnessSet = "d90102" + "81" + "82" + "5840" + extended + "5840" + TEST_SIG_HEX;
     const cborHex = "a2" + "01" + "62" + ht("id") + "02" + witnessSet;
-    const result = parseTxSigResponse({ type: "cardano-tx-sig-res", cborHex });
+    const result = parseTxSigResponse({ type: "cardano-tx-sig-res", cborHex }, "id");
     expect(result).toBe(encodeWitnessArray([{ pubKeyHex: TEST_PUB_KEY_HEX, sigHex: TEST_SIG_HEX }]));
+  });
+
+  // ── request-identifier matching ───────────────────────────────────────────
+
+  test("rejects a reply whose request id does not match the active request (stale scan)", () => {
+    const scanned: SeedSignerScannedUR = {
+      type: "cardano-tx-sig-res",
+      cborHex: txSigResCborHex(TEST_PUB_KEY_HEX, TEST_SIG_HEX, "earlier-request"),
+    };
+    expect(() => parseTxSigResponse(scanned, "id")).toThrow(/does not match the active request/i);
+  });
+
+  test("rejects a reply with no request id", () => {
+    const witnessSet = "d90102" + "81" + "82" + "5820" + TEST_PUB_KEY_HEX + "5840" + TEST_SIG_HEX;
+    const cborHex = "a1" + "02" + witnessSet; // map with only key 2 (witness set)
+    expect(() =>
+      parseTxSigResponse({ type: "cardano-tx-sig-res", cborHex }, "id"),
+    ).toThrow(/no request identifier/i);
+  });
+
+  test("rejects a reply whose request id is not a text string (malformed)", () => {
+    const witnessSet = "d90102" + "81" + "82" + "5820" + TEST_PUB_KEY_HEX + "5840" + TEST_SIG_HEX;
+    const cborHex = "a2" + "01" + "182a" + "02" + witnessSet; // key 1 = uint(42), not a string
+    expect(() =>
+      parseTxSigResponse({ type: "cardano-tx-sig-res", cborHex }, "id"),
+    ).toThrow(/malformed request identifier/i);
   });
 });
 
@@ -318,6 +409,20 @@ describe("connectSeedSigner", () => {
     expect(fragments[0].toLowerCase()).toMatch(/^ur:cardano-tx-sig-req\//);
 
     expect(result).toBe(encodeWitnessArray([{ pubKeyHex: TEST_PUB_KEY_HEX, sigHex: TEST_SIG_HEX }]));
+    expect(bridge.close).toHaveBeenCalled();
+  });
+
+  test("signTx rejects a reply carrying a different (stale) request id", async () => {
+    // A response left over from an EARLIER sign request — e.g. still showing on
+    // the device or re-scanned from a screenshot — must not be attached to the
+    // current operation just because it happens to be a well-formed signature.
+    const bridge = makeBridge();
+    bridge.scanResponse.mockResolvedValue({
+      type: "cardano-tx-sig-res",
+      cborHex: txSigResCborHex(TEST_PUB_KEY_HEX, TEST_SIG_HEX, "earlier-request"),
+    });
+    const session = await connectSeedSigner({ bridge, xfp: TEST_XFP });
+    await expect(session.signTx(NEUTRAL_REQ)).rejects.toThrow(/does not match the active request/i);
     expect(bridge.close).toHaveBeenCalled();
   });
 

--- a/ui/web/src/hw/seedsigner.ts
+++ b/ui/web/src/hw/seedsigner.ts
@@ -49,6 +49,7 @@ import { hexToBytes } from "./hex";
 import { decodeCbor, encodeCbor, type CborValue, type CborWritable } from "./qr/cbor";
 import { encodeUR } from "./qr/ur";
 import { isValidXfp } from "./qr/xfp";
+import { newRequestId, assertStringRequestIdMatches } from "./requestId";
 
 // ── UR type discriminators (SeedSigner's bespoke dialect) ─────────────────────
 
@@ -113,14 +114,6 @@ function normalizePath(path: string): string {
   return path.replace(/^m\//, "").trim();
 }
 
-// A random-enough request id; the device echoes it back on the reply so a stale
-// scan can be detected. crypto.randomUUID is available in every target
-// (secure-context browsers); fall back to a fixed nil UUID if it is missing.
-function newRequestId(): string {
-  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
-  return c?.randomUUID ? c.randomUUID() : "00000000-0000-0000-0000-000000000000";
-}
-
 // ── cardano-account-req (display) ─────────────────────────────────────────────
 
 export interface AccountRequestOptions {
@@ -171,6 +164,10 @@ function decodeAccountMap(scanned: ScannedUR): Map<number, CborValue> {
   return value;
 }
 
+function assertAccountResponseMatches(map: Map<number, CborValue>, expectedRequestId: string): void {
+  assertStringRequestIdMatches(expectedRequestId, map.get(1), "SeedSigner account reply");
+}
+
 function xfpFromAccountMap(map: Map<number, CborValue>): string {
   const raw = map.get(2);
   if (!(raw instanceof Uint8Array)) {
@@ -187,9 +184,15 @@ function xfpFromAccountMap(map: Map<number, CborValue>): string {
  * Read ONLY the master fingerprint (xfp) from a scanned `cardano-account` UR.
  * Account-independent — used by the Send recovery flow to re-learn the xfp of an
  * already-added wallet whose local hint was lost, without re-deriving its xpub.
+ *
+ * `expectedRequestId` must match the reply's echoed identifier (key 1) — the id
+ * of the `cardano-account-req` this scan is answering — so a stale or unrelated
+ * scan is rejected rather than silently accepted.
  */
-export function parseAccountXfp(scanned: ScannedUR): string {
-  return xfpFromAccountMap(decodeAccountMap(scanned));
+export function parseAccountXfp(scanned: ScannedUR, expectedRequestId: string): string {
+  const map = decodeAccountMap(scanned);
+  assertAccountResponseMatches(map, expectedRequestId);
+  return xfpFromAccountMap(map);
 }
 
 /**
@@ -198,9 +201,17 @@ export function parseAccountXfp(scanned: ScannedUR): string {
  * ({1:idx, 2:xpub64, 3:path}); we pick the one matching `account`, split its
  * 64-byte xpub (pubkey || chaincode) and re-encode it through the shared
  * hw/xpub.ts helper so it matches every other device byte-for-byte.
+ *
+ * `expectedRequestId` must match the reply's echoed identifier (key 1) — see
+ * {@link parseAccountXfp}.
  */
-export function parseAccountResponse(scanned: ScannedUR, account: number): SeedSignerAccount {
+export function parseAccountResponse(
+  scanned: ScannedUR,
+  account: number,
+  expectedRequestId: string,
+): SeedSignerAccount {
   const map = decodeAccountMap(scanned);
+  assertAccountResponseMatches(map, expectedRequestId);
   const xfp = xfpFromAccountMap(map);
 
   const records = map.get(3);
@@ -361,8 +372,12 @@ function witnessPairsFromValue(value: CborValue): { pubKeyHex: string; sigHex: s
  * Parse a scanned `cardano-tx-sig-res` UR into the standard vkey-witness-array
  * CBOR hex the backend's submit endpoint expects — byte-identical to every other
  * device's output (via the shared hw/witness.ts encoder).
+ *
+ * `expectedRequestId` must match the reply's echoed identifier (key 1) — the id
+ * of the `cardano-tx-sig-req` this scan is answering — so a stale or unrelated
+ * scan is rejected rather than silently signed and submitted.
  */
-export function parseTxSigResponse(scanned: ScannedUR): string {
+export function parseTxSigResponse(scanned: ScannedUR, expectedRequestId: string): string {
   if (scanned.type !== UR_TX_SIG_RES) {
     throw new Error(
       `Expected a SeedSigner signature QR (${UR_TX_SIG_RES}), got "${scanned.type}".`,
@@ -372,6 +387,7 @@ export function parseTxSigResponse(scanned: ScannedUR): string {
   if (!(value instanceof Map)) {
     throw new Error("SeedSigner signature payload is not a CBOR map");
   }
+  assertStringRequestIdMatches(expectedRequestId, value.get(1), "SeedSigner signature reply");
   const witnessSet = value.get(2);
   if (witnessSet === undefined) {
     throw new Error("SeedSigner signature payload has no witness set (key 2)");
@@ -381,10 +397,14 @@ export function parseTxSigResponse(scanned: ScannedUR): string {
 
 // ── Account import (display request → scan response) ──────────────────────────
 
-async function displayAccountRequest(bridge: AirGapQRBridge, account: number): Promise<void> {
-  const cbor = encodeAccountRequest({ accounts: [account] }, newRequestId());
+// Returns the request id it stamped on the display, so the caller can check
+// the scanned reply actually answers THIS request rather than a stale one.
+async function displayAccountRequest(bridge: AirGapQRBridge, account: number): Promise<string> {
+  const requestId = newRequestId();
+  const cbor = encodeAccountRequest({ accounts: [account] }, requestId);
   const fragments = await encodeUR(UR_ACCOUNT_REQ, cbor, UR_MAX_FRAGMENT_LEN);
   bridge.displayRequest(fragments);
+  return requestId;
 }
 
 /**
@@ -397,10 +417,10 @@ export async function importSeedSignerAccount(
   bridge: AirGapQRBridge,
   account: number,
 ): Promise<SeedSignerAccount> {
-  await displayAccountRequest(bridge, account);
+  const requestId = await displayAccountRequest(bridge, account);
   try {
     const scanned = await bridge.scanResponse();
-    return parseAccountResponse(scanned, account);
+    return parseAccountResponse(scanned, account, requestId);
   } finally {
     bridge.close();
   }
@@ -412,10 +432,10 @@ export async function importSeedSignerAccount(
  * Send's recovery flow to re-learn a lost xfp without re-deriving the xpub.
  */
 export async function recoverSeedSignerXfp(bridge: AirGapQRBridge, account = 0): Promise<string> {
-  await displayAccountRequest(bridge, account);
+  const requestId = await displayAccountRequest(bridge, account);
   try {
     const scanned = await bridge.scanResponse();
-    return parseAccountXfp(scanned);
+    return parseAccountXfp(scanned, requestId);
   } finally {
     bridge.close();
   }
@@ -465,12 +485,13 @@ export async function connectSeedSigner(
         );
       }
 
-      const cbor = encodeTxSigRequest(req, { xfp, requestId: newRequestId() });
+      const requestId = newRequestId();
+      const cbor = encodeTxSigRequest(req, { xfp, requestId });
       const fragments = await encodeUR(UR_TX_SIG_REQ, cbor, UR_MAX_FRAGMENT_LEN);
       bridge.displayRequest(fragments);
       try {
         const scanned = await bridge.scanResponse();
-        return parseTxSigResponse(scanned);
+        return parseTxSigResponse(scanned, requestId);
       } finally {
         bridge.close();
       }


### PR DESCRIPTION
## Summary

- Keystone and SeedSigner stamp a request identifier on every displayed
  air-gapped QR and expect the device to echo it back, but response handling
  never compared it against the active request.
- Adds a shared `hw/requestId.ts` with per-dialect matchers and wires them
  into every Keystone/SeedSigner request/response round-trip: transaction
  signing, SeedSigner account import, and xfp recovery.
- Missing, malformed, and mismatched identifiers are now rejected rather than
  silently accepted.

Closes #771.

## Test plan

- [x] `npx vitest run` — 69 files, 843 tests pass
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean (one pre-existing, unrelated warning)
- [x] New unit/integration tests cover matching, stale/mismatched, and
      malformed identifier cases for both devices


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects air-gapped Keystone and SeedSigner replies that don't echo the active request's identifier, so a stale or unrelated scan can't be silently attached to the current operation. Missing, malformed, or mismatched identifiers now abort the operation, and identifier generation fails closed (throws) when `crypto.randomUUID` is unavailable instead of falling back to a predictable id. Fixes #771.

<sup>Written for commit 15c1ae158e9591bddc2e66a7e780f869217879ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * QR-based hardware-wallet exchanges now verify that responses match the active signing or account request.
  * Stale, missing, malformed, or unrelated QR responses are rejected, and affected sessions close safely.

* **Reliability**
  * Request identifiers are consistently generated and validated across Keystone and SeedSigner account imports and transaction signing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->