### PR TITLE
fix(api): remove unused legacy wallet passwords

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -610,7 +610,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Deletes a wallet from persistent storage and optional password. Requires an authenticated wallet storage administrator.",
+                "description": "Deletes a wallet from persistent storage. Requires an authenticated wallet storage administrator.",
                 "consumes": [
                     "application/json"
                 ],
@@ -670,7 +670,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Gets a wallet from persistent storage and optional password and returns wallet details. Requires an authenticated wallet storage administrator.",
+                "description": "Gets a wallet from persistent storage and returns wallet details. Requires an authenticated wallet storage administrator.",
                 "consumes": [
                     "application/json"
                 ],
@@ -815,7 +815,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Updates a wallet from persistent storage and optional password and returns wallet details. Requires an authenticated wallet storage administrator.",
+                "description": "Updates a wallet from persistent storage and returns wallet details. Requires an authenticated wallet storage administrator.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1382,9 +1382,6 @@ const docTemplate = `{
                     "type": "string",
                     "maxLength": 100,
                     "minLength": 1
-                },
-                "password": {
-                    "type": "string"
                 }
             }
         },
@@ -1398,9 +1395,6 @@ const docTemplate = `{
                     "type": "string",
                     "maxLength": 100,
                     "minLength": 1
-                },
-                "password": {
-                    "type": "string"
                 }
             }
         },
@@ -1466,9 +1460,6 @@ const docTemplate = `{
                     "type": "string",
                     "maxLength": 100,
                     "minLength": 1
-                },
-                "password": {
-                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -606,7 +606,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Deletes a wallet from persistent storage and optional password. Requires an authenticated wallet storage administrator.",
+                "description": "Deletes a wallet from persistent storage. Requires an authenticated wallet storage administrator.",
                 "consumes": [
                     "application/json"
                 ],
@@ -666,7 +666,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Gets a wallet from persistent storage and optional password and returns wallet details. Requires an authenticated wallet storage administrator.",
+                "description": "Gets a wallet from persistent storage and returns wallet details. Requires an authenticated wallet storage administrator.",
                 "consumes": [
                     "application/json"
                 ],
@@ -811,7 +811,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Updates a wallet from persistent storage and optional password and returns wallet details. Requires an authenticated wallet storage administrator.",
+                "description": "Updates a wallet from persistent storage and returns wallet details. Requires an authenticated wallet storage administrator.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1378,9 +1378,6 @@
                     "type": "string",
                     "maxLength": 100,
                     "minLength": 1
-                },
-                "password": {
-                    "type": "string"
                 }
             }
         },
@@ -1394,9 +1391,6 @@
                     "type": "string",
                     "maxLength": 100,
                     "minLength": 1
-                },
-                "password": {
-                    "type": "string"
                 }
             }
         },
@@ -1462,9 +1456,6 @@
                     "type": "string",
                     "maxLength": 100,
                     "minLength": 1
