### PR TITLE
feat(release): verify and exercise the signed macOS wallet package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,16 @@ on:
     branches: ['main']
     tags:
       - 'v*.*.*'
+  # A tag is the only trigger that exercises Developer ID signing and
+  # notarization, so a defect there is only ever found during a release. This
+  # input runs that same path on demand: it signs, notarizes and verifies the
+  # .pkg, and uploads it as a workflow artifact without touching a release.
+  workflow_dispatch:
+    inputs:
+      exercise_macos_signing:
+        description: 'Build, sign, notarize and verify the macOS .pkg without cutting a tag'
+        type: boolean
+        default: false
 
 concurrency: ${{ github.ref }}
 
@@ -297,6 +307,9 @@ jobs:
         if: matrix.os == 'darwin'
         env:
           IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/') }}
+          # A tag always signs; a manual run signs when asked to. Everything
+          # else builds the pkg unsigned to keep exercising the packaging path.
+          IS_SIGNED_RUN: ${{ startsWith(github.ref, 'refs/tags/') || inputs.exercise_macos_signing }}
           MATRIX_ARCH: ${{ matrix.arch }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -311,7 +324,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "${IS_RELEASE}" = "true" ] && [ -n "${APPLE_CERTIFICATE}" ]; then
+          if [ "${IS_SIGNED_RUN}" = "true" ] && [ -n "${APPLE_CERTIFICATE}" ]; then
             echo "::group::Import Apple Developer ID certificate(s)"
             echo -n "${APPLE_CERTIFICATE}" | base64 --decode -o apple_app.p12
 
@@ -350,7 +363,12 @@ jobs:
 
             export TEAM_ID="${APPLE_TEAM_ID}"
             export NOTARY_PROFILE="bursa-notary"
-            export VERSION="${RELEASE_TAG#v}"
+            # A manual exercise run has no tag; let build-pkg.sh derive the
+            # version from git describe rather than naming the pkg after an
+            # empty string.
+            if [ "${IS_RELEASE}" = "true" ]; then
+              export VERSION="${RELEASE_TAG#v}"
+            fi
           fi
 
           export ARCH="${MATRIX_ARCH}"
@@ -368,15 +386,31 @@ jobs:
             exit 1
           fi
 
+          # Resolve the built pkg by globbing rather than reconstructing its
+          # name: build-pkg.sh derives the version itself when VERSION is unset,
+          # so a reconstructed path would miss the file on a non-tag run.
+          PKG_PATH=$(find dist -maxdepth 1 -name '*.pkg' | head -n1)
+          if [ -z "${PKG_PATH}" ]; then
+            echo "::error::build-pkg.sh produced no .pkg under dist/"
+            exit 1
+          fi
+          echo "PKG_PATH=${PKG_PATH}" >> "$GITHUB_ENV"
+
           if [ -n "${INSTALLER_IDENTITY:-}" ]; then
-            echo "::group::Verify pkg with spctl (must be accepted + Notarized Developer ID)"
-            PKG_PATH="dist/bursa-wallet-${VERSION}-darwin-${MATRIX_ARCH}.pkg"
-            spctl_out=$(spctl -a -vv --type install "${PKG_PATH}" 2>&1)
-            echo "${spctl_out}"
-            echo "${spctl_out}" | grep -q 'accepted'
-            echo "${spctl_out}" | grep -q 'Notarized Developer ID'
+            echo "::group::Verify pkg signature, notarization and installation"
+            ./packaging/macos/verify-pkg.sh "${PKG_PATH}"
             echo "::endgroup::"
           fi
