### PR TITLE
fix(api): return bad request for invalid mnemonic

### DIFF
--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -2357,8 +2357,8 @@ func serve[T any](w http.ResponseWriter, v T, err error) {
 		writeJSON(w, http.StatusNotFound, errBody(err)) // 404
 	case errors.Is(err, vault.ErrDuplicateWallet), errors.Is(err, vault.ErrDuplicateAccount):
 		writeJSON(w, http.StatusConflict, errBody(err)) // 409
-	case errors.Is(err, vault.ErrNoSeed):
-		writeJSON(w, http.StatusBadRequest, errBody(err)) // 400: cannot derive an account without a seed
+	case errors.Is(err, vault.ErrNoSeed), errors.Is(err, bursa.ErrInvalidMnemonic):
+		writeJSON(w, http.StatusBadRequest, errBody(err)) // 400: cannot derive an account without a valid seed
 	case errors.Is(err, vault.ErrLocked), errors.Is(err, vault.ErrNoActiveWallet),
 		errors.Is(err, wallet.ErrNoWallet), errors.Is(err, spend.ErrNoWallet),
 		errors.Is(err, poolops.ErrNoWallet), errors.Is(err, multisig.ErrNoKeystore):

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	bursa "github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/bursa/ui/internal/chain"
 	"github.com/blinklabs-io/bursa/ui/internal/connector"
 	"github.com/blinklabs-io/bursa/ui/internal/contacts"
@@ -1569,6 +1570,24 @@ func TestAddWalletDuplicateConflict(t *testing.T) {
 	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("POST /wallet duplicate = %d, want 409", rec.Code)
+	}
+}
+
+func TestAddWalletInvalidMnemonicBadRequest(t *testing.T) {
+	st := fakeStatuser{s: supervisor.Status{State: supervisor.StateReady}}
+	fv := &fakeVault{
+		exists: true,
+		addErr: fmt.Errorf(
+			"root key from mnemonic: %w",
+			bursa.ErrInvalidMnemonic,
+		),
+	}
+	h := NewHandler(st, fv, &fakeWallet{}, &fakeSpender{}, &fakeSettings{}, &fakeContacts{}, nil, &fakePoolOps{}, nil, &fakeMultiSig{}, "preview", http.NotFoundHandler())
+	rec := httptest.NewRecorder()
+	body := `{"name":"main","mnemonic":"not a valid mnemonic","network":"preview","vault_password":"valid-vault-password","spend_password":"valid-spend-password"}`
+	h.ServeHTTP(rec, localReq(http.MethodPost, "/wallet", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("POST /wallet invalid mnemonic = %d, want 400: %s", rec.Code, rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
Fixes #802

Map invalid wallet mnemonics to HTTP 400.

Tests: GOWORK=off GOCACHE=/tmp/bursa-802-go-cache go test ./internal/api; git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Maps invalid wallet mnemonics to HTTP 400 so callers get a clear bad request instead of an unspecified error.

- The `serve` helper now converts `bursa.ErrInvalidMnemonic` to a 400 status, matching the existing handling of `vault.ErrNoSeed`.
- Adds a regression test that posts an invalid mnemonic to `/wallet` and asserts a 400 response.

<sup>Written for commit 279b1d79e6f2a291d734af6bdf89151b2a5ddab9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