-                },
-                "password": {
-                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -356,8 +356,6 @@ definitions:
         maxLength: 100
         minLength: 1
         type: string
-      password:
-        type: string
     required:
     - name
     type: object
@@ -366,8 +364,6 @@ definitions:
       name:
         maxLength: 100
         minLength: 1
-        type: string
-      password:
         type: string
     required:
     - name
@@ -415,8 +411,6 @@ definitions:
       name:
         maxLength: 100
         minLength: 1
-        type: string
-      password:
         type: string
     required:
     - name
@@ -946,7 +940,7 @@ paths:
     post:
       consumes:
       - application/json
-      description: Deletes a wallet from persistent storage and optional password.
+      description: Deletes a wallet from persistent storage.
         Requires an authenticated wallet storage administrator.
       parameters:
       - description: Wallet Delete Request
@@ -985,7 +979,7 @@ paths:
     post:
       consumes:
       - application/json
-      description: Gets a wallet from persistent storage and optional password and
+      description: Gets a wallet from persistent storage and
         returns wallet details. Requires an authenticated wallet storage administrator.
       parameters:
       - description: Wallet Restore Request
@@ -1079,7 +1073,7 @@ paths:
     post:
       consumes:
       - application/json
-      description: Updates a wallet from persistent storage and optional password
+      description: Updates a wallet from persistent storage
         and returns wallet details. Requires an authenticated wallet storage administrator.
       parameters:
       - description: Wallet Update Request

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -322,14 +322,12 @@ type WalletCreateRequest struct {
 
 // WalletDeleteRequest defines the request payload for wallet deletion
 type WalletDeleteRequest struct {
-	Name     string `json:"name"     validate:"required,min=1,max=100"`
-	Password string `json:"password"` //nolint:gosec // G117: password field is intentional
+	Name string `json:"name" validate:"required,min=1,max=100"`
 }
 
 // WalletGetRequest defines the request payload for wallet loading
 type WalletGetRequest struct {
-	Name     string `json:"name"     validate:"required,min=1,max=100"`
-	Password string `json:"password"` //nolint:gosec // G117: password field is intentional
+	Name string `json:"name" validate:"required,min=1,max=100"`
 }
 
 // WalletRestoreRequest defines the request payload for wallet restoration
@@ -350,7 +348,6 @@ type WalletRestoreRequest struct {
 // WalletUpdateRequest defines the request payload for wallet update
 type WalletUpdateRequest struct {
 	Name        string `json:"name"        validate:"required,min=1,max=100"`
-	Password    string `json:"password"` //nolint:gosec // G117: password field is intentional
 	Description string `json:"description" validate:"max=500"`
 }
 
@@ -1224,7 +1221,7 @@ func handleWalletList(w http.ResponseWriter, r *http.Request) {
 // handleWalletGet handles the wallet get request.
 //
 //	@Summary		Get wallet from persistent storage
-//	@Description	Gets a wallet from persistent storage and optional password and returns wallet details. Requires an authenticated wallet storage administrator.
+//	@Description	Gets a wallet from persistent storage and returns wallet details. Requires an authenticated wallet storage administrator.
 //	@Accept			json
 //	@Produce		json
 //	@Param			request	body		WalletGetRequest	true	"Wallet Restore Request"
@@ -1291,7 +1288,7 @@ func handleWalletGet(w http.ResponseWriter, r *http.Request) {
 // handleWalletDelete handles the wallet delete request.
 //
 //	@Summary		Delete wallet from persistent storage
-//	@Description	Deletes a wallet from persistent storage and optional password. Requires an authenticated wallet storage administrator.
+//	@Description	Deletes a wallet from persistent storage. Requires an authenticated wallet storage administrator.
 //	@Accept			json
 //	@Produce		json
 //	@Param			request	body		WalletDeleteRequest	true	"Wallet Delete Request"
@@ -1348,7 +1345,7 @@ func handleWalletDelete(w http.ResponseWriter, r *http.Request) {
 // handleWalletUpdate handles the wallet update request.
 //
 //	@Summary		Update a wallet in persistent storage
-//	@Description	Updates a wallet from persistent storage and optional password and returns wallet details. Requires an authenticated wallet storage administrator.
+//	@Description	Updates a wallet from persistent storage and returns wallet details. Requires an authenticated wallet storage administrator.
 //	@Accept			json
 //	@Produce		json
 //	@Param			request	body		WalletUpdateRequest	true	"Wallet Update Request"

--- a/openapi/docs/ApiWalletDeleteRequest.md
+++ b/openapi/docs/ApiWalletDeleteRequest.md
@@ -5,7 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **string** |  | 
-**Password** | Pointer to **string** |  | [optional] 
 
 ## Methods
 
@@ -46,32 +45,6 @@ and a boolean to check if the value has been set.
 SetName sets Name field to given value.
 
 
-### GetPassword
-
-`func (o *ApiWalletDeleteRequest) GetPassword() string`
-
-GetPassword returns the Password field if non-nil, zero value otherwise.
-
-### GetPasswordOk
-
-`func (o *ApiWalletDeleteRequest) GetPasswordOk() (*string, bool)`
-
-GetPasswordOk returns a tuple with the Password field if it's non-nil, zero value otherwise
-and a boolean to check if the value has been set.
-
-### SetPassword
-
-`func (o *ApiWalletDeleteRequest) SetPassword(v string)`
-
-SetPassword sets Password field to given value.
-
-### HasPassword
-
-`func (o *ApiWalletDeleteRequest) HasPassword() bool`
-
-HasPassword returns a boolean if a field has been set.
-
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
-
 

--- a/openapi/docs/ApiWalletGetRequest.md
+++ b/openapi/docs/ApiWalletGetRequest.md
@@ -5,7 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **string** |  | 
-**Password** | Pointer to **string** |  | [optional] 
 
 ## Methods
 
@@ -46,32 +45,6 @@ and a boolean to check if the value has been set.
 SetName sets Name field to given value.
 
 
-### GetPassword
-
-`func (o *ApiWalletGetRequest) GetPassword() string`
-
-GetPassword returns the Password field if non-nil, zero value otherwise.
-
-### GetPasswordOk
-
-`func (o *ApiWalletGetRequest) GetPasswordOk() (*string, bool)`
-
-GetPasswordOk returns a tuple with the Password field if it's non-nil, zero value otherwise
-and a boolean to check if the value has been set.
-
-### SetPassword
-
-`func (o *ApiWalletGetRequest) SetPassword(v string)`
-
-SetPassword sets Password field to given value.
-
-### HasPassword
-
-`func (o *ApiWalletGetRequest) HasPassword() bool`
-
-HasPassword returns a boolean if a field has been set.
-
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
-
 

--- a/openapi/docs/ApiWalletUpdateRequest.md
+++ b/openapi/docs/ApiWalletUpdateRequest.md
@@ -6,7 +6,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Description** | Pointer to **string** |  | [optional] 
 **Name** | **string** |  | 
-**Password** | Pointer to **string** |  | [optional] 
 
 ## Methods
 
@@ -72,32 +71,6 @@ and a boolean to check if the value has been set.
 SetName sets Name field to given value.
 
 
-### GetPassword
-
-`func (o *ApiWalletUpdateRequest) GetPassword() string`
-
-GetPassword returns the Password field if non-nil, zero value otherwise.
-
-### GetPasswordOk
-
-`func (o *ApiWalletUpdateRequest) GetPasswordOk() (*string, bool)`
-
-GetPasswordOk returns a tuple with the Password field if it's non-nil, zero value otherwise
-and a boolean to check if the value has been set.
-
-### SetPassword
-
-`func (o *ApiWalletUpdateRequest) SetPassword(v string)`
-
-SetPassword sets Password field to given value.
-
-### HasPassword
-
-`func (o *ApiWalletUpdateRequest) HasPassword() bool`
-
-HasPassword returns a boolean if a field has been set.
-
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
-
 

--- a/openapi/model_api_wallet_delete_request.go
+++ b/openapi/model_api_wallet_delete_request.go
@@ -22,8 +22,7 @@ var _ MappedNullable = &ApiWalletDeleteRequest{}
 
 // ApiWalletDeleteRequest struct for ApiWalletDeleteRequest
 type ApiWalletDeleteRequest struct {
-	Name     string  `json:"name"`
-	Password *string `json:"password,omitempty"`
+	Name string `json:"name"`
 }
 
 type _ApiWalletDeleteRequest ApiWalletDeleteRequest
@@ -70,38 +69,6 @@ func (o *ApiWalletDeleteRequest) SetName(v string) {
 	o.Name = v
 }
 
-// GetPassword returns the Password field value if set, zero value otherwise.
-func (o *ApiWalletDeleteRequest) GetPassword() string {
-	if o == nil || IsNil(o.Password) {
-		var ret string
-		return ret
-	}
-	return *o.Password
-}
-
-// GetPasswordOk returns a tuple with the Password field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *ApiWalletDeleteRequest) GetPasswordOk() (*string, bool) {
-	if o == nil || IsNil(o.Password) {
-		return nil, false
-	}
-	return o.Password, true
-}
-
-// HasPassword returns a boolean if a field has been set.
-func (o *ApiWalletDeleteRequest) HasPassword() bool {
-	if o != nil && !IsNil(o.Password) {
-		return true
-	}
-
-	return false
-}
-
-// SetPassword gets a reference to the given string and assigns it to the Password field.
-func (o *ApiWalletDeleteRequest) SetPassword(v string) {
-	o.Password = &v
-}
-
 func (o ApiWalletDeleteRequest) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -113,9 +80,6 @@ func (o ApiWalletDeleteRequest) MarshalJSON() ([]byte, error) {
 func (o ApiWalletDeleteRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
-	if !IsNil(o.Password) {
-		toSerialize["password"] = o.Password
-	}
 	return toSerialize, nil
 }
 

--- a/openapi/model_api_wallet_get_request.go
+++ b/openapi/model_api_wallet_get_request.go
@@ -22,8 +22,7 @@ var _ MappedNullable = &ApiWalletGetRequest{}
 
 // ApiWalletGetRequest struct for ApiWalletGetRequest
 type ApiWalletGetRequest struct {
-	Name     string  `json:"name"`
-	Password *string `json:"password,omitempty"`
+	Name string `json:"name"`
 }
 
 type _ApiWalletGetRequest ApiWalletGetRequest
@@ -70,38 +69,6 @@ func (o *ApiWalletGetRequest) SetName(v string) {
 	o.Name = v
 }
 
-// GetPassword returns the Password field value if set, zero value otherwise.
-func (o *ApiWalletGetRequest) GetPassword() string {
-	if o == nil || IsNil(o.Password) {
-		var ret string
-		return ret
-	}
-	return *o.Password
-}
-
-// GetPasswordOk returns a tuple with the Password field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *ApiWalletGetRequest) GetPasswordOk() (*string, bool) {
-	if o == nil || IsNil(o.Password) {
-		return nil, false
-	}
-	return o.Password, true
-}
-
-// HasPassword returns a boolean if a field has been set.
-func (o *ApiWalletGetRequest) HasPassword() bool {
-	if o != nil && !IsNil(o.Password) {
-		return true
-	}
-
-	return false
-}
-
-// SetPassword gets a reference to the given string and assigns it to the Password field.
-func (o *ApiWalletGetRequest) SetPassword(v string) {
-	o.Password = &v
-}
-
 func (o ApiWalletGetRequest) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -113,9 +80,6 @@ func (o ApiWalletGetRequest) MarshalJSON() ([]byte, error) {
 func (o ApiWalletGetRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
-	if !IsNil(o.Password) {
-		toSerialize["password"] = o.Password
-	}
 	return toSerialize, nil
 }
 

--- a/openapi/model_api_wallet_update_request.go
+++ b/openapi/model_api_wallet_update_request.go
@@ -24,7 +24,6 @@ var _ MappedNullable = &ApiWalletUpdateRequest{}
 type ApiWalletUpdateRequest struct {
 	Description *string `json:"description,omitempty"`
 	Name        string  `json:"name"`
-	Password    *string `json:"password,omitempty"`
 }
 
 type _ApiWalletUpdateRequest ApiWalletUpdateRequest
@@ -103,38 +102,6 @@ func (o *ApiWalletUpdateRequest) SetName(v string) {
 	o.Name = v
 }
 
-// GetPassword returns the Password field value if set, zero value otherwise.
-func (o *ApiWalletUpdateRequest) GetPassword() string {
-	if o == nil || IsNil(o.Password) {
-		var ret string
-		return ret
-	}
-	return *o.Password
-}
-
-// GetPasswordOk returns a tuple with the Password field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *ApiWalletUpdateRequest) GetPasswordOk() (*string, bool) {
-	if o == nil || IsNil(o.Password) {
-		return nil, false
-	}
-	return o.Password, true
-}
-
-// HasPassword returns a boolean if a field has been set.
-func (o *ApiWalletUpdateRequest) HasPassword() bool {
-	if o != nil && !IsNil(o.Password) {
-		return true
-	}
-
-	return false
-}
-
-// SetPassword gets a reference to the given string and assigns it to the Password field.
-func (o *ApiWalletUpdateRequest) SetPassword(v string) {
-	o.Password = &v
-}
-
 func (o ApiWalletUpdateRequest) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -149,9 +116,6 @@ func (o ApiWalletUpdateRequest) ToMap() (map[string]interface{}, error) {
 		toSerialize["description"] = o.Description
 	}
 	toSerialize["name"] = o.Name
-	if !IsNil(o.Password) {
-		toSerialize["password"] = o.Password
-	}
 	return toSerialize, nil
 }
 


### PR DESCRIPTION
## Summary

- Remove unused password fields from legacy wallet get/delete/update requests.
- Update API schemas, generated client models, and documentation.
- Preserve existing restore and signing password behavior.

## Validation

- Internal API race tests passed.
- Generated client package tests passed.
- Generated-client integration tests were not run because they require unavailable socket-backed services.

This addresses the unused-parameter contract; rejecting obsolete JSON fields remains a separate compatibility decision.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused `password` field from legacy wallet get, delete, and update requests so the API no longer accepts a parameter the server ignores.

- Updates request schemas, generated client models, and OpenAPI docs to drop `password`.
- Keeps `password` on restore requests, which still use it.
- Internal API race tests and generated client package tests pass; generated-client integration tests were not run because socket-backed services were unavailable.

<sup>Written for commit cb29a44e0184093fadd53c14272c6f8897db0a13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

