### PR TITLE
fix(multisig): bind imported scripts to spent outputs

### DIFF
--- a/ui/internal/multisig/importtx_test.go
+++ b/ui/internal/multisig/importtx_test.go
@@ -219,9 +219,8 @@ func TestInspectTx_MintOnlyIsNotMultiSig(t *testing.T) {
 	}
 }
 
-// TestInspectTx_MultiSigSpendPlusMint covers the mixed case: the same native
-// script is used by a multisig spend and a mint policy in the same transaction.
-// The spent payment output must keep the script eligible for cosigning.
+// TestInspectTx_MultiSigSpendPlusMint covers a real multisig spend alongside an
+// unrelated mint policy script.
 func TestInspectTx_MultiSigSpendPlusMint(t *testing.T) {
 	fc := newFakeChain()
 	svc := NewService(fc, nil, &memAccounts{})
@@ -246,18 +245,12 @@ func TestInspectTx_MultiSigSpendPlusMint(t *testing.T) {
 		t.Fatalf("Build: %v", err)
 	}
 
-	// Reuse the account's payment script as the mint policy. This is the case
-	// where filtering mint policies before resolving spent outputs loses the
-	// valid payment authorization.
-	mintScript, err := decodeScript(acct.ScriptCBOR)
+	mintScript, err := bursa.NewScriptSig(bytesRepeat(8, 28))
 	if err != nil {
-		t.Fatalf("decodeScript: %v", err)
+		t.Fatalf("NewScriptSig: %v", err)
 	}
 	policyIDHex := hex.EncodeToString(mintScript.Hash().Bytes())
-	tx := decodeConwayTx(t, built.UnsignedTxCBOR)
-	// Keep the original spend witness once; its hash is also the mint policy.
-	injectMint(t, &tx, policyIDHex, tx.WitnessSet.NativeScripts())
-	txHex := encodeConwayTx(t, &tx)
+	txHex := addMintToTx(t, built.UnsignedTxCBOR, mintScript, policyIDHex)
 
 	info, err := svc.InspectTx(txHex)
 	if err != nil {
@@ -268,6 +261,37 @@ func TestInspectTx_MultiSigSpendPlusMint(t *testing.T) {
 	}
 	if info.Threshold != 2 || len(info.Participants) != 2 {
 		t.Errorf("got %d-of-%d, want 2-of-2", info.Threshold, len(info.Participants))
+	}
+}
+
+func TestInspectTx_SharedPaymentAndMintScript(t *testing.T) {
+	fc := newFakeChain()
+	svc := NewService(fc, nil, &memAccounts{})
+	_, khA, _ := multiSigKeyHash(t, mnemonicA)
+	_, khB, _ := multiSigKeyHash(t, mnemonicB)
+	acct, err := createForTest(svc, CreateRequest{Label: "treasury", Network: "preview", Policy: Policy{
+		Threshold: 2, Participants: []Participant{{KeyHashHex: khA}, {KeyHashHex: khB}},
+	}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	fc.addUTxO(acct.ScriptAddress, strings.Repeat("77", 32), 0, 10_000_000)
+	built, err := svc.Build(context.Background(), acct.ID, BuildRequest{To: externalAddr(t), Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	mintScript, err := decodeScript(acct.ScriptCBOR)
+	if err != nil {
+		t.Fatalf("decodeScript: %v", err)
+	}
+	tx := decodeConwayTx(t, built.UnsignedTxCBOR)
+	injectMint(t, &tx, hex.EncodeToString(mintScript.Hash().Bytes()), tx.WitnessSet.NativeScripts())
+	info, err := svc.InspectTx(encodeConwayTx(t, &tx))
+	if err != nil {
+		t.Fatalf("InspectTx: %v", err)
+	}
+	if !info.IsMultiSig || info.Threshold != 2 || len(info.Participants) != 2 {
+		t.Fatalf("shared payment/mint script must classify as 2-of-2 multisig: %+v", info)
 	}
 }
 

--- a/ui/internal/multisig/importtx_test.go
+++ b/ui/internal/multisig/importtx_test.go
@@ -599,6 +599,31 @@ func TestInspectTx_NotMultiSig(t *testing.T) {
 	}
 }
 
+// TestInspectTx_RejectsUnboundEmbeddedScript ensures an attacker cannot make
+// an arbitrary witness-set script look like a payment policy.  The script is
+// not the credential of any resolved input, so the import remains unsupported.
+func TestInspectTx_RejectsUnboundEmbeddedScript(t *testing.T) {
+	fc := newFakeChain()
+	svc := NewService(fc, nil, &memAccounts{})
+	_, kh, _ := multiSigKeyHash(t, mnemonicA)
+	ns, err := composeScript(Policy{Threshold: 1, Participants: []Participant{{KeyHashHex: kh}}})
+	if err != nil {
+		t.Fatalf("composeScript: %v", err)
+	}
+	tx := decodeConwayTx(t, ordinaryUnsignedTxHex(t, fc))
+	tx.WitnessSet.WsNativeScripts = gcbor.NewSetType([]lcommon.NativeScript{*ns}, true)
+	tx.SetCbor(nil)
+	tx.WitnessSet.SetCbor(nil)
+
+	info, err := svc.InspectTx(encodeConwayTx(t, &tx))
+	if err != nil {
+		t.Fatalf("InspectTx: %v", err)
+	}
+	if !info.IsMultiSig || info.Threshold != 0 {
+		t.Fatalf("unbound script classified as signable policy: %+v", info)
+	}
+}
+
 // TestInspectTx_MalformedHex covers the ErrInvalidTx wrapping requirement for
 // hex that doesn't even decode.
 func TestInspectTx_MalformedHex(t *testing.T) {

--- a/ui/internal/multisig/importtx_test.go
+++ b/ui/internal/multisig/importtx_test.go
@@ -219,10 +219,9 @@ func TestInspectTx_MintOnlyIsNotMultiSig(t *testing.T) {
 	}
 }
 
-// TestInspectTx_MultiSigSpendPlusMint covers the mixed case: a real multisig
-// spend script alongside an unrelated mint policy script in the same witness
-// set. The spend script must still be selected (it doesn't match any mint
-// policy ID) and the tx must still classify as multisig.
+// TestInspectTx_MultiSigSpendPlusMint covers the mixed case: the same native
+// script is used by a multisig spend and a mint policy in the same transaction.
+// The spent payment output must keep the script eligible for cosigning.
 func TestInspectTx_MultiSigSpendPlusMint(t *testing.T) {
 	fc := newFakeChain()
 	svc := NewService(fc, nil, &memAccounts{})
@@ -247,21 +246,25 @@ func TestInspectTx_MultiSigSpendPlusMint(t *testing.T) {
 		t.Fatalf("Build: %v", err)
 	}
 
-	// Attach an unrelated mint policy script (different hash) on top of the
-	// already-built multisig spend tx.
-	mintScript, err := bursa.NewScriptSig(bytesRepeat(8, 28))
+	// Reuse the account's payment script as the mint policy. This is the case
+	// where filtering mint policies before resolving spent outputs loses the
+	// valid payment authorization.
+	mintScript, err := decodeScript(acct.ScriptCBOR)
 	if err != nil {
-		t.Fatalf("NewScriptSig: %v", err)
+		t.Fatalf("decodeScript: %v", err)
 	}
 	policyIDHex := hex.EncodeToString(mintScript.Hash().Bytes())
-	txHex := addMintToTx(t, built.UnsignedTxCBOR, mintScript, policyIDHex)
+	tx := decodeConwayTx(t, built.UnsignedTxCBOR)
+	// Keep the original spend witness once; its hash is also the mint policy.
+	injectMint(t, &tx, policyIDHex, tx.WitnessSet.NativeScripts())
+	txHex := encodeConwayTx(t, &tx)
 
 	info, err := svc.InspectTx(txHex)
 	if err != nil {
 		t.Fatalf("InspectTx: %v", err)
 	}
 	if !info.IsMultiSig {
-		t.Fatalf("multisig spend script must still classify as multisig even with an unrelated mint policy attached: %+v", info)
+		t.Fatalf("shared payment/mint script must classify as multisig: %+v", info)
 	}
 	if info.Threshold != 2 || len(info.Participants) != 2 {
 		t.Errorf("got %d-of-%d, want 2-of-2", info.Threshold, len(info.Participants))

--- a/ui/internal/multisig/importtx_test.go
+++ b/ui/internal/multisig/importtx_test.go
@@ -257,7 +257,7 @@ func TestInspectTx_MultiSigSpendPlusMint(t *testing.T) {
 		t.Fatalf("InspectTx: %v", err)
 	}
 	if !info.IsMultiSig {
-		t.Fatalf("shared payment/mint script must classify as multisig: %+v", info)
+		t.Fatalf("unrelated mint script must not suppress real spend classification: %+v", info)
 	}
 	if info.Threshold != 2 || len(info.Participants) != 2 {
 		t.Errorf("got %d-of-%d, want 2-of-2", info.Threshold, len(info.Participants))

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -745,7 +745,7 @@ func (s *Service) InspectTx(txCbor string) (TxInfo, error) {
 			// reused as a mint policy still needs its stake/gov witness, so it
 			// must not be routed to the vkey path — the stake purpose dominates.
 			stakePurpose = true
-		case mintPolicies[hash] && (spendErr != nil || !spendScripts[hash]):
+		case mintPolicies[hash] && spendErr == nil && !spendScripts[hash]:
 			// mint-only evidence — not a spend on this basis alone.
 		default:
 			candidates = append(candidates, &scripts[i])

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -778,7 +778,19 @@ func (s *Service) InspectTx(txCbor string) (TxInfo, error) {
 		// than guess.
 		return TxInfo{IsMultiSig: true, ScriptEmbedded: true}, nil
 	}
+	// A non-mint script is only authorized for payment when an input actually
+	// spends an output locked by that script.  Witness-set membership alone is
+	// attacker-controlled and is not evidence that the wallet is authorizing
+	// this policy. Resolve every input before selecting the policy; unknown or
+	// malformed references fail closed as an unsupported import.
+	spendScripts, err := s.paymentScriptHashes(&tx)
+	if err != nil {
+		return TxInfo{IsMultiSig: true, ScriptEmbedded: true}, nil
+	}
 	ns := candidates[0]
+	if !spendScripts[hex.EncodeToString(ns.Hash().Bytes())] {
+		return TxInfo{IsMultiSig: true, ScriptEmbedded: true}, nil
+	}
 	scriptHash := hex.EncodeToString(ns.Hash().Bytes())
 
 	policy, err := PolicyFromScript(ns)
@@ -832,6 +844,32 @@ func (s *Service) InspectTx(txCbor string) (TxInfo, error) {
 		info.Participants = append(info.Participants, p)
 	}
 	return info, nil
+}
+
+// paymentScriptHashes resolves every transaction input and returns the native
+// script credentials of script-locked payment outputs.  Imported transactions
+// must be bound to these chain-owned outputs before a witness script is treated
+// as a payment authorization.  A missing output is an error: guessing would
+// recreate the decoy-script signing vulnerability this check prevents.
+func (s *Service) paymentScriptHashes(tx *conway.ConwayTransaction) (map[string]bool, error) {
+	if s.chain == nil {
+		return nil, errors.New("chain context unavailable")
+	}
+	out := make(map[string]bool)
+	for _, input := range tx.Body.Inputs().Items() {
+		utxo, err := s.chain.UtxoByRef(input.Id(), input.Index())
+		if err != nil {
+			return nil, fmt.Errorf("resolve input: %w", err)
+		}
+		if utxo == nil || utxo.Output == nil {
+			return nil, fmt.Errorf("resolve input: output not found")
+		}
+		payload, ok := utxo.Output.Address().PayloadPayload().(lcommon.AddressPayloadScriptHash)
+		if ok {
+			out[hex.EncodeToString(payload.Hash.Bytes())] = true
+		}
+	}
+	return out, nil
 }
 
 // Sign is a co-signer's step: it decrypts the seed, derives the wallet's CIP-1854

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -856,7 +856,7 @@ func (s *Service) paymentScriptHashes(tx *conway.ConwayTransaction) (map[string]
 		return nil, errors.New("chain context unavailable")
 	}
 	out := make(map[string]bool)
-	for _, input := range tx.Body.Inputs().Items() {
+	for _, input := range tx.Body.Inputs() {
 		utxo, err := s.chain.UtxoByRef(input.Id(), input.Index())
 		if err != nil {
 			return nil, fmt.Errorf("resolve input: %w", err)
@@ -864,7 +864,8 @@ func (s *Service) paymentScriptHashes(tx *conway.ConwayTransaction) (map[string]
 		if utxo == nil || utxo.Output == nil {
 			return nil, fmt.Errorf("resolve input: output not found")
 		}
-		payload, ok := utxo.Output.Address().PayloadPayload().(lcommon.AddressPayloadScriptHash)
+		addr := utxo.Output.Address()
+		payload, ok := (&addr).PayloadPayload().(lcommon.AddressPayloadScriptHash)
 		if ok {
 			out[hex.EncodeToString(payload.Hash.Bytes())] = true
 		}

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -785,7 +785,10 @@ func (s *Service) InspectTx(txCbor string) (TxInfo, error) {
 	// malformed references fail closed as an unsupported import.
 	spendScripts, err := s.paymentScriptHashes(&tx)
 	if err != nil {
-		return TxInfo{IsMultiSig: true, ScriptEmbedded: true}, nil
+		// Input lookup failures are intentionally classified as unsupported
+		// imports here; callers must not treat an unresolved input as a valid
+		// multisig authorization.
+		return TxInfo{IsMultiSig: true, ScriptEmbedded: true}, nil //nolint:nilerr // unresolved inputs are classified as unsupported imports
 	}
 	ns := candidates[0]
 	if !spendScripts[hex.EncodeToString(ns.Hash().Bytes())] {
@@ -862,7 +865,7 @@ func (s *Service) paymentScriptHashes(tx *conway.ConwayTransaction) (map[string]
 			return nil, fmt.Errorf("resolve input: %w", err)
 		}
 		if utxo == nil || utxo.Output == nil {
-			return nil, fmt.Errorf("resolve input: output not found")
+			return nil, errors.New("resolve input: output not found")
 		}
 		addr := utxo.Output.Address()
 		payload, ok := (&addr).PayloadPayload().(lcommon.AddressPayloadScriptHash)

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -729,6 +729,10 @@ func (s *Service) InspectTx(txCbor string) (TxInfo, error) {
 	// scripts can only be there to satisfy a spend, so those are the candidate
 	// payment-spend scripts.
 	stakeScriptHashes := stakeScriptCredentialHashes(&tx)
+	// Resolve spent payment scripts before filtering mint policies. A native
+	// script can legitimately be shared by a payment output and a mint policy;
+	// mint-policy membership alone must not hide the payment authorization.
+	spendScripts, spendErr := s.paymentScriptHashes(&tx)
 	var candidates []*lcommon.NativeScript
 	stakePurpose := false
 	for i := range scripts {
@@ -741,7 +745,7 @@ func (s *Service) InspectTx(txCbor string) (TxInfo, error) {
 			// reused as a mint policy still needs its stake/gov witness, so it
 			// must not be routed to the vkey path — the stake purpose dominates.
 			stakePurpose = true
-		case mintPolicies[hash]:
+		case mintPolicies[hash] && (spendErr != nil || !spendScripts[hash]):
 			// mint-only evidence — not a spend on this basis alone.
 		default:
 			candidates = append(candidates, &scripts[i])
@@ -783,8 +787,7 @@ func (s *Service) InspectTx(txCbor string) (TxInfo, error) {
 	// attacker-controlled and is not evidence that the wallet is authorizing
 	// this policy. Resolve every input before selecting the policy; unknown or
 	// malformed references fail closed as an unsupported import.
-	spendScripts, err := s.paymentScriptHashes(&tx)
-	if err != nil {
+	if spendErr != nil {
 		// Input lookup failures are intentionally classified as unsupported
 		// imports here; callers must not treat an unresolved input as a valid
 		// multisig authorization.


### PR DESCRIPTION
Fixes #815

Imported multisig inspection now resolves every input and accepts an embedded native script only when its hash matches a script-locked payment output. Unknown or unbound inputs remain unsupported, preventing decoy witness-set scripts from authorizing a victim signature. Adds a regression test for an unbound embedded script.

Checks: gofmt and git diff --check passed. Nested UI test could not complete: required Go 1.26.7 toolchain/dependencies were unavailable in the environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #815 by binding imported multisig scripts to the payment outputs they authorize. Previously any embedded native script could be treated as a signing policy; now only a script whose hash matches a spent script-locked output is eligible, unresolved inputs fail closed, and scripts shared by payment and mint policies remain eligible.

- Resolves every input through the chain before selecting a payment policy.
- Adds regression coverage for unbound scripts and shared payment/mint scripts.

<sup>Written for commit 3e5d69ed83fe24f378bce361b04c0dbea121dd8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multisig transaction validation to ensure embedded scripts are tied to actual payment inputs before a transaction is classified as signable.
  - Transactions containing unrelated or unbound witness scripts are now rejected as unsupported multisig transactions instead of being incorrectly classified or signed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->