### PR TITLE
fix(android): use installed SDK build tools

### DIFF
--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 android {
     namespace = "io.blinklabs.bursa"
     compileSdk = 35
+    buildToolsVersion = "35.0.0"
 
     defaultConfig {
         applicationId = "io.blinklabs.bursa"


### PR DESCRIPTION
Pins the Android app to Build Tools 35.0.0, matching the SDK installed in the canonical build image.

Closes #797.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the Android app to Build Tools 35.0.0 to match the SDK installed in the canonical build image, preventing build failures from version mismatches. Closes #797.

<sup>Written for commit 8482d2ab6d75e1825eaff2bc6731c9e6283c1e42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

