### PR TITLE
fix(keys): validate complete envelopes against derived public identity

### DIFF
--- a/bursa.go
+++ b/bursa.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"crypto/ed25519"
 	crand "crypto/rand"
+	"crypto/subtle"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
@@ -177,8 +178,7 @@ func (kf KeyFile) String() string {
 		return kf.CborHex
 	}
 	// cardano-cli format: CBOR-encoded raw bytes
-	var keyBytes []byte
-	_, err = cbor.Decode(cborData, &keyBytes)
+	keyBytes, err := decodeKeyEnvelopeBytes(cborData, "key")
 	if err != nil {
 		return kf.CborHex
 	}
@@ -2278,13 +2278,9 @@ func GetRewardAddress(
 		return nil, fmt.Errorf("failed to decode stake vkey CBOR: %w", err)
 	}
 	// cardano-cli format: CBOR-encoded raw 32-byte public key
-	var stakePubKeyBytes []byte
-	_, err = cbor.Decode(cborData, &stakePubKeyBytes)
+	stakePubKeyBytes, err := decodeVerificationKey(cborData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode stake vkey: %w", err)
-	}
-	if len(stakePubKeyBytes) != 32 {
-		return nil, errors.New("invalid stake public key: expected 32 bytes")
 	}
 
 	// Create stake public key and hash it
@@ -2333,11 +2329,32 @@ func GetKeyFile(keyFile KeyFile) (string, error) {
 	return result, nil
 }
 
