### PR TITLE
fix(signer): apply configured caller policies and policy hook

### DIFF
--- a/cmd/bursa/signer.go
+++ b/cmd/bursa/signer.go
@@ -134,6 +134,11 @@ key.`,
 				logger.Error("invalid signer.callers", "error", err)
 				os.Exit(1)
 			}
+			callerPolicies, err := signer.BuildCallerPolicies(cfg.Signer.CallerPolicies)
+			if err != nil {
+				logger.Error("invalid signer.caller_policies", "error", err)
+				os.Exit(1)
+			}
 			acl := api.NewCallerACL(aclMap)
 			if !acl.Restricted() {
 				logger.Warn("no signer.callers configured; any valid token may use any configured key")
@@ -183,11 +188,6 @@ key.`,
 			eng, err := policy.NewEngine(pols)
 			if err != nil {
 				logger.Error("invalid policy", "error", err)
-				os.Exit(1)
-			}
-			callerPolicies, err := signer.BuildCallerPolicies(cfg.Signer.CallerPolicies)
-			if err != nil {
-				logger.Error("invalid signer.caller_policies", "error", err)
 				os.Exit(1)
 			}
 			eng.SetCallerPolicies(callerPolicies)

--- a/cmd/bursa/signer.go
+++ b/cmd/bursa/signer.go
@@ -185,6 +185,13 @@ key.`,
 				logger.Error("invalid policy", "error", err)
 				os.Exit(1)
 			}
+			callerPolicies, err := signer.BuildCallerPolicies(cfg.Signer.CallerPolicies)
+			if err != nil {
+				logger.Error("invalid signer.caller_policies", "error", err)
+				os.Exit(1)
+			}
+			eng.SetCallerPolicies(callerPolicies)
+			policyHook := signer.BuildPolicyHook(cfg.Signer)
 			wm, mode, err := signer.BuildWatermark(ctx, cfg.Signer.Watermark)
 			if err != nil {
 				logger.Error("failed to build watermark", "error", err)
@@ -195,13 +202,14 @@ key.`,
 			m.Register(prometheus.DefaultRegisterer)
 
 			coord := signer.New(signer.Deps{
-				Resolver:  resolver,
-				Policy:    eng,
-				Watermark: wm,
-				WMMode:    mode,
-				Cardano:   operation.BursaCardano{},
-				Logger:    logger,
-				Metrics:   m,
+				Resolver:   resolver,
+				Policy:     eng,
+				Watermark:  wm,
+				WMMode:     mode,
+				Cardano:    operation.BursaCardano{},
+				Logger:     logger,
+				Metrics:    m,
+				PolicyHook: policyHook,
 			})
 
 			var validate api.Validator


### PR DESCRIPTION
Fixes #768

- Install configured caller policy overrides when building the signer.
- Pass the configured policy hook into the signing coordinator.
- Preserve fail-closed hook behavior for allow, deny, timeout, and unset cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Signer operations now apply caller-specific policies configured through `signer.caller_policies`.
  * Policy checks are integrated into the signer workflow for more targeted authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->