### PR TITLE
fix(script): cryptographically verify native-script signatures

### DIFF
--- a/bursa.go
+++ b/bursa.go
@@ -2070,15 +2070,6 @@ func validateScriptAllWithDepth(
 	requireSignatures bool,
 	depth int,
 ) bool {
-	if requireSignatures {
-		total := 0
-		for _, subScript := range script.Scripts {
-			total += minSignaturesRequired(&subScript)
-		}
-		if len(witnesses) < total {
-			return false
-		}
-	}
 	for _, subScript := range script.Scripts {
 		if !validateScriptWithDepth(
 			&subScript,
@@ -2130,22 +2121,6 @@ func validateScriptNOfWithDepth(
 	// Safety check: N should be reasonable for cryptographic purposes
 	if script.N > 255 {
 		return false
-	}
-	if requireSignatures {
-		// Lower bound on signatures needed for this node (accounts for 0-sig leaves like timelocks)
-		// Create a temporary NativeScript to call minSignaturesRequired
-		cborData, err := cbor.Encode(script)
-		if err != nil {
-			return false
-		}
-		var tempScript NativeScript
-		if _, err := cbor.Decode(cborData, &tempScript); err != nil {
-			return false
-		}
-		minReq := minSignaturesRequired(&tempScript)
-		if len(witnesses) < minReq {
-			return false
-		}
 	}
 	satisfied := 0
 	for _, subScript := range script.Scripts {

--- a/bursa.go
+++ b/bursa.go
@@ -95,6 +95,13 @@ type (
 	NativeScriptInvalidHereafter = lcommon.NativeScriptInvalidHereafter
 )
 
+// ScriptWitness pairs an Ed25519 verification key with its signature over the
+// script validation payload, mirroring a transaction's vkey witness. Both
+// fields are required for cryptographic validation: the key hash (Blake2b-224
+// of Vkey) must match a NativeScriptPubkey's key hash, and Signature must
+// verify against Vkey and the supplied message.
+type ScriptWitness = lcommon.VkeyWitness
+
 // GetScriptType returns the script type identifier for a native script.
 // Only accepts *NativeScript types; returns an error for other script types.
 func GetScriptType(script Script) (int, error) {
@@ -1910,18 +1917,23 @@ func GetScriptAddress(script Script, networkName string) (string, error) {
 // Maximum recursion depth for script validation to prevent stack overflow
 const maxScriptDepth = 20
 
-// ValidateScript checks if a script is satisfied given signatures and current slot
-// If requireSignatures is true, requires signatures for ScriptSig scripts and validates format.
-// If false, allows empty signatures for structural validation only.
+// ValidateScript checks if a script is satisfied given witnesses and current slot.
+// message is the signed payload (e.g. a transaction body hash) that each
+// witness's signature is verified against. If requireSignatures is true,
+// ScriptSig scripts require a witness whose verification key hash matches the
+// script and whose signature verifies against message. If false, allows empty
+// witnesses for structural validation only.
 func ValidateScript(
 	script Script,
-	signatures [][]byte,
+	message []byte,
+	witnesses []ScriptWitness,
 	slot uint64,
 	requireSignatures bool,
 ) bool {
 	return validateScriptWithDepth(
 		script,
-		signatures,
+		message,
+		witnesses,
 		slot,
 		requireSignatures,
 		0,
@@ -1977,7 +1989,8 @@ func minSignaturesRequired(script *NativeScript) int {
 // validateScriptWithDepth is the internal recursive validator with depth tracking
 func validateScriptWithDepth(
 	script Script,
-	signatures [][]byte,
+	message []byte,
+	witnesses []ScriptWitness,
 	slot uint64,
 	requireSignatures bool,
 	depth int,
@@ -1994,13 +2007,13 @@ func validateScriptWithDepth(
 
 	switch s := nativeScript.Item().(type) {
 	case *NativeScriptPubkey:
-		return validateScriptSig(s, signatures, requireSignatures)
+		return validateScriptSig(s, message, witnesses, requireSignatures)
 	case *NativeScriptAll:
-		return validateScriptAllWithDepth(s, signatures, slot, requireSignatures, depth+1)
+		return validateScriptAllWithDepth(s, message, witnesses, slot, requireSignatures, depth+1)
 	case *NativeScriptAny:
-		return validateScriptAnyWithDepth(s, signatures, slot, requireSignatures, depth+1)
+		return validateScriptAnyWithDepth(s, message, witnesses, slot, requireSignatures, depth+1)
 	case *NativeScriptNofK:
-		return validateScriptNOfWithDepth(s, signatures, slot, requireSignatures, depth+1)
+		return validateScriptNOfWithDepth(s, message, witnesses, slot, requireSignatures, depth+1)
 	case *NativeScriptInvalidBefore:
 		return validateScriptInvalidBefore(s, slot)
 	case *NativeScriptInvalidHereafter:
@@ -2010,43 +2023,49 @@ func validateScriptWithDepth(
 	}
 }
 
-// validateScriptSig checks if a signature script is satisfied
+// validateScriptSig checks if a signature script is satisfied.
 //
-// SECURITY WARNING: This function currently allows empty signatures for structural validation.
-// In production spending validation, signatures MUST be provided and cryptographically verified.
-// This implementation is a placeholder for testing script logic and should not be used
-// for actual transaction validation without proper Ed25519 signature verification.
+// If requireSignatures is true, at least one witness must carry a
+// verification key whose Blake2b-224 hash matches the script's key hash and
+// whose Ed25519 signature verifies against message. Random bytes, a witness
+// for an unrelated key, or a signature over the wrong payload are all
+// rejected because the cryptographic check fails.
 //
-// TODO: Implement full Ed25519 signature verification against transaction hash and script.Hash
+// If requireSignatures is false, only the script's structure is considered
+// (structural-only validation); no witness is inspected.
 func validateScriptSig(
-	_ *NativeScriptPubkey,
-	signatures [][]byte,
+	script *NativeScriptPubkey,
+	message []byte,
+	witnesses []ScriptWitness,
 	requireSignatures bool,
 ) bool {
-	if requireSignatures {
-		// Require signatures for format validation
-		if len(signatures) == 0 {
-			return false
-		}
-		// TODO: Implement proper Ed25519 signature verification against script.Hash
-		// For now, check basic signature format (64 bytes for Ed25519)
-		for _, sig := range signatures {
-			if len(sig) != 64 {
-				return false // Invalid Ed25519 signature length
-			}
-		}
-		return len(signatures) >= 1
-	} else {
-		// For structural validation, ignore all signature checks
-		// Only validate the script structure itself
+	if !requireSignatures {
+		// Structural validation only: ignore witnesses entirely.
 		return true
 	}
+	if len(script.Hash) != 28 {
+		return false
+	}
+	for _, witness := range witnesses {
+		if len(witness.Vkey) != ed25519.PublicKeySize {
+			continue
+		}
+		keyHash := lcommon.Blake2b224Hash(witness.Vkey)
+		if !bytes.Equal(keyHash.Bytes(), script.Hash) {
+			continue
+		}
+		if lcommon.VerifyVKeySignature(witness.Vkey, witness.Signature, message) == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // validateScriptAllWithDepth checks if all sub-scripts are satisfied
 func validateScriptAllWithDepth(
 	script *NativeScriptAll,
-	signatures [][]byte,
+	message []byte,
+	witnesses []ScriptWitness,
 	slot uint64,
 	requireSignatures bool,
 	depth int,
@@ -2056,14 +2075,15 @@ func validateScriptAllWithDepth(
 		for _, subScript := range script.Scripts {
 			total += minSignaturesRequired(&subScript)
 		}
-		if len(signatures) < total {
+		if len(witnesses) < total {
 			return false
 		}
 	}
 	for _, subScript := range script.Scripts {
 		if !validateScriptWithDepth(
 			&subScript,
-			signatures,
+			message,
+			witnesses,
 			slot,
 			requireSignatures,
 			depth,
@@ -2077,7 +2097,8 @@ func validateScriptAllWithDepth(
 // validateScriptAnyWithDepth checks if any sub-script is satisfied
 func validateScriptAnyWithDepth(
 	script *NativeScriptAny,
-	signatures [][]byte,
+	message []byte,
+	witnesses []ScriptWitness,
 	slot uint64,
 	requireSignatures bool,
 	depth int,
@@ -2085,7 +2106,8 @@ func validateScriptAnyWithDepth(
 	for _, subScript := range script.Scripts {
 		if validateScriptWithDepth(
 			&subScript,
-			signatures,
+			message,
+			witnesses,
 			slot,
 			requireSignatures,
 			depth,
@@ -2099,7 +2121,8 @@ func validateScriptAnyWithDepth(
 // validateScriptNOfWithDepth checks if at least N sub-scripts are satisfied
 func validateScriptNOfWithDepth(
 	script *NativeScriptNofK,
-	signatures [][]byte,
+	message []byte,
+	witnesses []ScriptWitness,
 	slot uint64,
 	requireSignatures bool,
 	depth int,
@@ -2120,7 +2143,7 @@ func validateScriptNOfWithDepth(
 			return false
 		}
 		minReq := minSignaturesRequired(&tempScript)
-		if len(signatures) < minReq {
+		if len(witnesses) < minReq {
 			return false
 		}
 	}
@@ -2128,7 +2151,8 @@ func validateScriptNOfWithDepth(
 	for _, subScript := range script.Scripts {
 		if validateScriptWithDepth(
 			&subScript,
-			signatures,
+			message,
+			witnesses,
 			slot,
 			requireSignatures,
 			depth,

--- a/bursa.go
+++ b/bursa.go
@@ -29,7 +29,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 
@@ -1938,52 +1937,6 @@ func ValidateScript(
 		requireSignatures,
 		0,
 	)
-}
-
-// minSignaturesRequired returns the minimum number of signatures required to satisfy the script
-func minSignaturesRequired(script *NativeScript) int {
-	switch s := script.Item().(type) {
-	case *NativeScriptPubkey:
-		return 1
-	case *NativeScriptAll:
-		total := 0
-		for _, subScript := range s.Scripts {
-			total += minSignaturesRequired(&subScript)
-		}
-		return total
-	case *NativeScriptAny:
-		min := 0
-		for _, subScript := range s.Scripts {
-			subMin := minSignaturesRequired(&subScript)
-			if min == 0 || subMin < min {
-				min = subMin
-			}
-		}
-		return min
-	case *NativeScriptNofK:
-		// For NofK, we need to satisfy N out of K sub-scripts
-		// To minimize signatures, we choose the N sub-scripts with the smallest min sigs
-		// But since it's complex, for now, assume we need at least N signatures if any sub needs sigs
-		// Actually, properly: sort the min sigs of sub-scripts, sum the smallest N
-		subMins := make([]int, len(s.Scripts))
-		for i, subScript := range s.Scripts {
-			subMins[i] = minSignaturesRequired(&subScript)
-		}
-		// Sort ascending
-		sort.Ints(subMins)
-		total := 0
-		for i := range subMins {
-			if uint(i) >= s.N { //nolint:gosec
-				break
-			}
-			total += subMins[i]
-		}
-		return total
-	case *NativeScriptInvalidBefore, *NativeScriptInvalidHereafter:
-		return 0
-	default:
-		return 0
-	}
 }
 
 // validateScriptWithDepth is the internal recursive validator with depth tracking

--- a/bursa_test.go
+++ b/bursa_test.go
@@ -32,7 +32,19 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/blake2b"
 )
+
+// blake2b224 returns the Blake2b-224 hash of data, matching the key-hash
+// derivation used for NativeScriptPubkey.Hash.
+func blake2b224(data []byte) []byte {
+	hasher, err := blake2b.New(28, nil)
+	if err != nil {
+		panic(err)
+	}
+	hasher.Write(data)
+	return hasher.Sum(nil)
+}
 
 // testKeyHash returns a 28-byte test key hash for use in tests
 func testKeyHash() []byte {
@@ -1381,7 +1393,7 @@ func TestValidateScript(t *testing.T) {
 	// Test ScriptSig validation (allows empty signatures for basic validation)
 	scriptSig, err := NewScriptSig(keyHash1)
 	assert.NoError(t, err)
-	assert.True(t, ValidateScript(scriptSig, nil, 1000, false))
+	assert.True(t, ValidateScript(scriptSig, nil, nil, 1000, false))
 
 	// Test ScriptAll validation (requires all sub-scripts satisfied)
 	// Since ScriptSig allows empty signatures, ScriptAll should succeed
@@ -1394,7 +1406,7 @@ func TestValidateScript(t *testing.T) {
 		script2,
 	)
 	assert.NoError(t, err)
-	assert.True(t, ValidateScript(scriptAll, nil, 1000, false))
+	assert.True(t, ValidateScript(scriptAll, nil, nil, 1000, false))
 
 	// Test ScriptAny validation (requires any sub-script satisfied)
 	// Since ScriptSig allows empty signatures, ScriptAny should succeed
@@ -1407,7 +1419,7 @@ func TestValidateScript(t *testing.T) {
 		script4,
 	)
 	assert.NoError(t, err)
-	assert.True(t, ValidateScript(scriptAny, nil, 1000, false))
+	assert.True(t, ValidateScript(scriptAny, nil, nil, 1000, false))
 
 	// Test ScriptNOf validation (2-of-3)
 	// Since ScriptSig allows empty signatures, ScriptNOf should succeed
@@ -1423,18 +1435,18 @@ func TestValidateScript(t *testing.T) {
 		script7,
 	)
 	assert.NoError(t, err)
-	assert.True(t, ValidateScript(scriptNOf, nil, 1000, false))
+	assert.True(t, ValidateScript(scriptNOf, nil, nil, 1000, false))
 
 	// Test ScriptBefore validation
 	scriptBefore, err := NewScriptBefore(2000)
 	assert.NoError(t, err)
 	assert.True(
 		t,
-		ValidateScript(scriptBefore, nil, 1000, false),
+		ValidateScript(scriptBefore, nil, nil, 1000, false),
 	) // Slot 1000 < 2000
 	assert.False(
 		t,
-		ValidateScript(scriptBefore, nil, 3000, false),
+		ValidateScript(scriptBefore, nil, nil, 3000, false),
 	) // Slot 3000 > 2000
 
 	// Test ScriptAfter validation
@@ -1442,11 +1454,11 @@ func TestValidateScript(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(
 		t,
-		ValidateScript(scriptAfter, nil, 2000, false),
+		ValidateScript(scriptAfter, nil, nil, 2000, false),
 	) // Slot 2000 > 1000
 	assert.False(
 		t,
-		ValidateScript(scriptAfter, nil, 500, false),
+		ValidateScript(scriptAfter, nil, nil, 500, false),
 	) // Slot 500 < 1000
 }
 
@@ -1526,7 +1538,7 @@ func TestMultiSigScriptFromKeys(t *testing.T) {
 	assert.Len(t, nofScript.Scripts, 3)
 
 	// Verify the script can be validated
-	assert.True(t, ValidateScript(script, nil, 1000, false))
+	assert.True(t, ValidateScript(script, nil, nil, 1000, false))
 }
 
 func TestScriptGenerationEdgeCases(t *testing.T) {
@@ -1560,89 +1572,77 @@ func TestScriptGenerationEdgeCases(t *testing.T) {
 }
 
 func TestValidateScriptWithSignatures(t *testing.T) {
-	keyHash1 := []byte{
-		0x01,
-		0x02,
-		0x03,
-		0x04,
-		0x05,
-		0x06,
-		0x07,
-		0x08,
-		0x09,
-		0x0a,
-		0x0b,
-		0x0c,
-		0x0d,
-		0x0e,
-		0x0f,
-		0x10,
-		0x11,
-		0x12,
-		0x13,
-		0x14,
-		0x15,
-		0x16,
-		0x17,
-		0x18,
-		0x19,
-		0x1a,
-		0x1b,
-		0x1c,
-	}
-	keyHash2 := []byte{
-		0x02,
-		0x03,
-		0x04,
-		0x05,
-		0x06,
-		0x07,
-		0x08,
-		0x09,
-		0x0a,
-		0x0b,
-		0x0c,
-		0x0d,
-		0x0e,
-		0x0f,
-		0x10,
-		0x11,
-		0x12,
-		0x13,
-		0x14,
-		0x15,
-		0x16,
-		0x17,
-		0x18,
-		0x19,
-		0x1a,
-		0x1b,
-		0x1c,
-		0x1d,
-	}
+	pub1, priv1, err := ed25519.GenerateKey(rand.Reader)
+	assert.NoError(t, err)
+	pub2, priv2, err := ed25519.GenerateKey(rand.Reader)
+	assert.NoError(t, err)
+	otherPub, otherPriv, err := ed25519.GenerateKey(rand.Reader)
+	assert.NoError(t, err)
 
-	validSig := make(
-		[]byte,
-		64,
-	) // 64-byte signature placeholder (structural validation only)
+	keyHash1 := blake2b224(pub1)
+	keyHash2 := blake2b224(pub2)
 
-	// Test ScriptSig with requireSignatures=true (structural validation: enforce signature presence and shape constraints only)
+	message := []byte("tx body hash placeholder")
+	otherMessage := []byte("a different payload")
+
+	sig1 := ed25519.Sign(priv1, message)
+	sig2 := ed25519.Sign(priv2, message)
+
+	randomSig := make([]byte, ed25519.SignatureSize)
+	_, err = rand.Read(randomSig)
+	assert.NoError(t, err)
+
+	// Test ScriptSig with requireSignatures=true: real cryptographic verification
 	scriptSig, err := NewScriptSig(keyHash1)
 	assert.NoError(t, err)
 	assert.False(
 		t,
-		ValidateScript(scriptSig, nil, 1000, true),
-	) // No signatures provided
+		ValidateScript(scriptSig, message, nil, 1000, true),
+	) // No witnesses provided
 	assert.False(
 		t,
-		ValidateScript(scriptSig, [][]byte{make([]byte, 32)}, 1000, true),
-	) // Invalid signature length (not 64 bytes)
+		ValidateScript(
+			scriptSig,
+			message,
+			[]ScriptWitness{{Vkey: pub1, Signature: randomSig}},
+			1000,
+			true,
+		),
+	) // Random signature bytes do not verify (issue #727)
+	assert.False(
+		t,
+		ValidateScript(
+			scriptSig,
+			message,
+			[]ScriptWitness{
+				{Vkey: otherPub, Signature: ed25519.Sign(otherPriv, message)},
+			},
+			1000,
+			true,
+		),
+	) // Valid signature, but the key does not match the script's key hash
+	assert.False(
+		t,
+		ValidateScript(
+			scriptSig,
+			message,
+			[]ScriptWitness{{Vkey: pub1, Signature: ed25519.Sign(priv1, otherMessage)}},
+			1000,
+			true,
+		),
+	) // Correct key, but the signature covers a different payload
 	assert.True(
 		t,
-		ValidateScript(scriptSig, [][]byte{validSig}, 1000, true),
-	) // Valid signature count and length (structural check only, no cryptographic verification)
+		ValidateScript(
+			scriptSig,
+			message,
+			[]ScriptWitness{{Vkey: pub1, Signature: sig1}},
+			1000,
+			true,
+		),
+	) // Correct key and a signature that verifies over the actual payload
 
-	// Test ScriptAll with requireSignatures=true (structural validation: enforce signature presence and shape constraints only)
+	// Test ScriptAll with requireSignatures=true (every sub-script must verify)
 	scriptAll1, err := NewScriptSig(keyHash1)
 	assert.NoError(t, err)
 	scriptAll2, err := NewScriptSig(keyHash2)
@@ -1651,23 +1651,38 @@ func TestValidateScriptWithSignatures(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(
 		t,
-		ValidateScript(scriptAll, nil, 1000, true),
-	) // No signatures
+		ValidateScript(scriptAll, message, nil, 1000, true),
+	) // No witnesses
 	assert.False(
 		t,
-		ValidateScript(scriptAll, [][]byte{validSig}, 1000, true),
-	) // Insufficient signatures (needs 2)
+		ValidateScript(
+			scriptAll,
+			message,
+			[]ScriptWitness{{Vkey: pub1, Signature: sig1}},
+			1000,
+			true,
+		),
+	) // Only one of the two required signatures is present
 	assert.True(
 		t,
-		ValidateScript(scriptAll, [][]byte{validSig, validSig}, 1000, true),
-	) // Sufficient signatures (structural check only, no cryptographic verification)
+		ValidateScript(
+			scriptAll,
+			message,
+			[]ScriptWitness{
+				{Vkey: pub1, Signature: sig1},
+				{Vkey: pub2, Signature: sig2},
+			},
+			1000,
+			true,
+		),
+	) // Both signatures present and verify
 
-	// Test ScriptNOf with requireSignatures=true (structural validation: enforce signature presence and shape constraints only)
+	// Test ScriptNOf (2-of-3) with requireSignatures=true
 	scriptNOf1, err := NewScriptSig(keyHash1)
 	assert.NoError(t, err)
 	scriptNOf2, err := NewScriptSig(keyHash2)
 	assert.NoError(t, err)
-	scriptNOf3, err := NewScriptSig(keyHash2)
+	scriptNOf3, err := NewScriptSig(blake2b224(otherPub))
 	assert.NoError(t, err)
 	scriptNOf, err := NewScriptNOf(
 		2,
@@ -1678,16 +1693,31 @@ func TestValidateScriptWithSignatures(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(
 		t,
-		ValidateScript(scriptNOf, nil, 1000, true),
-	) // No signatures
+		ValidateScript(scriptNOf, message, nil, 1000, true),
+	) // No witnesses
 	assert.False(
 		t,
-		ValidateScript(scriptNOf, [][]byte{validSig}, 1000, true),
-	) // Insufficient signatures (needs 2)
+		ValidateScript(
+			scriptNOf,
+			message,
+			[]ScriptWitness{{Vkey: pub1, Signature: sig1}},
+			1000,
+			true,
+		),
+	) // Only one of the two required sub-scripts is satisfied
 	assert.True(
 		t,
-		ValidateScript(scriptNOf, [][]byte{validSig, validSig}, 1000, true),
-	) // Sufficient signatures (structural check only, no cryptographic verification)
+		ValidateScript(
+			scriptNOf,
+			message,
+			[]ScriptWitness{
+				{Vkey: pub1, Signature: sig1},
+				{Vkey: pub2, Signature: sig2},
+			},
+			1000,
+			true,
+		),
+	) // Two of three sub-scripts satisfied
 }
 
 func TestValidateScriptTimelockBoundaries(t *testing.T) {
@@ -1696,15 +1726,15 @@ func TestValidateScriptTimelockBoundaries(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(
 		t,
-		ValidateScript(scriptBefore, nil, 999, false),
+		ValidateScript(scriptBefore, nil, nil, 999, false),
 	) // Slot < before
 	assert.False(
 		t,
-		ValidateScript(scriptBefore, nil, 1000, false),
+		ValidateScript(scriptBefore, nil, nil, 1000, false),
 	) // Slot == before
 	assert.False(
 		t,
-		ValidateScript(scriptBefore, nil, 1001, false),
+		ValidateScript(scriptBefore, nil, nil, 1001, false),
 	) // Slot > before
 
 	// Test ScriptAfter boundary
@@ -1712,15 +1742,15 @@ func TestValidateScriptTimelockBoundaries(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(
 		t,
-		ValidateScript(scriptAfter, nil, 999, false),
+		ValidateScript(scriptAfter, nil, nil, 999, false),
 	) // Slot 999 < 1000 (false)
 	assert.True(
 		t,
-		ValidateScript(scriptAfter, nil, 1000, false),
+		ValidateScript(scriptAfter, nil, nil, 1000, false),
 	) // Slot == after (>=)
 	assert.True(
 		t,
-		ValidateScript(scriptAfter, nil, 1001, false),
+		ValidateScript(scriptAfter, nil, nil, 1001, false),
 	) // Slot 1001 >= 1000 (true)
 }
 

--- a/bursa_test.go
+++ b/bursa_test.go
@@ -32,19 +32,7 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/blake2b"
 )
-
-// blake2b224 returns the Blake2b-224 hash of data, matching the key-hash
-// derivation used for NativeScriptPubkey.Hash.
-func blake2b224(data []byte) []byte {
-	hasher, err := blake2b.New(28, nil)
-	if err != nil {
-		panic(err)
-	}
-	hasher.Write(data)
-	return hasher.Sum(nil)
-}
 
 // testKeyHash returns a 28-byte test key hash for use in tests
 func testKeyHash() []byte {
@@ -1579,8 +1567,8 @@ func TestValidateScriptWithSignatures(t *testing.T) {
 	otherPub, otherPriv, err := ed25519.GenerateKey(rand.Reader)
 	assert.NoError(t, err)
 
-	keyHash1 := blake2b224(pub1)
-	keyHash2 := blake2b224(pub2)
+	keyHash1 := lcommon.Blake2b224Hash(pub1).Bytes()
+	keyHash2 := lcommon.Blake2b224Hash(pub2).Bytes()
 
 	message := []byte("tx body hash placeholder")
 	otherMessage := []byte("a different payload")
@@ -1677,12 +1665,20 @@ func TestValidateScriptWithSignatures(t *testing.T) {
 		),
 	) // Both signatures present and verify
 
+	// Reusing one witness across repeated signature leaves is valid.
+	repeatedAll, err := NewScriptAll(scriptAll1, scriptAll1)
+	assert.NoError(t, err)
+	assert.True(t, ValidateScript(repeatedAll, message, []ScriptWitness{{Vkey: pub1, Signature: sig1}}, 1000, true))
+	repeatedNOf, err := NewScriptNOf(2, scriptAll1, scriptAll1)
+	assert.NoError(t, err)
+	assert.True(t, ValidateScript(repeatedNOf, message, []ScriptWitness{{Vkey: pub1, Signature: sig1}}, 1000, true))
+
 	// Test ScriptNOf (2-of-3) with requireSignatures=true
 	scriptNOf1, err := NewScriptSig(keyHash1)
 	assert.NoError(t, err)
 	scriptNOf2, err := NewScriptSig(keyHash2)
 	assert.NoError(t, err)
-	scriptNOf3, err := NewScriptSig(blake2b224(otherPub))
+	scriptNOf3, err := NewScriptSig(lcommon.Blake2b224Hash(otherPub).Bytes())
 	assert.NoError(t, err)
 	scriptNOf, err := NewScriptNOf(
 		2,

--- a/cmd/bursa/script.go
+++ b/cmd/bursa/script.go
@@ -106,22 +106,30 @@ Examples:
 func scriptValidateCommand() *cobra.Command {
 	var (
 		scriptFile     string
+		publicKeys     []string
 		signatures     []string
+		message        string
+		messageHex     string
 		slot           uint64
 		structuralOnly bool
 	)
 
 	scriptValidateCommand := &cobra.Command{
 		Use:   "validate",
-		Short: "Validates a script against signatures and slot",
-		Long: `Validates whether a script is satisfied given a set of signatures and current slot.
+		Short: "Validates a script against witnesses and slot",
+		Long: `Validates whether a script is satisfied given a set of vkey witnesses and current slot.
 
-By default, performs format validation requiring signatures for signature scripts.
-Use --structural-only for basic structure validation without signatures.
+By default, performs cryptographic validation requiring, for each signature
+script, a witness whose verification key hash matches the script and whose
+Ed25519 signature verifies against --message/--message-hex. Use
+--structural-only for basic structure validation without witnesses.
+
+--public-keys and --signatures are parallel, comma-separated lists: the Nth
+public key is paired with the Nth signature.
 
 Examples:
-  # Validate a script with signatures (hex-encoded signatures)
-  bursa script validate --script script.json --signatures 0123ab...,4567cd... --slot 123456789
+  # Validate a script against a witness (hex-encoded public key and signature)
+  bursa script validate --script script.json --public-keys abcd1234... --signatures 0123ab... --message-hex 74657874 --slot 123456789
 
   # Validate a timelocked script
   bursa script validate --script script.json --slot 123456789 --structural-only
@@ -129,22 +137,37 @@ Examples:
   # Perform structural validation only
   bursa script validate --script script.json --structural-only`,
 		Run: func(cmd *cobra.Command, args []string) {
-			cli.RunScriptValidate(scriptFile, signatures, slot, structuralOnly)
+			cli.RunScriptValidate(
+				scriptFile,
+				publicKeys,
+				signatures,
+				message,
+				messageHex,
+				slot,
+				structuralOnly,
+			)
 		},
 	}
 
 	scriptValidateCommand.Flags().
 		StringVar(&scriptFile, "script", "", "Path to script file (required)")
 	scriptValidateCommand.Flags().
-		StringSliceVar(&signatures, "signatures", nil, "Comma-separated list of signatures (hex encoded)")
+		StringSliceVar(&publicKeys, "public-keys", nil, "Comma-separated list of Ed25519 verification keys (hex encoded), paired by position with --signatures")
+	scriptValidateCommand.Flags().
+		StringSliceVar(&signatures, "signatures", nil, "Comma-separated list of signatures (hex encoded), paired by position with --public-keys")
+	scriptValidateCommand.Flags().
+		StringVar(&message, "message", "", "Signed payload as UTF-8 text (the data each signature covers)")
+	scriptValidateCommand.Flags().
+		StringVar(&messageHex, "message-hex", "", "Signed payload as hex")
 	scriptValidateCommand.Flags().
 		Uint64Var(&slot, "slot", 0, "Current slot number for timelock validation")
 	scriptValidateCommand.Flags().
-		BoolVar(&structuralOnly, "structural-only", false, "Perform structural validation only (no signature format checking)")
+		BoolVar(&structuralOnly, "structural-only", false, "Perform structural validation only (no witness verification)")
 
 	if err := scriptValidateCommand.MarkFlagRequired("script"); err != nil {
 		panic(err)
 	}
+	scriptValidateCommand.MarkFlagsMutuallyExclusive("message", "message-hex")
 	scriptValidateCommand.Args = cobra.NoArgs
 
 	return scriptValidateCommand

--- a/cmd/bursa/script.go
+++ b/cmd/bursa/script.go
@@ -145,6 +145,7 @@ Examples:
 				messageHex,
 				slot,
 				structuralOnly,
+				cmd.Flags().Changed("message") || cmd.Flags().Changed("message-hex"),
 			)
 		},
 	}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1153,6 +1153,15 @@ const docTemplate = `{
                 "script"
             ],
             "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "public_keys": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "require_signatures": {
                     "type": "boolean"
                 },
@@ -1199,12 +1208,15 @@ const docTemplate = `{
             ],
             "properties": {
                 "address": {
+                    "description": "Address is a hex-encoded address.",
                     "type": "string"
                 },
                 "payload": {
+                    "description": "Payload is a hex-encoded message payload.",
                     "type": "string"
                 },
                 "signing_key": {
+                    "description": "SigningKey identifies the signing key.",
                     "type": "string"
                 }
             }
@@ -1232,6 +1244,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "witnesses": {
+                    "description": "Witnesses are hex-encoded transaction witnesses.",
                     "type": "array",
                     "minItems": 1,
                     "items": {
@@ -1413,6 +1426,7 @@ const docTemplate = `{
                     "maximum": 2147483647
                 },
                 "mnemonic": {
+                    "description": "Mnemonic is a BIP39 mnemonic phrase.",
                     "type": "string",
                     "minLength": 1
                 },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1154,11 +1154,16 @@ const docTemplate = `{
             ],
             "properties": {
                 "message": {
+                    "description": "Hex-encoded signed payload",
+                    "format": "hex",
                     "type": "string"
                 },
                 "public_keys": {
                     "type": "array",
                     "items": {
+                        "format": "hex",
+                        "maxLength": 64,
+                        "minLength": 64,
                         "type": "string"
                     }
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1149,6 +1149,15 @@
                 "script"
             ],
             "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "public_keys": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "require_signatures": {
                     "type": "boolean"
                 },
@@ -1195,12 +1204,15 @@
             ],
             "properties": {
                 "address": {
+                    "description": "Address is a hex-encoded address.",
                     "type": "string"
                 },
                 "payload": {
+                    "description": "Payload is a hex-encoded message payload.",
                     "type": "string"
                 },
                 "signing_key": {
+                    "description": "SigningKey identifies the signing key.",
                     "type": "string"
                 }
             }
@@ -1228,6 +1240,7 @@
                     "type": "string"
                 },
                 "witnesses": {
+                    "description": "Witnesses are hex-encoded transaction witnesses.",
                     "type": "array",
                     "minItems": 1,
                     "items": {
@@ -1409,6 +1422,7 @@
                     "maximum": 2147483647
                 },
                 "mnemonic": {
+                    "description": "Mnemonic is a BIP39 mnemonic phrase.",
                     "type": "string",
                     "minLength": 1
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1150,11 +1150,16 @@
             ],
             "properties": {
                 "message": {
+                    "description": "Hex-encoded signed payload",
+                    "format": "hex",
                     "type": "string"
                 },
                 "public_keys": {
                     "type": "array",
                     "items": {
+                        "format": "hex",
+                        "maxLength": 64,
+                        "minLength": 64,
                         "type": "string"
                     }
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -198,6 +198,12 @@ definitions:
     type: object
   api.ScriptValidateRequest:
     properties:
+      message:
+        type: string
+      public_keys:
+        items:
+          type: string
+        type: array
       require_signatures:
         type: boolean
       script:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -199,9 +199,14 @@ definitions:
   api.ScriptValidateRequest:
     properties:
       message:
+        description: Hex-encoded signed payload
+        format: hex
         type: string
       public_keys:
         items:
+          format: hex
+          maxLength: 64
+          minLength: 64
           type: string
         type: array
       require_signatures:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -365,8 +365,17 @@ type ScriptCreateRequest struct {
 }
 
 // ScriptValidateRequest defines the request payload for script validation
+//
+// PublicKeys and Signatures are parallel arrays: PublicKeys[i] is the
+// hex-encoded Ed25519 verification key whose signature over Message is
+// Signatures[i]. Message is the hex-encoded signed payload (e.g. a
+// transaction body hash) that each signature is verified against; it is
+// required whenever RequireSignatures is true and the script needs
+// signatures.
 type ScriptValidateRequest struct {
 	Script            map[string]any `json:"script"                       validate:"required"`
+	Message           string         `json:"message,omitempty"            validate:"omitempty,hexadecimal"`
+	PublicKeys        []string       `json:"public_keys,omitempty"        validate:"dive,hexadecimal,len=64"`
 	Signatures        []string       `json:"signatures,omitempty"         validate:"dive,hexadecimal,len=128"`
 	Slot              uint64         `json:"slot,omitempty"                                                   swaggertype:"integer" format:"int64"`
 	RequireSignatures bool           `json:"require_signatures,omitempty"`
@@ -1576,33 +1585,59 @@ func handleScriptValidate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse signatures if provided
-	var signatures [][]byte
-	if len(req.Signatures) > 0 {
-		signatures = make([][]byte, len(req.Signatures))
-		for i, sigStr := range req.Signatures {
-			sig, err := hex.DecodeString(sigStr)
-			if err != nil {
-				logger.Error(
-					"invalid signature format",
-					"signature",
-					sigStr,
-					"error",
-					err,
-				)
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write([]byte(`{"error":"Invalid signature format"}`))
-				return
-			}
-			signatures[i] = sig
+	// Public keys and signatures are parallel arrays forming vkey witnesses.
+	if len(req.PublicKeys) != len(req.Signatures) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(
+			[]byte(`{"error":"public_keys and signatures must have the same length"}`),
+		)
+		return
+	}
+
+	witnesses := make([]bursa.ScriptWitness, len(req.Signatures))
+	for i, sigStr := range req.Signatures {
+		vkey, err := hex.DecodeString(req.PublicKeys[i])
+		if err != nil {
+			logger.Error("invalid public key format", "publicKey", req.PublicKeys[i], "error", err)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"Invalid public key format"}`))
+			return
 		}
+		sig, err := hex.DecodeString(sigStr)
+		if err != nil {
+			logger.Error("invalid signature format", "signature", sigStr, "error", err)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"Invalid signature format"}`))
+			return
+		}
+		witnesses[i] = bursa.ScriptWitness{Vkey: vkey, Signature: sig}
+	}
+
+	message, err := hex.DecodeString(req.Message)
+	if err != nil {
+		logger.Error("invalid message format", "error", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"Invalid message format"}`))
+		return
+	}
+	if req.RequireSignatures && len(message) == 0 && len(witnesses) > 0 {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(
+			[]byte(`{"error":"message is required to verify signatures"}`),
+		)
+		return
 	}
 
 	// Validate the script
 	valid := bursa.ValidateScript(
 		script,
-		signatures,
+		message,
+		witnesses,
 		req.Slot,
 		req.RequireSignatures,
 	)
@@ -1617,7 +1652,7 @@ func handleScriptValidate(w http.ResponseWriter, r *http.Request) {
 
 	response := ScriptValidateResponse{
 		ScriptHash: hex.EncodeToString(hash),
-		Signatures: len(signatures),
+		Signatures: len(witnesses),
 		Slot:       req.Slot,
 		Valid:      valid,
 	}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -374,8 +374,8 @@ type ScriptCreateRequest struct {
 // signatures.
 type ScriptValidateRequest struct {
 	Script            map[string]any `json:"script"                       validate:"required"`
-	Message           string         `json:"message,omitempty"            validate:"omitempty,hexadecimal"`
-	PublicKeys        []string       `json:"public_keys,omitempty"        validate:"dive,hexadecimal,len=64"`
+	Message           string         `json:"message,omitempty"            validate:"omitempty,hexadecimal" format:"hex"`
+	PublicKeys        []string       `json:"public_keys,omitempty"        validate:"dive,hexadecimal,len=64" minLength:"64" maxLength:"64" format:"hex"`
 	Signatures        []string       `json:"signatures,omitempty"         validate:"dive,hexadecimal,len=128"`
 	Slot              uint64         `json:"slot,omitempty"                                                   swaggertype:"integer" format:"int64"`
 	RequireSignatures bool           `json:"require_signatures,omitempty"`
@@ -1585,8 +1585,8 @@ func handleScriptValidate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Public keys and signatures are parallel arrays forming vkey witnesses.
-	if len(req.PublicKeys) != len(req.Signatures) {
+	// Public keys and signatures are only relevant to cryptographic validation.
+	if req.RequireSignatures && len(req.PublicKeys) != len(req.Signatures) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write(
@@ -1595,8 +1595,11 @@ func handleScriptValidate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	witnesses := make([]bursa.ScriptWitness, len(req.Signatures))
+	witnesses := make([]bursa.ScriptWitness, 0, len(req.Signatures))
 	for i, sigStr := range req.Signatures {
+		if !req.RequireSignatures {
+			break
+		}
 		vkey, err := hex.DecodeString(req.PublicKeys[i])
 		if err != nil {
 			logger.Error("invalid public key format", "publicKey", req.PublicKeys[i], "error", err)
@@ -1613,7 +1616,7 @@ func handleScriptValidate(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte(`{"error":"Invalid signature format"}`))
 			return
 		}
-		witnesses[i] = bursa.ScriptWitness{Vkey: vkey, Signature: sig}
+		witnesses = append(witnesses, bursa.ScriptWitness{Vkey: vkey, Signature: sig})
 	}
 
 	message, err := hex.DecodeString(req.Message)

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -17,6 +17,8 @@ package api
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
@@ -2945,6 +2947,100 @@ func TestHandleScriptValidate_WithSlot(t *testing.T) {
 	err = json.Unmarshal(body, &result)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(12345), result.Slot)
+}
+
+// TestHandleScriptValidate_CryptographicVerification exercises the fix for
+// issue #727: /api/script/validate must cryptographically verify each
+// Ed25519 signature against its public key and the script's key hash, not
+// merely check that the signature is 64 bytes.
+func TestHandleScriptValidate_CryptographicVerification(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	otherPub, otherPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	keyHash := hex.EncodeToString(lcommon.Blake2b224Hash(pub).Bytes())
+	message := []byte("tx body hash placeholder")
+	messageHex := hex.EncodeToString(message)
+	validSig := hex.EncodeToString(ed25519.Sign(priv, message))
+
+	scriptJSON := fmt.Sprintf(`{"type":"sig","keyHash":"%s"}`, keyHash)
+
+	validate := func(t *testing.T, reqBody string) *ScriptValidateResponse {
+		t.Helper()
+		req := httptest.NewRequest(
+			http.MethodPost,
+			"/api/script/validate",
+			strings.NewReader(reqBody),
+		)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		handleScriptValidate(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+
+		var result ScriptValidateResponse
+		require.NoError(t, json.Unmarshal(body, &result))
+		return &result
+	}
+
+	t.Run("valid witness verifies", func(t *testing.T) {
+		reqBody := fmt.Sprintf(`{
+			"script": %s,
+			"message": "%s",
+			"public_keys": ["%s"],
+			"signatures": ["%s"],
+			"require_signatures": true
+		}`, scriptJSON, messageHex, hex.EncodeToString(pub), validSig)
+		result := validate(t, reqBody)
+		assert.True(t, result.Valid)
+	})
+
+	t.Run("random signature bytes are rejected", func(t *testing.T) {
+		randomSig := make([]byte, ed25519.SignatureSize)
+		_, err := rand.Read(randomSig)
+		require.NoError(t, err)
+		reqBody := fmt.Sprintf(`{
+			"script": %s,
+			"message": "%s",
+			"public_keys": ["%s"],
+			"signatures": ["%s"],
+			"require_signatures": true
+		}`, scriptJSON, messageHex, hex.EncodeToString(pub), hex.EncodeToString(randomSig))
+		result := validate(t, reqBody)
+		assert.False(t, result.Valid)
+	})
+
+	t.Run("signature from the wrong key is rejected", func(t *testing.T) {
+		wrongKeySig := ed25519.Sign(otherPriv, message)
+		reqBody := fmt.Sprintf(`{
+			"script": %s,
+			"message": "%s",
+			"public_keys": ["%s"],
+			"signatures": ["%s"],
+			"require_signatures": true
+		}`, scriptJSON, messageHex, hex.EncodeToString(otherPub), hex.EncodeToString(wrongKeySig))
+		result := validate(t, reqBody)
+		assert.False(t, result.Valid)
+	})
+
+	t.Run("signature over the wrong payload is rejected", func(t *testing.T) {
+		wrongPayloadSig := ed25519.Sign(priv, []byte("a different payload"))
+		reqBody := fmt.Sprintf(`{
+			"script": %s,
+			"message": "%s",
+			"public_keys": ["%s"],
+			"signatures": ["%s"],
+			"require_signatures": true
+		}`, scriptJSON, messageHex, hex.EncodeToString(pub), hex.EncodeToString(wrongPayloadSig))
+		result := validate(t, reqBody)
+		assert.False(t, result.Valid)
+	})
 }
 
 func TestHandleTxDecode(t *testing.T) {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -2949,6 +2949,39 @@ func TestHandleScriptValidate_WithSlot(t *testing.T) {
 	assert.Equal(t, uint64(12345), result.Slot)
 }
 
+// TestHandleScriptValidate_StructuralOnlyIgnoresLegacySignatures ensures a
+// structural-only request (require_signatures: false) that still supplies
+// the legacy "signatures" field without a matching "public_keys" array is
+// not rejected by the public_keys/signatures pairing check: that pairing is
+// only meaningful when cryptographic verification is requested.
+func TestHandleScriptValidate_StructuralOnlyIgnoresLegacySignatures(t *testing.T) {
+	reqBody := `{
+		"script": {"type": "sig", "keyHash": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c"},
+		"signatures": ["` + strings.Repeat("00", 64) + `"],
+		"require_signatures": false
+	}`
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/script/validate",
+		strings.NewReader(reqBody),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handleScriptValidate(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+
+	var result ScriptValidateResponse
+	require.NoError(t, json.Unmarshal(body, &result))
+	assert.True(t, result.Valid)
+}
+
 // TestHandleScriptValidate_CryptographicVerification exercises the fix for
 // issue #727: /api/script/validate must cryptographically verify each
 // Ed25519 signature against its public key and the script's key hash, not

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"time"
 
@@ -1779,40 +1778,6 @@ func RunScriptCreate(
 	return nil
 }
 
-func scriptRequiresSignatures(script bursa.Script) bool {
-	nativeScript, ok := script.(*bursa.NativeScript)
-	if !ok {
-		return false
-	}
-	switch s := nativeScript.Item().(type) {
-	case *bursa.NativeScriptPubkey:
-		return true
-	case *bursa.NativeScriptAll:
-		return anyScriptRequiresSignatures(convertScripts(s.Scripts))
-	case *bursa.NativeScriptAny:
-		return anyScriptRequiresSignatures(convertScripts(s.Scripts))
-	case *bursa.NativeScriptNofK:
-		return anyScriptRequiresSignatures(convertScripts(s.Scripts))
-	case *bursa.NativeScriptInvalidBefore, *bursa.NativeScriptInvalidHereafter:
-		return false
-	}
-	return false
-}
-
-// convertScripts converts []lcommon.NativeScript to []bursa.Script
-func convertScripts(scripts []lcommon.NativeScript) []bursa.Script {
-	result := make([]bursa.Script, len(scripts))
-	for i, scr := range scripts {
-		result[i] = scr
-	}
-	return result
-}
-
-// anyScriptRequiresSignatures checks if any script in the slice requires signatures
-func anyScriptRequiresSignatures(scripts []bursa.Script) bool {
-	return slices.ContainsFunc(scripts, scriptRequiresSignatures)
-}
-
 // RunScriptValidate validates a script against a set of vkey witnesses and the
 // current slot. publicKeys and signatures are parallel arrays: publicKeys[i]
 // is the hex-encoded Ed25519 verification key whose signature over message is
@@ -1827,6 +1792,7 @@ func RunScriptValidate(
 	messageHex string,
 	slot uint64,
 	structuralOnly bool,
+	messageProvided bool,
 ) {
 	logger := logging.GetLogger()
 
@@ -1927,14 +1893,8 @@ func RunScriptValidate(
 	}
 
 	// Check if signatures are required
-	if !structuralOnly && len(witnesses) == 0 &&
-		scriptRequiresSignatures(script) {
-		logger.Error(
-			"signatures required for format validation of scripts with signature requirements (use --structural-only for basic structure checks)",
-		)
-		os.Exit(1)
-	}
-	if !structuralOnly && len(witnesses) > 0 && len(messageBytes) == 0 {
+	if !structuralOnly && len(witnesses) > 0 && len(messageBytes) == 0 &&
+		!messageProvided {
 		logger.Error(
 			"--message or --message-hex is required to verify signatures",
 		)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1813,9 +1813,18 @@ func anyScriptRequiresSignatures(scripts []bursa.Script) bool {
 	return slices.ContainsFunc(scripts, scriptRequiresSignatures)
 }
 
+// RunScriptValidate validates a script against a set of vkey witnesses and the
+// current slot. publicKeys and signatures are parallel arrays: publicKeys[i]
+// is the hex-encoded Ed25519 verification key whose signature over message is
+// signatures[i]. message (or messageHex) is the signed payload, e.g. a
+// transaction body hash; it is required whenever the script needs signatures
+// and structuralOnly is false.
 func RunScriptValidate(
 	scriptFile string,
+	publicKeys []string,
 	signatures []string,
+	message string,
+	messageHex string,
 	slot uint64,
 	structuralOnly bool,
 ) {
@@ -1856,9 +1865,46 @@ func RunScriptValidate(
 	}
 	hashHex := hex.EncodeToString(hash)
 
-	// Parse signatures
-	sigBytes := make([][]byte, 0, len(signatures))
-	for _, sigStr := range signatures {
+	// Resolve the signed payload from --message or --message-hex
+	var messageBytes []byte
+	switch {
+	case message != "" && messageHex != "":
+		logger.Error("only one of --message or --message-hex may be specified")
+		os.Exit(1)
+	case messageHex != "":
+		messageBytes, err = hex.DecodeString(messageHex)
+		if err != nil {
+			logger.Error("invalid message-hex format", "error", err)
+			os.Exit(1)
+		}
+	case message != "":
+		messageBytes = []byte(message)
+	}
+
+	// Parse public keys and signatures into vkey witnesses (parallel arrays)
+	if len(publicKeys) != len(signatures) {
+		logger.Error(
+			"public-keys and signatures must be provided in matching pairs",
+			"publicKeys",
+			len(publicKeys),
+			"signatures",
+			len(signatures),
+		)
+		os.Exit(1)
+	}
+	witnesses := make([]bursa.ScriptWitness, 0, len(signatures))
+	for i, sigStr := range signatures {
+		vkey, err := hex.DecodeString(publicKeys[i])
+		if err != nil {
+			logger.Error(
+				"invalid public key format",
+				"publicKey",
+				publicKeys[i],
+				"error",
+				err,
+			)
+			os.Exit(1)
+		}
 		sig, err := hex.DecodeString(sigStr)
 		if err != nil {
 			logger.Error(
@@ -1874,26 +1920,41 @@ func RunScriptValidate(
 			logger.Error("decoded signature is empty", "signature", sigStr)
 			os.Exit(1)
 		}
-		sigBytes = append(sigBytes, sig)
+		witnesses = append(
+			witnesses,
+			bursa.ScriptWitness{Vkey: vkey, Signature: sig},
+		)
 	}
 
 	// Check if signatures are required
-	if !structuralOnly && len(sigBytes) == 0 &&
+	if !structuralOnly && len(witnesses) == 0 &&
 		scriptRequiresSignatures(script) {
 		logger.Error(
 			"signatures required for format validation of scripts with signature requirements (use --structural-only for basic structure checks)",
 		)
 		os.Exit(1)
 	}
+	if !structuralOnly && len(witnesses) > 0 && len(messageBytes) == 0 {
+		logger.Error(
+			"--message or --message-hex is required to verify signatures",
+		)
+		os.Exit(1)
+	}
 
 	// Validate script
-	valid := bursa.ValidateScript(script, sigBytes, slot, !structuralOnly)
+	valid := bursa.ValidateScript(
+		script,
+		messageBytes,
+		witnesses,
+		slot,
+		!structuralOnly,
+	)
 
 	// Output result
 	result := map[string]any{
 		"valid":          valid,
 		"slot":           slot,
-		"signatures":     len(signatures),
+		"signatures":     len(witnesses),
 		"scriptHash":     hashHex,
 		"structuralOnly": structuralOnly,
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -1778,6 +1779,46 @@ func RunScriptCreate(
 	return nil
 }
 
+// scriptRequiresSignatures reports whether script contains a signature leaf
+// anywhere in its tree. It says nothing about whether those signatures are
+// actually necessary for the script to validate (an "any" branch might make
+// them optional, a timelock might already be satisfied) -- callers must only
+// use it to choose a diagnostic message after the real evaluator has already
+// decided a script does not validate, never to decide validity itself.
+func scriptRequiresSignatures(script bursa.Script) bool {
+	nativeScript, ok := script.(*bursa.NativeScript)
+	if !ok {
+		return false
+	}
+	switch s := nativeScript.Item().(type) {
+	case *bursa.NativeScriptPubkey:
+		return true
+	case *bursa.NativeScriptAll:
+		return anyScriptRequiresSignatures(convertScripts(s.Scripts))
+	case *bursa.NativeScriptAny:
+		return anyScriptRequiresSignatures(convertScripts(s.Scripts))
+	case *bursa.NativeScriptNofK:
+		return anyScriptRequiresSignatures(convertScripts(s.Scripts))
+	case *bursa.NativeScriptInvalidBefore, *bursa.NativeScriptInvalidHereafter:
+		return false
+	}
+	return false
+}
+
+// convertScripts converts []lcommon.NativeScript to []bursa.Script
+func convertScripts(scripts []lcommon.NativeScript) []bursa.Script {
+	result := make([]bursa.Script, len(scripts))
+	for i, scr := range scripts {
+		result[i] = scr
+	}
+	return result
+}
+
+// anyScriptRequiresSignatures checks if any script in the slice requires signatures
+func anyScriptRequiresSignatures(scripts []bursa.Script) bool {
+	return slices.ContainsFunc(scripts, scriptRequiresSignatures)
+}
+
 // RunScriptValidate validates a script against a set of vkey witnesses and the
 // current slot. publicKeys and signatures are parallel arrays: publicKeys[i]
 // is the hex-encoded Ed25519 verification key whose signature over message is
@@ -1901,7 +1942,10 @@ func RunScriptValidate(
 		os.Exit(1)
 	}
 
-	// Validate script
+	// Validate script. This is the real, slot- and witness-aware evaluator,
+	// so it's the only thing allowed to decide satisfiability: a witness-free
+	// conditional script (e.g. an "any" branch whose timelock already holds)
+	// still validates true here even with no signatures supplied.
 	valid := bursa.ValidateScript(
 		script,
 		messageBytes,
@@ -1909,6 +1953,20 @@ func RunScriptValidate(
 		slot,
 		!structuralOnly,
 	)
+
+	// A false result with no witnesses at all, for a script that actually
+	// has a signature leaf somewhere, means signatures were required and
+	// simply weren't provided -- surface that plainly instead of a bare
+	// "valid": false, matching the pre-witness-based CLI contract. This
+	// check runs only after ValidateScript has already decided false, so it
+	// can never override a script that validated via a witness-free branch.
+	if !valid && !structuralOnly && len(witnesses) == 0 &&
+		scriptRequiresSignatures(script) {
+		logger.Error(
+			"signatures required for format validation of scripts with signature requirements (use --structural-only for basic structure checks)",
+		)
+		os.Exit(1)
+	}
 
 	// Output result
 	result := map[string]any{

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1808,8 +1808,13 @@ func scriptRequiresSignatures(script bursa.Script) bool {
 // convertScripts converts []lcommon.NativeScript to []bursa.Script
 func convertScripts(scripts []lcommon.NativeScript) []bursa.Script {
 	result := make([]bursa.Script, len(scripts))
-	for i, scr := range scripts {
-		result[i] = scr
+	for i := range scripts {
+		// Take the address of each element rather than storing the value:
+		// scriptRequiresSignatures type-asserts on *bursa.NativeScript, and a
+		// value-typed NativeScript stored in the Script interface fails that
+		// assertion even though it satisfies the interface, silently
+		// reporting every nested script as not requiring signatures.
+		result[i] = &scripts[i]
 	}
 	return result
 }

--- a/internal/cli/script_commands_test.go
+++ b/internal/cli/script_commands_test.go
@@ -604,3 +604,37 @@ func TestParseBech32VerificationKey_WrongHRP(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid key type")
 }
+
+// TestScriptRequiresSignatures_Nested guards against convertScripts losing
+// the pointer dynamic type when converting nested script nodes: if it
+// stores NativeScript values instead of *NativeScript, scriptRequiresSignatures'
+// type assertion silently fails for every nested script and RunScriptValidate's
+// witness-required diagnostic never fires for ordinary multisig scripts.
+func TestScriptRequiresSignatures_Nested(t *testing.T) {
+	keyHash1 := make([]byte, 28)
+	keyHash1[0] = 0x01
+	keyHash2 := make([]byte, 28)
+	keyHash2[0] = 0x02
+	keyHash3 := make([]byte, 28)
+	keyHash3[0] = 0x03
+
+	// A 2-of-3 multisig wraps its sig leaves in an NofK node: the common
+	// case RunScriptValidate needs this helper to see through.
+	multisig, err := bursa.NewMultiSigScript(2, keyHash1, keyHash2, keyHash3)
+	require.NoError(t, err)
+	assert.True(t, scriptRequiresSignatures(multisig))
+
+	// An "all" wrapping sig leaves must also be detected.
+	sig1, err := bursa.NewScriptSig(keyHash1)
+	require.NoError(t, err)
+	sig2, err := bursa.NewScriptSig(keyHash2)
+	require.NoError(t, err)
+	allScript, err := bursa.NewScriptAll(sig1, sig2)
+	require.NoError(t, err)
+	assert.True(t, scriptRequiresSignatures(allScript))
+
+	// A script with no signature leaf anywhere must not.
+	timelock, err := bursa.NewScriptBefore(999999999)
+	require.NoError(t, err)
+	assert.False(t, scriptRequiresSignatures(timelock))
+}

--- a/openapi/api/openapi.yaml
+++ b/openapi/api/openapi.yaml
@@ -862,6 +862,17 @@ components:
       type: object
     api.ScriptValidateRequest:
       properties:
+        message:
+          description: Hex-encoded signed payload
+          format: hex
+          type: string
+        public_keys:
+          items:
+            format: hex
+            maxLength: 64
+            minLength: 64
+            type: string
+          type: array
         require_signatures:
           type: boolean
         script:

--- a/openapi/docs/ApiScriptValidateRequest.md
+++ b/openapi/docs/ApiScriptValidateRequest.md
@@ -4,6 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**Message** | Pointer to **string** |  | [optional] 
+**PublicKeys** | Pointer to **[]string** |  | [optional] 
 **RequireSignatures** | Pointer to **bool** |  | [optional] 
 **Script** | **map[string]map[string]interface{}** |  | 
 **Signatures** | Pointer to **[]string** |  | [optional] 
@@ -27,6 +29,56 @@ will change when the set of required properties is changed
 NewApiScriptValidateRequestWithDefaults instantiates a new ApiScriptValidateRequest object
 This constructor will only assign default values to properties that have it defined,
 but it doesn't guarantee that properties required by API are set
+
+### GetMessage
+
+`func (o *ApiScriptValidateRequest) GetMessage() string`
+
+GetMessage returns the Message field if non-nil, zero value otherwise.
+
+### GetMessageOk
+
+`func (o *ApiScriptValidateRequest) GetMessageOk() (*string, bool)`
+
+GetMessageOk returns a tuple with the Message field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetMessage
+
+`func (o *ApiScriptValidateRequest) SetMessage(v string)`
+
+SetMessage sets Message field to given value.
+
+### HasMessage
+
+`func (o *ApiScriptValidateRequest) HasMessage() bool`
+
+HasMessage returns a boolean if a field has been set.
+
+### GetPublicKeys
+
+`func (o *ApiScriptValidateRequest) GetPublicKeys() []string`
+
+GetPublicKeys returns the PublicKeys field if non-nil, zero value otherwise.
+
+### GetPublicKeysOk
+
+`func (o *ApiScriptValidateRequest) GetPublicKeysOk() (*[]string, bool)`
+
+GetPublicKeysOk returns a tuple with the PublicKeys field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetPublicKeys
+
+`func (o *ApiScriptValidateRequest) SetPublicKeys(v []string)`
+
+SetPublicKeys sets PublicKeys field to given value.
+
+### HasPublicKeys
+
+`func (o *ApiScriptValidateRequest) HasPublicKeys() bool`
+
+HasPublicKeys returns a boolean if a field has been set.
 
 ### GetRequireSignatures
 

--- a/openapi/model_api_script_validate_request.go
+++ b/openapi/model_api_script_validate_request.go
@@ -22,6 +22,8 @@ var _ MappedNullable = &ApiScriptValidateRequest{}
 
 // ApiScriptValidateRequest struct for ApiScriptValidateRequest
 type ApiScriptValidateRequest struct {
+	Message           *string                           `json:"message,omitempty"`
+	PublicKeys        []string                          `json:"public_keys,omitempty"`
 	RequireSignatures *bool                             `json:"require_signatures,omitempty"`
 	Script            map[string]map[string]interface{} `json:"script"`
 	Signatures        []string                          `json:"signatures,omitempty"`
@@ -46,6 +48,70 @@ func NewApiScriptValidateRequest(script map[string]map[string]interface{}) *ApiS
 func NewApiScriptValidateRequestWithDefaults() *ApiScriptValidateRequest {
 	this := ApiScriptValidateRequest{}
 	return &this
+}
+
+// GetMessage returns the Message field value if set, zero value otherwise.
+func (o *ApiScriptValidateRequest) GetMessage() string {
+	if o == nil || IsNil(o.Message) {
+		var ret string
+		return ret
+	}
+	return *o.Message
+}
+
+// GetMessageOk returns a tuple with the Message field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ApiScriptValidateRequest) GetMessageOk() (*string, bool) {
+	if o == nil || IsNil(o.Message) {
+		return nil, false
+	}
+	return o.Message, true
+}
+
+// HasMessage returns a boolean if a field has been set.
+func (o *ApiScriptValidateRequest) HasMessage() bool {
+	if o != nil && !IsNil(o.Message) {
+		return true
+	}
+
+	return false
+}
+
+// SetMessage gets a reference to the given string and assigns it to the Message field.
+func (o *ApiScriptValidateRequest) SetMessage(v string) {
+	o.Message = &v
+}
+
+// GetPublicKeys returns the PublicKeys field value if set, zero value otherwise.
+func (o *ApiScriptValidateRequest) GetPublicKeys() []string {
+	if o == nil || IsNil(o.PublicKeys) {
+		var ret []string
+		return ret
+	}
+	return o.PublicKeys
+}
+
+// GetPublicKeysOk returns a tuple with the PublicKeys field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ApiScriptValidateRequest) GetPublicKeysOk() ([]string, bool) {
+	if o == nil || IsNil(o.PublicKeys) {
+		return nil, false
+	}
+	return o.PublicKeys, true
+}
+
+// HasPublicKeys returns a boolean if a field has been set.
+func (o *ApiScriptValidateRequest) HasPublicKeys() bool {
+	if o != nil && !IsNil(o.PublicKeys) {
+		return true
+	}
+
+	return false
+}
+
+// SetPublicKeys gets a reference to the given []string and assigns it to the PublicKeys field.
+func (o *ApiScriptValidateRequest) SetPublicKeys(v []string) {
+	o.PublicKeys = v
 }
 
 // GetRequireSignatures returns the RequireSignatures field value if set, zero value otherwise.
@@ -178,6 +244,12 @@ func (o ApiScriptValidateRequest) MarshalJSON() ([]byte, error) {
 
 func (o ApiScriptValidateRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	if !IsNil(o.Message) {
+		toSerialize["message"] = o.Message
+	}
+	if !IsNil(o.PublicKeys) {
+		toSerialize["public_keys"] = o.PublicKeys
+	}
 	if !IsNil(o.RequireSignatures) {
 		toSerialize["require_signatures"] = o.RequireSignatures
 	}


### PR DESCRIPTION
## Problem

`ValidateScript`'s `ScriptSig` check only verified that a witness was 64
bytes long. Any 64-byte blob satisfied a script's signature requirement:
no public key, no key-hash check, no actual Ed25519 verification. As a
result, `/api/script/validate` could return `valid: true` for unrelated
signature bytes.

## Fix

- `ValidateScript`/`validateScriptSig` now take a `message []byte` (the
  signed payload) plus `[]ScriptWitness` (vkey + signature pairs, aliased
  to gouroboros's `VkeyWitness`). A `ScriptSig` node only validates when
  some witness's Blake2b-224 key hash matches the script's key hash *and*
  its Ed25519 signature verifies against `message`. Random bytes, a
  witness for an unrelated key, and a signature over the wrong payload are
  all rejected.
- Structural-only validation (`requireSignatures=false`) is unchanged.
- HTTP API: `ScriptValidateRequest` gained `message` and `public_keys`
  (parallel array to `signatures`); `handleScriptValidate` builds
  witnesses from them and rejects mismatched-length key/signature arrays.
- CLI: `script validate` gained `--public-keys`, `--message`/
  `--message-hex` (mutually exclusive), paired positionally with
  `--signatures`.
- Regenerated `docs/swagger.{json,yaml}` and `docs/docs.go`; hand-updated
  the generated `openapi/` client model and its doc page to match (no
  Java/openapi-generator toolchain available in this environment).

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...`, `go test -race ./...`
  — pass (root module and `ui/`, `openapi/` nested modules)
- `golangci-lint run ./...` — 0 issues
- `nilaway -include-pkgs=github.com/blinklabs-io/bursa ./...` — clean
- `go test ./docs/...` — pass (swagger/docs consistency check)
- Added `TestValidateScriptWithSignatures` cases and
  `TestHandleScriptValidate_CryptographicVerification` (API-level)
  covering: valid witness verifies, random signature bytes rejected,
  signature from the wrong key rejected, signature over the wrong payload
  rejected. Confirmed both fail without the fix by temporarily
  reintroducing the old length-only check, then pass again with the fix
  restored.

Fixes #727

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #727 by replacing the length-only signature check in `ValidateScript` with real Ed25519 verification. Previously any 64-byte blob satisfied a script's signature requirement; now a witness must match the script's key hash (Blake2b-224) and verify against a supplied message payload.

**API and CLI**
- `ScriptValidateRequest` gains hex `message` and `public_keys` (parallel to `signatures`); the CLI gains `--public-keys`, `--message`, and `--message-hex`.
- Swagger docs and the `openapi` client model were updated to match.
- The CLI exits 1 with a diagnostic when a signature-requiring script runs with zero witnesses, including nested multisig leaves; this check runs after validation so witness-free valid branches are unaffected.

**Breaking changes**
- `ValidateScript` now takes `message []byte` and `[]ScriptWitness` instead of `[][]byte`.
- `public_keys` and `signatures` must have equal length; `message` is required when signatures are present and `require_signatures` is true.
- Scripts with signature requirements now fail unless a matching witness verifies; structural-only validation (`requireSignatures=false`) is unchanged.
- The per-node minimum signature counts were removed; a single witness can now satisfy repeated signature leaves.

<sup>Written for commit f5af4bb17275c2dd3211529311101213e5a5a5d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Script validation now verifies Ed25519 signatures against supplied public keys and message payloads.
  - Added message and public-key inputs to API and command-line script validation.
  - Added support for plain-text or hexadecimal message input, with mutually exclusive options.

- **Bug Fixes**
  - Invalid signatures, mismatched keys, and signatures for altered messages are now rejected.

- **Documentation**
  - Updated API schemas and generated documentation for the new validation fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->