### PR TITLE
fix(kes): require durable period guard

### DIFF
--- a/docs/signer/kes-agent.md
+++ b/docs/signer/kes-agent.md
@@ -76,6 +76,7 @@ clock jump, restart, or stale key re-install - a belt-and-suspenders complement
 to KES forward security. A period strictly below the floor is refused; a period
 equal to the floor is allowed (a producer signs many headers within one period).
 The floor is persisted to `guard_file` via an atomic temp-file + rename write.
+`guard_file` is required; the daemon refuses to start without a durable path.
 
 ## Locked memory
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,7 +69,7 @@ type KESAgentConfig struct {
 	MaxKESEvolutions uint64 `yaml:"max_kes_evolutions" envconfig:"KESAGENT_MAX_KES_EVOLUTIONS"`
 	// EvolveInterval is the scheduler tick as a Go duration string (default 1m).
 	EvolveInterval string `yaml:"evolve_interval" envconfig:"KESAGENT_EVOLVE_INTERVAL"`
-	// GuardFile is the durable monotonic-period store path.
+	// GuardFile is the required durable monotonic-period store path.
 	GuardFile string `yaml:"guard_file" envconfig:"KESAGENT_GUARD_FILE"`
 }
 

--- a/internal/kesagent/agent.go
+++ b/internal/kesagent/agent.go
@@ -163,6 +163,9 @@ func New(cfg Config, logger *slog.Logger, metrics *Metrics) (*Agent, error) {
 	if cfg.EvolveInterval <= 0 {
 		cfg.EvolveInterval = time.Minute
 	}
+	if cfg.GuardPath == "" {
+		return nil, errors.New("kesagent: guard_path is required")
+	}
 	guard, err := NewPeriodGuard(cfg.GuardPath)
 	if err != nil {
 		return nil, err

--- a/internal/kesagent/agent_test.go
+++ b/internal/kesagent/agent_test.go
@@ -111,6 +111,67 @@ func TestSignPastPeriodRejected(t *testing.T) {
 	}
 }
 
+func TestNewRequiresDurableGuardPath(t *testing.T) {
+	cold := newColdKey(t)
+	a, err := New(Config{
+		Mode:              ModeSign,
+		Depth:             kes.CardanoKesDepth,
+		SystemStart:       epoch,
+		SlotLength:        time.Second,
+		SlotsPerKESPeriod: 10,
+		MaxKESEvolutions:  62,
+		ColdVKey:          cold.pub,
+		EvolveInterval:    time.Hour,
+	}, nil, nil)
+	if err == nil {
+		a.Close()
+		t.Fatal("New accepted an empty guard path")
+	}
+}
+
+func TestAgentGuardFloorSurvivesRestart(t *testing.T) {
+	cold := newColdKey(t)
+	guardPath := filepath.Join(t.TempDir(), "guard.json")
+	cfg := Config{
+		Mode:              ModeSign,
+		Depth:             kes.CardanoKesDepth,
+		SystemStart:       epoch,
+		SlotLength:        time.Second,
+		SlotsPerKESPeriod: 10,
+		MaxKESEvolutions:  62,
+		ColdVKey:          cold.pub,
+		EvolveInterval:    time.Hour,
+		GuardPath:         guardPath,
+		Version:           "test",
+	}
+	newAgent := func(period uint64) *Agent {
+		a, err := New(cfg, nil, nil)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		a.now = func() time.Time { return atPeriod(period) }
+		return a
+	}
+
+	a := newAgent(5)
+	vkey, _ := a.GenStagedKey()
+	if _, err := a.InstallKey(makeOpCert(t, vkey, 1, 3, cold)); err != nil {
+		t.Fatalf("InstallKey: %v", err)
+	}
+	a.Close()
+
+	restarted := newAgent(4)
+	t.Cleanup(restarted.Close)
+	info := restarted.Info()
+	if !info.FloorInitialized || info.MonotonicFloor != 5 {
+		t.Fatalf("restarted guard floor = (%d, %v), want (5, true)", info.MonotonicFloor, info.FloorInitialized)
+	}
+	restartedVKey, _ := restarted.GenStagedKey()
+	if _, err := restarted.InstallKey(makeOpCert(t, restartedVKey, 2, 4, cold)); !errors.Is(err, ErrPeriodRollback) {
+		t.Fatalf("InstallKey below restarted floor: want ErrPeriodRollback, got %v", err)
+	}
+}
+
 func TestSignForwardEvolves(t *testing.T) {
 	cold := newColdKey(t)
 	a := testAgent(t, ModeSign, cold, kes.CardanoKesDepth, atPeriod(3))

--- a/internal/kesagent/guard.go
+++ b/internal/kesagent/guard.go
@@ -62,8 +62,9 @@ type guardState struct {
 	Vkey  string `json:"kes_vkey,omitempty"`
 }
 
-// NewPeriodGuard opens (or creates) a guard backed by the file at path. An
-// empty path yields a non-durable in-memory guard (tests / ephemeral use).
+// NewPeriodGuard opens (or creates) a guard backed by the file at path. Direct
+// guard tests may use an empty path for an in-memory instance; Agent.New
+// requires a durable path.
 func NewPeriodGuard(path string) (*PeriodGuard, error) {
 	// durable starts true: an in-memory guard has nothing to persist, an absent
 	// or empty file has no floor to lose, and a floor read back from the file was

--- a/internal/kesagent/helpers_test.go
+++ b/internal/kesagent/helpers_test.go
@@ -18,6 +18,7 @@ import (
 	"crypto/ed25519"
 	"io"
 	"log/slog"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -57,7 +58,7 @@ func testAgent(t *testing.T, mode string, cold coldKeyPair, depth uint64, clockA
 		MaxKESEvolutions:  62,
 		ColdVKey:          cold.pub,
 		EvolveInterval:    time.Hour,
-		GuardPath:         "", // in-memory guard
+		GuardPath:         filepath.Join(t.TempDir(), "guard.json"),
 		Version:           "test",
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))

--- a/packaging/signer/README.md
+++ b/packaging/signer/README.md
@@ -95,6 +95,7 @@ persistent state and point the relevant config field at a path inside it: the
 KES agent's `kes_agent.guard_file` (env `KESAGENT_GUARD_FILE`), and the
 signer's watermark database when using the `file` (SQLite) watermark type
 (`signer.watermark.path`, no env override - set it in the mounted config).
+The KES agent refuses to start when `guard_file` is empty.
 Without a mounted volume, that state lives only in the container's writable
 layer and is lost when the container is removed - equivalent to the
 `StateDirectory` the systemd units provision on bare metal.


### PR DESCRIPTION
Requires a durable KES period-guard path and preserves the rollback floor across agent restarts. Fixes #767.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires a durable KES period-guard path so the rollback floor persists across agent restarts, fixing #767.

- The agent now refuses to start when `guard_file` is empty instead of using an in-memory fallback.
- Existing configurations with an empty `guard_file` must set a durable path.
- Adds a restart test that verifies the persisted floor rejects period rollback.
- Updates the signer and packaging docs to state the new requirement.

<sup>Written for commit 35fbc26716bbefad6739626f15f051bf44d77476. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

