### PR TITLE
fix(ui): bound detached transaction submissions

### DIFF
--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -2390,7 +2390,8 @@ func serve[T any](w http.ResponseWriter, v T, err error) {
 		// structured rejection reason (for submit), the funding shortfall, or the
 		// "already in the requested state" note rides along in the message.
 		writeJSON(w, http.StatusUnprocessableEntity, errBody(err))
-	case errors.Is(err, poolops.ErrSubmitUnknown):
+	case errors.Is(err, spend.ErrSubmitUnknown), errors.Is(err, multisig.ErrSubmitUnknown),
+		errors.Is(err, poolops.ErrSubmitUnknown):
 		writeJSON(w, http.StatusServiceUnavailable, errBody(err))
 	default:
 		writeJSON(w, http.StatusInternalServerError, errBody(err))

--- a/ui/internal/api/api.go
+++ b/ui/internal/api/api.go
@@ -2390,6 +2390,8 @@ func serve[T any](w http.ResponseWriter, v T, err error) {
 		// structured rejection reason (for submit), the funding shortfall, or the
 		// "already in the requested state" note rides along in the message.
 		writeJSON(w, http.StatusUnprocessableEntity, errBody(err))
+	case errors.Is(err, poolops.ErrSubmitUnknown):
+		writeJSON(w, http.StatusServiceUnavailable, errBody(err))
 	default:
 		writeJSON(w, http.StatusInternalServerError, errBody(err))
 	}

--- a/ui/internal/api/api_test.go
+++ b/ui/internal/api/api_test.go
@@ -2805,6 +2805,39 @@ func TestSpendErrorStatusCodes(t *testing.T) {
 	}
 }
 
+func TestSubmitUnknownStatusCodes(t *testing.T) {
+	for name, err := range map[string]error{
+		"spend":    fmt.Errorf("%w: %w", spend.ErrSubmitUnknown, context.DeadlineExceeded),
+		"multisig": fmt.Errorf("%w: %w", multisig.ErrSubmitUnknown, context.Canceled),
+		"poolops":  fmt.Errorf("%w: %w", poolops.ErrSubmitUnknown, context.DeadlineExceeded),
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			serve(rec, struct{}{}, err)
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+			}
+		})
+	}
+	rec := httptest.NewRecorder()
+	serve(rec, struct{}{}, spend.ErrSubmitRejected)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("rejected status = %d, want %d", rec.Code, http.StatusUnprocessableEntity)
+	}
+	for name, err := range map[string]error{
+		"multisig": multisig.ErrSubmitRejected,
+		"poolops":  poolops.ErrSubmitRejected,
+	} {
+		t.Run(name+" rejected", func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			serve(rec, struct{}{}, err)
+			if rec.Code != http.StatusUnprocessableEntity {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnprocessableEntity)
+			}
+		})
+	}
+}
+
 type historyExpiryResponse struct {
 	Enabled         bool
 	RestartRequired bool

--- a/ui/internal/multisig/importtx_test.go
+++ b/ui/internal/multisig/importtx_test.go
@@ -949,6 +949,53 @@ func TestSubmitImported_ThresholdMetBroadcasts(t *testing.T) {
 	}
 }
 
