### PR TITLE
fix: validate canonical network names

### DIFF
--- a/bursa.go
+++ b/bursa.go
@@ -222,7 +222,7 @@ var jsonBufferPool = sync.Pool{
 // WalletConfig holds configuration options for wallet creation.
 // All index fields default to 0 and must be less than 2^31.
 type WalletConfig struct {
-	Network         string // Network name: "mainnet" or "testnet"
+	Network         string // Canonical network registry name
 	Password        string //nolint:gosec // G117: password field is intentional for key derivation
 	AccountID       uint32 // Account derivation index
 	PaymentID       uint32 // Payment key derivation index
@@ -242,7 +242,8 @@ type WalletConfig struct {
 type WalletOption func(*WalletConfig)
 
 // WithNetwork sets the network for the wallet.
-// Valid values are "mainnet" and "testnet".
+// Use a canonical network registry name, such as "mainnet", "preprod", or
+// "preview".
 // Default: "mainnet"
 func WithNetwork(network string) WalletOption {
 	return func(c *WalletConfig) {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -40,7 +40,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.AddressBuildRequest"
+                            "$ref": "#/definitions/api.AddressBuildRequest"
                         }
                     }
                 ],
@@ -48,19 +48,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Address built successfully",
                         "schema": {
-                            "$ref": "#/definitions/_.AddressBuildResponse"
+                            "$ref": "#/definitions/api.AddressBuildResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request or keys",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -88,7 +88,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.AddressEnumerateRequest"
+                            "$ref": "#/definitions/api.AddressEnumerateRequest"
                         }
                     }
                 ],
@@ -105,7 +105,7 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -128,7 +128,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.AddressParseRequest"
+                            "$ref": "#/definitions/api.AddressParseRequest"
                         }
                     }
                 ],
@@ -136,19 +136,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Address parsed successfully",
                         "schema": {
-                            "$ref": "#/definitions/_.AddressParseResponse"
+                            "$ref": "#/definitions/api.AddressParseResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request or address",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -171,7 +171,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.ScriptAddressRequest"
+                            "$ref": "#/definitions/api.ScriptAddressRequest"
                         }
                     }
                 ],
@@ -179,19 +179,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Script address generated",
                         "schema": {
-                            "$ref": "#/definitions/_.ScriptAddressResponse"
+                            "$ref": "#/definitions/api.ScriptAddressResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -214,7 +214,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.ScriptCreateRequest"
+                            "$ref": "#/definitions/api.ScriptCreateRequest"
                         }
                     }
                 ],
@@ -222,19 +222,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Script successfully created",
                         "schema": {
-                            "$ref": "#/definitions/_.ScriptResponse"
+                            "$ref": "#/definitions/api.ScriptResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -257,7 +257,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.ScriptValidateRequest"
+                            "$ref": "#/definitions/api.ScriptValidateRequest"
                         }
                     }
                 ],
@@ -265,19 +265,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Script validation result",
                         "schema": {
-                            "$ref": "#/definitions/_.ScriptValidateResponse"
+                            "$ref": "#/definitions/api.ScriptValidateResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -305,7 +305,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.SignDataRequest"
+                            "$ref": "#/definitions/api.SignDataRequest"
                         }
                     }
                 ],
@@ -313,19 +313,19 @@ const docTemplate = `{
                     "200": {
                         "description": "COSE_Sign1 signature and COSE_Key",
                         "schema": {
-                            "$ref": "#/definitions/_.SignDataResponse"
+                            "$ref": "#/definitions/api.SignDataResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -348,7 +348,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.VerifyDataRequest"
+                            "$ref": "#/definitions/api.VerifyDataRequest"
                         }
                     }
                 ],
@@ -356,13 +356,13 @@ const docTemplate = `{
                     "200": {
                         "description": "Verification result",
                         "schema": {
-                            "$ref": "#/definitions/_.VerifyDataResponse"
+                            "$ref": "#/definitions/api.VerifyDataResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -385,7 +385,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.TxAssembleRequest"
+                            "$ref": "#/definitions/api.TxAssembleRequest"
                         }
                     }
                 ],
@@ -393,19 +393,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Assembled signed transaction",
                         "schema": {
-                            "$ref": "#/definitions/_.TxCborResponse"
+                            "$ref": "#/definitions/api.TxCborResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -428,7 +428,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.TxDecodeRequest"
+                            "$ref": "#/definitions/api.TxDecodeRequest"
                         }
                     }
                 ],
@@ -442,7 +442,7 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -465,7 +465,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.TxIDRequest"
+                            "$ref": "#/definitions/api.TxIDRequest"
                         }
                     }
                 ],
@@ -473,13 +473,13 @@ const docTemplate = `{
                     "200": {
                         "description": "Transaction id",
                         "schema": {
-                            "$ref": "#/definitions/_.TxIDResponse"
+                            "$ref": "#/definitions/api.TxIDResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -507,7 +507,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.TxSignRequest"
+                            "$ref": "#/definitions/api.TxSignRequest"
                         }
                     }
                 ],
@@ -515,19 +515,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Signed transaction",
                         "schema": {
-                            "$ref": "#/definitions/_.TxCborResponse"
+                            "$ref": "#/definitions/api.TxCborResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -555,7 +555,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.TxWitnessRequest"
+                            "$ref": "#/definitions/api.TxWitnessRequest"
                         }
                     }
                 ],
@@ -563,19 +563,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Detached witness",
                         "schema": {
-                            "$ref": "#/definitions/_.TxWitnessResponse"
+                            "$ref": "#/definitions/api.TxWitnessResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -625,7 +625,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.WalletDeleteRequest"
+                            "$ref": "#/definitions/api.WalletDeleteRequest"
                         }
                     }
                 ],
@@ -639,13 +639,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -673,7 +673,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.WalletGetRequest"
+                            "$ref": "#/definitions/api.WalletGetRequest"
                         }
                     }
                 ],
@@ -687,13 +687,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -746,7 +746,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.WalletRestoreRequest"
+                            "$ref": "#/definitions/api.WalletRestoreRequest"
                         }
                     }
                 ],
@@ -760,13 +760,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -794,7 +794,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.WalletUpdateRequest"
+                            "$ref": "#/definitions/api.WalletUpdateRequest"
                         }
                     }
                 ],
@@ -822,7 +822,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "_.AddressBuildRequest": {
+        "api.AddressBuildRequest": {
             "type": "object",
             "required": [
                 "network"
@@ -855,7 +855,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.AddressBuildResponse": {
+        "api.AddressBuildResponse": {
             "type": "object",
             "properties": {
                 "address": {
@@ -869,7 +869,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.AddressEnumerateRequest": {
+        "api.AddressEnumerateRequest": {
             "type": "object",
             "required": [
                 "count",
@@ -906,7 +906,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.AddressParseRequest": {
+        "api.AddressParseRequest": {
             "type": "object",
             "required": [
                 "address"
@@ -917,26 +917,26 @@ const docTemplate = `{
                 }
             }
         },
