### PR TITLE
fix(kes): reject future signing periods

### DIFF
--- a/docs/signer/kes-agent.md
+++ b/docs/signer/kes-agent.md
@@ -76,6 +76,8 @@ clock jump, restart, or stale key re-install - a belt-and-suspenders complement
 to KES forward security. A period strictly below the floor is refused; a period
 equal to the floor is allowed (a producer signs many headers within one period).
 The floor is persisted to `guard_file` via an atomic temp-file + rename write.
+In `sign` mode, requests for a period later than the agent's wall-clock current
+period are rejected before key evolution or guard persistence.
 
 ## Locked memory
 

--- a/internal/kesagent/agent.go
+++ b/internal/kesagent/agent.go
@@ -39,6 +39,7 @@ var (
 	ErrNoStagedKey  = errors.New("kesagent: no staged KES key")
 	ErrExhausted    = errors.New("kesagent: active KES key has exhausted its evolutions")
 	ErrPastPeriod   = errors.New("kesagent: requested KES period is in the past for the active key")
+	ErrFuturePeriod = errors.New("kesagent: requested KES period is in the future")
 	ErrOpCertColdVK = errors.New("kesagent: opcert cold vkey does not match configured cold vkey")
 	ErrOpCertKESVK  = errors.New("kesagent: opcert KES vkey does not match the staged key")
 	ErrColdVKey     = errors.New("kesagent: configured cold verification key must be 32 bytes")
@@ -364,14 +365,21 @@ func (a *Agent) DropKey(target string) error {
 }
 
 // Sign produces a KES signature over msg at the given absolute KES period. The
-// key is evolved forward as needed; it never signs a period below the monotonic
-// floor or below the active key's current period.
+// key is evolved forward as needed, but never beyond the wall-clock period
+// derived from the configured genesis schedule. It never signs a period below
+// the monotonic floor or below the active key's current period.
 func (a *Agent) Sign(period uint64, msg []byte) ([]byte, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if a.active == nil {
 		a.metrics.incSign("error")
 		return nil, ErrNoActiveKey
+	}
+	currentPeriod := a.currentKESPeriod()
+	if period > currentPeriod {
+		a.metrics.incSign("error")
+		return nil, fmt.Errorf("%w: requested %d, current %d",
+			ErrFuturePeriod, period, currentPeriod)
 	}
 	if period < a.active.absPeriod() {
 		a.metrics.incSign("error")

--- a/internal/kesagent/agent_test.go
+++ b/internal/kesagent/agent_test.go
@@ -111,21 +111,70 @@ func TestSignPastPeriodRejected(t *testing.T) {
 	}
 }
 
-func TestSignForwardEvolves(t *testing.T) {
+func TestSignFuturePeriodRejectedWithoutStateChange(t *testing.T) {
 	cold := newColdKey(t)
 	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(3))
 	vkey, _ := a.GenStagedKey()
 	if _, err := a.InstallKey(makeOpCert(t, vkey, 1, 3, cold)); err != nil {
 		t.Fatalf("InstallKey: %v", err)
 	}
-	// Sign at a future period: the key must evolve forward to reach it.
-	msg := []byte("future")
-	sig, err := a.Sign(7, msg)
-	if err != nil {
-		t.Fatalf("Sign future: %v", err)
+	if _, err := a.Sign(7, []byte("future")); !errors.Is(err, ErrFuturePeriod) {
+		t.Fatalf("Sign future period: want ErrFuturePeriod, got %v", err)
 	}
-	if !kes.VerifySignedKES(vkey, 7-3, msg, sig) {
-		t.Fatal("forward-evolved signature failed to verify")
+	info := a.Info()
+	if info.ActivePeriod != 3 {
+		t.Fatalf("active period = %d after rejected request, want 3", info.ActivePeriod)
+	}
+	if info.MonotonicFloor != 3 {
+		t.Fatalf("guard floor = %d after rejected request, want 3", info.MonotonicFloor)
+	}
+	if info.Exhausted {
+		t.Fatal("rejected future request marked the active key exhausted")
+	}
+}
+
+func TestSignFuturePeriodDoesNotPoisonRestart(t *testing.T) {
+	cold := newColdKey(t)
+	guardPath := filepath.Join(t.TempDir(), "guard.json")
+	cfg := Config{
+		Mode:              ModeSign,
+		Depth:             kes.CardanoKesDepth,
+		SystemStart:       epoch,
+		SlotLength:        time.Second,
+		SlotsPerKESPeriod: 10,
+		MaxKESEvolutions:  62,
+		ColdVKey:          cold.pub,
+		EvolveInterval:    time.Hour,
+		GuardPath:         guardPath,
+		Version:           "test",
+	}
+	newAgent := func() *Agent {
+		a, err := New(cfg, nil, nil)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		a.now = func() time.Time { return atPeriod(3) }
+		return a
+	}
+
+	a := newAgent()
+	vkey, _ := a.GenStagedKey()
+	if _, err := a.InstallKey(makeOpCert(t, vkey, 1, 3, cold)); err != nil {
+		t.Fatalf("InstallKey: %v", err)
+	}
+	if _, err := a.Sign(4, []byte("future")); !errors.Is(err, ErrFuturePeriod) {
+		t.Fatalf("Sign future period: want ErrFuturePeriod, got %v", err)
+	}
+	a.Close()
+
+	restarted := newAgent()
+	t.Cleanup(restarted.Close)
+	restartedVKey, _ := restarted.GenStagedKey()
+	if _, err := restarted.InstallKey(makeOpCert(t, restartedVKey, 2, 3, cold)); err != nil {
+		t.Fatalf("InstallKey after restart: %v", err)
+	}
+	if got := restarted.Info().MonotonicFloor; got != 3 {
+		t.Fatalf("guard floor after restart = %d, want 3", got)
 	}
 }
 

--- a/internal/kesagent/service_test.go
+++ b/internal/kesagent/service_test.go
@@ -295,6 +295,22 @@ func TestServiceSignMode(t *testing.T) {
 		t.Fatal("signature from sign-mode socket failed to verify")
 	}
 
+	// A future period must be rejected before the active key or durable guard
+	// advances, so an authorized service peer cannot destroy the signing state.
+	if err := writeFrame(conn, SignRequest{Type: "sign_request", Period: 6, Message: msg}); err != nil {
+		t.Fatalf("write future-period request: %v", err)
+	}
+	var futureResp SignResponse
+	if err := readFrame(conn, &futureResp); err != nil {
+		t.Fatalf("read future-period response: %v", err)
+	}
+	if futureResp.Error == "" {
+		t.Fatal("expected error for future-period sign request")
+	}
+	if got := a.Info().ActivePeriod; got != 5 {
+		t.Fatalf("active period = %d after rejected request, want 5", got)
+	}
+
 	// A past period must be rejected with an error in the response.
 	if err := writeFrame(conn, SignRequest{Type: "sign_request", Period: 4, Message: msg}); err != nil {
 		t.Fatalf("write past-period request: %v", err)


### PR DESCRIPTION
Rejects sign requests after the wall-clock current KES period before key evolution or guard persistence. Fixes #769.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects sign requests for KES periods later than the agent's wall-clock current period, preventing an authorized peer from exhausting the active key or advancing the durable guard floor.

- Previously, `Sign` evolved the key forward to reach any future period; it now returns `ErrFuturePeriod` before key evolution or guard persistence.
- Documents the new rejection behavior in `docs/signer/kes-agent.md` and adds tests covering no state change and restart safety.

<sup>Written for commit 1031467fd0604e767a4094d82049a2e768259a0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Signing requests for future KES periods are now rejected before key evolution begins.
  - Rejected requests leave the agent’s active key and guard state unchanged, including across restarts.
  - Clear signing errors are returned for future-period requests.

- **Documentation**
  - Updated KES agent documentation to describe future-period request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->