+func TestSubmitImportedClassifiesBackendTimeout(t *testing.T) {
+	fc := newFakeChain()
+	ks := newTestKeystore(t, mnemonicA)
+	svc := NewService(fc, ks, &memAccounts{})
+	mk, err := svc.MyKey("test-password-123")
+	if err != nil {
+		t.Fatalf("MyKey: %v", err)
+	}
+	acct, err := createForTest(svc, CreateRequest{
+		Label: "1of1", Network: "preview",
+		Policy: Policy{Threshold: 1, Participants: []Participant{{KeyHashHex: mk.KeyHashHex}}},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	fc.addUTxO(acct.ScriptAddress, strings.Repeat("77", 32), 0, 10_000_000)
+	built, err := svc.Build(context.Background(), acct.ID, BuildRequest{To: externalAddr(t), Lovelace: "1000000"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	signed, err := svc.CosignImported(built.UnsignedTxCBOR, "test-password-123")
+	if err != nil {
+		t.Fatalf("CosignImported: %v", err)
+	}
+	for name, tc := range map[string]struct {
+		backendErr error
+		unknown    bool
+	}{
+		"timeout":  {backendErr: context.DeadlineExceeded, unknown: true},
+		"rejected": {backendErr: errors.New("ledger rejected")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			fc.submitErr = tc.backendErr
+			_, err := svc.SubmitImported(context.Background(), signed.TxCBOR)
+			if err == nil {
+				t.Fatal("SubmitImported returned nil error")
+			}
+			if got := errors.Is(err, ErrSubmitUnknown); got != tc.unknown {
+				t.Fatalf("ErrSubmitUnknown = %t, want %t: %v", got, tc.unknown, err)
+			}
+			if got := errors.Is(err, ErrSubmitRejected); got == tc.unknown {
+				t.Fatalf("ErrSubmitRejected = %t for unknown=%t: %v", got, tc.unknown, err)
+			}
+		})
+	}
+}
+
 // ordinaryUnsignedTxHex builds a plain (non-script) unsigned spend directly
 // through apollo — no AttachScript call — so the resulting Conway tx's
 // witness set carries zero native scripts. It exercises the same

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -17,6 +17,7 @@ import (
 	"github.com/blinklabs-io/bursa/ui/internal/cardanonet"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/submissionctx"
+	"github.com/blinklabs-io/bursa/ui/internal/submissionerror"
 	"github.com/blinklabs-io/bursa/ui/internal/txwitness"
 	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -47,13 +48,6 @@ var (
 	// ErrSubmitUnknown: broadcast outcome was not known before its deadline (→ 503).
 	ErrSubmitUnknown = errors.New("transaction submission outcome unknown")
 )
-
-func wrapSubmitError(err error) error {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return fmt.Errorf("%w: %w", ErrSubmitUnknown, err)
-	}
-	return fmt.Errorf("%w: %w", ErrSubmitRejected, err)
-}
 
 // Participant is one signer in a multi-sig policy. KeyHashHex (Blake2b-224 of the
 // CIP-1854 multi-sig vkey, 28 bytes / 56 hex chars) is the only field the script
@@ -1043,7 +1037,7 @@ func (s *Service) Submit(ctx context.Context, id, unsignedTxCBOR string, witness
 	defer cancel()
 	txHash, err := a.WithContext(submissionContext).Submit()
 	if err != nil {
-		return TxResult{}, wrapSubmitError(err)
+		return TxResult{}, submissionerror.Wrap(err, ErrSubmitUnknown, ErrSubmitRejected)
 	}
 	return TxResult{TxHash: hex.EncodeToString(txHash.Bytes())}, nil
 }
@@ -1107,7 +1101,7 @@ func (s *Service) SubmitImported(ctx context.Context, txCbor string) (TxResult, 
 	defer cancel()
 	txHash, err := a.WithContext(submissionContext).Submit()
 	if err != nil {
-		return TxResult{}, wrapSubmitError(err)
+		return TxResult{}, submissionerror.Wrap(err, ErrSubmitUnknown, ErrSubmitRejected)
 	}
 	return TxResult{TxHash: hex.EncodeToString(txHash.Bytes())}, nil
 }

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -44,7 +44,16 @@ var (
 	ErrInvalidWitness = errors.New("invalid witness")
 	// ErrSubmitRejected: the node rejected the signed transaction (→ 422).
 	ErrSubmitRejected = errors.New("transaction rejected by node")
+	// ErrSubmitUnknown: broadcast outcome was not known before its deadline (→ 503).
+	ErrSubmitUnknown = errors.New("transaction submission outcome unknown")
 )
+
+func wrapSubmitError(err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("%w: %w", ErrSubmitUnknown, err)
+	}
+	return fmt.Errorf("%w: %w", ErrSubmitRejected, err)
+}
 
 // Participant is one signer in a multi-sig policy. KeyHashHex (Blake2b-224 of the
 // CIP-1854 multi-sig vkey, 28 bytes / 56 hex chars) is the only field the script
@@ -1034,7 +1043,7 @@ func (s *Service) Submit(ctx context.Context, id, unsignedTxCBOR string, witness
 	defer cancel()
 	txHash, err := a.WithContext(submissionContext).Submit()
 	if err != nil {
-		return TxResult{}, fmt.Errorf("%w: %w", ErrSubmitRejected, err)
+		return TxResult{}, wrapSubmitError(err)
 	}
 	return TxResult{TxHash: hex.EncodeToString(txHash.Bytes())}, nil
 }
@@ -1098,7 +1107,7 @@ func (s *Service) SubmitImported(ctx context.Context, txCbor string) (TxResult, 
 	defer cancel()
 	txHash, err := a.WithContext(submissionContext).Submit()
 	if err != nil {
-		return TxResult{}, fmt.Errorf("%w: %w", ErrSubmitRejected, err)
+		return TxResult{}, wrapSubmitError(err)
 	}
 	return TxResult{TxHash: hex.EncodeToString(txHash.Bytes())}, nil
 }

--- a/ui/internal/multisig/multisig.go
+++ b/ui/internal/multisig/multisig.go
@@ -16,6 +16,7 @@ import (
 	"github.com/blinklabs-io/bursa/bip32"
 	"github.com/blinklabs-io/bursa/ui/internal/cardanonet"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
+	"github.com/blinklabs-io/bursa/ui/internal/submissionctx"
 	"github.com/blinklabs-io/bursa/ui/internal/txwitness"
 	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -1029,7 +1030,9 @@ func (s *Service) Submit(ctx context.Context, id, unsignedTxCBOR string, witness
 	// Submit passes this context to backend.SubmitTxContext, so detach from the
 	// request context: the tx is fully signed and a client disconnect must not
 	// cancel the node broadcast and strand it.
-	txHash, err := a.WithContext(context.WithoutCancel(ctx)).Submit()
+	submissionContext, cancel := submissionctx.New(ctx)
+	defer cancel()
+	txHash, err := a.WithContext(submissionContext).Submit()
 	if err != nil {
 		return TxResult{}, fmt.Errorf("%w: %w", ErrSubmitRejected, err)
 	}
@@ -1091,7 +1094,9 @@ func (s *Service) SubmitImported(ctx context.Context, txCbor string) (TxResult, 
 	// Submit passes this context to backend.SubmitTxContext, so detach from the
 	// request context: the tx is fully signed and a client disconnect must not
 	// cancel the node broadcast and strand it.
-	txHash, err := a.WithContext(context.WithoutCancel(ctx)).Submit()
+	submissionContext, cancel := submissionctx.New(ctx)
+	defer cancel()
+	txHash, err := a.WithContext(submissionContext).Submit()
 	if err != nil {
 		return TxResult{}, fmt.Errorf("%w: %w", ErrSubmitRejected, err)
 	}

--- a/ui/internal/multisig/multisig_test.go
+++ b/ui/internal/multisig/multisig_test.go
@@ -53,6 +53,7 @@ type fakeChain struct {
 	utxos      map[string][]lcommon.Utxo
 	pp         backend.ProtocolParameters
 	submitHash lcommon.Blake2b256
+	submitErr  error
 	submitCbor []byte
 	submitMu   sync.Mutex
 }
@@ -124,6 +125,9 @@ func (fc *fakeChain) SubmitTx(tx []byte) (lcommon.Blake2b256, error) {
 	fc.submitMu.Lock()
 	fc.submitCbor = append(fc.submitCbor[:0], tx...)
 	fc.submitMu.Unlock()
+	if fc.submitErr != nil {
+		return lcommon.Blake2b256{}, fc.submitErr
+	}
 	return fc.submitHash, nil
 }
 func (fc *fakeChain) EvaluateTx(_ []byte, _ []lcommon.Utxo) (map[lcommon.RedeemerKey]lcommon.ExUnits, error) {

--- a/ui/internal/multisig/submit_error_test.go
+++ b/ui/internal/multisig/submit_error_test.go
@@ -1,0 +1,16 @@
+package multisig
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestWrapSubmitErrorClassifiesOutcome(t *testing.T) {
+	if err := wrapSubmitError(context.Canceled); !errors.Is(err, ErrSubmitUnknown) {
+		t.Fatalf("cancellation error = %v, want ErrSubmitUnknown", err)
+	}
+	if err := wrapSubmitError(errors.New("ledger rejected")); !errors.Is(err, ErrSubmitRejected) {
+		t.Fatalf("ordinary error = %v, want ErrSubmitRejected", err)
+	}
+}

--- a/ui/internal/multisig/submit_error_test.go
+++ b/ui/internal/multisig/submit_error_test.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/blinklabs-io/bursa/ui/internal/submissionerror"
 )
 
 func TestWrapSubmitErrorClassifiesOutcome(t *testing.T) {
-	if err := wrapSubmitError(context.Canceled); !errors.Is(err, ErrSubmitUnknown) {
+	if err := submissionerror.Wrap(context.Canceled, ErrSubmitUnknown, ErrSubmitRejected); !errors.Is(err, ErrSubmitUnknown) {
 		t.Fatalf("cancellation error = %v, want ErrSubmitUnknown", err)
 	}
-	if err := wrapSubmitError(errors.New("ledger rejected")); !errors.Is(err, ErrSubmitRejected) {
+	if err := submissionerror.Wrap(errors.New("ledger rejected"), ErrSubmitUnknown, ErrSubmitRejected); !errors.Is(err, ErrSubmitRejected) {
 		t.Fatalf("ordinary error = %v, want ErrSubmitRejected", err)
 	}
 }

--- a/ui/internal/poolops/poolops.go
+++ b/ui/internal/poolops/poolops.go
@@ -63,6 +63,8 @@ var (
 	ErrWrongPassword = errors.New("incorrect spending password")
 	// ErrSubmitRejected: the node rejected the signed transaction (→ 422).
 	ErrSubmitRejected = errors.New("transaction rejected by node")
+	// ErrSubmitUnknown: the broadcast did not complete before its deadline (→ 503).
+	ErrSubmitUnknown = errors.New("transaction submission outcome unknown")
 )
 
 // coldVKeyLen is the length of a raw Ed25519 verification key (cold/VRF/KES are

--- a/ui/internal/poolops/service.go
+++ b/ui/internal/poolops/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/bursa/bip32"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
+	"github.com/blinklabs-io/bursa/ui/internal/submissionctx"
 	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
@@ -786,7 +787,9 @@ func (s *Service) SubmitRetirement(ctx context.Context, password string, epoch u
 	// Submit passes this context to backend.SubmitTxContext, so detach from the
 	// request context: the tx is fully signed and a client disconnect must not
 	// cancel the node broadcast and strand it.
-	txHash, err := a.WithContext(context.WithoutCancel(ctx)).Submit()
+	submissionContext, cancel := submissionctx.New(ctx)
+	defer cancel()
+	txHash, err := a.WithContext(submissionContext).Submit()
 	if err != nil {
 		return TxResult{}, fmt.Errorf("%w: %w", ErrSubmitRejected, err)
 	}

--- a/ui/internal/poolops/service.go
+++ b/ui/internal/poolops/service.go
@@ -791,6 +791,9 @@ func (s *Service) SubmitRetirement(ctx context.Context, password string, epoch u
 	defer cancel()
 	txHash, err := a.WithContext(submissionContext).Submit()
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return TxResult{}, fmt.Errorf("%w: %w", ErrSubmitUnknown, err)
+		}
 		return TxResult{}, fmt.Errorf("%w: %w", ErrSubmitRejected, err)
 	}
 	return TxResult{TxHash: hex.EncodeToString(txHash.Bytes())}, nil

--- a/ui/internal/poolops/service.go
+++ b/ui/internal/poolops/service.go
@@ -30,6 +30,7 @@ import (
 	"github.com/blinklabs-io/bursa/bip32"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/submissionctx"
+	"github.com/blinklabs-io/bursa/ui/internal/submissionerror"
 	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
@@ -791,10 +792,7 @@ func (s *Service) SubmitRetirement(ctx context.Context, password string, epoch u
 	defer cancel()
 	txHash, err := a.WithContext(submissionContext).Submit()
 	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return TxResult{}, fmt.Errorf("%w: %w", ErrSubmitUnknown, err)
-		}
-		return TxResult{}, fmt.Errorf("%w: %w", ErrSubmitRejected, err)
+		return TxResult{}, submissionerror.Wrap(err, ErrSubmitUnknown, ErrSubmitRejected)
 	}
 	return TxResult{TxHash: hex.EncodeToString(txHash.Bytes())}, nil
 }

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -49,6 +49,8 @@ var (
 	// ErrSubmitRejected: the node rejected the signed transaction; the wrapped
 	// message carries its structured reason (→ 422).
 	ErrSubmitRejected = errors.New("transaction rejected by node")
+	// ErrSubmitUnknown: broadcast outcome was not known before its deadline (→ 503).
+	ErrSubmitUnknown = errors.New("transaction submission outcome unknown")
 	// ErrWalletChanged: the active wallet changed while a transaction was being
 	// built, so the preview is discarded instead of storing a stale pending send.
 	ErrWalletChanged = errors.New("wallet changed while building transaction")
@@ -59,6 +61,13 @@ var (
 	// witnesses match the transaction's required signers (→ 400).
 	ErrInvalidWitness = errors.New("invalid witness")
 )
+
+func wrapSubmitError(err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("%w: %w", ErrSubmitUnknown, err)
+	}
+	return fmt.Errorf("%w: %w", ErrSubmitRejected, err)
+}
 
 // pendingTTL bounds how long a built-but-unconfirmed transaction is held. After
 // it elapses the preview's UTxOs/params may be stale, so Confirm rejects it.
@@ -1426,7 +1435,7 @@ func (s *Service) Confirm(ctx context.Context, pendingID, password string) (TxRe
 	defer cancel()
 	txHash, err := a.WithContext(submissionContext).Submit()
 	if err != nil {
-		return TxResult{}, fmt.Errorf("%w: %w", ErrSubmitRejected, err)
+		return TxResult{}, wrapSubmitError(err)
 	}
 
 	return TxResult{TxHash: hex.EncodeToString(txHash.Bytes())}, nil
@@ -1778,7 +1787,7 @@ func (s *Service) SubmitSigned(ctx context.Context, unsignedTxCBOR, witnessCBOR 
 	defer cancel()
 	txHash, err := a.WithContext(submissionContext).Submit()
 	if err != nil {
-		return TxResult{}, fmt.Errorf("%w: %w", ErrSubmitRejected, err)
+		return TxResult{}, wrapSubmitError(err)
 	}
 	return TxResult{TxHash: hex.EncodeToString(txHash.Bytes())}, nil
 }
@@ -1810,7 +1819,7 @@ func (s *Service) Submit(ctx context.Context, txBytes []byte) (string, error) {
 	defer cancel()
 	txHash, err := backend.SubmitTxContext(submissionContext, s.chain, txBytes)
 	if err != nil {
-		return "", fmt.Errorf("%w: %w", ErrSubmitRejected, err)
+		return "", wrapSubmitError(err)
 	}
 	return hex.EncodeToString(txHash.Bytes()), nil
 }

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -23,6 +23,7 @@ import (
 	"github.com/blinklabs-io/bursa/bip32"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
 	"github.com/blinklabs-io/bursa/ui/internal/submissionctx"
+	"github.com/blinklabs-io/bursa/ui/internal/submissionerror"
 	"github.com/blinklabs-io/bursa/ui/internal/txwitness"
 	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -61,13 +62,6 @@ var (
 	// witnesses match the transaction's required signers (→ 400).
 	ErrInvalidWitness = errors.New("invalid witness")
 )
-
-func wrapSubmitError(err error) error {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return fmt.Errorf("%w: %w", ErrSubmitUnknown, err)
-	}
-	return fmt.Errorf("%w: %w", ErrSubmitRejected, err)
-}
 
 // pendingTTL bounds how long a built-but-unconfirmed transaction is held. After
 // it elapses the preview's UTxOs/params may be stale, so Confirm rejects it.
@@ -1435,7 +1429,7 @@ func (s *Service) Confirm(ctx context.Context, pendingID, password string) (TxRe
 	defer cancel()
 	txHash, err := a.WithContext(submissionContext).Submit()
 	if err != nil {
-		return TxResult{}, wrapSubmitError(err)
+		return TxResult{}, submissionerror.Wrap(err, ErrSubmitUnknown, ErrSubmitRejected)
 	}
 
 	return TxResult{TxHash: hex.EncodeToString(txHash.Bytes())}, nil
@@ -1787,7 +1781,7 @@ func (s *Service) SubmitSigned(ctx context.Context, unsignedTxCBOR, witnessCBOR 
 	defer cancel()
 	txHash, err := a.WithContext(submissionContext).Submit()
 	if err != nil {
-		return TxResult{}, wrapSubmitError(err)
+		return TxResult{}, submissionerror.Wrap(err, ErrSubmitUnknown, ErrSubmitRejected)
 	}
 	return TxResult{TxHash: hex.EncodeToString(txHash.Bytes())}, nil
 }
@@ -1819,7 +1813,7 @@ func (s *Service) Submit(ctx context.Context, txBytes []byte) (string, error) {
 	defer cancel()
 	txHash, err := backend.SubmitTxContext(submissionContext, s.chain, txBytes)
 	if err != nil {
-		return "", wrapSubmitError(err)
+		return "", submissionerror.Wrap(err, ErrSubmitUnknown, ErrSubmitRejected)
 	}
 	return hex.EncodeToString(txHash.Bytes()), nil
 }

--- a/ui/internal/spend/spend.go
+++ b/ui/internal/spend/spend.go
@@ -22,6 +22,7 @@ import (
 	"github.com/blinklabs-io/bursa"
 	"github.com/blinklabs-io/bursa/bip32"
 	"github.com/blinklabs-io/bursa/ui/internal/keystore"
+	"github.com/blinklabs-io/bursa/ui/internal/submissionctx"
 	"github.com/blinklabs-io/bursa/ui/internal/txwitness"
 	"github.com/blinklabs-io/bursa/ui/internal/wallet"
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -1421,7 +1422,9 @@ func (s *Service) Confirm(ctx context.Context, pendingID, password string) (TxRe
 	// Detach from the request context: the pending entry has already been
 	// consumed and the tx signed, so a client disconnect here must not cancel the
 	// broadcast and strand a transaction that can no longer be replayed.
-	txHash, err := a.WithContext(context.WithoutCancel(ctx)).Submit()
+	submissionContext, cancel := submissionctx.New(ctx)
+	defer cancel()
+	txHash, err := a.WithContext(submissionContext).Submit()
 	if err != nil {
 		return TxResult{}, fmt.Errorf("%w: %w", ErrSubmitRejected, err)
 	}
@@ -1771,7 +1774,9 @@ func (s *Service) SubmitSigned(ctx context.Context, unsignedTxCBOR, witnessCBOR 
 
 	// Detach from the request context: once submitted the inputs are consumed, so
 	// a client disconnect must not strand a broadcast (mirrors Confirm).
-	txHash, err := a.WithContext(context.WithoutCancel(ctx)).Submit()
+	submissionContext, cancel := submissionctx.New(ctx)
+	defer cancel()
+	txHash, err := a.WithContext(submissionContext).Submit()
 	if err != nil {
 		return TxResult{}, fmt.Errorf("%w: %w", ErrSubmitRejected, err)
 	}
@@ -1801,7 +1806,9 @@ func certKindsRequireWitnesses(kinds []CertKind) (needsStake, needsDRep bool) {
 func (s *Service) Submit(ctx context.Context, txBytes []byte) (string, error) {
 	// Detach from the request context: the tx is already signed, so a client
 	// disconnect must not cancel the node broadcast and strand it.
-	txHash, err := backend.SubmitTxContext(context.WithoutCancel(ctx), s.chain, txBytes)
+	submissionContext, cancel := submissionctx.New(ctx)
+	defer cancel()
+	txHash, err := backend.SubmitTxContext(submissionContext, s.chain, txBytes)
 	if err != nil {
 		return "", fmt.Errorf("%w: %w", ErrSubmitRejected, err)
 	}

--- a/ui/internal/spend/spend_test.go
+++ b/ui/internal/spend/spend_test.go
@@ -51,6 +51,7 @@ type fakeChain struct {
 	pp          backend.ProtocolParameters
 	maxTxFeeErr error
 	submitHash  lcommon.Blake2b256 // canned hash returned by SubmitTx
+	submitErr   error
 	submitCalls int                // count of SubmitTx invocations
 	submitCbor  []byte
 	submitMu    sync.Mutex
@@ -213,6 +214,9 @@ func (fc *fakeChain) SubmitTx(tx []byte) (lcommon.Blake2b256, error) {
 	if fc.releaseSubmit != nil {
 		<-fc.releaseSubmit
 	}
+	if fc.submitErr != nil {
+		return lcommon.Blake2b256{}, fc.submitErr
+	}
 	return fc.submitHash, nil
 }
 
@@ -244,6 +248,31 @@ func (fc *fakeChain) ScriptCbor(_ lcommon.Blake2b224) ([]byte, error) {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+func TestSubmitClassifiesBackendOutcome(t *testing.T) {
+	acct := mustDeriveTestAccount(t)
+	for name, want := range map[string]struct {
+		backendErr error
+		unknown    bool
+	}{
+		"deadline": {backendErr: context.DeadlineExceeded, unknown: true},
+		"rejected": {backendErr: errors.New("ledger rejected")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			service := NewService(&fakeChain{submitErr: want.backendErr}, nil, acct)
+			_, err := service.Submit(context.Background(), []byte("signed-tx"))
+			if err == nil {
+				t.Fatal("Submit returned nil error")
+			}
+			if got := errors.Is(err, ErrSubmitUnknown); got != want.unknown {
+				t.Fatalf("ErrSubmitUnknown = %t, want %t: %v", got, want.unknown, err)
+			}
+			if got := errors.Is(err, ErrSubmitRejected); got == want.unknown {
+				t.Fatalf("ErrSubmitRejected = %t for unknown=%t: %v", got, want.unknown, err)
+			}
+		})
+	}
+}
 
 func TestBuildProducesPreview(t *testing.T) {
 	acct := mustDeriveTestAccount(t)

--- a/ui/internal/spend/submit_error_test.go
+++ b/ui/internal/spend/submit_error_test.go
@@ -1,0 +1,16 @@
+package spend
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestWrapSubmitErrorClassifiesOutcome(t *testing.T) {
+	if err := wrapSubmitError(context.DeadlineExceeded); !errors.Is(err, ErrSubmitUnknown) {
+		t.Fatalf("deadline error = %v, want ErrSubmitUnknown", err)
+	}
+	if err := wrapSubmitError(errors.New("ledger rejected")); !errors.Is(err, ErrSubmitRejected) {
+		t.Fatalf("ordinary error = %v, want ErrSubmitRejected", err)
+	}
+}

--- a/ui/internal/spend/submit_error_test.go
+++ b/ui/internal/spend/submit_error_test.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/blinklabs-io/bursa/ui/internal/submissionerror"
 )
 
 func TestWrapSubmitErrorClassifiesOutcome(t *testing.T) {
-	if err := wrapSubmitError(context.DeadlineExceeded); !errors.Is(err, ErrSubmitUnknown) {
+	if err := submissionerror.Wrap(context.DeadlineExceeded, ErrSubmitUnknown, ErrSubmitRejected); !errors.Is(err, ErrSubmitUnknown) {
 		t.Fatalf("deadline error = %v, want ErrSubmitUnknown", err)
 	}
-	if err := wrapSubmitError(errors.New("ledger rejected")); !errors.Is(err, ErrSubmitRejected) {
+	if err := submissionerror.Wrap(errors.New("ledger rejected"), ErrSubmitUnknown, ErrSubmitRejected); !errors.Is(err, ErrSubmitRejected) {
 		t.Fatalf("ordinary error = %v, want ErrSubmitRejected", err)
 	}
 }

--- a/ui/internal/submissionctx/submissionctx.go
+++ b/ui/internal/submissionctx/submissionctx.go
@@ -1,0 +1,19 @@
+// Package submissionctx defines the lifetime policy for signed transaction
+// broadcasts that must finish even if the initiating request disconnects.
+package submissionctx
+
+import (
+	"context"
+	"time"
+)
+
+// Timeout bounds the time allowed for a signed transaction broadcast.
+const Timeout = 10 * time.Second
+
+// New returns a context that preserves the request's values but ignores its
+// cancellation, while imposing a finite deadline on the downstream client.
+// This lets a completed signing flow finish after a client disconnect without
+// allowing an unavailable node to hold a handler indefinitely.
+func New(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(parent), Timeout)
+}

--- a/ui/internal/submissionctx/submissionctx_test.go
+++ b/ui/internal/submissionctx/submissionctx_test.go
@@ -1,0 +1,31 @@
+package submissionctx
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNewBoundsDisconnectedSubmission(t *testing.T) {
+	key := struct{}{}
+	parent, cancel := context.WithCancel(context.WithValue(context.Background(), key, "preserved"))
+	parentDeadline, parentCancel := context.WithDeadline(parent, time.Now().Add(time.Hour))
+	defer parentCancel()
+	ctx, submissionCancel := New(parentDeadline)
+	defer submissionCancel()
+	cancel()
+
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("submission context canceled with request: %v", err)
+	}
+	if got := ctx.Value(key); got != "preserved" {
+		t.Fatalf("context value = %v, want preserved", got)
+	}
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("submission context has no deadline")
+	}
+	if remaining := time.Until(deadline); remaining <= 0 || remaining > Timeout {
+		t.Fatalf("deadline remaining = %s, want >0 and <= %s", remaining, Timeout)
+	}
+}

--- a/ui/internal/submissionerror/submissionerror.go
+++ b/ui/internal/submissionerror/submissionerror.go
@@ -1,0 +1,21 @@
+// Package submissionerror classifies transaction broadcast failures while
+// preserving the package-specific sentinel used by the caller.
+package submissionerror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// Wrap classifies cancellation and deadline errors as unknown outcomes and all
+// other errors as definitive rejection, preserving both sentinel and cause.
+func Wrap(err, unknown, rejected error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("%w: %w", unknown, err)
+	}
+	return fmt.Errorf("%w: %w", rejected, err)
+}

--- a/ui/internal/submissionerror/submissionerror_test.go
+++ b/ui/internal/submissionerror/submissionerror_test.go
@@ -1,0 +1,40 @@
+package submissionerror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestWrapPreservesSentinelsAndCause(t *testing.T) {
+	unknown := errors.New("unknown")
+	rejected := errors.New("rejected")
+	cause := errors.New("backend failure")
+	wrappedDeadline := fmt.Errorf("rpc: %w", context.DeadlineExceeded)
+	wrappedCancellation := fmt.Errorf("rpc: %w", context.Canceled)
+
+	for _, tc := range []struct {
+		name    string
+		cause   error
+		want    error
+		notWant error
+	}{
+		{name: "deadline", cause: wrappedDeadline, want: unknown, notWant: rejected},
+		{name: "cancellation", cause: wrappedCancellation, want: unknown, notWant: rejected},
+		{name: "rejection", cause: cause, want: rejected, notWant: unknown},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Wrap(tc.cause, unknown, rejected)
+			if !errors.Is(got, tc.want) || errors.Is(got, tc.notWant) {
+				t.Fatalf("Wrap(%v) = %v, want %v only", tc.cause, got, tc.want)
+			}
+			if !errors.Is(got, tc.cause) {
+				t.Fatalf("Wrap(%v) = %v, want original cause preserved", tc.cause, got)
+			}
+		})
+	}
+	if Wrap(nil, unknown, rejected) != nil {
+		t.Fatal("Wrap(nil) must remain nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Bound detached signed-transaction broadcasts with a finite deadline.
- Preserve request context values while tolerating client disconnects.
- Apply the policy consistently across spend, multisig, and pool submissions.

## Validation

- Focused race tests passed for spend, multisig, and pool operations.
- `git diff --check` passed.

This addresses the Bursa-owned BH-02 submission boundary. Full live stalled-endpoint and deployed shutdown validation remain separate release gates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds signed transaction broadcasts to a 10-second deadline so an unresponsive node can no longer hold the submission handler open indefinitely. Broadcasts still detach from request cancellation and preserve request values, but now time out; spend, multisig, and pool submissions that hit the deadline return 503 with an unknown-outcome error instead of 422, addressing the BH-02 submission boundary.

**Validation**
- Focused outcome-classification tests pass for spend, multisig, and pool submissions.
- `git diff --check` passes.
- Full stalled-endpoint and deployed shutdown validation remain separate release gates.

<sup>Written for commit 326f3e7d92712baee82d909b00addf5cefbe0545. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction submissions now continue briefly when the initiating request is canceled or disconnected.
  * Submission attempts are bounded by a 10-second timeout.
  * Unknown submission outcomes now return a clearer “Service Unavailable” response instead of a generic server error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->