-        "_.AddressParseResponse": {
+        "api.AddressParseResponse": {
             "type": "object",
             "properties": {
                 "address": {
                     "type": "string"
                 },
                 "byron": {
-                    "$ref": "#/definitions/_.ByronAddressInfo"
+                    "$ref": "#/definitions/api.ByronAddressInfo"
                 },
                 "network": {
                     "type": "string"
                 },
                 "payment": {
-                    "$ref": "#/definitions/_.CredentialInfo"
+                    "$ref": "#/definitions/api.CredentialInfo"
                 },
                 "pointer": {
-                    "$ref": "#/definitions/_.PointerInfo"
+                    "$ref": "#/definitions/api.PointerInfo"
                 },
                 "stake": {
-                    "$ref": "#/definitions/_.CredentialInfo"
+                    "$ref": "#/definitions/api.CredentialInfo"
                 },
                 "type": {
                     "type": "string"
@@ -946,7 +946,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.ByronAddressInfo": {
+        "api.ByronAddressInfo": {
             "type": "object",
             "properties": {
                 "type": {
@@ -955,7 +955,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.CredentialInfo": {
+        "api.CredentialInfo": {
             "type": "object",
             "properties": {
                 "bech32": {
@@ -972,7 +972,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.ErrorResponse": {
+        "api.ErrorResponse": {
             "type": "object",
             "properties": {
                 "error": {
@@ -986,7 +986,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.PointerInfo": {
+        "api.PointerInfo": {
             "type": "object",
             "properties": {
                 "certIndex": {
@@ -1001,7 +1001,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.ScriptAddressRequest": {
+        "api.ScriptAddressRequest": {
             "type": "object",
             "required": [
                 "network",
@@ -1022,7 +1022,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.ScriptAddressResponse": {
+        "api.ScriptAddressResponse": {
             "type": "object",
             "properties": {
                 "address": {
@@ -1036,7 +1036,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.ScriptCreateRequest": {
+        "api.ScriptCreateRequest": {
             "type": "object",
             "required": [
                 "key_hashes",
@@ -1081,7 +1081,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.ScriptResponse": {
+        "api.ScriptResponse": {
             "type": "object",
             "properties": {
                 "address": {
@@ -1099,7 +1099,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.ScriptValidateRequest": {
+        "api.ScriptValidateRequest": {
             "type": "object",
             "required": [
                 "script"
@@ -1124,7 +1124,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.ScriptValidateResponse": {
+        "api.ScriptValidateResponse": {
             "type": "object",
             "properties": {
                 "scriptHash": {
@@ -1142,7 +1142,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.SignDataRequest": {
+        "api.SignDataRequest": {
             "type": "object",
             "required": [
                 "address",
@@ -1161,7 +1161,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.SignDataResponse": {
+        "api.SignDataResponse": {
             "type": "object",
             "properties": {
                 "key": {
@@ -1172,7 +1172,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.TxAssembleRequest": {
+        "api.TxAssembleRequest": {
             "type": "object",
             "required": [
                 "tx_cbor",
@@ -1192,7 +1192,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.TxCborResponse": {
+        "api.TxCborResponse": {
             "type": "object",
             "properties": {
                 "tx_cbor": {
@@ -1203,7 +1203,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.TxDecodeRequest": {
+        "api.TxDecodeRequest": {
             "type": "object",
             "required": [
                 "tx_cbor"
@@ -1215,7 +1215,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.TxIDRequest": {
+        "api.TxIDRequest": {
             "type": "object",
             "required": [
                 "tx_cbor"
@@ -1227,7 +1227,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.TxIDResponse": {
+        "api.TxIDResponse": {
             "type": "object",
             "properties": {
                 "tx_id": {
@@ -1235,7 +1235,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.TxSignRequest": {
+        "api.TxSignRequest": {
             "type": "object",
             "required": [
                 "signing_keys",
@@ -1255,7 +1255,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.TxWitnessRequest": {
+        "api.TxWitnessRequest": {
             "type": "object",
             "required": [
                 "signing_key",
@@ -1271,7 +1271,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.TxWitnessResponse": {
+        "api.TxWitnessResponse": {
             "type": "object",
             "properties": {
                 "witness": {
@@ -1279,7 +1279,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.VerifyDataRequest": {
+        "api.VerifyDataRequest": {
             "type": "object",
             "required": [
                 "key",
@@ -1298,7 +1298,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.VerifyDataResponse": {
+        "api.VerifyDataResponse": {
             "type": "object",
             "properties": {
                 "valid": {
@@ -1306,7 +1306,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.WalletDeleteRequest": {
+        "api.WalletDeleteRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1322,7 +1322,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.WalletGetRequest": {
+        "api.WalletGetRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1338,7 +1338,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.WalletRestoreRequest": {
+        "api.WalletRestoreRequest": {
             "type": "object",
             "required": [
                 "mnemonic"
@@ -1385,7 +1385,7 @@ const docTemplate = `{
                 }
             }
         },
-        "_.WalletUpdateRequest": {
+        "api.WalletUpdateRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1593,589 +1593,6 @@ const docTemplate = `{
                 },
                 "stake_vkey": {
                     "$ref": "#/definitions/bursa.KeyFile"
-                }
-            }
-        },
-        "internal_api.AddressBuildRequest": {
-            "type": "object",
-            "required": [
-                "network"
-            ],
-            "properties": {
-                "network": {
-                    "type": "string",
-                    "enum": [
-                        "mainnet",
-                        "preprod",
-                        "preview"
-                    ]
-                },
-                "paymentKey": {
-                    "description": "bech32-encoded verification key (required for base and enterprise address types)",
-                    "type": "string"
-                },
-                "stakeKey": {
-                    "description": "bech32-encoded verification key (required for base and reward address types)",
-                    "type": "string"
-                },
-                "type": {
-                    "description": "defaults to \"base\" - determines which keys are required: base requires both paymentKey and stakeKey, enterprise requires paymentKey only, reward requires stakeKey only",
-                    "type": "string",
-                    "enum": [
-                        "base",
-                        "enterprise",
-                        "reward"
-                    ]
-                }
-            }
-        },
-        "internal_api.AddressBuildResponse": {
-            "type": "object",
-            "properties": {
-                "address": {
-                    "type": "string"
-                },
-                "network": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.AddressEnumerateRequest": {
-            "type": "object",
-            "required": [
-                "count",
-                "mnemonic",
-                "network"
-            ],
-            "properties": {
-                "account": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                },
-                "count": {
-                    "type": "integer",
-                    "maximum": 1000,
-                    "minimum": 1
-                },
-                "mnemonic": {
-                    "type": "string"
-                },
-                "network": {
-                    "type": "string",
-                    "enum": [
-                        "mainnet",
-                        "preprod",
-                        "preview"
-                    ]
-                },
-                "password": {
-                    "type": "string"
-                },
-                "start": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                }
-            }
-        },
-        "internal_api.AddressParseRequest": {
-            "type": "object",
-            "required": [
-                "address"
-            ],
-            "properties": {
-                "address": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.AddressParseResponse": {
-            "type": "object",
-            "properties": {
-                "address": {
-                    "type": "string"
-                },
-                "byron": {
-                    "$ref": "#/definitions/internal_api.ByronAddressInfo"
-                },
-                "network": {
-                    "type": "string"
-                },
-                "payment": {
-                    "$ref": "#/definitions/internal_api.CredentialInfo"
-                },
-                "pointer": {
-                    "$ref": "#/definitions/internal_api.PointerInfo"
-                },
-                "stake": {
-                    "$ref": "#/definitions/internal_api.CredentialInfo"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "typeDescription": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.ByronAddressInfo": {
-            "type": "object",
-            "properties": {
-                "type": {
-                    "description": "\"pubkey\", \"script\", or \"redeem\"",
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.CredentialInfo": {
-            "type": "object",
-            "properties": {
-                "bech32": {
-                    "description": "bech32-encoded credential",
-                    "type": "string"
-                },
-                "hex": {
-                    "description": "hex-encoded credential",
-                    "type": "string"
-                },
-                "type": {
-                    "description": "\"key\" or \"script\"",
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.ErrorResponse": {
-            "type": "object",
-            "properties": {
-                "error": {
-                    "type": "string"
-                },
-                "fields": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "internal_api.PointerInfo": {
-            "type": "object",
-            "properties": {
-                "certIndex": {
-                    "type": "integer"
-                },
-                "slot": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "txIndex": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_api.ScriptAddressRequest": {
-            "type": "object",
-            "required": [
-                "network",
-                "script"
-            ],
-            "properties": {
-                "network": {
-                    "type": "string",
-                    "enum": [
-                        "mainnet",
-                        "preprod",
-                        "preview"
-                    ]
-                },
-                "script": {
-                    "type": "object",
-                    "additionalProperties": {}
-                }
-            }
-        },
-        "internal_api.ScriptAddressResponse": {
-            "type": "object",
-            "properties": {
-                "address": {
-                    "type": "string"
-                },
-                "network": {
-                    "type": "string"
-                },
-                "scriptHash": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.ScriptCreateRequest": {
-            "type": "object",
-            "required": [
-                "key_hashes",
-                "network",
-                "type"
-            ],
-            "properties": {
-                "key_hashes": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "network": {
-                    "type": "string",
-                    "enum": [
-                        "mainnet",
-                        "preprod",
-                        "preview"
-                    ]
-                },
-                "required": {
-                    "type": "integer",
-                    "minimum": 1
-                },
-                "timelock_after": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "timelock_before": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "nOf",
-                        "all",
-                        "any"
-                    ]
-                }
-            }
-        },
-        "internal_api.ScriptResponse": {
-            "type": "object",
-            "properties": {
-                "address": {
-                    "type": "string"
-                },
-                "script": {
-                    "type": "object",
-                    "additionalProperties": {}
-                },
-                "scriptHash": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.ScriptValidateRequest": {
-            "type": "object",
-            "required": [
-                "script"
-            ],
-            "properties": {
-                "require_signatures": {
-                    "type": "boolean"
-                },
-                "script": {
-                    "type": "object",
-                    "additionalProperties": {}
-                },
-                "signatures": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "slot": {
-                    "type": "integer",
-                    "format": "int64"
-                }
-            }
-        },
-        "internal_api.ScriptValidateResponse": {
-            "type": "object",
-            "properties": {
-                "scriptHash": {
-                    "type": "string"
-                },
-                "signatures": {
-                    "type": "integer"
-                },
-                "slot": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "valid": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_api.SignDataRequest": {
-            "type": "object",
-            "required": [
-                "address",
-                "payload",
-                "signing_key"
-            ],
-            "properties": {
-                "address": {
-                    "type": "string"
-                },
-                "payload": {
-                    "type": "string"
-                },
-                "signing_key": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.SignDataResponse": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "signature": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.TxAssembleRequest": {
-            "type": "object",
-            "required": [
-                "tx_cbor",
-                "witnesses"
-            ],
-            "properties": {
-                "tx_cbor": {
-                    "description": "raw hex CBOR or JSON text envelope",
-                    "type": "string"
-                },
-                "witnesses": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "internal_api.TxCborResponse": {
-            "type": "object",
-            "properties": {
-                "tx_cbor": {
-                    "type": "string"
-                },
-                "tx_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.TxDecodeRequest": {
-            "type": "object",
-            "required": [
-                "tx_cbor"
-            ],
-            "properties": {
-                "tx_cbor": {
-                    "description": "raw hex CBOR or JSON text envelope",
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.TxIDRequest": {
-            "type": "object",
-            "required": [
-                "tx_cbor"
-            ],
-            "properties": {
-                "tx_cbor": {
-                    "description": "raw hex CBOR or JSON text envelope",
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.TxIDResponse": {
-            "type": "object",
-            "properties": {
-                "tx_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.TxSignRequest": {
-            "type": "object",
-            "required": [
-                "signing_keys",
-                "tx_cbor"
-            ],
-            "properties": {
-                "signing_keys": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "tx_cbor": {
-                    "description": "raw hex CBOR or JSON text envelope",
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.TxWitnessRequest": {
-            "type": "object",
-            "required": [
-                "signing_key",
-                "tx_cbor"
-            ],
-            "properties": {
-                "signing_key": {
-                    "type": "string"
-                },
-                "tx_cbor": {
-                    "description": "raw hex CBOR or JSON text envelope",
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.TxWitnessResponse": {
-            "type": "object",
-            "properties": {
-                "witness": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.VerifyDataRequest": {
-            "type": "object",
-            "required": [
-                "key",
-                "payload",
-                "signature"
-            ],
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "payload": {
-                    "type": "string"
-                },
-                "signature": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.VerifyDataResponse": {
-            "type": "object",
-            "properties": {
-                "valid": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_api.WalletDeleteRequest": {
-            "type": "object",
-            "required": [
-                "name"
-            ],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "maxLength": 100,
-                    "minLength": 1
-                },
-                "password": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.WalletGetRequest": {
-            "type": "object",
-            "required": [
-                "name"
-            ],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "maxLength": 100,
-                    "minLength": 1
-                },
-                "password": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.WalletRestoreRequest": {
-            "type": "object",
-            "required": [
-                "mnemonic"
-            ],
-            "properties": {
-                "account_id": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                },
-                "address_id": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                },
-                "committee_cold_id": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                },
-                "committee_hot_id": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                },
-                "drep_id": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                },
-                "mnemonic": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "password": {
-                    "type": "string"
-                },
-                "payment_id": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                },
-                "pool_cold_id": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                },
-                "stake_id": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                }
-            }
-        },
-        "internal_api.WalletUpdateRequest": {
-            "type": "object",
-            "required": [
-                "name"
-            ],
-            "properties": {
-                "description": {
-                    "type": "string",
-                    "maxLength": 500
-                },
-                "name": {
-                    "type": "string",
-                    "maxLength": 100,
-                    "minLength": 1
-                },
-                "password": {
-                    "type": "string"
                 }
             }
         }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -40,7 +40,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.AddressBuildRequest"
+                            "$ref": "#/definitions/_.AddressBuildRequest"
                         }
                     }
                 ],
@@ -48,19 +48,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Address built successfully",
                         "schema": {
-                            "$ref": "#/definitions/api.AddressBuildResponse"
+                            "$ref": "#/definitions/_.AddressBuildResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request or keys",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -88,7 +88,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.AddressEnumerateRequest"
+                            "$ref": "#/definitions/_.AddressEnumerateRequest"
                         }
                     }
                 ],
@@ -105,7 +105,7 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -128,7 +128,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.AddressParseRequest"
+                            "$ref": "#/definitions/_.AddressParseRequest"
                         }
                     }
                 ],
@@ -136,19 +136,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Address parsed successfully",
                         "schema": {
-                            "$ref": "#/definitions/api.AddressParseResponse"
+                            "$ref": "#/definitions/_.AddressParseResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request or address",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -171,7 +171,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.ScriptAddressRequest"
+                            "$ref": "#/definitions/_.ScriptAddressRequest"
                         }
                     }
                 ],
@@ -179,19 +179,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Script address generated",
                         "schema": {
-                            "$ref": "#/definitions/api.ScriptAddressResponse"
+                            "$ref": "#/definitions/_.ScriptAddressResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -214,7 +214,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.ScriptCreateRequest"
+                            "$ref": "#/definitions/_.ScriptCreateRequest"
                         }
                     }
                 ],
@@ -222,19 +222,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Script successfully created",
                         "schema": {
-                            "$ref": "#/definitions/api.ScriptResponse"
+                            "$ref": "#/definitions/_.ScriptResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -257,7 +257,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.ScriptValidateRequest"
+                            "$ref": "#/definitions/_.ScriptValidateRequest"
                         }
                     }
                 ],
@@ -265,19 +265,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Script validation result",
                         "schema": {
-                            "$ref": "#/definitions/api.ScriptValidateResponse"
+                            "$ref": "#/definitions/_.ScriptValidateResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -305,7 +305,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.SignDataRequest"
+                            "$ref": "#/definitions/_.SignDataRequest"
                         }
                     }
                 ],
@@ -313,19 +313,19 @@ const docTemplate = `{
                     "200": {
                         "description": "COSE_Sign1 signature and COSE_Key",
                         "schema": {
-                            "$ref": "#/definitions/api.SignDataResponse"
+                            "$ref": "#/definitions/_.SignDataResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -348,7 +348,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.VerifyDataRequest"
+                            "$ref": "#/definitions/_.VerifyDataRequest"
                         }
                     }
                 ],
@@ -356,13 +356,13 @@ const docTemplate = `{
                     "200": {
                         "description": "Verification result",
                         "schema": {
-                            "$ref": "#/definitions/api.VerifyDataResponse"
+                            "$ref": "#/definitions/_.VerifyDataResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -385,7 +385,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.TxAssembleRequest"
+                            "$ref": "#/definitions/_.TxAssembleRequest"
                         }
                     }
                 ],
@@ -393,19 +393,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Assembled signed transaction",
                         "schema": {
-                            "$ref": "#/definitions/api.TxCborResponse"
+                            "$ref": "#/definitions/_.TxCborResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -428,7 +428,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.TxDecodeRequest"
+                            "$ref": "#/definitions/_.TxDecodeRequest"
                         }
                     }
                 ],
@@ -442,7 +442,7 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -465,7 +465,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.TxIDRequest"
+                            "$ref": "#/definitions/_.TxIDRequest"
                         }
                     }
                 ],
@@ -473,13 +473,13 @@ const docTemplate = `{
                     "200": {
                         "description": "Transaction id",
                         "schema": {
-                            "$ref": "#/definitions/api.TxIDResponse"
+                            "$ref": "#/definitions/_.TxIDResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -507,7 +507,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.TxSignRequest"
+                            "$ref": "#/definitions/_.TxSignRequest"
                         }
                     }
                 ],
@@ -515,19 +515,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Signed transaction",
                         "schema": {
-                            "$ref": "#/definitions/api.TxCborResponse"
+                            "$ref": "#/definitions/_.TxCborResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -555,7 +555,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.TxWitnessRequest"
+                            "$ref": "#/definitions/_.TxWitnessRequest"
                         }
                     }
                 ],
@@ -563,19 +563,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Detached witness",
                         "schema": {
-                            "$ref": "#/definitions/api.TxWitnessResponse"
+                            "$ref": "#/definitions/_.TxWitnessResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -625,7 +625,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.WalletDeleteRequest"
+                            "$ref": "#/definitions/_.WalletDeleteRequest"
                         }
                     }
                 ],
@@ -639,13 +639,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -673,7 +673,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.WalletGetRequest"
+                            "$ref": "#/definitions/_.WalletGetRequest"
                         }
                     }
                 ],
@@ -687,13 +687,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -746,7 +746,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.WalletRestoreRequest"
+                            "$ref": "#/definitions/_.WalletRestoreRequest"
                         }
                     }
                 ],
@@ -760,13 +760,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -794,7 +794,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.WalletUpdateRequest"
+                            "$ref": "#/definitions/_.WalletUpdateRequest"
                         }
                     }
                 ],
@@ -822,7 +822,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "api.AddressBuildRequest": {
+        "_.AddressBuildRequest": {
             "type": "object",
             "required": [
                 "network"
@@ -832,7 +832,8 @@ const docTemplate = `{
                     "type": "string",
                     "enum": [
                         "mainnet",
-                        "testnet"
+                        "preprod",
+                        "preview"
                     ]
                 },
                 "paymentKey": {
@@ -854,7 +855,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.AddressBuildResponse": {
+        "_.AddressBuildResponse": {
             "type": "object",
             "properties": {
                 "address": {
@@ -868,7 +869,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.AddressEnumerateRequest": {
+        "_.AddressEnumerateRequest": {
             "type": "object",
             "required": [
                 "count",
@@ -905,7 +906,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.AddressParseRequest": {
+        "_.AddressParseRequest": {
             "type": "object",
             "required": [
                 "address"
@@ -916,26 +917,26 @@ const docTemplate = `{
                 }
             }
         },
-        "api.AddressParseResponse": {
+        "_.AddressParseResponse": {
             "type": "object",
             "properties": {
                 "address": {
                     "type": "string"
                 },
                 "byron": {
-                    "$ref": "#/definitions/api.ByronAddressInfo"
+                    "$ref": "#/definitions/_.ByronAddressInfo"
                 },
                 "network": {
                     "type": "string"
                 },
                 "payment": {
-                    "$ref": "#/definitions/api.CredentialInfo"
+                    "$ref": "#/definitions/_.CredentialInfo"
                 },
                 "pointer": {
-                    "$ref": "#/definitions/api.PointerInfo"
+                    "$ref": "#/definitions/_.PointerInfo"
                 },
                 "stake": {
-                    "$ref": "#/definitions/api.CredentialInfo"
+                    "$ref": "#/definitions/_.CredentialInfo"
                 },
                 "type": {
                     "type": "string"
@@ -945,7 +946,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.ByronAddressInfo": {
+        "_.ByronAddressInfo": {
             "type": "object",
             "properties": {
                 "type": {
@@ -954,7 +955,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.CredentialInfo": {
+        "_.CredentialInfo": {
             "type": "object",
             "properties": {
                 "bech32": {
@@ -971,7 +972,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.ErrorResponse": {
+        "_.ErrorResponse": {
             "type": "object",
             "properties": {
                 "error": {
@@ -985,7 +986,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.PointerInfo": {
+        "_.PointerInfo": {
             "type": "object",
             "properties": {
                 "certIndex": {
@@ -1000,7 +1001,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.ScriptAddressRequest": {
+        "_.ScriptAddressRequest": {
             "type": "object",
             "required": [
                 "network",
@@ -1011,7 +1012,8 @@ const docTemplate = `{
                     "type": "string",
                     "enum": [
                         "mainnet",
-                        "testnet"
+                        "preprod",
+                        "preview"
                     ]
                 },
                 "script": {
@@ -1020,7 +1022,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.ScriptAddressResponse": {
+        "_.ScriptAddressResponse": {
             "type": "object",
             "properties": {
                 "address": {
@@ -1034,7 +1036,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.ScriptCreateRequest": {
+        "_.ScriptCreateRequest": {
             "type": "object",
             "required": [
                 "key_hashes",
@@ -1053,7 +1055,8 @@ const docTemplate = `{
                     "type": "string",
                     "enum": [
                         "mainnet",
-                        "testnet"
+                        "preprod",
+                        "preview"
                     ]
                 },
                 "required": {
@@ -1078,7 +1081,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.ScriptResponse": {
+        "_.ScriptResponse": {
             "type": "object",
             "properties": {
                 "address": {
@@ -1096,7 +1099,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.ScriptValidateRequest": {
+        "_.ScriptValidateRequest": {
             "type": "object",
             "required": [
                 "script"
@@ -1121,7 +1124,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.ScriptValidateResponse": {
+        "_.ScriptValidateResponse": {
             "type": "object",
             "properties": {
                 "scriptHash": {
@@ -1139,7 +1142,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.SignDataRequest": {
+        "_.SignDataRequest": {
             "type": "object",
             "required": [
                 "address",
@@ -1158,7 +1161,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.SignDataResponse": {
+        "_.SignDataResponse": {
             "type": "object",
             "properties": {
                 "key": {
@@ -1169,7 +1172,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.TxAssembleRequest": {
+        "_.TxAssembleRequest": {
             "type": "object",
             "required": [
                 "tx_cbor",
@@ -1189,7 +1192,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.TxCborResponse": {
+        "_.TxCborResponse": {
             "type": "object",
             "properties": {
                 "tx_cbor": {
@@ -1200,7 +1203,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.TxDecodeRequest": {
+        "_.TxDecodeRequest": {
             "type": "object",
             "required": [
                 "tx_cbor"
@@ -1212,7 +1215,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.TxIDRequest": {
+        "_.TxIDRequest": {
             "type": "object",
             "required": [
                 "tx_cbor"
@@ -1224,7 +1227,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.TxIDResponse": {
+        "_.TxIDResponse": {
             "type": "object",
             "properties": {
                 "tx_id": {
@@ -1232,7 +1235,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.TxSignRequest": {
+        "_.TxSignRequest": {
             "type": "object",
             "required": [
                 "signing_keys",
@@ -1252,7 +1255,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.TxWitnessRequest": {
+        "_.TxWitnessRequest": {
             "type": "object",
             "required": [
                 "signing_key",
@@ -1268,7 +1271,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.TxWitnessResponse": {
+        "_.TxWitnessResponse": {
             "type": "object",
             "properties": {
                 "witness": {
@@ -1276,7 +1279,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.VerifyDataRequest": {
+        "_.VerifyDataRequest": {
             "type": "object",
             "required": [
                 "key",
@@ -1295,7 +1298,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.VerifyDataResponse": {
+        "_.VerifyDataResponse": {
             "type": "object",
             "properties": {
                 "valid": {
@@ -1303,7 +1306,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.WalletDeleteRequest": {
+        "_.WalletDeleteRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1319,7 +1322,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.WalletGetRequest": {
+        "_.WalletGetRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1335,7 +1338,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.WalletRestoreRequest": {
+        "_.WalletRestoreRequest": {
             "type": "object",
             "required": [
                 "mnemonic"
@@ -1382,7 +1385,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.WalletUpdateRequest": {
+        "_.WalletUpdateRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1590,6 +1593,589 @@ const docTemplate = `{
                 },
                 "stake_vkey": {
                     "$ref": "#/definitions/bursa.KeyFile"
+                }
+            }
+        },
+        "internal_api.AddressBuildRequest": {
+            "type": "object",
+            "required": [
+                "network"
+            ],
+            "properties": {
+                "network": {
+                    "type": "string",
+                    "enum": [
+                        "mainnet",
+                        "preprod",
+                        "preview"
+                    ]
+                },
+                "paymentKey": {
+                    "description": "bech32-encoded verification key (required for base and enterprise address types)",
+                    "type": "string"
+                },
+                "stakeKey": {
+                    "description": "bech32-encoded verification key (required for base and reward address types)",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "defaults to \"base\" - determines which keys are required: base requires both paymentKey and stakeKey, enterprise requires paymentKey only, reward requires stakeKey only",
+                    "type": "string",
+                    "enum": [
+                        "base",
+                        "enterprise",
+                        "reward"
+                    ]
+                }
+            }
+        },
+        "internal_api.AddressBuildResponse": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "network": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.AddressEnumerateRequest": {
+            "type": "object",
+            "required": [
+                "count",
+                "mnemonic",
+                "network"
+            ],
+            "properties": {
+                "account": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
+                "count": {
+                    "type": "integer",
+                    "maximum": 1000,
+                    "minimum": 1
+                },
+                "mnemonic": {
+                    "type": "string"
+                },
+                "network": {
+                    "type": "string",
+                    "enum": [
+                        "mainnet",
+                        "preprod",
+                        "preview"
+                    ]
+                },
+                "password": {
+                    "type": "string"
+                },
+                "start": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                }
+            }
+        },
+        "internal_api.AddressParseRequest": {
+            "type": "object",
+            "required": [
+                "address"
+            ],
+            "properties": {
+                "address": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.AddressParseResponse": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "byron": {
+                    "$ref": "#/definitions/internal_api.ByronAddressInfo"
+                },
+                "network": {
+                    "type": "string"
+                },
+                "payment": {
+                    "$ref": "#/definitions/internal_api.CredentialInfo"
+                },
+                "pointer": {
+                    "$ref": "#/definitions/internal_api.PointerInfo"
+                },
+                "stake": {
+                    "$ref": "#/definitions/internal_api.CredentialInfo"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "typeDescription": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.ByronAddressInfo": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "description": "\"pubkey\", \"script\", or \"redeem\"",
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.CredentialInfo": {
+            "type": "object",
+            "properties": {
+                "bech32": {
+                    "description": "bech32-encoded credential",
+                    "type": "string"
+                },
+                "hex": {
+                    "description": "hex-encoded credential",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "\"key\" or \"script\"",
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.ErrorResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "fields": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "internal_api.PointerInfo": {
+            "type": "object",
+            "properties": {
+                "certIndex": {
+                    "type": "integer"
+                },
+                "slot": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "txIndex": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_api.ScriptAddressRequest": {
+            "type": "object",
+            "required": [
+                "network",
+                "script"
+            ],
+            "properties": {
+                "network": {
+                    "type": "string",
+                    "enum": [
+                        "mainnet",
+                        "preprod",
+                        "preview"
+                    ]
+                },
+                "script": {
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            }
+        },
+        "internal_api.ScriptAddressResponse": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "network": {
+                    "type": "string"
+                },
+                "scriptHash": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.ScriptCreateRequest": {
+            "type": "object",
+            "required": [
+                "key_hashes",
+                "network",
+                "type"
+            ],
+            "properties": {
+                "key_hashes": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "network": {
+                    "type": "string",
+                    "enum": [
+                        "mainnet",
+                        "preprod",
+                        "preview"
+                    ]
+                },
+                "required": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "timelock_after": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "timelock_before": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "nOf",
+                        "all",
+                        "any"
+                    ]
+                }
+            }
+        },
+        "internal_api.ScriptResponse": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "script": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "scriptHash": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.ScriptValidateRequest": {
+            "type": "object",
+            "required": [
+                "script"
+            ],
+            "properties": {
+                "require_signatures": {
+                    "type": "boolean"
+                },
+                "script": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "signatures": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "slot": {
+                    "type": "integer",
+                    "format": "int64"
+                }
+            }
+        },
+        "internal_api.ScriptValidateResponse": {
+            "type": "object",
+            "properties": {
+                "scriptHash": {
+                    "type": "string"
+                },
+                "signatures": {
+                    "type": "integer"
+                },
+                "slot": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "valid": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_api.SignDataRequest": {
+            "type": "object",
+            "required": [
+                "address",
+                "payload",
+                "signing_key"
+            ],
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "payload": {
+                    "type": "string"
+                },
+                "signing_key": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.SignDataResponse": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "signature": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.TxAssembleRequest": {
+            "type": "object",
+            "required": [
+                "tx_cbor",
+                "witnesses"
+            ],
+            "properties": {
+                "tx_cbor": {
+                    "description": "raw hex CBOR or JSON text envelope",
+                    "type": "string"
+                },
+                "witnesses": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "internal_api.TxCborResponse": {
+            "type": "object",
+            "properties": {
+                "tx_cbor": {
+                    "type": "string"
+                },
+                "tx_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.TxDecodeRequest": {
+            "type": "object",
+            "required": [
+                "tx_cbor"
+            ],
+            "properties": {
+                "tx_cbor": {
+                    "description": "raw hex CBOR or JSON text envelope",
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.TxIDRequest": {
+            "type": "object",
+            "required": [
+                "tx_cbor"
+            ],
+            "properties": {
+                "tx_cbor": {
+                    "description": "raw hex CBOR or JSON text envelope",
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.TxIDResponse": {
+            "type": "object",
+            "properties": {
+                "tx_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.TxSignRequest": {
+            "type": "object",
+            "required": [
+                "signing_keys",
+                "tx_cbor"
+            ],
+            "properties": {
+                "signing_keys": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "tx_cbor": {
+                    "description": "raw hex CBOR or JSON text envelope",
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.TxWitnessRequest": {
+            "type": "object",
+            "required": [
+                "signing_key",
+                "tx_cbor"
+            ],
+            "properties": {
+                "signing_key": {
+                    "type": "string"
+                },
+                "tx_cbor": {
+                    "description": "raw hex CBOR or JSON text envelope",
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.TxWitnessResponse": {
+            "type": "object",
+            "properties": {
+                "witness": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.VerifyDataRequest": {
+            "type": "object",
+            "required": [
+                "key",
+                "payload",
+                "signature"
+            ],
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "payload": {
+                    "type": "string"
+                },
+                "signature": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.VerifyDataResponse": {
+            "type": "object",
+            "properties": {
+                "valid": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_api.WalletDeleteRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 1
+                },
+                "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.WalletGetRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 1
+                },
+                "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.WalletRestoreRequest": {
+            "type": "object",
+            "required": [
+                "mnemonic"
+            ],
+            "properties": {
+                "account_id": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
+                "address_id": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
+                "committee_cold_id": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
+                "committee_hot_id": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
+                "drep_id": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
+                "mnemonic": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "password": {
+                    "type": "string"
+                },
+                "payment_id": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
+                "pool_cold_id": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
+                "stake_id": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                }
+            }
+        },
+        "internal_api.WalletUpdateRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "maxLength": 500
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 1
+                },
+                "password": {
+                    "type": "string"
                 }
             }
         }

--- a/docs/docs_generated_test.go
+++ b/docs/docs_generated_test.go
@@ -1,0 +1,39 @@
+package docs
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSwaggerDefinitionsAreCurrentAndCorrectlyNamed(t *testing.T) {
+	raw, err := os.ReadFile("swagger.json")
+	require.NoError(t, err)
+
+	var spec struct {
+		Definitions map[string]json.RawMessage `json:"definitions"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &spec))
+	full := string(raw)
+
+	apiTypes := []string{
+		"AddressBuildRequest", "AddressBuildResponse", "AddressEnumerateRequest",
+		"AddressParseRequest", "AddressParseResponse", "ErrorResponse",
+		"ScriptAddressRequest", "ScriptAddressResponse", "ScriptCreateRequest",
+		"ScriptResponse", "ScriptValidateRequest", "ScriptValidateResponse",
+	}
+	for _, name := range apiTypes {
+		_, ok := spec.Definitions["api."+name]
+		assert.True(t, ok, "definitions missing api.%s", name)
+		_, wrongPrefix := spec.Definitions["_."+name]
+		assert.False(t, wrongPrefix, "definitions contains _.%s", name)
+	}
+
+	for name := range spec.Definitions {
+		assert.Contains(t, full, `"#/definitions/`+name+`"`,
+			"definitions.%s is never referenced by $ref", name)
+	}
+}

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -36,7 +36,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.AddressBuildRequest"
+                            "$ref": "#/definitions/_.AddressBuildRequest"
                         }
                     }
                 ],
@@ -44,19 +44,19 @@
                     "200": {
                         "description": "Address built successfully",
                         "schema": {
-                            "$ref": "#/definitions/api.AddressBuildResponse"
+                            "$ref": "#/definitions/_.AddressBuildResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request or keys",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -84,7 +84,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.AddressEnumerateRequest"
+                            "$ref": "#/definitions/_.AddressEnumerateRequest"
                         }
                     }
                 ],
@@ -101,7 +101,7 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -124,7 +124,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.AddressParseRequest"
+                            "$ref": "#/definitions/_.AddressParseRequest"
                         }
                     }
                 ],
@@ -132,19 +132,19 @@
                     "200": {
                         "description": "Address parsed successfully",
                         "schema": {
-                            "$ref": "#/definitions/api.AddressParseResponse"
+                            "$ref": "#/definitions/_.AddressParseResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request or address",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -167,7 +167,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.ScriptAddressRequest"
+                            "$ref": "#/definitions/_.ScriptAddressRequest"
                         }
                     }
                 ],
@@ -175,19 +175,19 @@
                     "200": {
                         "description": "Script address generated",
                         "schema": {
-                            "$ref": "#/definitions/api.ScriptAddressResponse"
+                            "$ref": "#/definitions/_.ScriptAddressResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -210,7 +210,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.ScriptCreateRequest"
+                            "$ref": "#/definitions/_.ScriptCreateRequest"
                         }
                     }
                 ],
@@ -218,19 +218,19 @@
                     "200": {
                         "description": "Script successfully created",
                         "schema": {
-                            "$ref": "#/definitions/api.ScriptResponse"
+                            "$ref": "#/definitions/_.ScriptResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -253,7 +253,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.ScriptValidateRequest"
+                            "$ref": "#/definitions/_.ScriptValidateRequest"
                         }
                     }
                 ],
@@ -261,19 +261,19 @@
                     "200": {
                         "description": "Script validation result",
                         "schema": {
-                            "$ref": "#/definitions/api.ScriptValidateResponse"
+                            "$ref": "#/definitions/_.ScriptValidateResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -301,7 +301,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.SignDataRequest"
+                            "$ref": "#/definitions/_.SignDataRequest"
                         }
                     }
                 ],
@@ -309,19 +309,19 @@
                     "200": {
                         "description": "COSE_Sign1 signature and COSE_Key",
                         "schema": {
-                            "$ref": "#/definitions/api.SignDataResponse"
+                            "$ref": "#/definitions/_.SignDataResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -344,7 +344,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.VerifyDataRequest"
+                            "$ref": "#/definitions/_.VerifyDataRequest"
                         }
                     }
                 ],
@@ -352,13 +352,13 @@
                     "200": {
                         "description": "Verification result",
                         "schema": {
-                            "$ref": "#/definitions/api.VerifyDataResponse"
+                            "$ref": "#/definitions/_.VerifyDataResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -381,7 +381,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.TxAssembleRequest"
+                            "$ref": "#/definitions/_.TxAssembleRequest"
                         }
                     }
                 ],
@@ -389,19 +389,19 @@
                     "200": {
                         "description": "Assembled signed transaction",
                         "schema": {
-                            "$ref": "#/definitions/api.TxCborResponse"
+                            "$ref": "#/definitions/_.TxCborResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -424,7 +424,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.TxDecodeRequest"
+                            "$ref": "#/definitions/_.TxDecodeRequest"
                         }
                     }
                 ],
@@ -438,7 +438,7 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -461,7 +461,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.TxIDRequest"
+                            "$ref": "#/definitions/_.TxIDRequest"
                         }
                     }
                 ],
@@ -469,13 +469,13 @@
                     "200": {
                         "description": "Transaction id",
                         "schema": {
-                            "$ref": "#/definitions/api.TxIDResponse"
+                            "$ref": "#/definitions/_.TxIDResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -503,7 +503,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.TxSignRequest"
+                            "$ref": "#/definitions/_.TxSignRequest"
                         }
                     }
                 ],
@@ -511,19 +511,19 @@
                     "200": {
                         "description": "Signed transaction",
                         "schema": {
-                            "$ref": "#/definitions/api.TxCborResponse"
+                            "$ref": "#/definitions/_.TxCborResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -551,7 +551,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.TxWitnessRequest"
+                            "$ref": "#/definitions/_.TxWitnessRequest"
                         }
                     }
                 ],
@@ -559,19 +559,19 @@
                     "200": {
                         "description": "Detached witness",
                         "schema": {
-                            "$ref": "#/definitions/api.TxWitnessResponse"
+                            "$ref": "#/definitions/_.TxWitnessResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -621,7 +621,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.WalletDeleteRequest"
+                            "$ref": "#/definitions/_.WalletDeleteRequest"
                         }
                     }
                 ],
@@ -635,13 +635,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -669,7 +669,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.WalletGetRequest"
+                            "$ref": "#/definitions/_.WalletGetRequest"
                         }
                     }
                 ],
@@ -683,13 +683,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -742,7 +742,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.WalletRestoreRequest"
+                            "$ref": "#/definitions/_.WalletRestoreRequest"
                         }
                     }
                 ],
@@ -756,13 +756,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
+                            "$ref": "#/definitions/_.ErrorResponse"
                         }
                     }
                 }
@@ -790,7 +790,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.WalletUpdateRequest"
+                            "$ref": "#/definitions/_.WalletUpdateRequest"
                         }
                     }
                 ],
@@ -818,7 +818,7 @@
         }
     },
     "definitions": {
-        "api.AddressBuildRequest": {
+        "_.AddressBuildRequest": {
             "type": "object",
             "required": [
                 "network"
@@ -828,7 +828,8 @@
                     "type": "string",
                     "enum": [
                         "mainnet",
-                        "testnet"
+                        "preprod",
+                        "preview"
                     ]
                 },
                 "paymentKey": {
@@ -850,7 +851,7 @@
                 }
             }
         },
-        "api.AddressBuildResponse": {
+        "_.AddressBuildResponse": {
             "type": "object",
             "properties": {
                 "address": {
@@ -864,7 +865,7 @@
                 }
             }
         },
-        "api.AddressEnumerateRequest": {
+        "_.AddressEnumerateRequest": {
             "type": "object",
             "required": [
                 "count",
@@ -901,7 +902,7 @@
                 }
             }
         },
-        "api.AddressParseRequest": {
+        "_.AddressParseRequest": {
             "type": "object",
             "required": [
                 "address"
@@ -912,26 +913,26 @@
                 }
             }
         },
-        "api.AddressParseResponse": {
+        "_.AddressParseResponse": {
             "type": "object",
             "properties": {
                 "address": {
                     "type": "string"
                 },
                 "byron": {
-                    "$ref": "#/definitions/api.ByronAddressInfo"
+                    "$ref": "#/definitions/_.ByronAddressInfo"
                 },
                 "network": {
                     "type": "string"
                 },
                 "payment": {
-                    "$ref": "#/definitions/api.CredentialInfo"
+                    "$ref": "#/definitions/_.CredentialInfo"
                 },
                 "pointer": {
-                    "$ref": "#/definitions/api.PointerInfo"
+                    "$ref": "#/definitions/_.PointerInfo"
                 },
                 "stake": {
-                    "$ref": "#/definitions/api.CredentialInfo"
+                    "$ref": "#/definitions/_.CredentialInfo"
                 },
                 "type": {
                     "type": "string"
@@ -941,7 +942,7 @@
                 }
             }
         },
-        "api.ByronAddressInfo": {
+        "_.ByronAddressInfo": {
             "type": "object",
             "properties": {
                 "type": {
@@ -950,7 +951,7 @@
                 }
             }
         },
-        "api.CredentialInfo": {
+        "_.CredentialInfo": {
             "type": "object",
             "properties": {
                 "bech32": {
@@ -967,7 +968,7 @@
                 }
             }
         },
-        "api.ErrorResponse": {
+        "_.ErrorResponse": {
             "type": "object",
             "properties": {
                 "error": {
@@ -981,7 +982,7 @@
                 }
             }
         },
-        "api.PointerInfo": {
+        "_.PointerInfo": {
             "type": "object",
             "properties": {
                 "certIndex": {
@@ -996,7 +997,7 @@
                 }
             }
         },
-        "api.ScriptAddressRequest": {
+        "_.ScriptAddressRequest": {
             "type": "object",
             "required": [
                 "network",
@@ -1007,7 +1008,8 @@
                     "type": "string",
                     "enum": [
                         "mainnet",
-                        "testnet"
+                        "preprod",
+                        "preview"
                     ]
                 },
                 "script": {
@@ -1016,7 +1018,7 @@
                 }
             }
         },
-        "api.ScriptAddressResponse": {
+        "_.ScriptAddressResponse": {
             "type": "object",
             "properties": {
                 "address": {
@@ -1030,7 +1032,7 @@
                 }
             }
         },
-        "api.ScriptCreateRequest": {
+        "_.ScriptCreateRequest": {
             "type": "object",
             "required": [
                 "key_hashes",
@@ -1049,7 +1051,8 @@
                     "type": "string",
                     "enum": [
                         "mainnet",
-                        "testnet"
+                        "preprod",
+                        "preview"
                     ]
                 },
                 "required": {
@@ -1074,7 +1077,7 @@
                 }
             }
         },
-        "api.ScriptResponse": {
+        "_.ScriptResponse": {
             "type": "object",
             "properties": {
                 "address": {
@@ -1092,7 +1095,7 @@
                 }
             }
         },
-        "api.ScriptValidateRequest": {
+        "_.ScriptValidateRequest": {
             "type": "object",
             "required": [
                 "script"
@@ -1117,7 +1120,7 @@
                 }
             }
         },
-        "api.ScriptValidateResponse": {
+        "_.ScriptValidateResponse": {
             "type": "object",
             "properties": {
                 "scriptHash": {
@@ -1135,7 +1138,7 @@
                 }
             }
         },
-        "api.SignDataRequest": {
+        "_.SignDataRequest": {
             "type": "object",
             "required": [
                 "address",
@@ -1154,7 +1157,7 @@
                 }
             }
         },
-        "api.SignDataResponse": {
+        "_.SignDataResponse": {
             "type": "object",
             "properties": {
                 "key": {
@@ -1165,7 +1168,7 @@
                 }
             }
         },
-        "api.TxAssembleRequest": {
+        "_.TxAssembleRequest": {
             "type": "object",
             "required": [
                 "tx_cbor",
@@ -1185,7 +1188,7 @@
                 }
             }
         },
-        "api.TxCborResponse": {
+        "_.TxCborResponse": {
             "type": "object",
             "properties": {
                 "tx_cbor": {
@@ -1196,7 +1199,7 @@
                 }
             }
         },
-        "api.TxDecodeRequest": {
+        "_.TxDecodeRequest": {
             "type": "object",
             "required": [
                 "tx_cbor"
@@ -1208,7 +1211,7 @@
                 }
             }
         },
-        "api.TxIDRequest": {
+        "_.TxIDRequest": {
             "type": "object",
             "required": [
                 "tx_cbor"
@@ -1220,7 +1223,7 @@
                 }
             }
         },
-        "api.TxIDResponse": {
+        "_.TxIDResponse": {
             "type": "object",
             "properties": {
                 "tx_id": {
@@ -1228,7 +1231,7 @@
                 }
             }
         },
-        "api.TxSignRequest": {
+        "_.TxSignRequest": {
             "type": "object",
             "required": [
                 "signing_keys",
@@ -1248,7 +1251,7 @@
                 }
             }
         },
-        "api.TxWitnessRequest": {
+        "_.TxWitnessRequest": {
             "type": "object",
             "required": [
                 "signing_key",
@@ -1264,7 +1267,7 @@
                 }
             }
         },
-        "api.TxWitnessResponse": {
+        "_.TxWitnessResponse": {
             "type": "object",
             "properties": {
                 "witness": {
@@ -1272,7 +1275,7 @@
                 }
             }
         },
-        "api.VerifyDataRequest": {
+        "_.VerifyDataRequest": {
             "type": "object",
             "required": [
                 "key",
@@ -1291,7 +1294,7 @@
                 }
             }
         },
-        "api.VerifyDataResponse": {
+        "_.VerifyDataResponse": {
             "type": "object",
             "properties": {
                 "valid": {
@@ -1299,7 +1302,7 @@
                 }
             }
         },
-        "api.WalletDeleteRequest": {
+        "_.WalletDeleteRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1315,7 +1318,7 @@
                 }
             }
         },
-        "api.WalletGetRequest": {
+        "_.WalletGetRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1331,7 +1334,7 @@
                 }
             }
         },
-        "api.WalletRestoreRequest": {
+        "_.WalletRestoreRequest": {
             "type": "object",
             "required": [
                 "mnemonic"
@@ -1378,7 +1381,7 @@
                 }
             }
         },
-        "api.WalletUpdateRequest": {
+        "_.WalletUpdateRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1586,6 +1589,589 @@
                 },
                 "stake_vkey": {
                     "$ref": "#/definitions/bursa.KeyFile"
+                }
+            }
+        },
+        "internal_api.AddressBuildRequest": {
+            "type": "object",
+            "required": [
+                "network"
+            ],
+            "properties": {
+                "network": {
+                    "type": "string",
+                    "enum": [
+                        "mainnet",
+                        "preprod",
+                        "preview"
+                    ]
+                },
+                "paymentKey": {
+                    "description": "bech32-encoded verification key (required for base and enterprise address types)",
+                    "type": "string"
+                },
+                "stakeKey": {
+                    "description": "bech32-encoded verification key (required for base and reward address types)",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "defaults to \"base\" - determines which keys are required: base requires both paymentKey and stakeKey, enterprise requires paymentKey only, reward requires stakeKey only",
+                    "type": "string",
+                    "enum": [
+                        "base",
+                        "enterprise",
+                        "reward"
+                    ]
+                }
+            }
+        },
+        "internal_api.AddressBuildResponse": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "network": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.AddressEnumerateRequest": {
+            "type": "object",
+            "required": [
+                "count",
+                "mnemonic",
+                "network"
+            ],
+            "properties": {
+                "account": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
+                "count": {
+                    "type": "integer",
+                    "maximum": 1000,
+                    "minimum": 1
+                },
+                "mnemonic": {
+                    "type": "string"
+                },
+                "network": {
+                    "type": "string",
+                    "enum": [
+                        "mainnet",
+                        "preprod",
+                        "preview"
+                    ]
+                },
+                "password": {
+                    "type": "string"
+                },
+                "start": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                }
+            }
+        },
+        "internal_api.AddressParseRequest": {
+            "type": "object",
+            "required": [
+                "address"
+            ],
+            "properties": {
+                "address": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.AddressParseResponse": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "byron": {
+                    "$ref": "#/definitions/internal_api.ByronAddressInfo"
+                },
+                "network": {
+                    "type": "string"
+                },
+                "payment": {
+                    "$ref": "#/definitions/internal_api.CredentialInfo"
+                },
+                "pointer": {
+                    "$ref": "#/definitions/internal_api.PointerInfo"
+                },
+                "stake": {
+                    "$ref": "#/definitions/internal_api.CredentialInfo"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "typeDescription": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.ByronAddressInfo": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "description": "\"pubkey\", \"script\", or \"redeem\"",
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.CredentialInfo": {
+            "type": "object",
+            "properties": {
+                "bech32": {
+                    "description": "bech32-encoded credential",
+                    "type": "string"
+                },
+                "hex": {
+                    "description": "hex-encoded credential",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "\"key\" or \"script\"",
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.ErrorResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "fields": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "internal_api.PointerInfo": {
+            "type": "object",
+            "properties": {
+                "certIndex": {
+                    "type": "integer"
+                },
+                "slot": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "txIndex": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_api.ScriptAddressRequest": {
+            "type": "object",
+            "required": [
+                "network",
+                "script"
+            ],
+            "properties": {
+                "network": {
+                    "type": "string",
+                    "enum": [
+                        "mainnet",
+                        "preprod",
+                        "preview"
+                    ]
+                },
+                "script": {
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            }
+        },
+        "internal_api.ScriptAddressResponse": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "network": {
+                    "type": "string"
+                },
+                "scriptHash": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.ScriptCreateRequest": {
+            "type": "object",
+            "required": [
+                "key_hashes",
+                "network",
+                "type"
+            ],
+            "properties": {
+                "key_hashes": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "network": {
+                    "type": "string",
+                    "enum": [
+                        "mainnet",
+                        "preprod",
+                        "preview"
+                    ]
+                },
+                "required": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "timelock_after": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "timelock_before": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "nOf",
+                        "all",
+                        "any"
+                    ]
+                }
+            }
+        },
+        "internal_api.ScriptResponse": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "script": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "scriptHash": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.ScriptValidateRequest": {
+            "type": "object",
+            "required": [
+                "script"
+            ],
+            "properties": {
+                "require_signatures": {
+                    "type": "boolean"
+                },
+                "script": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "signatures": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "slot": {
+                    "type": "integer",
+                    "format": "int64"
+                }
+            }
+        },
+        "internal_api.ScriptValidateResponse": {
+            "type": "object",
+            "properties": {
+                "scriptHash": {
+                    "type": "string"
+                },
+                "signatures": {
+                    "type": "integer"
+                },
+                "slot": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "valid": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_api.SignDataRequest": {
+            "type": "object",
+            "required": [
+                "address",
+                "payload",
+                "signing_key"
+            ],
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "payload": {
+                    "type": "string"
+                },
+                "signing_key": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.SignDataResponse": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "signature": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.TxAssembleRequest": {
+            "type": "object",
+            "required": [
+                "tx_cbor",
+                "witnesses"
+            ],
+            "properties": {
+                "tx_cbor": {
+                    "description": "raw hex CBOR or JSON text envelope",
+                    "type": "string"
+                },
+                "witnesses": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "internal_api.TxCborResponse": {
+            "type": "object",
+            "properties": {
+                "tx_cbor": {
+                    "type": "string"
+                },
+                "tx_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.TxDecodeRequest": {
+            "type": "object",
+            "required": [
+                "tx_cbor"
+            ],
+            "properties": {
+                "tx_cbor": {
+                    "description": "raw hex CBOR or JSON text envelope",
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.TxIDRequest": {
+            "type": "object",
+            "required": [
+                "tx_cbor"
+            ],
+            "properties": {
+                "tx_cbor": {
+                    "description": "raw hex CBOR or JSON text envelope",
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.TxIDResponse": {
+            "type": "object",
+            "properties": {
+                "tx_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.TxSignRequest": {
+            "type": "object",
+            "required": [
+                "signing_keys",
+                "tx_cbor"
+            ],
+            "properties": {
+                "signing_keys": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "tx_cbor": {
+                    "description": "raw hex CBOR or JSON text envelope",
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.TxWitnessRequest": {
+            "type": "object",
+            "required": [
+                "signing_key",
+                "tx_cbor"
+            ],
+            "properties": {
+                "signing_key": {
+                    "type": "string"
+                },
+                "tx_cbor": {
+                    "description": "raw hex CBOR or JSON text envelope",
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.TxWitnessResponse": {
+            "type": "object",
+            "properties": {
+                "witness": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.VerifyDataRequest": {
+            "type": "object",
+            "required": [
+                "key",
+                "payload",
+                "signature"
+            ],
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "payload": {
+                    "type": "string"
+                },
+                "signature": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.VerifyDataResponse": {
+            "type": "object",
+            "properties": {
+                "valid": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_api.WalletDeleteRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 1
+                },
+                "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.WalletGetRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 1
+                },
+                "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.WalletRestoreRequest": {
+            "type": "object",
+            "required": [
+                "mnemonic"
+            ],
+            "properties": {
+                "account_id": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
+                "address_id": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
+                "committee_cold_id": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
+                "committee_hot_id": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
+                "drep_id": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
+                "mnemonic": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "password": {
+                    "type": "string"
+                },
+                "payment_id": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
+                "pool_cold_id": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
+                "stake_id": {
+                    "type": "integer",
+                    "maximum": 2147483647
+                }
+            }
+        },
+        "internal_api.WalletUpdateRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "maxLength": 500
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 1
+                },
+                "password": {
+                    "type": "string"
                 }
             }
         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -36,7 +36,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.AddressBuildRequest"
+                            "$ref": "#/definitions/api.AddressBuildRequest"
                         }
                     }
                 ],
@@ -44,19 +44,19 @@
                     "200": {
                         "description": "Address built successfully",
                         "schema": {
-                            "$ref": "#/definitions/_.AddressBuildResponse"
+                            "$ref": "#/definitions/api.AddressBuildResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request or keys",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -84,7 +84,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.AddressEnumerateRequest"
+                            "$ref": "#/definitions/api.AddressEnumerateRequest"
                         }
                     }
                 ],
@@ -101,7 +101,7 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -124,7 +124,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.AddressParseRequest"
+                            "$ref": "#/definitions/api.AddressParseRequest"
                         }
                     }
                 ],
@@ -132,19 +132,19 @@
                     "200": {
                         "description": "Address parsed successfully",
                         "schema": {
-                            "$ref": "#/definitions/_.AddressParseResponse"
+                            "$ref": "#/definitions/api.AddressParseResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request or address",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -167,7 +167,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.ScriptAddressRequest"
+                            "$ref": "#/definitions/api.ScriptAddressRequest"
                         }
                     }
                 ],
@@ -175,19 +175,19 @@
                     "200": {
                         "description": "Script address generated",
                         "schema": {
-                            "$ref": "#/definitions/_.ScriptAddressResponse"
+                            "$ref": "#/definitions/api.ScriptAddressResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -210,7 +210,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.ScriptCreateRequest"
+                            "$ref": "#/definitions/api.ScriptCreateRequest"
                         }
                     }
                 ],
@@ -218,19 +218,19 @@
                     "200": {
                         "description": "Script successfully created",
                         "schema": {
-                            "$ref": "#/definitions/_.ScriptResponse"
+                            "$ref": "#/definitions/api.ScriptResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -253,7 +253,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.ScriptValidateRequest"
+                            "$ref": "#/definitions/api.ScriptValidateRequest"
                         }
                     }
                 ],
@@ -261,19 +261,19 @@
                     "200": {
                         "description": "Script validation result",
                         "schema": {
-                            "$ref": "#/definitions/_.ScriptValidateResponse"
+                            "$ref": "#/definitions/api.ScriptValidateResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -301,7 +301,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.SignDataRequest"
+                            "$ref": "#/definitions/api.SignDataRequest"
                         }
                     }
                 ],
@@ -309,19 +309,19 @@
                     "200": {
                         "description": "COSE_Sign1 signature and COSE_Key",
                         "schema": {
-                            "$ref": "#/definitions/_.SignDataResponse"
+                            "$ref": "#/definitions/api.SignDataResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -344,7 +344,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.VerifyDataRequest"
+                            "$ref": "#/definitions/api.VerifyDataRequest"
                         }
                     }
                 ],
@@ -352,13 +352,13 @@
                     "200": {
                         "description": "Verification result",
                         "schema": {
-                            "$ref": "#/definitions/_.VerifyDataResponse"
+                            "$ref": "#/definitions/api.VerifyDataResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -381,7 +381,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.TxAssembleRequest"
+                            "$ref": "#/definitions/api.TxAssembleRequest"
                         }
                     }
                 ],
@@ -389,19 +389,19 @@
                     "200": {
                         "description": "Assembled signed transaction",
                         "schema": {
-                            "$ref": "#/definitions/_.TxCborResponse"
+                            "$ref": "#/definitions/api.TxCborResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -424,7 +424,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.TxDecodeRequest"
+                            "$ref": "#/definitions/api.TxDecodeRequest"
                         }
                     }
                 ],
@@ -438,7 +438,7 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -461,7 +461,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.TxIDRequest"
+                            "$ref": "#/definitions/api.TxIDRequest"
                         }
                     }
                 ],
@@ -469,13 +469,13 @@
                     "200": {
                         "description": "Transaction id",
                         "schema": {
-                            "$ref": "#/definitions/_.TxIDResponse"
+                            "$ref": "#/definitions/api.TxIDResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -503,7 +503,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.TxSignRequest"
+                            "$ref": "#/definitions/api.TxSignRequest"
                         }
                     }
                 ],
@@ -511,19 +511,19 @@
                     "200": {
                         "description": "Signed transaction",
                         "schema": {
-                            "$ref": "#/definitions/_.TxCborResponse"
+                            "$ref": "#/definitions/api.TxCborResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -551,7 +551,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.TxWitnessRequest"
+                            "$ref": "#/definitions/api.TxWitnessRequest"
                         }
                     }
                 ],
@@ -559,19 +559,19 @@
                     "200": {
                         "description": "Detached witness",
                         "schema": {
-                            "$ref": "#/definitions/_.TxWitnessResponse"
+                            "$ref": "#/definitions/api.TxWitnessResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -621,7 +621,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.WalletDeleteRequest"
+                            "$ref": "#/definitions/api.WalletDeleteRequest"
                         }
                     }
                 ],
@@ -635,13 +635,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -669,7 +669,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.WalletGetRequest"
+                            "$ref": "#/definitions/api.WalletGetRequest"
                         }
                     }
                 ],
@@ -683,13 +683,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -742,7 +742,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.WalletRestoreRequest"
+                            "$ref": "#/definitions/api.WalletRestoreRequest"
                         }
                     }
                 ],
@@ -756,13 +756,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/_.ErrorResponse"
+                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     }
                 }
@@ -790,7 +790,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/_.WalletUpdateRequest"
+                            "$ref": "#/definitions/api.WalletUpdateRequest"
                         }
                     }
                 ],
@@ -818,7 +818,7 @@
         }
     },
     "definitions": {
-        "_.AddressBuildRequest": {
+        "api.AddressBuildRequest": {
             "type": "object",
             "required": [
                 "network"
@@ -851,7 +851,7 @@
                 }
             }
         },
-        "_.AddressBuildResponse": {
+        "api.AddressBuildResponse": {
             "type": "object",
             "properties": {
                 "address": {
@@ -865,7 +865,7 @@
                 }
             }
         },
-        "_.AddressEnumerateRequest": {
+        "api.AddressEnumerateRequest": {
             "type": "object",
             "required": [
                 "count",
@@ -902,7 +902,7 @@
                 }
             }
         },
-        "_.AddressParseRequest": {
+        "api.AddressParseRequest": {
             "type": "object",
             "required": [
                 "address"
@@ -913,26 +913,26 @@
                 }
             }
         },
-        "_.AddressParseResponse": {
+        "api.AddressParseResponse": {
             "type": "object",
             "properties": {
                 "address": {
                     "type": "string"
                 },
                 "byron": {
-                    "$ref": "#/definitions/_.ByronAddressInfo"
+                    "$ref": "#/definitions/api.ByronAddressInfo"
                 },
                 "network": {
                     "type": "string"
                 },
                 "payment": {
-                    "$ref": "#/definitions/_.CredentialInfo"
+                    "$ref": "#/definitions/api.CredentialInfo"
                 },
                 "pointer": {
-                    "$ref": "#/definitions/_.PointerInfo"
+                    "$ref": "#/definitions/api.PointerInfo"
                 },
                 "stake": {
-                    "$ref": "#/definitions/_.CredentialInfo"
+                    "$ref": "#/definitions/api.CredentialInfo"
                 },
                 "type": {
                     "type": "string"
@@ -942,7 +942,7 @@
                 }
             }
         },
-        "_.ByronAddressInfo": {
+        "api.ByronAddressInfo": {
             "type": "object",
             "properties": {
                 "type": {
@@ -951,7 +951,7 @@
                 }
             }
         },
-        "_.CredentialInfo": {
+        "api.CredentialInfo": {
             "type": "object",
             "properties": {
                 "bech32": {
@@ -968,7 +968,7 @@
                 }
             }
         },
-        "_.ErrorResponse": {
+        "api.ErrorResponse": {
             "type": "object",
             "properties": {
                 "error": {
@@ -982,7 +982,7 @@
                 }
             }
         },
-        "_.PointerInfo": {
+        "api.PointerInfo": {
             "type": "object",
             "properties": {
                 "certIndex": {
@@ -997,7 +997,7 @@
                 }
             }
         },
-        "_.ScriptAddressRequest": {
+        "api.ScriptAddressRequest": {
             "type": "object",
             "required": [
                 "network",
@@ -1018,7 +1018,7 @@
                 }
             }
         },
-        "_.ScriptAddressResponse": {
+        "api.ScriptAddressResponse": {
             "type": "object",
             "properties": {
                 "address": {
@@ -1032,7 +1032,7 @@
                 }
             }
         },
-        "_.ScriptCreateRequest": {
+        "api.ScriptCreateRequest": {
             "type": "object",
             "required": [
                 "key_hashes",
@@ -1077,7 +1077,7 @@
                 }
             }
         },
-        "_.ScriptResponse": {
+        "api.ScriptResponse": {
             "type": "object",
             "properties": {
                 "address": {
@@ -1095,7 +1095,7 @@
                 }
             }
         },
-        "_.ScriptValidateRequest": {
+        "api.ScriptValidateRequest": {
             "type": "object",
             "required": [
                 "script"
@@ -1120,7 +1120,7 @@
                 }
             }
         },
-        "_.ScriptValidateResponse": {
+        "api.ScriptValidateResponse": {
             "type": "object",
             "properties": {
                 "scriptHash": {
@@ -1138,7 +1138,7 @@
                 }
             }
         },
-        "_.SignDataRequest": {
+        "api.SignDataRequest": {
             "type": "object",
             "required": [
                 "address",
@@ -1157,7 +1157,7 @@
                 }
             }
         },
-        "_.SignDataResponse": {
+        "api.SignDataResponse": {
             "type": "object",
             "properties": {
                 "key": {
@@ -1168,7 +1168,7 @@
                 }
             }
         },
-        "_.TxAssembleRequest": {
+        "api.TxAssembleRequest": {
             "type": "object",
             "required": [
                 "tx_cbor",
@@ -1188,7 +1188,7 @@
                 }
             }
         },
-        "_.TxCborResponse": {
+        "api.TxCborResponse": {
             "type": "object",
             "properties": {
                 "tx_cbor": {
@@ -1199,7 +1199,7 @@
                 }
             }
         },
-        "_.TxDecodeRequest": {
+        "api.TxDecodeRequest": {
             "type": "object",
             "required": [
                 "tx_cbor"
@@ -1211,7 +1211,7 @@
                 }
             }
         },
-        "_.TxIDRequest": {
+        "api.TxIDRequest": {
             "type": "object",
             "required": [
                 "tx_cbor"
@@ -1223,7 +1223,7 @@
                 }
             }
         },
-        "_.TxIDResponse": {
+        "api.TxIDResponse": {
             "type": "object",
             "properties": {
                 "tx_id": {
@@ -1231,7 +1231,7 @@
                 }
             }
         },
-        "_.TxSignRequest": {
+        "api.TxSignRequest": {
             "type": "object",
             "required": [
                 "signing_keys",
@@ -1251,7 +1251,7 @@
                 }
             }
         },
-        "_.TxWitnessRequest": {
+        "api.TxWitnessRequest": {
             "type": "object",
             "required": [
                 "signing_key",
@@ -1267,7 +1267,7 @@
                 }
             }
         },
-        "_.TxWitnessResponse": {
+        "api.TxWitnessResponse": {
             "type": "object",
             "properties": {
                 "witness": {
@@ -1275,7 +1275,7 @@
                 }
             }
         },
-        "_.VerifyDataRequest": {
+        "api.VerifyDataRequest": {
             "type": "object",
             "required": [
                 "key",
@@ -1294,7 +1294,7 @@
                 }
             }
         },
-        "_.VerifyDataResponse": {
+        "api.VerifyDataResponse": {
             "type": "object",
             "properties": {
                 "valid": {
@@ -1302,7 +1302,7 @@
                 }
             }
         },
-        "_.WalletDeleteRequest": {
+        "api.WalletDeleteRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1318,7 +1318,7 @@
                 }
             }
         },
-        "_.WalletGetRequest": {
+        "api.WalletGetRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1334,7 +1334,7 @@
                 }
             }
         },
-        "_.WalletRestoreRequest": {
+        "api.WalletRestoreRequest": {
             "type": "object",
             "required": [
                 "mnemonic"
@@ -1381,7 +1381,7 @@
                 }
             }
         },
-        "_.WalletUpdateRequest": {
+        "api.WalletUpdateRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1589,589 +1589,6 @@
                 },
                 "stake_vkey": {
                     "$ref": "#/definitions/bursa.KeyFile"
-                }
-            }
-        },
-        "internal_api.AddressBuildRequest": {
-            "type": "object",
-            "required": [
-                "network"
-            ],
-            "properties": {
-                "network": {
-                    "type": "string",
-                    "enum": [
-                        "mainnet",
-                        "preprod",
-                        "preview"
-                    ]
-                },
-                "paymentKey": {
-                    "description": "bech32-encoded verification key (required for base and enterprise address types)",
-                    "type": "string"
-                },
-                "stakeKey": {
-                    "description": "bech32-encoded verification key (required for base and reward address types)",
-                    "type": "string"
-                },
-                "type": {
-                    "description": "defaults to \"base\" - determines which keys are required: base requires both paymentKey and stakeKey, enterprise requires paymentKey only, reward requires stakeKey only",
-                    "type": "string",
-                    "enum": [
-                        "base",
-                        "enterprise",
-                        "reward"
-                    ]
-                }
-            }
-        },
-        "internal_api.AddressBuildResponse": {
-            "type": "object",
-            "properties": {
-                "address": {
-                    "type": "string"
-                },
-                "network": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.AddressEnumerateRequest": {
-            "type": "object",
-            "required": [
-                "count",
-                "mnemonic",
-                "network"
-            ],
-            "properties": {
-                "account": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                },
-                "count": {
-                    "type": "integer",
-                    "maximum": 1000,
-                    "minimum": 1
-                },
-                "mnemonic": {
-                    "type": "string"
-                },
-                "network": {
-                    "type": "string",
-                    "enum": [
-                        "mainnet",
-                        "preprod",
-                        "preview"
-                    ]
-                },
-                "password": {
-                    "type": "string"
-                },
-                "start": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                }
-            }
-        },
-        "internal_api.AddressParseRequest": {
-            "type": "object",
-            "required": [
-                "address"
-            ],
-            "properties": {
-                "address": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.AddressParseResponse": {
-            "type": "object",
-            "properties": {
-                "address": {
-                    "type": "string"
-                },
-                "byron": {
-                    "$ref": "#/definitions/internal_api.ByronAddressInfo"
-                },
-                "network": {
-                    "type": "string"
-                },
-                "payment": {
-                    "$ref": "#/definitions/internal_api.CredentialInfo"
-                },
-                "pointer": {
-                    "$ref": "#/definitions/internal_api.PointerInfo"
-                },
-                "stake": {
-                    "$ref": "#/definitions/internal_api.CredentialInfo"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "typeDescription": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.ByronAddressInfo": {
-            "type": "object",
-            "properties": {
-                "type": {
-                    "description": "\"pubkey\", \"script\", or \"redeem\"",
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.CredentialInfo": {
-            "type": "object",
-            "properties": {
-                "bech32": {
-                    "description": "bech32-encoded credential",
-                    "type": "string"
-                },
-                "hex": {
-                    "description": "hex-encoded credential",
-                    "type": "string"
-                },
-                "type": {
-                    "description": "\"key\" or \"script\"",
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.ErrorResponse": {
-            "type": "object",
-            "properties": {
-                "error": {
-                    "type": "string"
-                },
-                "fields": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "internal_api.PointerInfo": {
-            "type": "object",
-            "properties": {
-                "certIndex": {
-                    "type": "integer"
-                },
-                "slot": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "txIndex": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_api.ScriptAddressRequest": {
-            "type": "object",
-            "required": [
-                "network",
-                "script"
-            ],
-            "properties": {
-                "network": {
-                    "type": "string",
-                    "enum": [
-                        "mainnet",
-                        "preprod",
-                        "preview"
-                    ]
-                },
-                "script": {
-                    "type": "object",
-                    "additionalProperties": {}
-                }
-            }
-        },
-        "internal_api.ScriptAddressResponse": {
-            "type": "object",
-            "properties": {
-                "address": {
-                    "type": "string"
-                },
-                "network": {
-                    "type": "string"
-                },
-                "scriptHash": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.ScriptCreateRequest": {
-            "type": "object",
-            "required": [
-                "key_hashes",
-                "network",
-                "type"
-            ],
-            "properties": {
-                "key_hashes": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "network": {
-                    "type": "string",
-                    "enum": [
-                        "mainnet",
-                        "preprod",
-                        "preview"
-                    ]
-                },
-                "required": {
-                    "type": "integer",
-                    "minimum": 1
-                },
-                "timelock_after": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "timelock_before": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "nOf",
-                        "all",
-                        "any"
-                    ]
-                }
-            }
-        },
-        "internal_api.ScriptResponse": {
-            "type": "object",
-            "properties": {
-                "address": {
-                    "type": "string"
-                },
-                "script": {
-                    "type": "object",
-                    "additionalProperties": {}
-                },
-                "scriptHash": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.ScriptValidateRequest": {
-            "type": "object",
-            "required": [
-                "script"
-            ],
-            "properties": {
-                "require_signatures": {
-                    "type": "boolean"
-                },
-                "script": {
-                    "type": "object",
-                    "additionalProperties": {}
-                },
-                "signatures": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "slot": {
-                    "type": "integer",
-                    "format": "int64"
-                }
-            }
-        },
-        "internal_api.ScriptValidateResponse": {
-            "type": "object",
-            "properties": {
-                "scriptHash": {
-                    "type": "string"
-                },
-                "signatures": {
-                    "type": "integer"
-                },
-                "slot": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "valid": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_api.SignDataRequest": {
-            "type": "object",
-            "required": [
-                "address",
-                "payload",
-                "signing_key"
-            ],
-            "properties": {
-                "address": {
-                    "type": "string"
-                },
-                "payload": {
-                    "type": "string"
-                },
-                "signing_key": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.SignDataResponse": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "signature": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.TxAssembleRequest": {
-            "type": "object",
-            "required": [
-                "tx_cbor",
-                "witnesses"
-            ],
-            "properties": {
-                "tx_cbor": {
-                    "description": "raw hex CBOR or JSON text envelope",
-                    "type": "string"
-                },
-                "witnesses": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "internal_api.TxCborResponse": {
-            "type": "object",
-            "properties": {
-                "tx_cbor": {
-                    "type": "string"
-                },
-                "tx_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.TxDecodeRequest": {
-            "type": "object",
-            "required": [
-                "tx_cbor"
-            ],
-            "properties": {
-                "tx_cbor": {
-                    "description": "raw hex CBOR or JSON text envelope",
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.TxIDRequest": {
-            "type": "object",
-            "required": [
-                "tx_cbor"
-            ],
-            "properties": {
-                "tx_cbor": {
-                    "description": "raw hex CBOR or JSON text envelope",
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.TxIDResponse": {
-            "type": "object",
-            "properties": {
-                "tx_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.TxSignRequest": {
-            "type": "object",
-            "required": [
-                "signing_keys",
-                "tx_cbor"
-            ],
-            "properties": {
-                "signing_keys": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "tx_cbor": {
-                    "description": "raw hex CBOR or JSON text envelope",
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.TxWitnessRequest": {
-            "type": "object",
-            "required": [
-                "signing_key",
-                "tx_cbor"
-            ],
-            "properties": {
-                "signing_key": {
-                    "type": "string"
-                },
-                "tx_cbor": {
-                    "description": "raw hex CBOR or JSON text envelope",
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.TxWitnessResponse": {
-            "type": "object",
-            "properties": {
-                "witness": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.VerifyDataRequest": {
-            "type": "object",
-            "required": [
-                "key",
-                "payload",
-                "signature"
-            ],
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "payload": {
-                    "type": "string"
-                },
-                "signature": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.VerifyDataResponse": {
-            "type": "object",
-            "properties": {
-                "valid": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_api.WalletDeleteRequest": {
-            "type": "object",
-            "required": [
-                "name"
-            ],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "maxLength": 100,
-                    "minLength": 1
-                },
-                "password": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.WalletGetRequest": {
-            "type": "object",
-            "required": [
-                "name"
-            ],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "maxLength": 100,
-                    "minLength": 1
-                },
-                "password": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_api.WalletRestoreRequest": {
-            "type": "object",
-            "required": [
-                "mnemonic"
-            ],
-            "properties": {
-                "account_id": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                },
-                "address_id": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                },
-                "committee_cold_id": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                },
-                "committee_hot_id": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                },
-                "drep_id": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                },
-                "mnemonic": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "password": {
-                    "type": "string"
-                },
-                "payment_id": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                },
-                "pool_cold_id": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                },
-                "stake_id": {
-                    "type": "integer",
-                    "maximum": 2147483647
-                }
-            }
-        },
-        "internal_api.WalletUpdateRequest": {
-            "type": "object",
-            "required": [
-                "name"
-            ],
-            "properties": {
-                "description": {
-                    "type": "string",
-                    "maxLength": 500
-                },
-                "name": {
-                    "type": "string",
-                    "maxLength": 100,
-                    "minLength": 1
-                },
-                "password": {
-                    "type": "string"
                 }
             }
         }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,6 +1,6 @@
 basePath: /
 definitions:
-  _.AddressBuildRequest:
+  api.AddressBuildRequest:
     properties:
       network:
         enum:
@@ -28,7 +28,7 @@ definitions:
     required:
     - network
     type: object
-  _.AddressBuildResponse:
+  api.AddressBuildResponse:
     properties:
       address:
         type: string
@@ -37,7 +37,7 @@ definitions:
       type:
         type: string
     type: object
-  _.AddressEnumerateRequest:
+  api.AddressEnumerateRequest:
     properties:
       account:
         maximum: 2147483647
@@ -64,39 +64,39 @@ definitions:
     - mnemonic
     - network
     type: object
-  _.AddressParseRequest:
+  api.AddressParseRequest:
     properties:
       address:
         type: string
     required:
     - address
     type: object
-  _.AddressParseResponse:
+  api.AddressParseResponse:
     properties:
       address:
         type: string
       byron:
-        $ref: '#/definitions/_.ByronAddressInfo'
+        $ref: '#/definitions/api.ByronAddressInfo'
       network:
         type: string
       payment:
-        $ref: '#/definitions/_.CredentialInfo'
+        $ref: '#/definitions/api.CredentialInfo'
       pointer:
-        $ref: '#/definitions/_.PointerInfo'
+        $ref: '#/definitions/api.PointerInfo'
       stake:
-        $ref: '#/definitions/_.CredentialInfo'
+        $ref: '#/definitions/api.CredentialInfo'
       type:
         type: string
       typeDescription:
         type: string
     type: object
-  _.ByronAddressInfo:
+  api.ByronAddressInfo:
     properties:
       type:
         description: '"pubkey", "script", or "redeem"'
         type: string
     type: object
-  _.CredentialInfo:
+  api.CredentialInfo:
     properties:
       bech32:
         description: bech32-encoded credential
@@ -108,7 +108,7 @@ definitions:
         description: '"key" or "script"'
         type: string
     type: object
-  _.ErrorResponse:
+  api.ErrorResponse:
     properties:
       error:
         type: string
@@ -117,7 +117,7 @@ definitions:
           type: string
         type: object
     type: object
-  _.PointerInfo:
+  api.PointerInfo:
     properties:
       certIndex:
         type: integer
@@ -127,7 +127,7 @@ definitions:
       txIndex:
         type: integer
     type: object
-  _.ScriptAddressRequest:
+  api.ScriptAddressRequest:
     properties:
       network:
         enum:
@@ -142,7 +142,7 @@ definitions:
     - network
     - script
     type: object
-  _.ScriptAddressResponse:
+  api.ScriptAddressResponse:
     properties:
       address:
         type: string
@@ -151,7 +151,7 @@ definitions:
       scriptHash:
         type: string
     type: object
-  _.ScriptCreateRequest:
+  api.ScriptCreateRequest:
     properties:
       key_hashes:
         items:
@@ -184,7 +184,7 @@ definitions:
     - network
     - type
     type: object
-  _.ScriptResponse:
+  api.ScriptResponse:
     properties:
       address:
         type: string
@@ -196,7 +196,7 @@ definitions:
       type:
         type: string
     type: object
-  _.ScriptValidateRequest:
+  api.ScriptValidateRequest:
     properties:
       require_signatures:
         type: boolean
@@ -213,7 +213,7 @@ definitions:
     required:
     - script
     type: object
-  _.ScriptValidateResponse:
+  api.ScriptValidateResponse:
     properties:
       scriptHash:
         type: string
@@ -225,7 +225,7 @@ definitions:
       valid:
         type: boolean
     type: object
-  _.SignDataRequest:
+  api.SignDataRequest:
     properties:
       address:
         type: string
@@ -238,14 +238,14 @@ definitions:
     - payload
     - signing_key
     type: object
-  _.SignDataResponse:
+  api.SignDataResponse:
     properties:
       key:
         type: string
       signature:
         type: string
     type: object
-  _.TxAssembleRequest:
+  api.TxAssembleRequest:
     properties:
       tx_cbor:
         description: raw hex CBOR or JSON text envelope
@@ -259,14 +259,14 @@ definitions:
     - tx_cbor
     - witnesses
     type: object
-  _.TxCborResponse:
+  api.TxCborResponse:
     properties:
       tx_cbor:
         type: string
       tx_id:
         type: string
     type: object
-  _.TxDecodeRequest:
+  api.TxDecodeRequest:
     properties:
       tx_cbor:
         description: raw hex CBOR or JSON text envelope
@@ -274,7 +274,7 @@ definitions:
     required:
     - tx_cbor
     type: object
-  _.TxIDRequest:
+  api.TxIDRequest:
     properties:
       tx_cbor:
         description: raw hex CBOR or JSON text envelope
@@ -282,12 +282,12 @@ definitions:
     required:
     - tx_cbor
     type: object
-  _.TxIDResponse:
+  api.TxIDResponse:
     properties:
       tx_id:
         type: string
     type: object
-  _.TxSignRequest:
+  api.TxSignRequest:
     properties:
       signing_keys:
         items:
@@ -301,7 +301,7 @@ definitions:
     - signing_keys
     - tx_cbor
     type: object
-  _.TxWitnessRequest:
+  api.TxWitnessRequest:
     properties:
       signing_key:
         type: string
@@ -312,12 +312,12 @@ definitions:
     - signing_key
     - tx_cbor
     type: object
-  _.TxWitnessResponse:
+  api.TxWitnessResponse:
     properties:
       witness:
         type: string
     type: object
-  _.VerifyDataRequest:
+  api.VerifyDataRequest:
     properties:
       key:
         type: string
@@ -330,12 +330,12 @@ definitions:
     - payload
     - signature
     type: object
-  _.VerifyDataResponse:
+  api.VerifyDataResponse:
     properties:
       valid:
         type: boolean
     type: object
-  _.WalletDeleteRequest:
+  api.WalletDeleteRequest:
     properties:
       name:
         maxLength: 100
@@ -346,7 +346,7 @@ definitions:
     required:
     - name
     type: object
-  _.WalletGetRequest:
+  api.WalletGetRequest:
     properties:
       name:
         maxLength: 100
@@ -357,7 +357,7 @@ definitions:
     required:
     - name
     type: object
-  _.WalletRestoreRequest:
+  api.WalletRestoreRequest:
     properties:
       account_id:
         maximum: 2147483647
@@ -391,7 +391,7 @@ definitions:
     required:
     - mnemonic
     type: object
-  _.WalletUpdateRequest:
+  api.WalletUpdateRequest:
     properties:
       description:
         maxLength: 500
@@ -542,411 +542,6 @@ definitions:
       stake_vkey:
         $ref: '#/definitions/bursa.KeyFile'
     type: object
-  internal_api.AddressBuildRequest:
-    properties:
-      network:
-        enum:
-        - mainnet
-        - preprod
-        - preview
-        type: string
-      paymentKey:
-        description: bech32-encoded verification key (required for base and enterprise
-          address types)
-        type: string
-      stakeKey:
-        description: bech32-encoded verification key (required for base and reward
-          address types)
-        type: string
-      type:
-        description: 'defaults to "base" - determines which keys are required: base
-          requires both paymentKey and stakeKey, enterprise requires paymentKey only,
-          reward requires stakeKey only'
-        enum:
-        - base
-        - enterprise
-        - reward
-        type: string
-    required:
-    - network
-    type: object
-  internal_api.AddressBuildResponse:
-    properties:
-      address:
-        type: string
-      network:
-        type: string
-      type:
-        type: string
-    type: object
-  internal_api.AddressEnumerateRequest:
-    properties:
-      account:
-        maximum: 2147483647
-        type: integer
-      count:
-        maximum: 1000
-        minimum: 1
-        type: integer
-      mnemonic:
-        type: string
-      network:
-        enum:
-        - mainnet
-        - preprod
-        - preview
-        type: string
-      password:
-        type: string
-      start:
-        maximum: 2147483647
-        type: integer
-    required:
-    - count
-    - mnemonic
-    - network
-    type: object
-  internal_api.AddressParseRequest:
-    properties:
-      address:
-        type: string
-    required:
-    - address
-    type: object
-  internal_api.AddressParseResponse:
-    properties:
-      address:
-        type: string
-      byron:
-        $ref: '#/definitions/internal_api.ByronAddressInfo'
-      network:
-        type: string
-      payment:
-        $ref: '#/definitions/internal_api.CredentialInfo'
-      pointer:
-        $ref: '#/definitions/internal_api.PointerInfo'
-      stake:
-        $ref: '#/definitions/internal_api.CredentialInfo'
-      type:
-        type: string
-      typeDescription:
-        type: string
-    type: object
-  internal_api.ByronAddressInfo:
-    properties:
-      type:
-        description: '"pubkey", "script", or "redeem"'
-        type: string
-    type: object
-  internal_api.CredentialInfo:
-    properties:
-      bech32:
-        description: bech32-encoded credential
-        type: string
-      hex:
-        description: hex-encoded credential
-        type: string
-      type:
-        description: '"key" or "script"'
-        type: string
-    type: object
-  internal_api.ErrorResponse:
-    properties:
-      error:
-        type: string
-      fields:
-        additionalProperties:
-          type: string
-        type: object
-    type: object
-  internal_api.PointerInfo:
-    properties:
-      certIndex:
-        type: integer
-      slot:
-        format: int64
-        type: integer
-      txIndex:
-        type: integer
-    type: object
-  internal_api.ScriptAddressRequest:
-    properties:
-      network:
-        enum:
-        - mainnet
-        - preprod
-        - preview
-        type: string
-      script:
-        additionalProperties: {}
-        type: object
-    required:
-    - network
-    - script
-    type: object
-  internal_api.ScriptAddressResponse:
-    properties:
-      address:
-        type: string
-      network:
-        type: string
-      scriptHash:
-        type: string
-    type: object
-  internal_api.ScriptCreateRequest:
-    properties:
-      key_hashes:
-        items:
-          type: string
-        minItems: 1
-        type: array
-      network:
-        enum:
-        - mainnet
-        - preprod
-        - preview
-        type: string
-      required:
-        minimum: 1
-        type: integer
-      timelock_after:
-        format: int64
-        type: integer
-      timelock_before:
-        format: int64
-        type: integer
-      type:
-        enum:
-        - nOf
-        - all
-        - any
-        type: string
-    required:
-    - key_hashes
-    - network
-    - type
-    type: object
-  internal_api.ScriptResponse:
-    properties:
-      address:
-        type: string
-      script:
-        additionalProperties: {}
-        type: object
-      scriptHash:
-        type: string
-      type:
-        type: string
-    type: object
-  internal_api.ScriptValidateRequest:
-    properties:
-      require_signatures:
-        type: boolean
-      script:
-        additionalProperties: {}
-        type: object
-      signatures:
-        items:
-          type: string
-        type: array
-      slot:
-        format: int64
-        type: integer
-    required:
-    - script
-    type: object
-  internal_api.ScriptValidateResponse:
-    properties:
-      scriptHash:
-        type: string
-      signatures:
-        type: integer
-      slot:
-        format: int64
-        type: integer
-      valid:
-        type: boolean
-    type: object
-  internal_api.SignDataRequest:
-    properties:
-      address:
-        type: string
-      payload:
-        type: string
-      signing_key:
-        type: string
-    required:
-    - address
-    - payload
-    - signing_key
-    type: object
-  internal_api.SignDataResponse:
-    properties:
-      key:
-        type: string
-      signature:
-        type: string
-    type: object
-  internal_api.TxAssembleRequest:
-    properties:
-      tx_cbor:
-        description: raw hex CBOR or JSON text envelope
-        type: string
-      witnesses:
-        items:
-          type: string
-        minItems: 1
-        type: array
-    required:
-    - tx_cbor
-    - witnesses
-    type: object
-  internal_api.TxCborResponse:
-    properties:
-      tx_cbor:
-        type: string
-      tx_id:
-        type: string
-    type: object
-  internal_api.TxDecodeRequest:
-    properties:
-      tx_cbor:
-        description: raw hex CBOR or JSON text envelope
-        type: string
-    required:
-    - tx_cbor
-    type: object
-  internal_api.TxIDRequest:
-    properties:
-      tx_cbor:
-        description: raw hex CBOR or JSON text envelope
-        type: string
-    required:
-    - tx_cbor
-    type: object
-  internal_api.TxIDResponse:
-    properties:
-      tx_id:
-        type: string
-    type: object
-  internal_api.TxSignRequest:
-    properties:
-      signing_keys:
-        items:
-          type: string
-        minItems: 1
-        type: array
-      tx_cbor:
-        description: raw hex CBOR or JSON text envelope
-        type: string
-    required:
-    - signing_keys
-    - tx_cbor
-    type: object
-  internal_api.TxWitnessRequest:
-    properties:
-      signing_key:
-        type: string
-      tx_cbor:
-        description: raw hex CBOR or JSON text envelope
-        type: string
-    required:
-    - signing_key
-    - tx_cbor
-    type: object
-  internal_api.TxWitnessResponse:
-    properties:
-      witness:
-        type: string
-    type: object
-  internal_api.VerifyDataRequest:
-    properties:
-      key:
-        type: string
-      payload:
-        type: string
-      signature:
-        type: string
-    required:
-    - key
-    - payload
-    - signature
-    type: object
-  internal_api.VerifyDataResponse:
-    properties:
-      valid:
-        type: boolean
-    type: object
-  internal_api.WalletDeleteRequest:
-    properties:
-      name:
-        maxLength: 100
-        minLength: 1
-        type: string
-      password:
-        type: string
-    required:
-    - name
-    type: object
-  internal_api.WalletGetRequest:
-    properties:
-      name:
-        maxLength: 100
-        minLength: 1
-        type: string
-      password:
-        type: string
-    required:
-    - name
-    type: object
-  internal_api.WalletRestoreRequest:
-    properties:
-      account_id:
-        maximum: 2147483647
-        type: integer
-      address_id:
-        maximum: 2147483647
-        type: integer
-      committee_cold_id:
-        maximum: 2147483647
-        type: integer
-      committee_hot_id:
-        maximum: 2147483647
-        type: integer
-      drep_id:
-        maximum: 2147483647
-        type: integer
-      mnemonic:
-        minLength: 1
-        type: string
-      password:
-        type: string
-      payment_id:
-        maximum: 2147483647
-        type: integer
-      pool_cold_id:
-        maximum: 2147483647
-        type: integer
-      stake_id:
-        maximum: 2147483647
-        type: integer
-    required:
-    - mnemonic
-    type: object
-  internal_api.WalletUpdateRequest:
-    properties:
-      description:
-        maxLength: 500
-        type: string
-      name:
-        maxLength: 100
-        minLength: 1
-        type: string
-      password:
-        type: string
-    required:
-    - name
-    type: object
 info:
   contact:
     email: support@blinklabs.io
@@ -970,22 +565,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/_.AddressBuildRequest'
+          $ref: '#/definitions/api.AddressBuildRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Address built successfully
           schema:
-            $ref: '#/definitions/_.AddressBuildResponse'
+            $ref: '#/definitions/api.AddressBuildResponse'
         "400":
           description: Invalid request or keys
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Build Cardano address
   /api/address/enumerate:
     post:
@@ -999,7 +594,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/_.AddressEnumerateRequest'
+          $ref: '#/definitions/api.AddressEnumerateRequest'
       produces:
       - application/json
       responses:
@@ -1012,7 +607,7 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Enumerate derived addresses for a wallet
@@ -1027,22 +622,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/_.AddressParseRequest'
+          $ref: '#/definitions/api.AddressParseRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Address parsed successfully
           schema:
-            $ref: '#/definitions/_.AddressParseResponse'
+            $ref: '#/definitions/api.AddressParseResponse'
         "400":
           description: Invalid request or address
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Parse Cardano address
   /api/script/address:
     post:
@@ -1055,22 +650,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/_.ScriptAddressRequest'
+          $ref: '#/definitions/api.ScriptAddressRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Script address generated
           schema:
-            $ref: '#/definitions/_.ScriptAddressResponse'
+            $ref: '#/definitions/api.ScriptAddressResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Generate script address
   /api/script/create:
     post:
@@ -1083,22 +678,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/_.ScriptCreateRequest'
+          $ref: '#/definitions/api.ScriptCreateRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Script successfully created
           schema:
-            $ref: '#/definitions/_.ScriptResponse'
+            $ref: '#/definitions/api.ScriptResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Create a multi-signature script
   /api/script/validate:
     post:
@@ -1111,22 +706,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/_.ScriptValidateRequest'
+          $ref: '#/definitions/api.ScriptValidateRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Script validation result
           schema:
-            $ref: '#/definitions/_.ScriptValidateResponse'
+            $ref: '#/definitions/api.ScriptValidateResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Validate a script
   /api/sign/data:
     post:
@@ -1139,22 +734,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/_.SignDataRequest'
+          $ref: '#/definitions/api.SignDataRequest'
       produces:
       - application/json
       responses:
         "200":
           description: COSE_Sign1 signature and COSE_Key
           schema:
-            $ref: '#/definitions/_.SignDataResponse'
+            $ref: '#/definitions/api.SignDataResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Sign a message (CIP-8/CIP-30 signData)
@@ -1169,18 +764,18 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/_.VerifyDataRequest'
+          $ref: '#/definitions/api.VerifyDataRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Verification result
           schema:
-            $ref: '#/definitions/_.VerifyDataResponse'
+            $ref: '#/definitions/api.VerifyDataResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Verify a CIP-8/CIP-30 signData signature
   /api/tx/assemble:
     post:
@@ -1193,22 +788,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/_.TxAssembleRequest'
+          $ref: '#/definitions/api.TxAssembleRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Assembled signed transaction
           schema:
-            $ref: '#/definitions/_.TxCborResponse'
+            $ref: '#/definitions/api.TxCborResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Assemble a signed transaction
   /api/tx/decode:
     post:
@@ -1221,7 +816,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/_.TxDecodeRequest'
+          $ref: '#/definitions/api.TxDecodeRequest'
       produces:
       - application/json
       responses:
@@ -1232,7 +827,7 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Decode a transaction
   /api/tx/id:
     post:
@@ -1245,18 +840,18 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/_.TxIDRequest'
+          $ref: '#/definitions/api.TxIDRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Transaction id
           schema:
-            $ref: '#/definitions/_.TxIDResponse'
+            $ref: '#/definitions/api.TxIDResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Get a transaction id
   /api/tx/sign:
     post:
@@ -1269,22 +864,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/_.TxSignRequest'
+          $ref: '#/definitions/api.TxSignRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Signed transaction
           schema:
-            $ref: '#/definitions/_.TxCborResponse'
+            $ref: '#/definitions/api.TxCborResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Sign a transaction
@@ -1299,22 +894,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/_.TxWitnessRequest'
+          $ref: '#/definitions/api.TxWitnessRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Detached witness
           schema:
-            $ref: '#/definitions/_.TxWitnessResponse'
+            $ref: '#/definitions/api.TxWitnessResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Produce a transaction witness
@@ -1342,7 +937,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/_.WalletDeleteRequest'
+          $ref: '#/definitions/api.WalletDeleteRequest'
       produces:
       - application/json
       responses:
@@ -1353,11 +948,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Delete wallet from persistent storage
@@ -1373,7 +968,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/_.WalletGetRequest'
+          $ref: '#/definitions/api.WalletGetRequest'
       produces:
       - application/json
       responses:
@@ -1384,11 +979,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Get wallet from persistent storage
@@ -1419,7 +1014,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/_.WalletRestoreRequest'
+          $ref: '#/definitions/api.WalletRestoreRequest'
       produces:
       - application/json
       responses:
@@ -1430,11 +1025,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/_.ErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Restore a wallet using a mnemonic seed phrase
@@ -1450,7 +1045,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/_.WalletUpdateRequest'
+          $ref: '#/definitions/api.WalletUpdateRequest'
       produces:
       - application/json
       responses:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,11 +1,12 @@
 basePath: /
 definitions:
-  api.AddressBuildRequest:
+  _.AddressBuildRequest:
     properties:
       network:
         enum:
         - mainnet
-        - testnet
+        - preprod
+        - preview
         type: string
       paymentKey:
         description: bech32-encoded verification key (required for base and enterprise
@@ -27,7 +28,7 @@ definitions:
     required:
     - network
     type: object
-  api.AddressBuildResponse:
+  _.AddressBuildResponse:
     properties:
       address:
         type: string
@@ -36,7 +37,7 @@ definitions:
       type:
         type: string
     type: object
-  api.AddressEnumerateRequest:
+  _.AddressEnumerateRequest:
     properties:
       account:
         maximum: 2147483647
@@ -63,39 +64,39 @@ definitions:
     - mnemonic
     - network
     type: object
-  api.AddressParseRequest:
+  _.AddressParseRequest:
     properties:
       address:
         type: string
     required:
     - address
     type: object
-  api.AddressParseResponse:
+  _.AddressParseResponse:
     properties:
       address:
         type: string
       byron:
-        $ref: '#/definitions/api.ByronAddressInfo'
+        $ref: '#/definitions/_.ByronAddressInfo'
       network:
         type: string
       payment:
-        $ref: '#/definitions/api.CredentialInfo'
+        $ref: '#/definitions/_.CredentialInfo'
       pointer:
-        $ref: '#/definitions/api.PointerInfo'
+        $ref: '#/definitions/_.PointerInfo'
       stake:
-        $ref: '#/definitions/api.CredentialInfo'
+        $ref: '#/definitions/_.CredentialInfo'
       type:
         type: string
       typeDescription:
         type: string
     type: object
-  api.ByronAddressInfo:
+  _.ByronAddressInfo:
     properties:
       type:
         description: '"pubkey", "script", or "redeem"'
         type: string
     type: object
-  api.CredentialInfo:
+  _.CredentialInfo:
     properties:
       bech32:
         description: bech32-encoded credential
@@ -107,7 +108,7 @@ definitions:
         description: '"key" or "script"'
         type: string
     type: object
-  api.ErrorResponse:
+  _.ErrorResponse:
     properties:
       error:
         type: string
@@ -116,7 +117,7 @@ definitions:
           type: string
         type: object
     type: object
-  api.PointerInfo:
+  _.PointerInfo:
     properties:
       certIndex:
         type: integer
@@ -126,12 +127,13 @@ definitions:
       txIndex:
         type: integer
     type: object
-  api.ScriptAddressRequest:
+  _.ScriptAddressRequest:
     properties:
       network:
         enum:
         - mainnet
-        - testnet
+        - preprod
+        - preview
         type: string
       script:
         additionalProperties: {}
@@ -140,7 +142,7 @@ definitions:
     - network
     - script
     type: object
-  api.ScriptAddressResponse:
+  _.ScriptAddressResponse:
     properties:
       address:
         type: string
@@ -149,7 +151,7 @@ definitions:
       scriptHash:
         type: string
     type: object
-  api.ScriptCreateRequest:
+  _.ScriptCreateRequest:
     properties:
       key_hashes:
         items:
@@ -159,7 +161,8 @@ definitions:
       network:
         enum:
         - mainnet
-        - testnet
+        - preprod
+        - preview
         type: string
       required:
         minimum: 1
@@ -181,7 +184,7 @@ definitions:
     - network
     - type
     type: object
-  api.ScriptResponse:
+  _.ScriptResponse:
     properties:
       address:
         type: string
@@ -193,7 +196,7 @@ definitions:
       type:
         type: string
     type: object
-  api.ScriptValidateRequest:
+  _.ScriptValidateRequest:
     properties:
       require_signatures:
         type: boolean
@@ -210,7 +213,7 @@ definitions:
     required:
     - script
     type: object
-  api.ScriptValidateResponse:
+  _.ScriptValidateResponse:
     properties:
       scriptHash:
         type: string
@@ -222,7 +225,7 @@ definitions:
       valid:
         type: boolean
     type: object
-  api.SignDataRequest:
+  _.SignDataRequest:
     properties:
       address:
         type: string
@@ -235,14 +238,14 @@ definitions:
     - payload
     - signing_key
     type: object
-  api.SignDataResponse:
+  _.SignDataResponse:
     properties:
       key:
         type: string
       signature:
         type: string
     type: object
-  api.TxAssembleRequest:
+  _.TxAssembleRequest:
     properties:
       tx_cbor:
         description: raw hex CBOR or JSON text envelope
@@ -256,14 +259,14 @@ definitions:
     - tx_cbor
     - witnesses
     type: object
-  api.TxCborResponse:
+  _.TxCborResponse:
     properties:
       tx_cbor:
         type: string
       tx_id:
         type: string
     type: object
-  api.TxDecodeRequest:
+  _.TxDecodeRequest:
     properties:
       tx_cbor:
         description: raw hex CBOR or JSON text envelope
@@ -271,7 +274,7 @@ definitions:
     required:
     - tx_cbor
     type: object
-  api.TxIDRequest:
+  _.TxIDRequest:
     properties:
       tx_cbor:
         description: raw hex CBOR or JSON text envelope
@@ -279,12 +282,12 @@ definitions:
     required:
     - tx_cbor
     type: object
-  api.TxIDResponse:
+  _.TxIDResponse:
     properties:
       tx_id:
         type: string
     type: object
-  api.TxSignRequest:
+  _.TxSignRequest:
     properties:
       signing_keys:
         items:
@@ -298,7 +301,7 @@ definitions:
     - signing_keys
     - tx_cbor
     type: object
-  api.TxWitnessRequest:
+  _.TxWitnessRequest:
     properties:
       signing_key:
         type: string
@@ -309,12 +312,12 @@ definitions:
     - signing_key
     - tx_cbor
     type: object
-  api.TxWitnessResponse:
+  _.TxWitnessResponse:
     properties:
       witness:
         type: string
     type: object
-  api.VerifyDataRequest:
+  _.VerifyDataRequest:
     properties:
       key:
         type: string
@@ -327,12 +330,12 @@ definitions:
     - payload
     - signature
     type: object
-  api.VerifyDataResponse:
+  _.VerifyDataResponse:
     properties:
       valid:
         type: boolean
     type: object
-  api.WalletDeleteRequest:
+  _.WalletDeleteRequest:
     properties:
       name:
         maxLength: 100
@@ -343,7 +346,7 @@ definitions:
     required:
     - name
     type: object
-  api.WalletGetRequest:
+  _.WalletGetRequest:
     properties:
       name:
         maxLength: 100
@@ -354,7 +357,7 @@ definitions:
     required:
     - name
     type: object
-  api.WalletRestoreRequest:
+  _.WalletRestoreRequest:
     properties:
       account_id:
         maximum: 2147483647
@@ -388,7 +391,7 @@ definitions:
     required:
     - mnemonic
     type: object
-  api.WalletUpdateRequest:
+  _.WalletUpdateRequest:
     properties:
       description:
         maxLength: 500
@@ -539,6 +542,411 @@ definitions:
       stake_vkey:
         $ref: '#/definitions/bursa.KeyFile'
     type: object
+  internal_api.AddressBuildRequest:
+    properties:
+      network:
+        enum:
+        - mainnet
+        - preprod
+        - preview
+        type: string
+      paymentKey:
+        description: bech32-encoded verification key (required for base and enterprise
+          address types)
+        type: string
+      stakeKey:
+        description: bech32-encoded verification key (required for base and reward
+          address types)
+        type: string
+      type:
+        description: 'defaults to "base" - determines which keys are required: base
+          requires both paymentKey and stakeKey, enterprise requires paymentKey only,
+          reward requires stakeKey only'
+        enum:
+        - base
+        - enterprise
+        - reward
+        type: string
+    required:
+    - network
+    type: object
+  internal_api.AddressBuildResponse:
+    properties:
+      address:
+        type: string
+      network:
+        type: string
+      type:
+        type: string
+    type: object
+  internal_api.AddressEnumerateRequest:
+    properties:
+      account:
+        maximum: 2147483647
+        type: integer
+      count:
+        maximum: 1000
+        minimum: 1
+        type: integer
+      mnemonic:
+        type: string
+      network:
+        enum:
+        - mainnet
+        - preprod
+        - preview
+        type: string
+      password:
+        type: string
+      start:
+        maximum: 2147483647
+        type: integer
+    required:
+    - count
+    - mnemonic
+    - network
+    type: object
+  internal_api.AddressParseRequest:
+    properties:
+      address:
+        type: string
+    required:
+    - address
+    type: object
+  internal_api.AddressParseResponse:
+    properties:
+      address:
+        type: string
+      byron:
+        $ref: '#/definitions/internal_api.ByronAddressInfo'
+      network:
+        type: string
+      payment:
+        $ref: '#/definitions/internal_api.CredentialInfo'
+      pointer:
+        $ref: '#/definitions/internal_api.PointerInfo'
+      stake:
+        $ref: '#/definitions/internal_api.CredentialInfo'
+      type:
+        type: string
+      typeDescription:
+        type: string
+    type: object
+  internal_api.ByronAddressInfo:
+    properties:
+      type:
+        description: '"pubkey", "script", or "redeem"'
+        type: string
+    type: object
+  internal_api.CredentialInfo:
+    properties:
+      bech32:
+        description: bech32-encoded credential
+        type: string
+      hex:
+        description: hex-encoded credential
+        type: string
+      type:
+        description: '"key" or "script"'
+        type: string
+    type: object
+  internal_api.ErrorResponse:
+    properties:
+      error:
+        type: string
+      fields:
+        additionalProperties:
+          type: string
+        type: object
+    type: object
+  internal_api.PointerInfo:
+    properties:
+      certIndex:
+        type: integer
+      slot:
+        format: int64
+        type: integer
+      txIndex:
+        type: integer
+    type: object
+  internal_api.ScriptAddressRequest:
+    properties:
+      network:
+        enum:
+        - mainnet
+        - preprod
+        - preview
+        type: string
+      script:
+        additionalProperties: {}
+        type: object
+    required:
+    - network
+    - script
+    type: object
+  internal_api.ScriptAddressResponse:
+    properties:
+      address:
+        type: string
+      network:
+        type: string
+      scriptHash:
+        type: string
+    type: object
+  internal_api.ScriptCreateRequest:
+    properties:
+      key_hashes:
+        items:
+          type: string
+        minItems: 1
+        type: array
+      network:
+        enum:
+        - mainnet
+        - preprod
+        - preview
+        type: string
+      required:
+        minimum: 1
+        type: integer
+      timelock_after:
+        format: int64
+        type: integer
+      timelock_before:
+        format: int64
+        type: integer
+      type:
+        enum:
+        - nOf
+        - all
+        - any
+        type: string
+    required:
+    - key_hashes
+    - network
+    - type
+    type: object
+  internal_api.ScriptResponse:
+    properties:
+      address:
+        type: string
+      script:
+        additionalProperties: {}
+        type: object
+      scriptHash:
+        type: string
+      type:
+        type: string
+    type: object
+  internal_api.ScriptValidateRequest:
+    properties:
+      require_signatures:
+        type: boolean
+      script:
+        additionalProperties: {}
+        type: object
+      signatures:
+        items:
+          type: string
+        type: array
+      slot:
+        format: int64
+        type: integer
+    required:
+    - script
+    type: object
+  internal_api.ScriptValidateResponse:
+    properties:
+      scriptHash:
+        type: string
+      signatures:
+        type: integer
+      slot:
+        format: int64
+        type: integer
+      valid:
+        type: boolean
+    type: object
+  internal_api.SignDataRequest:
+    properties:
+      address:
+        type: string
+      payload:
+        type: string
+      signing_key:
+        type: string
+    required:
+    - address
+    - payload
+    - signing_key
+    type: object
+  internal_api.SignDataResponse:
+    properties:
+      key:
+        type: string
+      signature:
+        type: string
+    type: object
+  internal_api.TxAssembleRequest:
+    properties:
+      tx_cbor:
+        description: raw hex CBOR or JSON text envelope
+        type: string
+      witnesses:
+        items:
+          type: string
+        minItems: 1
+        type: array
+    required:
+    - tx_cbor
+    - witnesses
+    type: object
+  internal_api.TxCborResponse:
+    properties:
+      tx_cbor:
+        type: string
+      tx_id:
+        type: string
+    type: object
+  internal_api.TxDecodeRequest:
+    properties:
+      tx_cbor:
+        description: raw hex CBOR or JSON text envelope
+        type: string
+    required:
+    - tx_cbor
+    type: object
+  internal_api.TxIDRequest:
+    properties:
+      tx_cbor:
+        description: raw hex CBOR or JSON text envelope
+        type: string
+    required:
+    - tx_cbor
+    type: object
+  internal_api.TxIDResponse:
+    properties:
+      tx_id:
+        type: string
+    type: object
+  internal_api.TxSignRequest:
+    properties:
+      signing_keys:
+        items:
+          type: string
+        minItems: 1
+        type: array
+      tx_cbor:
+        description: raw hex CBOR or JSON text envelope
+        type: string
+    required:
+    - signing_keys
+    - tx_cbor
+    type: object
+  internal_api.TxWitnessRequest:
+    properties:
+      signing_key:
+        type: string
+      tx_cbor:
+        description: raw hex CBOR or JSON text envelope
+        type: string
+    required:
+    - signing_key
+    - tx_cbor
+    type: object
+  internal_api.TxWitnessResponse:
+    properties:
+      witness:
+        type: string
+    type: object
+  internal_api.VerifyDataRequest:
+    properties:
+      key:
+        type: string
+      payload:
+        type: string
+      signature:
+        type: string
+    required:
+    - key
+    - payload
+    - signature
+    type: object
+  internal_api.VerifyDataResponse:
+    properties:
+      valid:
+        type: boolean
+    type: object
+  internal_api.WalletDeleteRequest:
+    properties:
+      name:
+        maxLength: 100
+        minLength: 1
+        type: string
+      password:
+        type: string
+    required:
+    - name
+    type: object
+  internal_api.WalletGetRequest:
+    properties:
+      name:
+        maxLength: 100
+        minLength: 1
+        type: string
+      password:
+        type: string
+    required:
+    - name
+    type: object
+  internal_api.WalletRestoreRequest:
+    properties:
+      account_id:
+        maximum: 2147483647
+        type: integer
+      address_id:
+        maximum: 2147483647
+        type: integer
+      committee_cold_id:
+        maximum: 2147483647
+        type: integer
+      committee_hot_id:
+        maximum: 2147483647
+        type: integer
+      drep_id:
+        maximum: 2147483647
+        type: integer
+      mnemonic:
+        minLength: 1
+        type: string
+      password:
+        type: string
+      payment_id:
+        maximum: 2147483647
+        type: integer
+      pool_cold_id:
+        maximum: 2147483647
+        type: integer
+      stake_id:
+        maximum: 2147483647
+        type: integer
+    required:
+    - mnemonic
+    type: object
+  internal_api.WalletUpdateRequest:
+    properties:
+      description:
+        maxLength: 500
+        type: string
+      name:
+        maxLength: 100
+        minLength: 1
+        type: string
+      password:
+        type: string
+    required:
+    - name
+    type: object
 info:
   contact:
     email: support@blinklabs.io
@@ -562,22 +970,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.AddressBuildRequest'
+          $ref: '#/definitions/_.AddressBuildRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Address built successfully
           schema:
-            $ref: '#/definitions/api.AddressBuildResponse'
+            $ref: '#/definitions/_.AddressBuildResponse'
         "400":
           description: Invalid request or keys
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
       summary: Build Cardano address
   /api/address/enumerate:
     post:
@@ -591,7 +999,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.AddressEnumerateRequest'
+          $ref: '#/definitions/_.AddressEnumerateRequest'
       produces:
       - application/json
       responses:
@@ -604,7 +1012,7 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Enumerate derived addresses for a wallet
@@ -619,22 +1027,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.AddressParseRequest'
+          $ref: '#/definitions/_.AddressParseRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Address parsed successfully
           schema:
-            $ref: '#/definitions/api.AddressParseResponse'
+            $ref: '#/definitions/_.AddressParseResponse'
         "400":
           description: Invalid request or address
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
       summary: Parse Cardano address
   /api/script/address:
     post:
@@ -647,22 +1055,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.ScriptAddressRequest'
+          $ref: '#/definitions/_.ScriptAddressRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Script address generated
           schema:
-            $ref: '#/definitions/api.ScriptAddressResponse'
+            $ref: '#/definitions/_.ScriptAddressResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
       summary: Generate script address
   /api/script/create:
     post:
@@ -675,22 +1083,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.ScriptCreateRequest'
+          $ref: '#/definitions/_.ScriptCreateRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Script successfully created
           schema:
-            $ref: '#/definitions/api.ScriptResponse'
+            $ref: '#/definitions/_.ScriptResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
       summary: Create a multi-signature script
   /api/script/validate:
     post:
@@ -703,22 +1111,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.ScriptValidateRequest'
+          $ref: '#/definitions/_.ScriptValidateRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Script validation result
           schema:
-            $ref: '#/definitions/api.ScriptValidateResponse'
+            $ref: '#/definitions/_.ScriptValidateResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
       summary: Validate a script
   /api/sign/data:
     post:
@@ -731,22 +1139,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.SignDataRequest'
+          $ref: '#/definitions/_.SignDataRequest'
       produces:
       - application/json
       responses:
         "200":
           description: COSE_Sign1 signature and COSE_Key
           schema:
-            $ref: '#/definitions/api.SignDataResponse'
+            $ref: '#/definitions/_.SignDataResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Sign a message (CIP-8/CIP-30 signData)
@@ -761,18 +1169,18 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.VerifyDataRequest'
+          $ref: '#/definitions/_.VerifyDataRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Verification result
           schema:
-            $ref: '#/definitions/api.VerifyDataResponse'
+            $ref: '#/definitions/_.VerifyDataResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
       summary: Verify a CIP-8/CIP-30 signData signature
   /api/tx/assemble:
     post:
@@ -785,22 +1193,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.TxAssembleRequest'
+          $ref: '#/definitions/_.TxAssembleRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Assembled signed transaction
           schema:
-            $ref: '#/definitions/api.TxCborResponse'
+            $ref: '#/definitions/_.TxCborResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
       summary: Assemble a signed transaction
   /api/tx/decode:
     post:
@@ -813,7 +1221,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.TxDecodeRequest'
+          $ref: '#/definitions/_.TxDecodeRequest'
       produces:
       - application/json
       responses:
@@ -824,7 +1232,7 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
       summary: Decode a transaction
   /api/tx/id:
     post:
@@ -837,18 +1245,18 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.TxIDRequest'
+          $ref: '#/definitions/_.TxIDRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Transaction id
           schema:
-            $ref: '#/definitions/api.TxIDResponse'
+            $ref: '#/definitions/_.TxIDResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
       summary: Get a transaction id
   /api/tx/sign:
     post:
@@ -861,22 +1269,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.TxSignRequest'
+          $ref: '#/definitions/_.TxSignRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Signed transaction
           schema:
-            $ref: '#/definitions/api.TxCborResponse'
+            $ref: '#/definitions/_.TxCborResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Sign a transaction
@@ -891,22 +1299,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.TxWitnessRequest'
+          $ref: '#/definitions/_.TxWitnessRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Detached witness
           schema:
-            $ref: '#/definitions/api.TxWitnessResponse'
+            $ref: '#/definitions/_.TxWitnessResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Produce a transaction witness
@@ -934,7 +1342,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.WalletDeleteRequest'
+          $ref: '#/definitions/_.WalletDeleteRequest'
       produces:
       - application/json
       responses:
@@ -945,11 +1353,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Delete wallet from persistent storage
@@ -965,7 +1373,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.WalletGetRequest'
+          $ref: '#/definitions/_.WalletGetRequest'
       produces:
       - application/json
       responses:
@@ -976,11 +1384,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Get wallet from persistent storage
@@ -1011,7 +1419,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.WalletRestoreRequest'
+          $ref: '#/definitions/_.WalletRestoreRequest'
       produces:
       - application/json
       responses:
@@ -1022,11 +1430,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: '#/definitions/api.ErrorResponse'
+            $ref: '#/definitions/_.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Restore a wallet using a mnemonic seed phrase
@@ -1042,7 +1450,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.WalletUpdateRequest'
+          $ref: '#/definitions/_.WalletUpdateRequest'
       produces:
       - application/json
       responses:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -360,7 +360,7 @@ type ScriptCreateRequest struct {
 	KeyHashes      []string `json:"key_hashes"                validate:"required,min=1,dive,hexadecimal,len=56"`
 	TimelockBefore uint64   `json:"timelock_before,omitempty"                                                   swaggertype:"integer" format:"int64"`
 	TimelockAfter  uint64   `json:"timelock_after,omitempty"                                                    swaggertype:"integer" format:"int64"`
-	Network        string   `json:"network"                   validate:"required,oneof=mainnet testnet"`
+	Network        string   `json:"network"                   validate:"required,oneof=mainnet preprod preview"`
 }
 
 // ScriptValidateRequest defines the request payload for script validation
@@ -374,7 +374,7 @@ type ScriptValidateRequest struct {
 // ScriptAddressRequest defines the request payload for script address generation
 type ScriptAddressRequest struct {
 	Script  map[string]any `json:"script"  validate:"required"`
-	Network string         `json:"network" validate:"required,oneof=mainnet testnet"`
+	Network string         `json:"network" validate:"required,oneof=mainnet preprod preview"`
 }
 
 // ScriptResponse defines the response payload for script operations
@@ -440,7 +440,7 @@ type ByronAddressInfo struct {
 type AddressBuildRequest struct {
 	PaymentKey string `json:"paymentKey,omitempty"` // bech32-encoded verification key (required for base and enterprise address types)
 	StakeKey   string `json:"stakeKey,omitempty"`   // bech32-encoded verification key (required for base and reward address types)
-	Network    string `json:"network"              validate:"required,oneof=mainnet testnet"`
+	Network    string `json:"network"              validate:"required,oneof=mainnet preprod preview"`
 	Type       string `json:"type,omitempty"       validate:"omitempty,oneof=base enterprise reward"` // defaults to "base" - determines which keys are required: base requires both paymentKey and stakeKey, enterprise requires paymentKey only, reward requires stakeKey only
 }
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1935,11 +1935,44 @@ func TestHandleScriptCreate_BothTimelocks(t *testing.T) {
 	assert.Contains(t, string(body), "cannot specify both")
 }
 
-func TestHandleScriptCreate_TestnetNetworkError(t *testing.T) {
-	// "testnet" passes validation but fails in
-	// bursa.MarshalScript because gouroboros does not
-	// recognize "testnet" as a network name. This covers
-	// the MarshalScript error path.
+func TestHandleScriptCreate_CanonicalNetworks(t *testing.T) {
+	for _, network := range []string{"mainnet", "preprod", "preview"} {
+		t.Run(network, func(t *testing.T) {
+			reqBody := fmt.Sprintf(`{
+				"type": "nOf",
+				"required": 1,
+				"key_hashes": [
+					"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c"
+				],
+				"network": %q
+			}`, network)
+
+			req := httptest.NewRequest(
+				http.MethodPost,
+				"/api/script/create",
+				strings.NewReader(reqBody),
+			)
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			handleScriptCreate(w, req)
+
+			resp := w.Result()
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			assert.NoError(t, err)
+			assert.Equal(
+				t,
+				http.StatusOK,
+				resp.StatusCode,
+				"response body: %s",
+				body,
+			)
+		})
+	}
+}
+
+func TestHandleScriptCreate_LegacyTestnetRejected(t *testing.T) {
 	reqBody := `{
 		"type": "nOf",
 		"required": 1,
@@ -1961,10 +1994,10 @@ func TestHandleScriptCreate_TestnetNetworkError(t *testing.T) {
 
 	resp := w.Result()
 	defer resp.Body.Close()
-	// MarshalScript fails because testnet is not valid
-	assert.Equal(
-		t, http.StatusInternalServerError, resp.StatusCode,
-	)
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Contains(t, string(body), "Validation failed")
 }
 
 func TestHandleScriptValidate_MethodNotAllowed(t *testing.T) {
@@ -2153,36 +2186,47 @@ func TestHandleScriptAddress_InvalidScript(t *testing.T) {
 	assert.Contains(t, string(body), "Invalid script format")
 }
 
-func TestHandleScriptAddress_TestnetError(t *testing.T) {
-	// "testnet" is not recognized by gouroboros
-	// GetScriptAddress. This exercises the error path.
-	reqBody := `{
-		"script": {
-			"type": "all",
-			"scripts": [
-				{"type": "sig", "keyHash": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c"}
-			]
-		},
-		"network": "testnet"
-	}`
+func TestHandleScriptAddress_CanonicalNetworks(t *testing.T) {
+	for _, network := range []string{"mainnet", "preprod", "preview"} {
+		t.Run(network, func(t *testing.T) {
+			reqBody := fmt.Sprintf(`{
+				"script": {
+					"type": "all",
+					"scripts": [
+						{"type": "sig", "keyHash": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c"}
+					]
+				},
+				"network": %q
+			}`, network)
 
-	req := httptest.NewRequest(
-		http.MethodPost,
-		"/api/script/address",
-		strings.NewReader(reqBody),
-	)
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
+			req := httptest.NewRequest(
+				http.MethodPost,
+				"/api/script/address",
+				strings.NewReader(reqBody),
+			)
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
 
-	handleScriptAddress(w, req)
+			handleScriptAddress(w, req)
 
-	resp := w.Result()
-	defer resp.Body.Close()
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			resp := w.Result()
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			assert.NoError(t, err)
+			assert.Equal(
+				t,
+				http.StatusOK,
+				resp.StatusCode,
+				"response body: %s",
+				body,
+			)
 
-	body, err := io.ReadAll(resp.Body)
-	assert.NoError(t, err)
-	assert.Contains(t, string(body), "Invalid network")
+			var response ScriptAddressResponse
+			err = json.Unmarshal(body, &response)
+			assert.NoError(t, err)
+			assert.Equal(t, network, response.Network)
+		})
+	}
 }
 
 func TestHandleAddressParse_MethodNotAllowed(t *testing.T) {
@@ -2416,32 +2460,43 @@ func TestHandleAddressBuild_RewardMissingStakeKey(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
-func TestHandleAddressBuild_TestnetReturnsError(t *testing.T) {
-	// Note: buildAddressFromKeys uses ouroboros.NetworkByName
-	// which does not recognize "testnet" (only mainnet,
-	// preprod, preview, sanchonet). Validation accepts
-	// "testnet" but the build step fails. This tests the
-	// error path.
-	reqBody := `{
-		"paymentKey": "addr_vk18nqps65rh0azud77qruff3dctszahutmrhkxg87mlfny0addcles83lnyc",
-		"stakeKey": "stake_vk1swf4qsf28mzdn2kexqumas5fj43psj674xathpv45mcj04y2lv5scvw4uv",
-		"network": "testnet"
-	}`
+func TestHandleAddressBuild_CanonicalNetworks(t *testing.T) {
+	for _, network := range []string{"mainnet", "preprod", "preview"} {
+		t.Run(network, func(t *testing.T) {
+			reqBody := fmt.Sprintf(`{
+				"paymentKey": "addr_vk18nqps65rh0azud77qruff3dctszahutmrhkxg87mlfny0addcles83lnyc",
+				"stakeKey": "stake_vk1swf4qsf28mzdn2kexqumas5fj43psj674xathpv45mcj04y2lv5scvw4uv",
+				"network": %q
+			}`, network)
 
-	req := httptest.NewRequest(
-		http.MethodPost,
-		"/api/address/build",
-		strings.NewReader(reqBody),
-	)
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
+			req := httptest.NewRequest(
+				http.MethodPost,
+				"/api/address/build",
+				strings.NewReader(reqBody),
+			)
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
 
-	handleAddressBuild(w, req)
+			handleAddressBuild(w, req)
 
-	resp := w.Result()
-	defer resp.Body.Close()
-	// testnet is not recognized by gouroboros NetworkByName
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			resp := w.Result()
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			assert.NoError(t, err)
+			assert.Equal(
+				t,
+				http.StatusOK,
+				resp.StatusCode,
+				"response body: %s",
+				body,
+			)
+
+			var response AddressBuildResponse
+			err = json.Unmarshal(body, &response)
+			assert.NoError(t, err)
+			assert.Equal(t, network, response.Network)
+		})
+	}
 }
 
 func TestHandleAddressBuild_DefaultType(t *testing.T) {

--- a/openapi/api/openapi.yaml
+++ b/openapi/api/openapi.yaml
@@ -325,7 +325,8 @@ components:
         network:
           enum:
           - mainnet
-          - testnet
+          - preprod
+          - preview
           type: string
         script:
           additionalProperties:
@@ -358,7 +359,8 @@ components:
         network:
           enum:
           - mainnet
-          - testnet
+          - preprod
+          - preview
           type: string
         required:
           minimum: 1
@@ -450,7 +452,8 @@ components:
         network:
           enum:
           - mainnet
-          - testnet
+          - preprod
+          - preview
           type: string
         paymentKey:
           description: bech32-encoded verification key
@@ -473,7 +476,8 @@ components:
         network:
           enum:
           - mainnet
-          - testnet
+          - preprod
+          - preview
           type: string
         paymentKey:
           description: bech32-encoded verification key
@@ -493,7 +497,8 @@ components:
         network:
           enum:
           - mainnet
-          - testnet
+          - preprod
+          - preview
           type: string
         stakeKey:
           description: bech32-encoded verification key


### PR DESCRIPTION
Align network validation and OpenAPI enums with mainnet, preprod, and preview. Reject legacy testnet input consistently.

Tests: GOWORK=off go test -race ./internal/api; make swagger; git diff --check.

Closes #766

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the legacy `testnet` network name with `preprod` and `preview` in request validation and OpenAPI specs, so invalid network names are rejected consistently before reaching downstream handling. Closes #766.

**Migration**
- Existing clients sending `"network": "testnet"` must switch to `"preprod"` or `"preview"`.
- `docs/` files are regenerated from the updated OpenAPI spec; a new test now verifies the generated definitions stay current and correctly named.

<sup>Written for commit 92bb3b3292404d9c9edf3d2773991659eed65e57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `mainnet`, `preprod`, and `preview` network names across address and script operations.
  * Updated API documentation and schemas to reflect the supported network options.

* **Bug Fixes**
  * Legacy `testnet` requests are now consistently rejected with a clear validation error.

* **Documentation**
  * Clarified network configuration guidance and refreshed API reference definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->