### PR TITLE
fix(ios): separate app and framework modules

### DIFF
--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -30,6 +30,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: io.blinklabs.bursa
         PRODUCT_NAME: Bursa
         PRODUCT_MODULE_NAME: BursaApp
+        OTHER_LDFLAGS: "$(inherited) -lresolv"
         GENERATE_INFOPLIST_FILE: NO
         # Allow building without a signing identity in CI (simulator/unsigned).
         CODE_SIGNING_ALLOWED: NO

--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -29,6 +29,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: io.blinklabs.bursa
         PRODUCT_NAME: Bursa
+        PRODUCT_MODULE_NAME: BursaApp
         GENERATE_INFOPLIST_FILE: NO
         # Allow building without a signing identity in CI (simulator/unsigned).
         CODE_SIGNING_ALLOWED: NO


### PR DESCRIPTION
Compiles the iOS application as Swift module `BursaApp` so `import Bursa` resolves to the gomobile framework. The product name, scheme, and bundle identifier remain unchanged.

Closes #798.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS module naming so `import Bursa` resolves to the gomobile framework instead of the app. The app now compiles as Swift module `BursaApp`; product name, scheme, and bundle identifier are unchanged. Also links `libresolv` so wallet networking can resolve DNS. Closes #798.

<sup>Written for commit 2bb5949c083592b1d907a971e7540bd925effa96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS build and linking compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->