### PR TITLE
fix: raise Go security floors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/blinklabs-io/bursa
 
-go 1.25.8
+go 1.25.13
 
 require (
 	cloud.google.com/go/secretmanager v1.21.0

--- a/openapi/go.mod
+++ b/openapi/go.mod
@@ -1,6 +1,6 @@
 module github.com/blinklabs-io/bursa/openapi
 
-go 1.24.0
+go 1.25.13
 
 require github.com/stretchr/testify v1.12.1
 


### PR DESCRIPTION
## Summary

- Raise the root Bursa Go floor from 1.25.8 to 1.25.13.
- Raise the OpenAPI module Go floor from 1.24.0 to 1.25.13.

## Validation

- Root `go test -race -timeout 20m ./...` passed.
- Nested `ui` `go test -race -timeout 20m ./...` passed.
- `openapi` `go test -race -timeout 10m ./...` passed.
- `govulncheck ./...` reports no reachable vulnerabilities in root, `ui`, or `openapi`.
- `go mod tidy -diff` passed for root and `openapi`.
- `docker build --check .` passed.

This is a release-gate fix for the Bursa 0.17.0 preparation. It does not claim that the security report's remaining DB-ACT-13, DB-ACT-14, or BH-02 scope is closed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the Go toolchain floors to 1.25.13 to close a release-gate security vulnerability.

Updates the root `go.mod` from 1.25.8 to 1.25.13 and the `openapi` module from 1.24.0 to 1.25.13.

Validated with `go test -race` and `govulncheck`; no reachable vulnerabilities remain.

<sup>Written for commit aeea1291411edda4d2d6bd023dd56300c1b4a1f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required Go version to 1.25.13 across the project modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->