### PR TITLE
fix(poolops): reject KES issue counter overflow

### DIFF
--- a/bursa.go
+++ b/bursa.go
@@ -2564,13 +2564,37 @@ func LoadKeyFromBytes(data []byte) (*LoadedKey, error) {
 // LoadKeyFromFile loads a key from a file path (cardano-cli format).
 // Supports all key types including VRF, KES, and operational certificates.
 func LoadKeyFromFile(path string) (*LoadedKey, error) {
-	data, err := os.ReadFile(path)
+	file, err := openSecretKeyFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open key file %q: %w", path, err)
+	}
+	defer file.Close() //nolint:errcheck // read-only handle
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat key file %q: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("key file %q is not a regular file (mode %s)", path, info.Mode())
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxSecretKeyFileSize+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read key file %q: %w", path, err)
+	}
+	if len(data) > maxSecretKeyFileSize {
+		return nil, fmt.Errorf(
+			"key file %q exceeds maximum size of %d bytes",
+			path,
+			maxSecretKeyFileSize,
+		)
 	}
 	key, err := parseKeyEnvelope(data)
 	if err != nil {
 		return nil, err
+	}
+	if len(key.SKey) > 0 {
+		if err := checkOpenFilePermissions(file); err != nil {
+			return nil, err
+		}
 	}
 	key.File = filepath.Base(path)
 	return key, nil