+
+      # A manual exercise run publishes nothing to a release, so surface the
+      # verified pkg as a workflow artifact for inspection.
+      - name: Upload exercised macOS .pkg
+        if: matrix.os == 'darwin' && github.event_name == 'workflow_dispatch' && inputs.exercise_macos_signing
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 https://github.com/actions/upload-artifact/releases/tag/v7.0.1
+        with:
+          name: bursa-wallet-macos-pkg-${{ matrix.arch }}
+          path: dist/*.pkg
+          if-no-files-found: error
 
       # ---- Windows: build the webview .exe (validates the CGO build) -------
       - name: Build web bundle (Windows)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -416,7 +416,9 @@ jobs:
           # Resolve the built pkg by globbing rather than reconstructing its
           # name: build-pkg.sh derives the version itself when VERSION is unset,
           # so a reconstructed path would miss the file on a non-tag run.
-          PKG_PATH=$(find dist -maxdepth 1 -name '*.pkg' | head -n1)
+          # -print -quit rather than `| head -n1`: under pipefail, head exiting
+          # first kills find with SIGPIPE and the assignment returns 141.
+          PKG_PATH=$(find dist -maxdepth 1 -name '*.pkg' -print -quit || true)
           if [ -z "${PKG_PATH}" ]; then
             echo "::error::build-pkg.sh produced no .pkg under dist/"
             exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,13 +28,14 @@ jobs:
     steps:
       # Every job here depends on this one, so this guard gates the workflow.
       #
-      # A manual run is confined to the default branch, whether or not it signs.
-      # The macOS packaging step carries the Apple credentials in its step
-      # environment on every run and executes build-pkg.sh and the web build
-      # from the checked-out ref, so a dispatch from an arbitrary branch would
-      # let that branch's code read them. Restricting the ref keeps the
-      # credentials reachable only from reviewed code, as they were when a tag
-      # was the sole trigger.
+      # Keeps a maintainer from dispatching this workflow from the wrong ref.
+      #
+      # This is a convenience guard, NOT a security control: a workflow_dispatch
+      # run executes the workflow file from the dispatched ref, so anyone with
+      # write access could push a branch with this step deleted and dispatch
+      # that. Confining the Apple credentials to reviewed code requires a
+      # GitHub Environment with a deployment-branch policy, which GitHub
+      # enforces outside the workflow file.
       #
       # A tag ref is rejected outright: a manual run there would take the
       # tag-only branches all the way through, creating a second draft release
@@ -78,6 +79,9 @@ jobs:
             }
 
   build-binaries:
+    # A manual run exists to exercise the macOS packaging path. This job
+    # publishes or finalises release output, so it stays on the push triggers.
+    if: github.event_name != 'workflow_dispatch'
     strategy:
       matrix:
         include:
@@ -423,13 +427,13 @@ jobs:
             echo "::error::build-pkg.sh produced no .pkg under dist/"
             exit 1
           fi
-          echo "PKG_PATH=${PKG_PATH}" >> "$GITHUB_ENV"
 
           if [ -n "${INSTALLER_IDENTITY:-}" ]; then
             echo "::group::Verify pkg signature, notarization and installation"
             # The runner is ephemeral, so replacing anything already at
             # /Applications/Bursa.app is safe here.
-            BURSA_REPLACE_INSTALLED=1 ./packaging/macos/verify-pkg.sh "${PKG_PATH}"
+            BURSA_REPLACE_INSTALLED=1 BURSA_EXPECTED_ARCH="${MATRIX_ARCH}" \
+              ./packaging/macos/verify-pkg.sh "${PKG_PATH}"
             echo "::endgroup::"
           fi
 
@@ -717,6 +721,9 @@ jobs:
           subject-path: ${{ env.TARBALL_PATH }}
 
   build-images:
+    # A manual run exists to exercise the macOS packaging path. This job
+    # publishes or finalises release output, so it stays on the push triggers.
+    if: github.event_name != 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -790,6 +797,9 @@ jobs:
           push-to-registry: true
 
   build-image-manifest:
+    # A manual run exists to exercise the macOS packaging path. This job
+    # publishes or finalises release output, so it stays on the push triggers.
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: [build-images]
     permissions:
@@ -867,6 +877,9 @@ jobs:
           short-description: "Bursa is a programmatic Cardano wallet and CLI tool"
 
   finalize-release:
+    # A manual run exists to exercise the macOS packaging path. This job
+    # publishes or finalises release output, so it stays on the push triggers.
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,24 +28,29 @@ jobs:
     steps:
       # Every job here depends on this one, so this guard gates the workflow.
       #
-      # A manual run against a tag would take the tag-only branches all the way
-      # through: a second draft release, duplicate asset uploads, and duplicate
-      # attestations. And a signed run hands Developer ID and notarization
-      # credentials to whatever code the chosen ref contains, so it is confined
-      # to the default branch rather than any branch a writer can push.
+      # A manual run is confined to the default branch, whether or not it signs.
+      # The macOS packaging step carries the Apple credentials in its step
+      # environment on every run and executes build-pkg.sh and the web build
+      # from the checked-out ref, so a dispatch from an arbitrary branch would
+      # let that branch's code read them. Restricting the ref keeps the
+      # credentials reachable only from reviewed code, as they were when a tag
+      # was the sole trigger.
+      #
+      # A tag ref is rejected outright: a manual run there would take the
+      # tag-only branches all the way through, creating a second draft release
+      # with duplicate uploads and attestations.
       - name: Validate manual dispatch
         if: github.event_name == 'workflow_dispatch'
         env:
-          EXERCISE_MACOS_SIGNING: ${{ inputs.exercise_macos_signing }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             echo "::error::Do not dispatch this workflow against a tag; push the tag instead. A manual run on a tag would create a second draft release and re-upload its assets."
             exit 1
           fi
-          if [[ "${EXERCISE_MACOS_SIGNING}" == "true" \
-                && "${GITHUB_REF}" != "refs/heads/${{ github.event.repository.default_branch }}" ]]; then
-            echo "::error::exercise_macos_signing is limited to the ${{ github.event.repository.default_branch }} branch: it exposes the Apple signing and notarization credentials to the code on the selected ref."
+          if [[ "${GITHUB_REF}" != "refs/heads/${DEFAULT_BRANCH}" ]]; then
+            echo "::error::This workflow may only be dispatched from ${DEFAULT_BRANCH}. Its macOS job holds the Apple signing and notarization credentials and runs the packaging scripts from the selected ref."
             exit 1
           fi
       - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,28 @@ jobs:
     outputs:
       RELEASE_ID: ${{ steps.create-release.outputs.result }}
     steps:
+      # Every job here depends on this one, so this guard gates the workflow.
+      #
+      # A manual run against a tag would take the tag-only branches all the way
+      # through: a second draft release, duplicate asset uploads, and duplicate
+      # attestations. And a signed run hands Developer ID and notarization
+      # credentials to whatever code the chosen ref contains, so it is confined
+      # to the default branch rather than any branch a writer can push.
+      - name: Validate manual dispatch
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          EXERCISE_MACOS_SIGNING: ${{ inputs.exercise_macos_signing }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "::error::Do not dispatch this workflow against a tag; push the tag instead. A manual run on a tag would create a second draft release and re-upload its assets."
+            exit 1
+          fi
+          if [[ "${EXERCISE_MACOS_SIGNING}" == "true" \
+                && "${GITHUB_REF}" != "refs/heads/${{ github.event.repository.default_branch }}" ]]; then
+            echo "::error::exercise_macos_signing is limited to the ${{ github.event.repository.default_branch }} branch: it exposes the Apple signing and notarization credentials to the code on the selected ref."
+            exit 1
+          fi
       - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 https://github.com/actions/github-script/releases/tag/v9.0.0
         id: create-release
@@ -381,8 +403,8 @@ jobs:
           # tag push, if either is missing, fail loudly instead of uploading +
           # attesting an unsigned installer. Unsigned output stays allowed ONLY
           # for non-tag/dev builds (which merely validate the packaging path).
-          if [ "${IS_RELEASE}" = "true" ] && { [ -z "${SIGNING_IDENTITY:-}" ] || [ -z "${INSTALLER_IDENTITY:-}" ]; }; then
-            echo "::error::Refusing to publish an unsigned macOS .pkg for a release: both APPLE_CERTIFICATE (app signing) and APPLE_INSTALLER_CERTIFICATE (installer signing + notarization) must be set on tag pushes."
+          if [ "${IS_SIGNED_RUN}" = "true" ] && { [ -z "${SIGNING_IDENTITY:-}" ] || [ -z "${INSTALLER_IDENTITY:-}" ]; }; then
+            echo "::error::Refusing to finish a signed macOS run with an unsigned .pkg: both APPLE_CERTIFICATE (app signing) and APPLE_INSTALLER_CERTIFICATE (installer signing + notarization) must be set. A run that is asked to sign and cannot must fail, not fall back to an unsigned installer."
             exit 1
           fi
 
@@ -398,7 +420,9 @@ jobs:
 
           if [ -n "${INSTALLER_IDENTITY:-}" ]; then
             echo "::group::Verify pkg signature, notarization and installation"
-            ./packaging/macos/verify-pkg.sh "${PKG_PATH}"
+            # The runner is ephemeral, so replacing anything already at
+            # /Applications/Bursa.app is safe here.
+            BURSA_REPLACE_INSTALLED=1 ./packaging/macos/verify-pkg.sh "${PKG_PATH}"
             echo "::endgroup::"
           fi
 

--- a/packaging/macos/build-pkg.sh
+++ b/packaging/macos/build-pkg.sh
@@ -80,11 +80,9 @@ NOTARY_PROFILE="${NOTARY_PROFILE:-}"
 APPLE_ID="${APPLE_ID:-}"
 APPLE_APP_PASSWORD="${APPLE_APP_PASSWORD:-}"
 
-# Bundle identity constants.
-BUNDLE_ID="com.blinklabssoftware.bursa"
-APP_NAME="Bursa"
-# The single GUI executable's on-disk name (matches ui/cmd/bursa-wallet output).
-BIN_NAME="bursa-wallet"
+# Bundle identity constants, shared with verify-pkg.sh.
+# shellcheck source=packaging/macos/identity.sh
+. "${SCRIPT_DIR}/identity.sh"
 
 # Output / work locations.
 DIST_DIR="${DIST_DIR:-${REPO_ROOT}/dist}"

--- a/packaging/macos/identity.sh
+++ b/packaging/macos/identity.sh
@@ -1,0 +1,30 @@
+# shellcheck shell=bash
+# Copyright 2026 Blink Labs Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Identity of the macOS artifact, shared by build-pkg.sh and verify-pkg.sh.
+#
+# These must not drift: verify-pkg.sh looks for the bundle build-pkg.sh
+# produces, and a verifier that checks for the wrong name fails open only by
+# luck. Sourced rather than duplicated so a rename lands in both at once.
+#
+# Info.plist and distribution.xml also carry BUNDLE_ID and must be updated with
+# it.
+# shellcheck disable=SC2034 # consumed by the scripts that source this file
+BUNDLE_ID="com.blinklabssoftware.bursa"
+# shellcheck disable=SC2034 # consumed by the scripts that source this file
+APP_NAME="Bursa"
+# The single GUI executable's on-disk name (matches ui/cmd/bursa-wallet output).
+# shellcheck disable=SC2034 # consumed by the scripts that source this file
+BIN_NAME="bursa-wallet"

--- a/packaging/macos/verify-pkg.sh
+++ b/packaging/macos/verify-pkg.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Copyright 2026 Blink Labs Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# verify-pkg.sh - prove a built .pkg is actually distributable.
+#
+# build-pkg.sh signs, notarizes and staples, but a build that merely completed
+# is not evidence: productsign can emit a pkg whose chain Gatekeeper rejects,
+# a staple can be missing, and an installer can fail on a machine that is not
+# the build host. This checks the three properties a user depends on:
+#
+#   1. signature   - the pkg carries a Developer ID Installer chain
+#   2. notarization- Gatekeeper assesses it as a Notarized Developer ID, and
+#                    the ticket is stapled so it verifies offline
+#   3. installation- it actually installs, and the installed app is itself
+#                    signed and accepted by Gatekeeper
+#
+# Usage: verify-pkg.sh <path-to-pkg>
+#
+# Set BURSA_VERIFY_INSTALL=0 to check only signature + notarization (for a host
+# where installing to /Applications is not acceptable).
+
+set -euo pipefail
+
+PKG="${1:?usage: verify-pkg.sh <path-to-pkg>}"
+APP_PATH="/Applications/Bursa.app"
+BUNDLE_ID="com.blinklabssoftware.bursa"
+BIN_NAME="bursa-wallet"
+VERIFY_INSTALL="${BURSA_VERIFY_INSTALL:-1}"
+
+log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+die()  { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+[ -f "${PKG}" ] || die "pkg not found: ${PKG}"
+
+# ---------------------------------------------------------------------------
+# 1. Installer signature
+# ---------------------------------------------------------------------------
+log "Checking pkg signature (pkgutil --check-signature)"
+sig_out="$(pkgutil --check-signature "${PKG}" 2>&1)" || {
+    printf '%s\n' "${sig_out}" >&2
+    die "pkgutil could not verify a signature on ${PKG}"
+}
+printf '%s\n' "${sig_out}"
+printf '%s' "${sig_out}" | grep -q 'Developer ID Installer' \
+    || die "pkg is not signed by a Developer ID Installer certificate"
+
+# ---------------------------------------------------------------------------
+# 2. Notarization: Gatekeeper assessment + a stapled ticket
+# ---------------------------------------------------------------------------
+log "Assessing the pkg with Gatekeeper (spctl --type install)"
+spctl_out="$(spctl -a -vv --type install "${PKG}" 2>&1)" || {
+    printf '%s\n' "${spctl_out}" >&2
+    die "Gatekeeper rejected ${PKG}"
+}
+printf '%s\n' "${spctl_out}"
+printf '%s' "${spctl_out}" | grep -q 'accepted' \
+    || die "Gatekeeper did not accept ${PKG}"
+printf '%s' "${spctl_out}" | grep -q 'Notarized Developer ID' \
+    || die "${PKG} is not notarized (no 'Notarized Developer ID' source)"
+
+# stapler validate is the offline check: without a stapled ticket a first
+# launch on a machine with no network is refused.
+log "Validating the stapled notarization ticket"
+xcrun stapler validate "${PKG}" \
+    || die "no valid notarization ticket is stapled to ${PKG}"
+
+if [ "${VERIFY_INSTALL}" != "1" ]; then
+    log "BURSA_VERIFY_INSTALL=0 - skipping the installation check"
+    log "Signature and notarization verified: ${PKG}"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Installation
+# ---------------------------------------------------------------------------
+# Start from a clean slate so a pre-existing app cannot make the check pass.
+if [ -d "${APP_PATH}" ]; then
+    log "Removing a pre-existing ${APP_PATH} so the install is really tested"
+    sudo rm -rf "${APP_PATH}"
+fi
+sudo pkgutil --forget "${BUNDLE_ID}" >/dev/null 2>&1 || true
+
+log "Installing (installer -pkg ... -target /)"
+sudo installer -pkg "${PKG}" -target / -verbose
+
+[ -d "${APP_PATH}" ] || die "installer reported success but ${APP_PATH} is missing"
+[ -x "${APP_PATH}/Contents/MacOS/${BIN_NAME}" ] \
+    || die "${APP_PATH}/Contents/MacOS/${BIN_NAME} is missing or not executable"
+
+log "Confirming the installer receipt was recorded"
+pkgutil --pkg-info "${BUNDLE_ID}" \
+    || die "no installer receipt for ${BUNDLE_ID}"
+
+log "Verifying the installed app's code signature"
+codesign --verify --deep --strict --verbose=2 "${APP_PATH}" \
+    || die "the installed app fails code signature verification"
+
+log "Assessing the installed app with Gatekeeper (spctl --type exec)"
+app_spctl="$(spctl -a -vv -t exec "${APP_PATH}" 2>&1)" || {
+    printf '%s\n' "${app_spctl}" >&2
+    die "Gatekeeper rejected the installed app"
+}
+printf '%s\n' "${app_spctl}"
+printf '%s' "${app_spctl}" | grep -q 'accepted' \
+    || die "Gatekeeper did not accept the installed app"
+printf '%s' "${app_spctl}" | grep -q 'Notarized Developer ID' \
+    || die "the installed app is not notarized"
+
+log "Confirming the installed binary's architecture"
+lipo -archs "${APP_PATH}/Contents/MacOS/${BIN_NAME}"
+
+# Leave the runner as it was found: a later step attesting or uploading should
+# not see an installed copy, and a self-hosted host must not accumulate them.
+log "Uninstalling"
+sudo rm -rf "${APP_PATH}"
+sudo pkgutil --forget "${BUNDLE_ID}" >/dev/null 2>&1 || true
+
+log "Signature, notarization and installation verified: ${PKG}"

--- a/packaging/macos/verify-pkg.sh
+++ b/packaging/macos/verify-pkg.sh
@@ -30,6 +30,11 @@
 #
 # Set BURSA_VERIFY_INSTALL=0 to check only signature + notarization (for a host
 # where installing to /Applications is not acceptable).
+#
+# The install check refuses to run when a Bursa.app is already present, because
+# installing over it and uninstalling afterwards would destroy it. Set
+# BURSA_REPLACE_INSTALLED=1 to accept that on a throwaway host such as a CI
+# runner.
 
 set -euo pipefail
 
@@ -38,6 +43,7 @@ APP_PATH="/Applications/Bursa.app"
 BUNDLE_ID="com.blinklabssoftware.bursa"
 BIN_NAME="bursa-wallet"
 VERIFY_INSTALL="${BURSA_VERIFY_INSTALL:-1}"
+REPLACE_INSTALLED="${BURSA_REPLACE_INSTALLED:-0}"
 
 log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 die()  { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
@@ -85,9 +91,23 @@ fi
 # ---------------------------------------------------------------------------
 # 3. Installation
 # ---------------------------------------------------------------------------
-# Start from a clean slate so a pre-existing app cannot make the check pass.
+# A pre-existing app would let the check pass without proving anything, and
+# this script cannot put one back after it installs over it. Refuse rather than
+# destroy it; a throwaway host can opt in.
+if [ -d "${APP_PATH}" ] && [ "${REPLACE_INSTALLED}" != "1" ]; then
+    die "${APP_PATH} already exists. Verifying the install would overwrite and then remove it. Set BURSA_REPLACE_INSTALLED=1 to allow that (throwaway hosts only), or BURSA_VERIFY_INSTALL=0 to check signature and notarization only."
+fi
+
+# From here on the app is this script's to clean up, however it exits: an early
+# failure must not leave a half-verified build installed on the host.
+cleanup_install() {
+    sudo rm -rf "${APP_PATH}"
+    sudo pkgutil --forget "${BUNDLE_ID}" >/dev/null 2>&1 || true
+}
+trap cleanup_install EXIT
+
 if [ -d "${APP_PATH}" ]; then
-    log "Removing a pre-existing ${APP_PATH} so the install is really tested"
+    log "Removing the pre-existing ${APP_PATH} (BURSA_REPLACE_INSTALLED=1)"
     sudo rm -rf "${APP_PATH}"
 fi
 sudo pkgutil --forget "${BUNDLE_ID}" >/dev/null 2>&1 || true
@@ -121,10 +141,8 @@ printf '%s' "${app_spctl}" | grep -q 'Notarized Developer ID' \
 log "Confirming the installed binary's architecture"
 lipo -archs "${APP_PATH}/Contents/MacOS/${BIN_NAME}"
 
-# Leave the runner as it was found: a later step attesting or uploading should
-# not see an installed copy, and a self-hosted host must not accumulate them.
+# The EXIT trap uninstalls, so a later step attesting or uploading never sees an
+# installed copy and a long-lived host does not accumulate them.
 log "Uninstalling"
-sudo rm -rf "${APP_PATH}"
-sudo pkgutil --forget "${BUNDLE_ID}" >/dev/null 2>&1 || true
 
 log "Signature, notarization and installation verified: ${PKG}"

--- a/packaging/macos/verify-pkg.sh
+++ b/packaging/macos/verify-pkg.sh
@@ -44,7 +44,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # for a bundle nothing produces.
 # shellcheck source=packaging/macos/identity.sh
 . "${SCRIPT_DIR}/identity.sh"
-APP_PATH="${BURSA_APP_PATH:-/Applications/${APP_NAME}.app}"
+# Not overridable: `installer -pkg -target /` always writes to /Applications,
+# so a path override would verify and clean up somewhere the package never
+# installed, leaving the real install behind. Tests point this elsewhere by
+# editing a copy of the script, not by a knob that ships.
+APP_PATH="/Applications/${APP_NAME}.app"
 VERIFY_INSTALL="${BURSA_VERIFY_INSTALL:-1}"
 REPLACE_INSTALLED="${BURSA_REPLACE_INSTALLED:-0}"
 EXPECTED_ARCH="${BURSA_EXPECTED_ARCH:-}"

--- a/packaging/macos/verify-pkg.sh
+++ b/packaging/macos/verify-pkg.sh
@@ -39,13 +39,18 @@
 set -euo pipefail
 
 PKG="${1:?usage: verify-pkg.sh <path-to-pkg>}"
-APP_PATH="/Applications/Bursa.app"
-BUNDLE_ID="com.blinklabssoftware.bursa"
-BIN_NAME="bursa-wallet"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Same identity build-pkg.sh packages, so a rename cannot leave this checking
+# for a bundle nothing produces.
+# shellcheck source=packaging/macos/identity.sh
+. "${SCRIPT_DIR}/identity.sh"
+APP_PATH="${BURSA_APP_PATH:-/Applications/${APP_NAME}.app}"
 VERIFY_INSTALL="${BURSA_VERIFY_INSTALL:-1}"
 REPLACE_INSTALLED="${BURSA_REPLACE_INSTALLED:-0}"
+EXPECTED_ARCH="${BURSA_EXPECTED_ARCH:-}"
 
 log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33mWARNING:\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
 
 [ -f "${PKG}" ] || die "pkg not found: ${PKG}"
@@ -94,7 +99,9 @@ fi
 # A pre-existing app would let the check pass without proving anything, and
 # this script cannot put one back after it installs over it. Refuse rather than
 # destroy it; a throwaway host can opt in.
-if [ -d "${APP_PATH}" ] && [ "${REPLACE_INSTALLED}" != "1" ]; then
+# -e misses a dangling symlink, so test for that too: anything at this path is
+# about to be removed, whatever its type.
+if { [ -e "${APP_PATH}" ] || [ -L "${APP_PATH}" ]; } && [ "${REPLACE_INSTALLED}" != "1" ]; then
     die "${APP_PATH} already exists. Verifying the install would overwrite and then remove it. Set BURSA_REPLACE_INSTALLED=1 to allow that (throwaway hosts only), or BURSA_VERIFY_INSTALL=0 to check signature and notarization only."
 fi
 
@@ -106,7 +113,7 @@ cleanup_install() {
 }
 trap cleanup_install EXIT
 
-if [ -d "${APP_PATH}" ]; then
+if [ -e "${APP_PATH}" ] || [ -L "${APP_PATH}" ]; then
     log "Removing the pre-existing ${APP_PATH} (BURSA_REPLACE_INSTALLED=1)"
     sudo rm -rf "${APP_PATH}"
 fi
@@ -139,10 +146,33 @@ printf '%s' "${app_spctl}" | grep -q 'Notarized Developer ID' \
     || die "the installed app is not notarized"
 
 log "Confirming the installed binary's architecture"
-lipo -archs "${APP_PATH}/Contents/MacOS/${BIN_NAME}"
+archs="$(lipo -archs "${APP_PATH}/Contents/MacOS/${BIN_NAME}")"
+printf '%s\n' "${archs}"
+if [ -n "${EXPECTED_ARCH}" ]; then
+    # Apple and Go spell these differently; accept the Go name the release
+    # matrix uses and compare on Apple's.
+    case "${EXPECTED_ARCH}" in
+        arm64 | aarch64) want=arm64 ;;
+        amd64 | x86_64) want=x86_64 ;;
+        *) die "unsupported BURSA_EXPECTED_ARCH '${EXPECTED_ARCH}' (use arm64 or amd64)" ;;
+    esac
+    # A wrong-architecture package installs and passes every signature check;
+    # only this comparison catches it.
+    if ! grep -qw "${want}" <<< "${archs}"; then
+        die "installed binary is '${archs}', expected ${want}"
+    fi
+    log "Architecture matches the expected ${want}"
+else
+    warn "BURSA_EXPECTED_ARCH unset - not asserting the binary's architecture"
+fi
 
-# The EXIT trap uninstalls, so a later step attesting or uploading never sees an
-# installed copy and a long-lived host does not accumulate them.
+# Uninstall here rather than leaving it to the trap, so the success message
+# below cannot claim a verified, cleaned-up state before cleanup has run, and a
+# failure to remove the app is reported instead of happening silently after the
+# body returns. The trap stays armed until this point to cover the failure
+# paths above, and is cleared once it has nothing left to undo.
 log "Uninstalling"
+cleanup_install
+trap - EXIT
 
 log "Signature, notarization and installation verified: ${PKG}"


### PR DESCRIPTION
Fixes #804

Developer ID signing and notarization ran only on a tag, so the path was first exercised during a release. The run checked the signature and the Gatekeeper assessment but never that the package installs.

- `packaging/macos/verify-pkg.sh` requires a Developer ID Installer chain, a Gatekeeper `accepted` + `Notarized Developer ID` assessment, and a stapled ticket that validates offline; then it installs with `installer -pkg -target /`, confirms the receipt and the installed `Bursa.app`, verifies that app's own signature and Gatekeeper assessment, reports its architecture, and uninstalls.
- A `workflow_dispatch` input runs the same signed and notarized path without cutting a tag and uploads the pkg as a workflow artifact. Nothing is published to a release on that trigger.
- The built pkg is resolved by globbing `dist/` instead of reconstructing its name, so a non-tag run — where `build-pkg.sh` derives the version from `git describe` — still finds it.

This does not close the issue. Exercising the path for v0.17.0 needs a run holding the Apple credentials, either the dispatch added here or the tag itself. Publishing and attesting the arm64 pkg were already implemented and are unchanged.

Validation: shellcheck and actionlint. `verify-pkg.sh` requires a macOS host with the signing credentials and runs first in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional manual macOS packaging run for signing, notarization, verification, and artifact download without publishing a release.
  * Added comprehensive validation to confirm macOS installer signatures, notarization, Gatekeeper approval, and successful installation.

* **Bug Fixes**
  * Improved macOS package verification and cleanup after validation, reducing the risk of leaving temporary installed files behind.

* **Chores**
  * Restricted manual packaging exercises to the default branch and prevented use with tag references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->