+// decodeKeyEnvelopeBytes decodes the single CBOR byte string carried by a
+// cardano-cli key envelope. An envelope holds exactly one CBOR value, so any
+// bytes left after it are rejected rather than ignored: a decoder that stops at
+// the first value would otherwise accept a file whose visible key is followed
+// by a second, unread payload.
+func decodeKeyEnvelopeBytes(cborData []byte, what string) ([]byte, error) {
+	var keyBytes []byte
+	read, err := cbor.Decode(cborData, &keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal %s CBOR: %w", what, err)
+	}
+	if read != len(cborData) {
+		return nil, fmt.Errorf(
+			"invalid %s: %d trailing byte(s) after CBOR value",
+			what,
+			len(cborData)-read,
+		)
+	}
+	return keyBytes, nil
+}
+
 func decodeNonExtendedCborKey(skeyBytes []byte) ([]byte, []byte, error) {
 	// cardano-cli format: CBOR-encoded raw 32-byte seed
-	var keyBytes []byte
-	if _, err := cbor.Decode(skeyBytes, &keyBytes); err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal skey CBOR: %w", err)
+	keyBytes, err := decodeKeyEnvelopeBytes(skeyBytes, "skey")
+	if err != nil {
+		return nil, nil, err
 	}
 	if len(keyBytes) != 32 {
 		return nil, nil, errors.New("invalid skey bytes: expected 32 bytes")
@@ -2349,32 +2366,35 @@ func decodeNonExtendedCborKey(skeyBytes []byte) ([]byte, []byte, error) {
 func decodeExtendedCborKey(skeyBytes []byte) ([]byte, []byte, error) {
 	// cardano-cli format: CBOR-encoded 128-byte blob
 	// privKey (64) || pubKey (32) || chainCode (32)
-	var keyBytes []byte
-	if _, err := cbor.Decode(skeyBytes, &keyBytes); err != nil {
-		return nil, nil, fmt.Errorf(
-			"failed to unmarshal extended skey CBOR: %w",
-			err,
-		)
+	keyBytes, err := decodeKeyEnvelopeBytes(skeyBytes, "extended skey")
+	if err != nil {
+		return nil, nil, err
 	}
 	if len(keyBytes) != 128 {
 		return nil, nil, errors.New("invalid extended skey: expected 128 bytes")
 	}
-	// Extract components: privKey (64) | pubKey (32) | chainCode (32)
-	// Important: make copies to avoid slice aliasing issues with append
-	pubBytes := make([]byte, 32)
-	copy(pubBytes, keyBytes[64:96])
 	// Create XPrv: privKey (64) || chainCode (32)
 	xprv := make([]byte, 96)
 	copy(xprv[0:64], keyBytes[0:64])
 	copy(xprv[64:96], keyBytes[96:128])
-	return xprv, pubBytes, nil
+	// The embedded public key is just another field of an untrusted file, so it
+	// is not the key's identity until it has been checked. Derive the identity
+	// from the private half and accept the envelope only when the two agree, so
+	// a caller can never sign with one key while presenting another.
+	derived := bip32.XPrv(xprv).PublicKey()
+	if subtle.ConstantTimeCompare(derived, keyBytes[64:96]) != 1 {
+		return nil, nil, errors.New(
+			"invalid extended skey: embedded public key does not match the key derived from the private key",
+		)
+	}
+	return xprv, derived, nil
 }
 
 func decodeVerificationKey(vkeyBytes []byte) ([]byte, error) {
 	// cardano-cli format: CBOR-encoded raw 32-byte public key
-	var keyBytes []byte
-	if _, err := cbor.Decode(vkeyBytes, &keyBytes); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal vkey CBOR: %w", err)
+	keyBytes, err := decodeKeyEnvelopeBytes(vkeyBytes, "vkey")
+	if err != nil {
+		return nil, err
 	}
 	if len(keyBytes) != 32 {
 		return nil, errors.New("invalid vkey bytes: expected 32 bytes")
@@ -2387,9 +2407,9 @@ func decodeVerificationKey(vkeyBytes []byte) ([]byte, error) {
 // - 32 bytes: just the seed (bursa format)
 // - 64 bytes: seed (32) + public key (32) (cardano-cli format)
 func decodeVRFSKey(skeyBytes []byte) ([]byte, []byte, error) {
-	var keyBytes []byte
-	if _, err := cbor.Decode(skeyBytes, &keyBytes); err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal VRF skey CBOR: %w", err)
+	keyBytes, err := decodeKeyEnvelopeBytes(skeyBytes, "VRF skey")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	switch len(keyBytes) {
@@ -2397,14 +2417,31 @@ func decodeVRFSKey(skeyBytes []byte) ([]byte, []byte, error) {
 		// Just the seed - generate public key
 		pubKey, _, err := vrf.KeyGen(keyBytes)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to derive VRF public key: %w", err)
+			return nil, nil, fmt.Errorf(
+				"failed to derive VRF public key: %w",
+				err,
+			)
 		}
 		return keyBytes, pubKey, nil
 	case vrf.SeedSize + vrf.PublicKeySize:
-		// Seed + public key (cardano-cli format)
-		seed := keyBytes[:vrf.SeedSize]
-		pubKey := keyBytes[vrf.SeedSize:]
-		return seed, pubKey, nil
+		// Seed + public key (cardano-cli format). Same rule as the extended
+		// Ed25519 case: the stored public key is checked against one derived
+		// from the seed instead of being taken on trust.
+		seed := make([]byte, vrf.SeedSize)
+		copy(seed, keyBytes[:vrf.SeedSize])
+		derived, _, err := vrf.KeyGen(seed)
+		if err != nil {
+			return nil, nil, fmt.Errorf(
+				"failed to derive VRF public key: %w",
+				err,
+			)
+		}
+		if subtle.ConstantTimeCompare(derived, keyBytes[vrf.SeedSize:]) != 1 {
+			return nil, nil, errors.New(
+				"invalid VRF skey: embedded public key does not match the key derived from the seed",
+			)
+		}
+		return seed, derived, nil
 	default:
 		return nil, nil, fmt.Errorf(
 			"invalid VRF skey bytes: expected %d or %d, got %d",
@@ -2418,9 +2455,9 @@ func decodeVRFSKey(skeyBytes []byte) ([]byte, []byte, error) {
 // decodeKESSKey decodes a KES signing key from CBOR.
 // KES signing keys for depth 6 (Cardano) are 608 bytes.
 func decodeKESSKey(skeyBytes []byte) ([]byte, []byte, error) {
-	var keyBytes []byte
-	if _, err := cbor.Decode(skeyBytes, &keyBytes); err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal KES skey CBOR: %w", err)
+	keyBytes, err := decodeKeyEnvelopeBytes(skeyBytes, "KES skey")
+	if err != nil {
+		return nil, nil, err
 	}
 	if len(keyBytes) != kes.CardanoKesSecretKeySize {
 		return nil, nil, fmt.Errorf(
@@ -2587,13 +2624,21 @@ const maxSecretKeyFileSize = 1 << 20
 func ReadSecretKeyFile(path string) ([]byte, error) {
 	file, err := openSecretKeyFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open secret key file %q: %w", path, err)
+		return nil, fmt.Errorf(
+			"failed to open secret key file %q: %w",
+			path,
+			err,
+		)
 	}
 	defer file.Close() //nolint:errcheck // read-only handle
 
 	info, err := file.Stat()
 	if err != nil {
-		return nil, fmt.Errorf("failed to stat secret key file %q: %w", path, err)
+		return nil, fmt.Errorf(
+			"failed to stat secret key file %q: %w",
+			path,
+			err,
+		)
 	}
 	if !info.Mode().IsRegular() {
 		return nil, fmt.Errorf(
@@ -2606,7 +2651,11 @@ func ReadSecretKeyFile(path string) ([]byte, error) {
 	}
 	data, err := io.ReadAll(io.LimitReader(file, maxSecretKeyFileSize+1))
 	if err != nil {
-		return nil, fmt.Errorf("failed to read secret key file %q: %w", path, err)
+		return nil, fmt.Errorf(
+			"failed to read secret key file %q: %w",
+			path,
+			err,
+		)
 	}
 	if len(data) > maxSecretKeyFileSize {
 		return nil, fmt.Errorf(
@@ -2715,10 +2764,17 @@ func LoadSecretKeyFromFile(path string) (*LoadedKey, error) {
 	}
 	key, err := LoadKeyFromBytes(data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse secret key file %q: %w", path, err)
+		return nil, fmt.Errorf(
+			"failed to parse secret key file %q: %w",
+			path,
+			err,
+		)
 	}
 	if len(key.SKey) == 0 {
-		return nil, fmt.Errorf("key file %q does not contain a secret key", path)
+		return nil, fmt.Errorf(
+			"key file %q does not contain a secret key",
+			path,
+		)
 	}
 	key.File = filepath.Base(path)
 	return key, nil

--- a/key_envelope_test.go
+++ b/key_envelope_test.go
@@ -1,0 +1,282 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bursa
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const envelopeTestMnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+// envelopeCorpus is one valid envelope of every type parseKeyEnvelope accepts,
+// keyed by the envelope type string that will be written into the JSON file.
+type envelopeCase struct {
+	name    string
+	keyType string
+	cborHex string
+}
+
+// buildEnvelopeCorpus derives a real key of every supported envelope shape from
+// a fixed mnemonic, so the negative vectors below mutate genuine material
+// rather than hand-written bytes that could fail for an unrelated reason.
+func buildEnvelopeCorpus(t *testing.T) []envelopeCase {
+	t.Helper()
+
+	rootKey, err := GetRootKeyFromMnemonic(envelopeTestMnemonic, "")
+	require.NoError(t, err)
+	accountKey, err := GetAccountKey(rootKey, 0)
+	require.NoError(t, err)
+	paymentKey, err := GetPaymentKey(accountKey, 0)
+	require.NoError(t, err)
+
+	paymentVKey, err := GetPaymentVKey(paymentKey)
+	require.NoError(t, err)
+	paymentSKey, err := GetPaymentSKey(paymentKey)
+	require.NoError(t, err)
+	paymentExtSKey, err := GetPaymentExtendedSKey(paymentKey)
+	require.NoError(t, err)
+
+	vrfSeed, err := GetVRFSeed(rootKey, 0)
+	require.NoError(t, err)
+	vrfPub, vrfSec, err := GetVRFKeyPair(vrfSeed)
+	require.NoError(t, err)
+	vrfVKey, err := GetVRFVKey(vrfPub)
+	require.NoError(t, err)
+	vrfSKey, err := GetVRFSKey(vrfSec)
+	require.NoError(t, err)
+
+	kesSeed, err := GetKESSeed(rootKey, 0)
+	require.NoError(t, err)
+	kesSec, kesPub, err := GetKESKeyPair(kesSeed)
+	require.NoError(t, err)
+	kesVKey, err := GetKESVKey(kesPub)
+	require.NoError(t, err)
+	kesSKey, err := GetKESSKey(kesSec)
+	require.NoError(t, err)
+
+	opCert, err := CreateOperationalCertificate(
+		kesPub,
+		1,
+		0,
+		paymentSKeySeed(t, paymentSKey),
+	)
+	require.NoError(t, err)
+	opCertCbor, err := cbor.Encode(
+		[]any{
+			[]any{
+				opCert.KesVkey,
+				opCert.IssueNumber,
+				opCert.KesPeriod,
+				opCert.ColdSignature,
+			},
+			opCert.ColdVkey,
+		},
+	)
+	require.NoError(t, err)
+
+	return []envelopeCase{
+		{
+			"ed25519 vkey",
+			"PaymentVerificationKeyShelley_ed25519",
+			paymentVKey.CborHex,
+		},
+		{
+			"ed25519 skey",
+			"PaymentSigningKeyShelley_ed25519",
+			paymentSKey.CborHex,
+		},
+		{
+			"extended skey",
+			"PaymentExtendedSigningKeyShelley_ed25519_bip32",
+			paymentExtSKey.CborHex,
+		},
+		{"VRF vkey", "VRFVerificationKey_PraosVRF", vrfVKey.CborHex},
+		{"VRF skey", "VRFSigningKey_PraosVRF", vrfSKey.CborHex},
+		{"KES vkey", "KESVerificationKey_PraosV2", kesVKey.CborHex},
+		{"KES skey", "KESSigningKey_PraosV2", kesSKey.CborHex},
+		{
+			"operational certificate",
+			"NodeOperationalCertificate",
+			hex.EncodeToString(opCertCbor),
+		},
+	}
+}
+
+// paymentSKeySeed pulls the raw 32-byte seed back out of a non-extended signing
+// key envelope, which is the form CreateOperationalCertificate expects.
+func paymentSKeySeed(t *testing.T, skey KeyFile) []byte {
+	t.Helper()
+	raw, err := hex.DecodeString(skey.CborHex)
+	require.NoError(t, err)
+	var seed []byte
+	_, err = cbor.Decode(raw, &seed)
+	require.NoError(t, err)
+	require.Len(t, seed, 32)
+	return seed
+}
+
+func envelopeJSON(t *testing.T, keyType, cborHex string) []byte {
+	t.Helper()
+	data, err := json.Marshal(KeyFile{
+		Type:        keyType,
+		Description: "test envelope",
+		CborHex:     cborHex,
+	})
+	require.NoError(t, err)
+	return data
+}
+
+// TestKeyEnvelopeAcceptsValidVectors is the positive control for the two
+// negative tests below: every corpus entry must still load cleanly, so a
+// rejection there is attributable to the mutation and not to the corpus.
+func TestKeyEnvelopeAcceptsValidVectors(t *testing.T) {
+	for _, tc := range buildEnvelopeCorpus(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			loaded, err := LoadKeyFromBytes(
+				envelopeJSON(t, tc.keyType, tc.cborHex),
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tc.keyType, loaded.Type)
+			assert.NotEmpty(t, loaded.VKey)
+		})
+	}
+}
+
+// TestKeyEnvelopeRejectsTrailingData covers the first acceptance criterion: a
+// decoder that stops at the first CBOR value would silently accept a file
+// carrying a second, unread payload after the key.
+func TestKeyEnvelopeRejectsTrailingData(t *testing.T) {
+	for _, tc := range buildEnvelopeCorpus(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			// A single 0x00 (CBOR unsigned 0) appended after the encoded value.
+			polluted := tc.cborHex + "00"
+			_, err := LoadKeyFromBytes(envelopeJSON(t, tc.keyType, polluted))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "trailing byte")
+		})
+	}
+}
+
+// TestExtendedEnvelopeRejectsMismatchedPublicKey covers the second acceptance
+// criterion for every extended Ed25519 envelope type: the embedded public key
+// is not the key's identity until it has been checked against one derived from
+// the private half.
+func TestExtendedEnvelopeRejectsMismatchedPublicKey(t *testing.T) {
+	rootKey, err := GetRootKeyFromMnemonic(envelopeTestMnemonic, "")
+	require.NoError(t, err)
+	accountKey, err := GetAccountKey(rootKey, 0)
+	require.NoError(t, err)
+	paymentKey, err := GetPaymentKey(accountKey, 0)
+	require.NoError(t, err)
+	extSKey, err := GetPaymentExtendedSKey(paymentKey)
+	require.NoError(t, err)
+
+	raw, err := hex.DecodeString(extSKey.CborHex)
+	require.NoError(t, err)
+	var keyBytes []byte
+	_, err = cbor.Decode(raw, &keyBytes)
+	require.NoError(t, err)
+	require.Len(t, keyBytes, 128)
+
+	// Flip one bit of the embedded public key, leaving the private half and the
+	// chain code intact.
+	tampered := make([]byte, len(keyBytes))
+	copy(tampered, keyBytes)
+	tampered[64] ^= 0x01
+	tamperedCbor, err := cbor.Encode(tampered)
+	require.NoError(t, err)
+	tamperedHex := hex.EncodeToString(tamperedCbor)
+
+	extendedTypes := []string{
+		"PaymentExtendedSigningKeyShelley_ed25519_bip32",
+		"StakeExtendedSigningKeyShelley_ed25519_bip32",
+		"DRepExtendedSigningKeyShelley_ed25519_bip32",
+		"CommitteeColdExtendedSigningKeyShelley_ed25519_bip32",
+		"CommitteeHotExtendedSigningKeyShelley_ed25519_bip32",
+		"StakePoolExtendedSigningKeyShelley_ed25519_bip32",
+		"PolicyExtendedSigningKeyShelley_ed25519_bip32",
+	}
+	for _, keyType := range extendedTypes {
+		t.Run(keyType, func(t *testing.T) {
+			_, err := LoadKeyFromBytes(envelopeJSON(t, keyType, tamperedHex))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "does not match")
+		})
+	}
+}
+
+// TestExtendedEnvelopeReturnsDerivedIdentity covers the third acceptance
+// criterion: the identity handed back is the derived one, not the bytes the
+// file happened to carry.
+func TestExtendedEnvelopeReturnsDerivedIdentity(t *testing.T) {
+	rootKey, err := GetRootKeyFromMnemonic(envelopeTestMnemonic, "")
+	require.NoError(t, err)
+	accountKey, err := GetAccountKey(rootKey, 0)
+	require.NoError(t, err)
+	paymentKey, err := GetPaymentKey(accountKey, 0)
+	require.NoError(t, err)
+	extSKey, err := GetPaymentExtendedSKey(paymentKey)
+	require.NoError(t, err)
+
+	loaded, err := LoadKeyFromBytes(
+		envelopeJSON(
+			t,
+			"PaymentExtendedSigningKeyShelley_ed25519_bip32",
+			extSKey.CborHex,
+		),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(paymentKey.Public().PublicKey()), loaded.VKey)
+}
+
+// TestVRFEnvelopeRejectsMismatchedPublicKey covers the cardano-cli VRF signing
+// key form, which is the other envelope that carries a public key alongside the
+// private material.
+func TestVRFEnvelopeRejectsMismatchedPublicKey(t *testing.T) {
+	rootKey, err := GetRootKeyFromMnemonic(envelopeTestMnemonic, "")
+	require.NoError(t, err)
+	seed, err := GetVRFSeed(rootKey, 0)
+	require.NoError(t, err)
+	pub, sec, err := GetVRFKeyPair(seed)
+	require.NoError(t, err)
+
+	// cardano-cli stores seed (32) || public key (32).
+	combined := make([]byte, 0, len(sec)+len(pub))
+	combined = append(combined, sec...)
+	combined = append(combined, pub...)
+
+	valid, err := cbor.Encode(combined)
+	require.NoError(t, err)
+	loaded, err := LoadKeyFromBytes(
+		envelopeJSON(t, "VRFSigningKey_PraosVRF", hex.EncodeToString(valid)),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, pub, loaded.VKey)
+
+	combined[len(sec)] ^= 0x01
+	tampered, err := cbor.Encode(combined)
+	require.NoError(t, err)
+	_, err = LoadKeyFromBytes(
+		envelopeJSON(t, "VRFSigningKey_PraosVRF", hex.EncodeToString(tampered)),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match")
+}

--- a/opcert.go
+++ b/opcert.go
@@ -47,8 +47,15 @@ type DecodedOpCert struct {
 // parser for opcerts across the module (both key loading and the KES agent).
 func DecodeOpCert(certBytes []byte) (*DecodedOpCert, error) {
 	var outer []any
-	if _, err := cbor.Decode(certBytes, &outer); err != nil {
+	read, err := cbor.Decode(certBytes, &outer)
+	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal OpCert CBOR: %w", err)
+	}
+	if read != len(certBytes) {
+		return nil, fmt.Errorf(
+			"invalid OpCert: %d trailing byte(s) after CBOR value",
+			len(certBytes)-read,
+		)
 	}
 	if len(outer) != 2 {
 		return nil, fmt.Errorf(


### PR DESCRIPTION
Closes #811

Key envelope decoders stopped at the first CBOR value, so a file carrying a second payload after the key decoded without error. All eight envelope types accepted trailing data.

- `decodeKeyEnvelopeBytes` rejects any input whose decoded length falls short of the envelope bytes; applied to the ed25519 vkey/skey, extended skey, VRF vkey/skey and KES vkey/skey decoders, `KeyFile.String()`, `GetRewardAddress`, and `DecodeOpCert`.
- Extended Ed25519 and cardano-cli VRF signing envelopes carry a public key next to the private material. The identity is now derived from the private half, compared in constant time with the embedded value, and the derived key is what gets returned.

Tests: `key_envelope_test.go` adds trailing-data vectors for all eight envelope types and mismatched-public-key vectors for the seven extended types and the VRF form, plus a positive control and a derived-identity assertion.

Reverting the source change fails every new vector; the full suite passes with `-race`, and `golangci-lint run ./...` reports 0 issues.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #811. Key envelope decoders now reject any trailing bytes after the first CBOR value, and extended signing envelopes validate that the embedded public key matches the one derived from the private half (returning the derived key instead of trusting the file). Previously, all eight envelope types silently accepted trailing data, and extended Ed25519 and VRF envelopes trusted an embedded public key that could disagree with the private material.

- Applies strict length checks to all eight envelope decoders plus `DecodeOpCert`, `KeyFile.String()`, and `GetRewardAddress`.
- Derives the identity from the private half for extended Ed25519 and cardano-cli VRF signing envelopes, comparing constant-time against the embedded value.
- Adds trailing-data vectors for all eight envelope types and mismatched-public-key vectors for the extended and VRF forms.

<sup>Written for commit 5c58a9ff0ca0884232b495a44cc18d5f381c5af0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when loading key files and certificates.
  * Invalid files with trailing data are now rejected.
  * Extended and VRF keys are checked to ensure embedded public keys match the derived keys.
  * Valid extended key files now consistently return the derived public key identity.

* **Tests**
  * Added coverage for valid key files and malformed or inconsistent key data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->