### PR TITLE
fix(ci): compose release manifests only from published architecture tags

### DIFF
--- a/.github/scripts/publish-image-manifests.sh
+++ b/.github/scripts/publish-image-manifests.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Compose the multi-architecture image manifests for a publish run.
+#
+# The build matrix publishes one image per architecture, tagged with the
+# versioned tag plus an `-amd64` / `-arm64` suffix. It deliberately publishes no
+# floating tag: a floating tag pushed from each architecture job would race, and
+# the winner would be a single-architecture image.
+#
+# This script therefore does two distinct things, in order:
+#
+#   1. Compose every versioned tag from the architecture tags the matrix
+#      actually published.
+#   2. Point each floating alias (`:latest`) at the versioned manifest composed
+#      in step 1, so an alias never exists before the manifest it names.
+#
+# Inputs:
+#   IMAGE_TAGS      newline-separated tag list from docker/metadata-action
+#   PRIMARY_VERSION metadata-action's `version` output, i.e. the versioned tag
+#                   that floating aliases resolve to
+#   GITHUB_OUTPUT   step output file
+set -euo pipefail
+
+: "${IMAGE_TAGS:?IMAGE_TAGS is required}"
+: "${PRIMARY_VERSION:?PRIMARY_VERSION is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+declare -A seen=()
+declare -a versioned=()
+declare -a floating=()
+dockerhub_tag=""
+ghcr_tag=""
+
+while IFS= read -r tag; do
+  tag="${tag%$'\r'}"
+  [[ -z "$tag" ]] && continue
+  [[ -n "${seen[$tag]+set}" ]] && continue
+  seen["$tag"]=1
+
+  # Split on the final colon so a registry host:port stays with the image.
+  image="${tag%:*}"
+  version="${tag##*:}"
+
+  if [[ "$version" == latest ]]; then
+    floating+=("$image")
+    continue
+  fi
+
+  versioned+=("$tag")
+  # Attestations must name the versioned manifest, so record the first
+  # versioned tag seen for each registry.
+  if [[ "$tag" == ghcr.io/* ]]; then
+    [[ -z "$ghcr_tag" ]] && ghcr_tag="$tag"
+  else
+    [[ -z "$dockerhub_tag" ]] && dockerhub_tag="$tag"
+  fi
+done <<< "$IMAGE_TAGS"
+
+if [[ ${#versioned[@]} -eq 0 ]]; then
+  echo "no versioned image manifest tags were planned" >&2
+  exit 1
+fi
+if [[ -z "$dockerhub_tag" || -z "$ghcr_tag" ]]; then
+  echo "expected a versioned tag for both Docker Hub and GHCR" >&2
+  echo "planned: ${versioned[*]}" >&2
+  exit 1
+fi
+
+# Step 1: versioned manifests, composed from the published architecture tags.
+#
+# Use `docker buildx imagetools create`, not `docker manifest create`: buildx
+# pushes each per-architecture tag as an OCI image index (image + provenance
+# attestation), and `docker manifest create` refuses to nest one, failing with
+# "<tag>-amd64 is a manifest list". imagetools composes the per-architecture
+# indexes into a single multi-architecture index and pushes it in one step.
+for tag in "${versioned[@]}"; do
+  docker buildx imagetools create -t "$tag" \
+    "${tag}-amd64" \
+    "${tag}-arm64"
+done
+
+# Step 2: floating aliases, resolved from the versioned manifest just composed.
+for image in "${floating[@]}"; do
+  source_tag="${image}:${PRIMARY_VERSION}"
+  found=""
+  for tag in "${versioned[@]}"; do
+    [[ "$tag" == "$source_tag" ]] && found=1 && break
+  done
+  if [[ -z "$found" ]]; then
+    echo "cannot alias ${image}:latest: no versioned manifest ${source_tag}" >&2
+    exit 1
+  fi
+  docker buildx imagetools create -t "${image}:latest" "$source_tag"
+done
+
+dockerhub_digest="$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$dockerhub_tag")"
+ghcr_digest="$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$ghcr_tag")"
+printf 'dockerhub-digest=%s\n' "$dockerhub_digest" >> "$GITHUB_OUTPUT"
+printf 'ghcr-digest=%s\n' "$ghcr_digest" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/test-image-manifests.sh
+++ b/.github/scripts/test-image-manifests.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#
+# Deterministic contract test for publish-image-manifests.sh.
+#
+# A release run cannot be rehearsed, so this test replaces `docker` with a stub
+# that records its argv and asserts the exact source and destination tags the
+# script would use, in order. The regression it guards is a manifest composed
+# from an architecture tag the build matrix never published.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+publisher="$script_dir/publish-image-manifests.sh"
+ci_workflow="$script_dir/../workflows/ci-docker.yml"
+publish_workflow="$script_dir/../workflows/publish.yml"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+failures=0
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  failures=$((failures + 1))
+}
+
+assert_equals() {
+  local expected="$1" actual="$2" description="$3"
+  if [[ "$actual" != "$expected" ]]; then
+    fail "$description"
+    printf 'expected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" description="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    fail "$description"
+    printf 'missing: %s\n' "$needle" >&2
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" description="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    fail "$description"
+    printf 'unexpected: %s\nactual:\n%s\n' "$needle" "$haystack" >&2
+  fi
+}
+
+# Stub docker: log argv, and answer `inspect` with a stable per-tag digest so
+# the recorded outputs are reproducible.
+mkdir "$tmpdir/bin"
+cat > "$tmpdir/bin/docker" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s|' "$@" >> "$DOCKER_LOG"
+printf '\n' >> "$DOCKER_LOG"
+if [[ "${1:-}" == buildx && "${2:-}" == imagetools && "${3:-}" == inspect ]]; then
+  printf 'sha256:digest-of-%s\n' "${!#}"
+fi
+STUB
+chmod +x "$tmpdir/bin/docker"
+
+run_publisher() {
+  local name="$1" tags="$2" version="$3"
+  DOCKER_LOG="$tmpdir/$name.log"
+  : > "$DOCKER_LOG"
+  : > "$tmpdir/$name.out"
+  PATH="$tmpdir/bin:$PATH" DOCKER_LOG="$DOCKER_LOG" \
+    GITHUB_OUTPUT="$tmpdir/$name.out" \
+    IMAGE_TAGS="$tags" PRIMARY_VERSION="$version" \
+    bash "$publisher"
+}
+
+expect_failure() {
+  local name="$1" tags="$2" version="$3" description="$4"
+  if run_publisher "$name" "$tags" "$version" 2>"$tmpdir/$name.err"; then
+    fail "$description (expected a non-zero exit)"
+  fi
+}
+
+# --- Release run: versioned tags plus a floating latest alias ---------------
+release_tags=$(printf '%s\n' \
+  'blinklabs/bursa:0.17.0' \
+  'blinklabs/bursa:latest' \
+  'ghcr.io/blinklabs-io/bursa:0.17.0' \
+  'ghcr.io/blinklabs-io/bursa:latest')
+run_publisher release "$release_tags" '0.17.0'
+
+release_expected=$(printf '%s\n' \
+  'buildx|imagetools|create|-t|blinklabs/bursa:0.17.0|blinklabs/bursa:0.17.0-amd64|blinklabs/bursa:0.17.0-arm64|' \
+  'buildx|imagetools|create|-t|ghcr.io/blinklabs-io/bursa:0.17.0|ghcr.io/blinklabs-io/bursa:0.17.0-amd64|ghcr.io/blinklabs-io/bursa:0.17.0-arm64|' \
+  'buildx|imagetools|create|-t|blinklabs/bursa:latest|blinklabs/bursa:0.17.0|' \
+  'buildx|imagetools|create|-t|ghcr.io/blinklabs-io/bursa:latest|ghcr.io/blinklabs-io/bursa:0.17.0|' \
+  'buildx|imagetools|inspect|--format|{{.Manifest.Digest}}|blinklabs/bursa:0.17.0|' \
+  'buildx|imagetools|inspect|--format|{{.Manifest.Digest}}|ghcr.io/blinklabs-io/bursa:0.17.0|')
+release_log="$(<"$tmpdir/release.log")"
+assert_equals "$release_expected" "$release_log" \
+  'release run composes versioned manifests first, then floating aliases'
+
+# The exact failure from the v0.17.0 run: a floating architecture tag the build
+# matrix never published being used as a manifest input.
+assert_not_contains "$release_log" 'latest-amd64' \
+  'release run never reads a latest-amd64 input'
+assert_not_contains "$release_log" 'latest-arm64' \
+  'release run never reads a latest-arm64 input'
+
+# Attestation digests must name the versioned manifests, not the aliases.
+release_output=$(printf '%s\n' \
+  'dockerhub-digest=sha256:digest-of-blinklabs/bursa:0.17.0' \
+  'ghcr-digest=sha256:digest-of-ghcr.io/blinklabs-io/bursa:0.17.0')
+assert_equals "$release_output" "$(<"$tmpdir/release.out")" \
+  'release digests are bound to the versioned manifests'
+
+# --- Prerelease run: versioned tags, no floating alias ----------------------
+prerelease_tags=$(printf '%s\n' \
+  'blinklabs/bursa:0.18.0-rc1' \
+  'ghcr.io/blinklabs-io/bursa:0.18.0-rc1')
+run_publisher prerelease "$prerelease_tags" '0.18.0-rc1'
+prerelease_expected=$(printf '%s\n' \
+  'buildx|imagetools|create|-t|blinklabs/bursa:0.18.0-rc1|blinklabs/bursa:0.18.0-rc1-amd64|blinklabs/bursa:0.18.0-rc1-arm64|' \
+  'buildx|imagetools|create|-t|ghcr.io/blinklabs-io/bursa:0.18.0-rc1|ghcr.io/blinklabs-io/bursa:0.18.0-rc1-amd64|ghcr.io/blinklabs-io/bursa:0.18.0-rc1-arm64|' \
+  'buildx|imagetools|inspect|--format|{{.Manifest.Digest}}|blinklabs/bursa:0.18.0-rc1|' \
+  'buildx|imagetools|inspect|--format|{{.Manifest.Digest}}|ghcr.io/blinklabs-io/bursa:0.18.0-rc1|')
+assert_equals "$prerelease_expected" "$(<"$tmpdir/prerelease.log")" \
+  'a prerelease composes its versioned manifests and adds no alias'
+
+# --- Branch run: a single versioned tag per registry, no alias --------------
+branch_tags=$(printf '%s\n' \
+  'blinklabs/bursa:main' \
+  'ghcr.io/blinklabs-io/bursa:main')
+run_publisher branch "$branch_tags" 'main'
+branch_expected=$(printf '%s\n' \
+  'buildx|imagetools|create|-t|blinklabs/bursa:main|blinklabs/bursa:main-amd64|blinklabs/bursa:main-arm64|' \
+  'buildx|imagetools|create|-t|ghcr.io/blinklabs-io/bursa:main|ghcr.io/blinklabs-io/bursa:main-amd64|ghcr.io/blinklabs-io/bursa:main-arm64|' \
+  'buildx|imagetools|inspect|--format|{{.Manifest.Digest}}|blinklabs/bursa:main|' \
+  'buildx|imagetools|inspect|--format|{{.Manifest.Digest}}|ghcr.io/blinklabs-io/bursa:main|')
+assert_equals "$branch_expected" "$(<"$tmpdir/branch.log")" \
+  'a branch run composes only its branch manifests'
+
+# --- Guard rails ------------------------------------------------------------
+expect_failure alias_without_version \
+  "$(printf '%s\n' 'blinklabs/bursa:latest' 'ghcr.io/blinklabs-io/bursa:latest')" \
+  '0.17.0' \
+  'a tag list of aliases alone is rejected'
+expect_failure single_registry \
+  'blinklabs/bursa:0.17.0' \
+  '0.17.0' \
+  'a tag list missing a registry is rejected'
+
+# --- Workflow wiring --------------------------------------------------------
+# The script only protects the release if the workflows actually call it, and
+# the test only protects the script if CI actually runs it.
+publish_contents="$(<"$publish_workflow")"
+assert_contains "$publish_contents" 'bash .github/scripts/publish-image-manifests.sh' \
+  'the publish workflow composes manifests through this script'
+# shellcheck disable=SC2016 # literal workflow text, not a shell expansion
+assert_contains "$publish_contents" 'IMAGE_TAGS: ${{ steps.meta.outputs.tags }}' \
+  'the publish workflow passes the metadata tag list to the script'
+# shellcheck disable=SC2016 # literal workflow text, not a shell expansion
+assert_contains "$publish_contents" 'PRIMARY_VERSION: ${{ steps.meta.outputs.version }}' \
+  'the publish workflow passes the primary version to the script'
+assert_contains "$publish_contents" 'latest=false' \
+  'the per-architecture build publishes no floating tag of its own'
+
+ci_contents="$(<"$ci_workflow")"
+assert_contains "$ci_contents" 'bash .github/scripts/test-image-manifests.sh' \
+  'Docker CI runs this contract test'
+assert_contains "$ci_contents" '.github/scripts/**' \
+  'Docker CI triggers when the manifest script changes'
+assert_contains "$ci_contents" '.github/workflows/publish.yml' \
+  'Docker CI triggers when the manifest wiring changes'
+
+if [[ "$failures" -ne 0 ]]; then
+  printf '\n%d image manifest assertion(s) failed\n' "$failures" >&2
+  exit 1
+fi
+echo "image manifest publish tests passed"

--- a/.github/scripts/test-image-manifests.sh
+++ b/.github/scripts/test-image-manifests.sh
@@ -161,6 +161,12 @@ assert_contains "$publish_contents" 'PRIMARY_VERSION: ${{ steps.meta.outputs.ver
   'the publish workflow passes the primary version to the script'
 assert_contains "$publish_contents" 'latest=false' \
   'the per-architecture build publishes no floating tag of its own'
+# The script composes "<tag>-amd64"/"<tag>-arm64"; if the matrix stopped
+# suffixing its tags those inputs would not exist, and this test would still
+# pass while the release failed. Assert the other half of the wiring too.
+# shellcheck disable=SC2016 # literal workflow text, not a shell expansion
+assert_contains "$publish_contents" 'suffix=-${{ matrix.arch }}' \
+  'the per-architecture build suffixes its tags with the architecture'
 
 ci_contents="$(<"$ci_workflow")"
 assert_contains "$ci_contents" 'bash .github/scripts/test-image-manifests.sh' \

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -3,7 +3,7 @@ name: Docker CI
 on:
   pull_request:
     branches: ['main']
-    paths: ['Dockerfile','*.go','cmd/**','internal/**','go.*','.github/workflows/ci-docker.yml']
+    paths: ['Dockerfile','*.go','cmd/**','internal/**','go.*','.github/scripts/**','.github/workflows/ci-docker.yml','.github/workflows/publish.yml']
 
 env:
   GHCR_IMAGE_NAME: ghcr.io/blinklabs-io/bursa
@@ -12,6 +12,15 @@ permissions:
   contents: read
 
 jobs:
+  # The release manifest composition cannot be rehearsed on a pull request, so
+  # its source and destination tags are checked against a docker stub instead.
+  image-manifest-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+      - name: test image manifest composition
+        run: bash .github/scripts/test-image-manifests.sh
+
   docker:
     strategy:
       fail-fast: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -695,6 +695,11 @@ jobs:
             blinklabs/bursa
             ghcr.io/${{ github.repository }}
           flavor: |
+            # The matrix publishes one image per architecture. A floating tag
+            # here would be pushed by both jobs and race, leaving `latest`
+            # pointing at whichever architecture finished last; the manifest
+            # job creates it from the composed manifest instead.
+            latest=false
             suffix=-${{ matrix.arch }}
           tags: |
             # Only version, no revision
@@ -744,6 +749,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
       - id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0 https://github.com/docker/metadata-action/releases/tag/v6.2.0
         with:
@@ -762,22 +768,10 @@ jobs:
       - name: Create and push image manifests
         id: manifest
         shell: bash
-        run: |
-          # Use `docker buildx imagetools create` (not `docker manifest create`):
-          # buildx pushes each per-arch tag as an OCI image index (image +
-          # provenance attestation), so `docker manifest create` rejects nesting
-          # it and fails with "<tag>-amd64 is a manifest list". imagetools
-          # composes the per-arch indexes into one multi-arch index and pushes
-          # it in a single step.
-          while IFS= read -r tag; do
-            docker buildx imagetools create -t "${tag}" \
-              "${tag}-amd64" \
-              "${tag}-arm64"
-          done <<< "${{ steps.meta.outputs.tags }}"
-          dockerhub_tag=$(echo "${{ steps.meta.outputs.tags }}" | grep -v '^ghcr' | head -1)
-          ghcr_tag=$(echo "${{ steps.meta.outputs.tags }}" | grep '^ghcr' | head -1)
-          echo "dockerhub-digest=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' ${dockerhub_tag})" >> $GITHUB_OUTPUT
-          echo "ghcr-digest=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' ${ghcr_tag})" >> $GITHUB_OUTPUT
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+          PRIMARY_VERSION: ${{ steps.meta.outputs.version }}
+        run: bash .github/scripts/publish-image-manifests.sh
       - name: Attest Docker Hub manifest
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2 https://github.com/actions/attest/releases/tag/v4.2.2
         with:
@@ -790,7 +784,6 @@ jobs:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.manifest.outputs.ghcr-digest }}
           push-to-registry: true
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
       # Update Docker Hub from README
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0 https://github.com/peter-evans/dockerhub-description/releases/tag/v5.0.0


### PR DESCRIPTION
Closes #824

The per-architecture build applied its arch suffix to the versioned tags but not to the floating one (metadata-action does not suffix `latest` unless `onlatest=true`). Both matrix jobs therefore pushed a bare `latest`, racing each other, and neither published `latest-amd64` or `latest-arm64`. The manifest job then iterated every metadata tag and composed each from those suffixes, so the release created the versioned Docker Hub manifest and failed on the missing `latest-arm64` before reaching the GHCR versioned manifest.

- `build-images` sets `latest=false`, so the matrix publishes only versioned architecture tags.
- `.github/scripts/publish-image-manifests.sh` composes every versioned tag from its `-amd64`/`-arm64` inputs first, then points each floating alias at the versioned manifest that now exists. Attestation digests stay bound to the versioned tags.
- The versioned/floating split is structural (tag `latest` vs anything else) rather than a version-shape regex, so a prerelease tag such as `0.18.0-rc1` still gets its manifest.

Tests: `.github/scripts/test-image-manifests.sh` runs the script against a docker stub and asserts the exact source and destination tags and their order for release, prerelease and branch runs, that `latest-amd64`/`latest-arm64` are never read, that digests name the versioned manifests, and that the workflows are wired to the script. Docker CI runs it.

Restoring the old inline loop fails four of its assertions, including the two naming the exact tags the v0.17.0 run died on. `shellcheck` is clean and `actionlint` reports nothing new.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the v0.17.0 release failure where the manifest job composed manifests from `latest-amd64`/`latest-arm64` tags the build matrix never published.

- The per-architecture build now sets `latest=false`, so the two matrix jobs no longer race to push a bare `latest`.
- `.github/scripts/publish-image-manifests.sh` composes every versioned tag from its `-amd64`/`-arm64` inputs, then points each floating alias at the composed versioned manifest; attestation digests stay bound to versioned tags.
- The versioned/floating split is structural, so prerelease tags like `0.18.0-rc1` still get their manifests.

**Tests**
- The contract test runs the script against a docker stub and asserts the exact source and destination tags for release, prerelease, and branch runs, including that `latest-amd64`/`latest-arm64` are never read.
- It also asserts the workflow wiring, including `latest=false` and the `suffix=-${{ matrix.arch }}` tag suffix, so removing either fails the test.
- Docker CI runs the test and now triggers on changes to `.github/scripts/**` and `publish.yml`.

<sup>Written for commit f110ca84135180df790b0116872a563d186e642e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