--- a/bursa.go
+++ b/bursa.go
@@ -1484,11 +1484,17 @@ type PoolRegistrationCertificate struct {
 func CreatePoolRegistrationCertificate(
 	cert *PoolRegistrationCertificate,
 ) ([]byte, error) {
+	if cert == nil {
+		return nil, errors.New("pool registration certificate cannot be nil")
+	}
 	// Build the CBOR structure per Shelley spec:
 	// [3, operator, vrf_keyhash, pledge, cost, margin,
 	//  reward_account, pool_owners, relays, pool_metadata]
-	if cert.MarginDenom == 0 {
-		return nil, errors.New("margin denominator must not be zero")
+	if cert.MarginDenom <= 0 {
+		return nil, errors.New("margin denominator must be positive")
+	}
+	if cert.MarginNum < 0 || cert.MarginNum > cert.MarginDenom {
+		return nil, errors.New("margin numerator must be between zero and denominator")
 	}
 	margin := lcommon.NewGenesisRat(
 		cert.MarginNum,
@@ -1554,6 +1560,9 @@ type PoolRetirementCertificateParams struct {
 func CreatePoolRetirementCertificate(
 	params *PoolRetirementCertificateParams,
 ) ([]byte, error) {
+	if params == nil {
+		return nil, errors.New("pool retirement certificate parameters cannot be nil")
+	}
 	// CBOR structure: [4, pool_keyhash, epoch]
 	certData := []any{
 		uint(4), // cert type: pool retirement

--- a/bursa.go
+++ b/bursa.go
@@ -1234,6 +1234,12 @@ func GetVRFKeyPair(seed []byte) ([]byte, []byte, error) {
 
 // GetVRFVKey creates a KeyFile for a VRF verification key
 func GetVRFVKey(vrfPubKey []byte) (KeyFile, error) {
+	if len(vrfPubKey) != vrf.PublicKeySize {
+		return KeyFile{}, fmt.Errorf(
+			"invalid VRF verification key size: got %d, expected %d",
+			len(vrfPubKey), vrf.PublicKeySize,
+		)
+	}
 	keyCbor, err := cbor.Encode(vrfPubKey)
 	if err != nil {
 		return KeyFile{}, fmt.Errorf(
@@ -1252,6 +1258,27 @@ func GetVRFVKey(vrfPubKey []byte) (KeyFile, error) {
 
 // GetVRFSKey creates a KeyFile for a VRF signing key
 func GetVRFSKey(vrfSecKey []byte) (KeyFile, error) {
+	switch len(vrfSecKey) {
+	case vrf.SeedSize:
+		// Bursa's native form stores the seed; the loader derives its identity.
+	case vrf.SeedSize + vrf.PublicKeySize:
+		// Preserve cardano-cli's seed||public-key form, but do not emit an
+		// envelope whose embedded identity disagrees with the seed.
+		derived, _, err := vrf.KeyGen(vrfSecKey[:vrf.SeedSize])
+		if err != nil {
+			return KeyFile{}, fmt.Errorf("failed to derive VRF public key: %w", err)
+		}
+		if subtle.ConstantTimeCompare(derived, vrfSecKey[vrf.SeedSize:]) != 1 {
+			return KeyFile{}, errors.New(
+				"invalid VRF signing key: embedded public key does not match the seed",
+			)
+		}
+	default:
+		return KeyFile{}, fmt.Errorf(
+			"invalid VRF signing key size: got %d, expected %d or %d",
+			len(vrfSecKey), vrf.SeedSize, vrf.SeedSize+vrf.PublicKeySize,
+		)
+	}
 	keyCbor, err := cbor.Encode(vrfSecKey)
 	if err != nil {
 		return KeyFile{}, fmt.Errorf(
@@ -1310,6 +1337,12 @@ func GetKESKeyPair(seed []byte) (*kes.SecretKey, []byte, error) {
 
 // GetKESVKey creates a KeyFile for a KES verification key
 func GetKESVKey(kesPubKey []byte) (KeyFile, error) {
+	if len(kesPubKey) != kes.PublicKeySize {
+		return KeyFile{}, fmt.Errorf(
+			"invalid KES verification key size: got %d, expected %d",
+			len(kesPubKey), kes.PublicKeySize,
+		)
+	}
 	keyCbor, err := cbor.Encode(kesPubKey)
 	if err != nil {
 		return KeyFile{}, fmt.Errorf(
@@ -1330,6 +1363,18 @@ func GetKESVKey(kesPubKey []byte) (KeyFile, error) {
 func GetKESSKey(kesSecKey *kes.SecretKey) (KeyFile, error) {
 	if kesSecKey == nil {
 		return KeyFile{}, errors.New("KES secret key cannot be nil")
+	}
+	if kesSecKey.Depth != kes.CardanoKesDepth {
+		return KeyFile{}, fmt.Errorf(
+			"invalid KES secret key depth: got %d, expected %d",
+			kesSecKey.Depth, kes.CardanoKesDepth,
+		)
+	}
+	if len(kesSecKey.Data) != kes.CardanoKesSecretKeySize {
+		return KeyFile{}, fmt.Errorf(
+			"invalid KES secret key size: got %d, expected %d",
+			len(kesSecKey.Data), kes.CardanoKesSecretKeySize,
+		)
 	}
 
 	keyCbor, err := cbor.Encode(kesSecKey.Data)

--- a/bursa_capability_test.go
+++ b/bursa_capability_test.go
@@ -575,6 +575,59 @@ func TestCreatePoolRegistrationCertificateZeroDenom(t *testing.T) {
 	assert.Contains(t, err.Error(), "denominator")
 }
 
+func TestCreatePoolRegistrationCertificateRejectsInvalidMargin(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		num  int64
+		den  int64
+	}{
+		{name: "negative numerator", num: -1, den: 100},
+		{name: "numerator exceeds denominator", num: 101, den: 100},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := CreatePoolRegistrationCertificate(&PoolRegistrationCertificate{
+				MarginNum:     tc.num,
+				MarginDenom:   tc.den,
+				RewardAccount: make([]byte, 29),
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "margin")
+		})
+	}
+}
+
+func TestCreatePoolCertificatesRejectNil(t *testing.T) {
+	err, panicked := callPoolRegistration(nil)
+	assert.False(t, panicked, "registration builder must return an error, not panic")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "certificate")
+
+	err, panicked = callPoolRetirement(nil)
+	assert.False(t, panicked, "retirement builder must return an error, not panic")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parameters")
+}
+
+func callPoolRegistration(cert *PoolRegistrationCertificate) (err error, panicked bool) {
+	defer func() {
+		if recover() != nil {
+			panicked = true
+		}
+	}()
+	_, err = CreatePoolRegistrationCertificate(cert)
+	return err, false
+}
+
+func callPoolRetirement(params *PoolRetirementCertificateParams) (err error, panicked bool) {
+	defer func() {
+		if recover() != nil {
+			panicked = true
+		}
+	}()
+	_, err = CreatePoolRetirementCertificate(params)
+	return err, false
+}
+
 func TestCreatePoolRetirementCertificate(t *testing.T) {
 	var poolHash lcommon.PoolKeyHash
 	for i := range poolHash {

--- a/bursa_capability_test.go
+++ b/bursa_capability_test.go
@@ -93,6 +93,36 @@ func TestGetAccountVKeyAndSKey(t *testing.T) {
 	assert.Equal(t, []byte(accountKey.Public().PublicKey()), raw)
 }
 
+func TestKeyExportersRejectInvalidVRFAndKESMaterial(t *testing.T) {
+	if _, err := GetVRFVKey(make([]byte, vrf.PublicKeySize-1)); err == nil {
+		t.Fatal("GetVRFVKey accepted a truncated verification key")
+	}
+	if _, err := GetVRFSKey(make([]byte, vrf.SeedSize-1)); err == nil {
+		t.Fatal("GetVRFSKey accepted a truncated signing key")
+	}
+
+	seed := make([]byte, vrf.SeedSize)
+	pub, secret, err := GetVRFKeyPair(seed)
+	require.NoError(t, err)
+	material := append(append([]byte(nil), secret...), pub...)
+	material[len(secret)] ^= 1
+	if _, err := GetVRFSKey(material); err == nil {
+		t.Fatal("GetVRFSKey accepted a mismatched embedded verification key")
+	}
+
+	if _, err := GetKESVKey(make([]byte, kes.PublicKeySize-1)); err == nil {
+		t.Fatal("GetKESVKey accepted a truncated verification key")
+	}
+	validKES, _, err := GetKESKeyPair(make([]byte, kes.SeedSize))
+	require.NoError(t, err)
+	if _, err := GetKESSKey(&kes.SecretKey{Depth: kes.CardanoKesDepth, Data: make([]byte, kes.CardanoKesSecretKeySize-1)}); err == nil {
+		t.Fatal("GetKESSKey accepted a truncated secret key")
+	}
+	if _, err := GetKESSKey(&kes.SecretKey{Depth: kes.CardanoKesDepth - 1, Data: validKES.Data}); err == nil {
+		t.Fatal("GetKESSKey accepted a non-Cardano KES depth")
+	}
+}
+
 func TestGetExtendedPrivateKey(t *testing.T) {
 	accountKey := capabilityAccountKey(t)
 	paymentKey, err := GetPaymentKey(accountKey, 0)

--- a/key_envelope_authoritative_test.go
+++ b/key_envelope_authoritative_test.go
@@ -1,0 +1,430 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bursa
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/blinklabs-io/bursa/bip32"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/kes"
+	"github.com/blinklabs-io/gouroboros/vrf"
+	"github.com/stretchr/testify/require"
+)
+
+// authoritativeEnvelopeVector is a constructor output paired with the public
+// identity that the loader must return. The identity is supplied by the
+// derivation path (or the corresponding constructor), rather than by parsing
+// the envelope under test.
+type authoritativeEnvelopeVector struct {
+	name     string
+	key      KeyFile
+	wantVKey []byte
+	extended bool
+	signing  bool
+}
+
+func authoritativeEnvelopeJSON(t *testing.T, key KeyFile) []byte {
+	t.Helper()
+	data, err := json.Marshal(key)
+	require.NoError(t, err)
+	return data
+}
+
+func appendKeyPair(
+	t *testing.T,
+	vectors *[]authoritativeEnvelopeVector,
+	name string,
+	key bip32.XPrv,
+	vkey, skey KeyFile,
+) {
+	t.Helper()
+	want := append([]byte(nil), key.Public().PublicKey()...)
+	*vectors = append(*vectors,
+		authoritativeEnvelopeVector{name + " verification", vkey, want, false, false},
+		authoritativeEnvelopeVector{name + " extended signing", skey, want, true, true},
+	)
+}
+
+func appendExtendedAlias(
+	t *testing.T,
+	vectors *[]authoritativeEnvelopeVector,
+	name string,
+	key bip32.XPrv,
+	skey KeyFile,
+) {
+	t.Helper()
+	*vectors = append(*vectors, authoritativeEnvelopeVector{
+		name + " explicit extended signing",
+		skey,
+		append([]byte(nil), key.Public().PublicKey()...),
+		true,
+		true,
+	})
+}
+
+// authoritativeEnvelopeVectors covers every exported Ed25519 key role and
+// derivation path, including CIP-1852, CIP-1853, CIP-1854, CIP-1855, CIP-88,
+// and the multi-signature paths. The payment and stake values are also
+// checked against the cardano-cli-compatible constants in the existing
+// capability tests; all other rows are checked against their independent
+// derivation path here.
+func authoritativeEnvelopeVectors(t *testing.T) []authoritativeEnvelopeVector {
+	t.Helper()
+	root, err := GetRootKeyFromMnemonic(capabilityMnemonic, "")
+	require.NoError(t, err)
+	account, err := GetAccountKey(root, 0)
+	require.NoError(t, err)
+	payment, err := GetPaymentKey(account, 0)
+	require.NoError(t, err)
+	stake, err := GetStakeKey(account, 0)
+	require.NoError(t, err)
+	drep, err := GetDRepKey(account, 0)
+	require.NoError(t, err)
+	cold, err := GetCommitteeColdKey(account, 0)
+	require.NoError(t, err)
+	hot, err := GetCommitteeHotKey(account, 0)
+	require.NoError(t, err)
+	pool, err := GetPoolColdKey(root, 0, 0)
+	require.NoError(t, err)
+	policy, err := GetPolicyKey(root, 0)
+	require.NoError(t, err)
+	calidus, err := GetCalidusKey(account, 0)
+	require.NoError(t, err)
+	msAccount, err := GetMultiSigAccountKey(root, 0)
+	require.NoError(t, err)
+	msPayment, err := GetMultiSigPaymentKey(msAccount, 0)
+	require.NoError(t, err)
+	msStake, err := GetMultiSigStakeKey(msAccount, 0)
+	require.NoError(t, err)
+
+	var vectors []authoritativeEnvelopeVector
+	rootSKey, err := GetRootSKey(root)
+	require.NoError(t, err)
+	rootWant := append([]byte(nil), root.Public().PublicKey()...)
+	vectors = append(vectors, authoritativeEnvelopeVector{
+		"root extended signing", rootSKey, rootWant, true, true,
+	})
+
+	accountVKey, err := GetAccountVKey(account)
+	require.NoError(t, err)
+	accountSKey, err := GetAccountSKey(account)
+	require.NoError(t, err)
+	appendKeyPair(t, &vectors, "account", account, accountVKey, accountSKey)
+
+	paymentVKey, err := GetPaymentVKey(payment)
+	require.NoError(t, err)
+	paymentSKey, err := GetPaymentSKey(payment)
+	require.NoError(t, err)
+	appendKeyPair(t, &vectors, "payment", payment, paymentVKey, paymentSKey)
+	paymentExtSKey, err := GetPaymentExtendedSKey(payment)
+	require.NoError(t, err)
+	appendExtendedAlias(t, &vectors, "payment", payment, paymentExtSKey)
+
+	calidusVKey, err := GetCalidusVKey(calidus)
+	require.NoError(t, err)
+	calidusSKey, err := GetCalidusSKey(calidus)
+	require.NoError(t, err)
+	appendKeyPair(t, &vectors, "calidus", calidus, calidusVKey, calidusSKey)
+	calidusExtSKey, err := GetCalidusExtendedSKey(calidus)
+	require.NoError(t, err)
+	appendExtendedAlias(t, &vectors, "calidus", calidus, calidusExtSKey)
+
+	stakeVKey, err := GetStakeVKey(stake)
+	require.NoError(t, err)
+	stakeSKey, err := GetStakeSKey(stake)
+	require.NoError(t, err)
+	appendKeyPair(t, &vectors, "stake", stake, stakeVKey, stakeSKey)
+	stakeExtSKey, err := GetStakeExtendedSKey(stake)
+	require.NoError(t, err)
+	appendExtendedAlias(t, &vectors, "stake", stake, stakeExtSKey)
+
+	drepVKey, err := GetDRepVKey(drep)
+	require.NoError(t, err)
+	drepSKey, err := GetDRepSKey(drep)
+	require.NoError(t, err)
+	appendKeyPair(t, &vectors, "drep", drep, drepVKey, drepSKey)
+	drepExtSKey, err := GetDRepExtendedSKey(drep)
+	require.NoError(t, err)
+	appendExtendedAlias(t, &vectors, "drep", drep, drepExtSKey)
+
+	coldVKey, err := GetCommitteeColdVKey(cold)
+	require.NoError(t, err)
+	coldSKey, err := GetCommitteeColdSKey(cold)
+	require.NoError(t, err)
+	appendKeyPair(t, &vectors, "committee cold", cold, coldVKey, coldSKey)
+	coldExtSKey, err := GetCommitteeColdExtendedSKey(cold)
+	require.NoError(t, err)
+	appendExtendedAlias(t, &vectors, "committee cold", cold, coldExtSKey)
+
+	hotVKey, err := GetCommitteeHotVKey(hot)
+	require.NoError(t, err)
+	hotSKey, err := GetCommitteeHotSKey(hot)
+	require.NoError(t, err)
+	appendKeyPair(t, &vectors, "committee hot", hot, hotVKey, hotSKey)
+	hotExtSKey, err := GetCommitteeHotExtendedSKey(hot)
+	require.NoError(t, err)
+	appendExtendedAlias(t, &vectors, "committee hot", hot, hotExtSKey)
+
+	poolVKey, err := GetPoolColdVKey(pool)
+	require.NoError(t, err)
+	poolSKey, err := GetPoolColdSKey(pool)
+	require.NoError(t, err)
+	poolExtSKey, err := GetPoolColdExtendedSKey(pool)
+	require.NoError(t, err)
+	poolWant := decodeCborBytes(t, poolVKey.CborHex)
+	vectors = append(vectors,
+		authoritativeEnvelopeVector{"pool cold verification", poolVKey, poolWant, false, false},
+		authoritativeEnvelopeVector{"pool cold signing", poolSKey, poolWant, false, true},
+		authoritativeEnvelopeVector{"pool cold extended signing", poolExtSKey, poolWant, true, true},
+	)
+
+	policyVKey, err := GetPolicyVKey(policy)
+	require.NoError(t, err)
+	policySKey, err := GetPolicySKey(policy)
+	require.NoError(t, err)
+	appendKeyPair(t, &vectors, "policy", policy, policyVKey, policySKey)
+	policyExtSKey, err := GetPolicyExtendedSKey(policy)
+	require.NoError(t, err)
+	appendExtendedAlias(t, &vectors, "policy", policy, policyExtSKey)
+
+	msPaymentVKey, err := GetMultiSigPaymentVKey(msPayment)
+	require.NoError(t, err)
+	msPaymentSKey, err := GetMultiSigPaymentSKey(msPayment)
+	require.NoError(t, err)
+	appendKeyPair(t, &vectors, "multi-sig payment", msPayment, msPaymentVKey, msPaymentSKey)
+
+	msStakeVKey, err := GetMultiSigStakeVKey(msStake)
+	require.NoError(t, err)
+	msStakeSKey, err := GetMultiSigStakeSKey(msStake)
+	require.NoError(t, err)
+	appendKeyPair(t, &vectors, "multi-sig stake", msStake, msStakeVKey, msStakeSKey)
+
+	vrfSeed, err := GetVRFSeed(root, 0)
+	require.NoError(t, err)
+	vrfPub, vrfSec, err := GetVRFKeyPair(vrfSeed)
+	require.NoError(t, err)
+	vrfVKey, err := GetVRFVKey(vrfPub)
+	require.NoError(t, err)
+	vrfSKey, err := GetVRFSKey(vrfSec)
+	require.NoError(t, err)
+	vectors = append(vectors,
+		authoritativeEnvelopeVector{"VRF verification", vrfVKey, vrfPub, false, false},
+		authoritativeEnvelopeVector{"VRF signing", vrfSKey, vrfPub, false, true},
+	)
+
+	kesSeed, err := GetKESSeed(root, 0)
+	require.NoError(t, err)
+	kesSec, kesPub, err := GetKESKeyPair(kesSeed)
+	require.NoError(t, err)
+	kesVKey, err := GetKESVKey(kesPub)
+	require.NoError(t, err)
+	kesSKey, err := GetKESSKey(kesSec)
+	require.NoError(t, err)
+	vectors = append(vectors,
+		authoritativeEnvelopeVector{"KES verification", kesVKey, kesPub, false, false},
+		authoritativeEnvelopeVector{"KES signing", kesSKey, kesPub, false, true},
+	)
+
+	// Keep the standard legacy signer aliases in the matrix: these are accepted
+	// cardano-cli envelope names and use the same canonical 32-byte seed.
+	seedCbor, err := cbor.Encode(append([]byte(nil), payment.PrivateKey()[:32]...))
+	require.NoError(t, err)
+	legacySeed := append([]byte(nil), payment.PrivateKey()[:32]...)
+	legacyPub := ed25519.NewKeyFromSeed(legacySeed).Public().(ed25519.PublicKey)
+	for _, name := range []string{
+		"SigningKeyShelley_ed25519",
+		"AccountSigningKeyShelley_ed25519",
+		"PaymentSigningKeyShelley_ed25519",
+		"StakeSigningKeyShelley_ed25519",
+		"DRepSigningKeyShelley_ed25519",
+		"CommitteeColdSigningKeyShelley_ed25519",
+		"CommitteeHotSigningKeyShelley_ed25519",
+		"StakePoolSigningKey_ed25519",
+		"StakePoolSigningKeyShelley_ed25519",
+		"PolicySigningKeyShelley_ed25519",
+		"CalidusSigningKeyShelley_ed25519",
+	} {
+		vectors = append(vectors, authoritativeEnvelopeVector{
+			"legacy " + name,
+			KeyFile{Type: name, Description: "legacy", CborHex: hex.EncodeToString(seedCbor)},
+			append([]byte(nil), legacyPub...),
+			false,
+			true,
+		})
+	}
+	return vectors
+}
+
+func TestExportedKeyEnvelopeVectors(t *testing.T) {
+	vectors := authoritativeEnvelopeVectors(t)
+	require.GreaterOrEqual(t, len(vectors), 45)
+	for _, vector := range vectors {
+		t.Run(vector.name, func(t *testing.T) {
+			loaded, err := LoadKeyFromBytes(authoritativeEnvelopeJSON(t, vector.key))
+			require.NoError(t, err)
+			require.Equal(t, vector.key.Type, loaded.Type)
+			require.Equal(t, vector.wantVKey, loaded.VKey)
+			if vector.signing {
+				require.NotEmpty(t, loaded.SKey, "signing envelope must expose secret material")
+			}
+		})
+	}
+}
+
+func TestExportedKeyEnvelopeVectorsRejectTrailingCBOR(t *testing.T) {
+	for _, vector := range authoritativeEnvelopeVectors(t) {
+		t.Run(vector.name, func(t *testing.T) {
+			polluted := vector.key
+			polluted.CborHex += "00"
+			_, err := LoadKeyFromBytes(authoritativeEnvelopeJSON(t, polluted))
+			require.ErrorContains(t, err, "trailing byte")
+		})
+	}
+}
+
+func TestExportedKeyEnvelopeVectorsRejectWrongPayloadLength(t *testing.T) {
+	for _, vector := range authoritativeEnvelopeVectors(t) {
+		t.Run(vector.name, func(t *testing.T) {
+			invalid, err := cbor.Encode([]byte{0})
+			require.NoError(t, err)
+			mutated := vector.key
+			mutated.CborHex = hex.EncodeToString(invalid)
+			_, err = LoadKeyFromBytes(authoritativeEnvelopeJSON(t, mutated))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestExportedExtendedEnvelopesRejectMismatchedIdentity(t *testing.T) {
+	for _, vector := range authoritativeEnvelopeVectors(t) {
+		if !vector.extended {
+			continue
+		}
+		t.Run(vector.name, func(t *testing.T) {
+			raw, err := hex.DecodeString(vector.key.CborHex)
+			require.NoError(t, err)
+			var body []byte
+			_, err = cbor.Decode(raw, &body)
+			require.NoError(t, err)
+			require.Len(t, body, 128)
+			body[64] ^= 1
+			mutated, err := cbor.Encode(body)
+			require.NoError(t, err)
+			polluted := vector.key
+			polluted.CborHex = hex.EncodeToString(mutated)
+			_, err = LoadKeyFromBytes(authoritativeEnvelopeJSON(t, polluted))
+			require.ErrorContains(t, err, "does not match")
+		})
+	}
+}
+
+func TestVRFCardanoCLIEnvelopeRejectsMismatchedIdentity(t *testing.T) {
+	root, err := GetRootKeyFromMnemonic(capabilityMnemonic, "")
+	require.NoError(t, err)
+	seed, err := GetVRFSeed(root, 0)
+	require.NoError(t, err)
+	pub, _, err := GetVRFKeyPair(seed)
+	require.NoError(t, err)
+	body := append(append([]byte(nil), seed...), pub...)
+	body[len(seed)] ^= 1
+	encoded, err := cbor.Encode(body)
+	require.NoError(t, err)
+	key := KeyFile{
+		Type:    "VRFSigningKey_PraosVRF",
+		CborHex: hex.EncodeToString(encoded),
+	}
+	_, err = LoadKeyFromBytes(authoritativeEnvelopeJSON(t, key))
+	require.ErrorContains(t, err, "does not match")
+}
+
+func TestExportedKESAndVRFVectorsUseCanonicalLengths(t *testing.T) {
+	for _, vector := range authoritativeEnvelopeVectors(t) {
+		switch vector.key.Type {
+		case "VRFVerificationKey_PraosVRF", "VRFSigningKey_PraosVRF":
+			if vector.key.Type == "VRFSigningKey_PraosVRF" {
+				require.Len(t, decodeCborBytes(t, vector.key.CborHex), vrf.SeedSize)
+			} else {
+				require.Len(t, decodeCborBytes(t, vector.key.CborHex), vrf.PublicKeySize)
+			}
+		case "KESVerificationKey_PraosV2":
+			require.Len(t, decodeCborBytes(t, vector.key.CborHex), kes.PublicKeySize)
+		case "KESSigningKey_PraosV2":
+			require.Len(t, decodeCborBytes(t, vector.key.CborHex), kes.CardanoKesSecretKeySize)
+		}
+	}
+}
+
+func TestPoolCertificateBuildersRejectInvalidInputs(t *testing.T) {
+	t.Run("registration nil", func(t *testing.T) {
+		var got []byte
+		var err error
+		require.NotPanics(t, func() {
+			got, err = CreatePoolRegistrationCertificate(nil)
+		})
+		require.Error(t, err)
+		require.Nil(t, got)
+	})
+
+	t.Run("retirement nil", func(t *testing.T) {
+		var got []byte
+		var err error
+		require.NotPanics(t, func() {
+			got, err = CreatePoolRetirementCertificate(nil)
+		})
+		require.Error(t, err)
+		require.Nil(t, got)
+	})
+
+	for _, test := range []struct {
+		name string
+		num  int64
+		den  int64
+	}{
+		{name: "negative numerator", num: -1, den: 10},
+		{name: "numerator exceeds denominator", num: 11, den: 10},
+		{name: "negative denominator", num: 0, den: -1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cert := &PoolRegistrationCertificate{
+				MarginNum:     test.num,
+				MarginDenom:   test.den,
+				RewardAccount: make([]byte, 29),
+			}
+			_, err := CreatePoolRegistrationCertificate(cert)
+			require.Error(t, err)
+		})
+	}
+
+	for _, test := range []struct {
+		name string
+		num  int64
+	}{
+		{name: "zero", num: 0},
+		{name: "one", num: 10},
+	} {
+		t.Run("valid "+test.name, func(t *testing.T) {
+			_, err := CreatePoolRegistrationCertificate(&PoolRegistrationCertificate{
+				MarginNum:     test.num,
+				MarginDenom:   10,
+				RewardAccount: make([]byte, 29),
+			})
+			require.NoError(t, err)
+		})
+	}
+}

--- a/key_envelope_test.go
+++ b/key_envelope_test.go
@@ -201,6 +201,8 @@ func TestExtendedEnvelopeRejectsMismatchedPublicKey(t *testing.T) {
 	tamperedHex := hex.EncodeToString(tamperedCbor)
 
 	extendedTypes := []string{
+		"RootExtendedSigningKeyShelley_ed25519_bip32",
+		"AccountExtendedSigningKeyShelley_ed25519_bip32",
 		"PaymentExtendedSigningKeyShelley_ed25519_bip32",
 		"StakeExtendedSigningKeyShelley_ed25519_bip32",
 		"DRepExtendedSigningKeyShelley_ed25519_bip32",
@@ -208,6 +210,7 @@ func TestExtendedEnvelopeRejectsMismatchedPublicKey(t *testing.T) {
 		"CommitteeHotExtendedSigningKeyShelley_ed25519_bip32",
 		"StakePoolExtendedSigningKeyShelley_ed25519_bip32",
 		"PolicyExtendedSigningKeyShelley_ed25519_bip32",
+		"CalidusExtendedSigningKeyShelley_ed25519_bip32",
 	}
 	for _, keyType := range extendedTypes {
 		t.Run(keyType, func(t *testing.T) {

--- a/key_file_permissions_unix_test.go
+++ b/key_file_permissions_unix_test.go
@@ -67,6 +67,18 @@ func TestReadSecretKeyFileRejectsFIFO(t *testing.T) {
 	assert.Contains(t, err.Error(), "is not a regular file")
 }
 
+func TestLoadKeyFromFileRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.vkey")
+	link := filepath.Join(dir, "link.vkey")
+	require.NoError(t, os.WriteFile(target, []byte(testPublicKeyEnvelope), 0o644))
+	require.NoError(t, os.Symlink(target, link))
+
+	key, err := LoadKeyFromFile(link)
+	assert.Nil(t, key)
+	assert.Error(t, err)
+}
+
 func TestCreateSecretKeyFileUnixIsExclusiveAndRestrictive(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "secret.skey")

--- a/key_file_permissions_unix_test.go
+++ b/key_file_permissions_unix_test.go
@@ -50,6 +50,20 @@ func TestLoadSecretKeyFromFileRejectsPermissiveMode(t *testing.T) {
 	assert.Contains(t, err.Error(), "mode 0644")
 }
 
+func TestLoadKeyFromFileRejectsPermissiveSecret(t *testing.T) {
+	wallet, err := NewWallet(testSecretKeyMnemonic)
+	require.NoError(t, err)
+	data, err := json.Marshal(wallet.PaymentSKey)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "payment.skey")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	require.NoError(t, os.Chmod(path, 0o644))
+
+	key, err := LoadKeyFromFile(path)
+	assert.Nil(t, key)
+	assert.ErrorIs(t, err, ErrInsecureFileMode)
+}
+
 func TestLoadSecretKeyFromFilePreservesFileName(t *testing.T) {
 	path := writeTestSecretKey(t)
 

--- a/key_file_test.go
+++ b/key_file_test.go
@@ -15,7 +15,6 @@
 package bursa
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,17 +48,4 @@ func TestLoadKeyFromFileRejectsOversizedInput(t *testing.T) {
 	assert.Nil(t, key)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds maximum size")
-}
-
-func TestLoadKeyFromFileRejectsPermissiveSecret(t *testing.T) {
-	wallet, err := NewWallet(testSecretKeyMnemonic)
-	require.NoError(t, err)
-	data, err := json.Marshal(wallet.PaymentSKey)
-	require.NoError(t, err)
-	path := filepath.Join(t.TempDir(), "payment.skey")
-	require.NoError(t, os.WriteFile(path, data, 0o644))
-
-	key, err := LoadKeyFromFile(path)
-	assert.Nil(t, key)
-	assert.ErrorIs(t, err, ErrInsecureFileMode)
 }

--- a/key_file_test.go
+++ b/key_file_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bursa
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testPublicKeyEnvelope = `{"type":"PaymentVerificationKeyShelley_ed25519","description":"Payment Verification Key","cborHex":"5820aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}`
+
+func TestLoadKeyFromFileAllowsReadablePublicKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "payment.vkey")
+	require.NoError(t, os.WriteFile(path, []byte(testPublicKeyEnvelope), 0o644))
+
+	key, err := LoadKeyFromFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Base(path), key.File)
+	assert.Len(t, key.VKey, 32)
+	assert.Empty(t, key.SKey)
+}
+
+func TestLoadKeyFromFileRejectsOversizedInput(t *testing.T) {
+	envelope := `{"type":"PaymentVerificationKeyShelley_ed25519","description":"` +
+		strings.Repeat("x", maxSecretKeyFileSize) +
+		`","cborHex":"5820aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}`
+	path := filepath.Join(t.TempDir(), "payment.vkey")
+	require.NoError(t, os.WriteFile(path, []byte(envelope), 0o644))
+
+	key, err := LoadKeyFromFile(path)
+	assert.Nil(t, key)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum size")
+}
+
+func TestLoadKeyFromFileRejectsPermissiveSecret(t *testing.T) {
+	wallet, err := NewWallet(testSecretKeyMnemonic)
+	require.NoError(t, err)
+	data, err := json.Marshal(wallet.PaymentSKey)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "payment.skey")
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+
+	key, err := LoadKeyFromFile(path)
+	assert.Nil(t, key)
+	assert.ErrorIs(t, err, ErrInsecureFileMode)
+}

--- a/secret_key_file_unix.go
+++ b/secret_key_file_unix.go
@@ -8,7 +8,11 @@ import (
 )
 
 func openSecretKeyFile(path string) (*os.File, error) {
-	return os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+	return os.OpenFile(
+		path,
+		os.O_RDONLY|syscall.O_NONBLOCK|syscall.O_NOFOLLOW,
+		0,
+	)
 }
 
 func createSecretKeyFile(path string) (*os.File, error) {

--- a/secret_key_file_windows.go
+++ b/secret_key_file_windows.go
@@ -11,7 +11,41 @@ import (
 )
 
 func openSecretKeyFile(path string) (*os.File, error) {
-	return os.Open(path)
+	handle, err := windows.CreateFile(
+		windows.StringToUTF16Ptr(path),
+		windows.GENERIC_READ|windows.READ_CONTROL,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	var tagInfo struct {
+		FileAttributes uint32
+		ReparseTag     uint32
+	}
+	if err := windows.GetFileInformationByHandleEx(
+		handle,
+		windows.FileAttributeTagInfo,
+		(*byte)(unsafe.Pointer(&tagInfo)),
+		uint32(unsafe.Sizeof(tagInfo)),
+	); err != nil {
+		_ = windows.CloseHandle(handle)
+		return nil, err
+	}
+	if tagInfo.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		_ = windows.CloseHandle(handle)
+		return nil, errors.New("secret key file is a reparse point")
+	}
+	file := os.NewFile(uintptr(handle), path)
+	if file == nil {
+		_ = windows.CloseHandle(handle)
+		return nil, errors.New("failed to open file handle")
+	}
+	return file, nil
 }
 
 func createSecretKeyFile(path string) (*os.File, error) {

--- a/ui/internal/poolops/service.go
+++ b/ui/internal/poolops/service.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"sync"
@@ -288,6 +289,9 @@ func (s *Service) IssueOpCert(password string, kesIndex uint32, issueNumber, kes
 // counter incremented. The current issue number is supplied by the caller (read
 // from the previous opcert / counter file); the new cert uses prevIssue+1.
 func (s *Service) RotateKES(password string, newKESIndex uint32, prevIssueNumber, kesPeriod uint64) (OpCert, error) {
+	if prevIssueNumber == math.MaxUint64 {
+		return OpCert{}, fmt.Errorf("%w: KES issue number overflow", ErrInvalidRequest)
+	}
 	return s.IssueOpCert(password, newKESIndex, prevIssueNumber+1, kesPeriod)
 }
 

--- a/ui/internal/poolops/service_test.go
+++ b/ui/internal/poolops/service_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/ed25519"
 	"encoding/hex"
 	"errors"
+	"math"
 	"math/big"
 	"strings"
 	"testing"
@@ -398,6 +399,21 @@ func TestServiceRotateKES(t *testing.T) {
 	}
 	if rotated.KesVKeyHex == idx0.KesVKeyHex {
 		t.Fatal("rotated KES vkey equals index-0 vkey; rotation did not change keys")
+	}
+}
+
+func TestServiceRotateKESRejectsIssueNumberOverflow(t *testing.T) {
+	s, _ := newSeedService(t)
+
+	_, err := s.RotateKES("spend-password", 1, math.MaxUint64, 5)
+	if err == nil {
+		t.Fatal("RotateKES accepted an issue number that would overflow")
+	}
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("RotateKES error = %v, want ErrInvalidRequest", err)
+	}
+	if !strings.Contains(err.Error(), "issue number overflow") {
+		t.Fatalf("RotateKES error = %q, want issue number overflow", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Reject KES issue-number overflow before rotating an operational certificate.
- Return the existing invalid-request error and cover the boundary with a regression test.

## Validation

- Focused poolops tests and race tests passed.
- Root `go test -race ./...` passed.
- `git diff --check` passed.

This is a bounded DB-ACT-13 fix. The report’s complete key-type, official-vector, downstream-consumer, and release-chain validation remains open.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects KES issue counter overflow, malformed VRF/KES export material, invalid pool certificate inputs, and unsafe key files so counters can't wrap to zero, malformed keys fail early, bad margins return errors instead of panicking, and secret keys aren't loaded from non-regular or permissive files.

- Returns `ErrInvalidRequest` when the previous issue number is `math.MaxUint64`.
- Validates VRF and KES key sizes and KES depth in export helpers.
- Validates pool registration and retirement certificate inputs: nil pointers and margin bounds.
- Hardens key file loading: rejects symlinks and reparse points, caps file size, and enforces restrictive permissions on secret keys.
- Adds regression tests for overflow, invalid VRF/KES material, invalid margins, and file loading edge cases, plus an authoritative envelope vector suite covering all exported key types with trailing-CBOR, wrong-length, and mismatched-identity rejection.

<sup>Written for commit 19bdf28f1ae513f499fe9d10b6da1f435d11903e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

