### PR TITLE
fix(api): shut down HTTP servers on cancellation

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -958,8 +958,17 @@ func Start(
 			10*time.Second,
 		)
 		defer cancel()
-		_ = metricsServer.Shutdown(shutdownCtx)
-		_ = apiServer.Shutdown(shutdownCtx)
+		var shutdownServers sync.WaitGroup
+		shutdownServers.Add(2)
+		go func() {
+			defer shutdownServers.Done()
+			_ = metricsServer.Shutdown(shutdownCtx)
+		}()
+		go func() {
+			defer shutdownServers.Done()
+			_ = apiServer.Shutdown(shutdownCtx)
+		}()
+		shutdownServers.Wait()
 		_ = metricsServer.Close()
 		_ = apiServer.Close()
 	}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/blinklabs-io/bursa"
@@ -878,75 +879,101 @@ func Start(
 	metricsMux := http.NewServeMux()
 	metricsMux.Handle("/metrics", promhttp.Handler())
 
-	// Start metrics server
-	go func() {
-		logger.Info("starting metrics listener",
-			"address", cfg.Metrics.ListenAddress,
-			"port", cfg.Metrics.ListenPort,
+	metricsServer := &http.Server{
+		Handler:           metricsMux,
+		ReadHeaderTimeout: 60 * time.Second,
+	}
+	if metricsListener == nil {
+		metricsServer.Addr = fmt.Sprintf(
+			"%s:%d",
+			cfg.Metrics.ListenAddress,
+			cfg.Metrics.ListenPort,
 		)
-		var err error
-		if metricsListener == nil {
-			server := &http.Server{
-				Addr: fmt.Sprintf(
-					"%s:%d",
-					cfg.Metrics.ListenAddress,
-					cfg.Metrics.ListenPort,
-				),
-				Handler:           metricsMux,
-				ReadHeaderTimeout: 60 * time.Second,
-			}
-			err = server.ListenAndServe()
-		} else {
-			server := &http.Server{
-				Handler:           metricsMux,
-				ReadHeaderTimeout: 60 * time.Second,
-			}
-			err = server.Serve(metricsListener)
-		}
-		if err != nil && err != http.ErrServerClosed {
-			logger.Error("metrics listener failed to start", "error", err)
-		}
-	}()
+	}
 
-	// Start API server
+	apiServer := &http.Server{
+		Handler:           mainHandler,
+		ReadHeaderTimeout: 60 * time.Second,
+		TLSConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		},
+	}
+	if apiListener == nil {
+		apiServer.Addr = fmt.Sprintf(
+			"%s:%d",
+			cfg.Api.ListenAddress,
+			cfg.Api.ListenPort,
+		)
+	}
+
+	serveErrs := make(chan error, 2)
+	var servers sync.WaitGroup
+	serve := func(server *http.Server, listener net.Listener, tlsEnabled bool) {
+		defer servers.Done()
+		var err error
+		if listener == nil {
+			if tlsEnabled {
+				err = server.ListenAndServeTLS(
+					cfg.Api.TLSCertFile,
+					cfg.Api.TLSKeyFile,
+				)
+			} else {
+				err = server.ListenAndServe()
+			}
+		} else {
+			if tlsEnabled {
+				err = server.ServeTLS(
+					listener,
+					cfg.Api.TLSCertFile,
+					cfg.Api.TLSKeyFile,
+				)
+			} else {
+				err = server.Serve(listener)
+			}
+		}
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serveErrs <- err
+		}
+	}
+
+	servers.Add(2)
+	logger.Info("starting metrics listener",
+		"address", cfg.Metrics.ListenAddress,
+		"port", cfg.Metrics.ListenPort,
+	)
+	// Start metrics server.
+	go serve(metricsServer, metricsListener, false)
+
 	logger.Info("starting API listener",
 		"address", cfg.Api.ListenAddress,
 		"port", cfg.Api.ListenPort,
 		"tls", tlsConfigured,
 	)
-	if apiListener == nil {
-		server := &http.Server{
-			Addr: fmt.Sprintf(
-				"%s:%d",
-				cfg.Api.ListenAddress,
-				cfg.Api.ListenPort,
-			),
-			Handler:           mainHandler,
-			ReadHeaderTimeout: 60 * time.Second,
-			TLSConfig: &tls.Config{
-				MinVersion: tls.VersionTLS12,
-			},
-		}
-		if tlsConfigured {
-			err = server.ListenAndServeTLS(cfg.Api.TLSCertFile, cfg.Api.TLSKeyFile)
-		} else {
-			err = server.ListenAndServe()
-		}
-	} else {
-		server := &http.Server{
-			Handler:           mainHandler,
-			ReadHeaderTimeout: 60 * time.Second,
-			TLSConfig: &tls.Config{
-				MinVersion: tls.VersionTLS12,
-			},
-		}
-		if tlsConfigured {
-			err = server.ServeTLS(apiListener, cfg.Api.TLSCertFile, cfg.Api.TLSKeyFile)
-		} else {
-			err = server.Serve(apiListener)
-		}
+	// Start API server.
+	go serve(apiServer, apiListener, tlsConfigured)
+
+	shutdown := func() {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(),
+			10*time.Second,
+		)
+		defer cancel()
+		_ = metricsServer.Shutdown(shutdownCtx)
+		_ = apiServer.Shutdown(shutdownCtx)
+		_ = metricsServer.Close()
+		_ = apiServer.Close()
 	}
-	return err
+
+	select {
+	case err := <-serveErrs:
+		shutdown()
+		servers.Wait()
+		return err
+	case <-ctx.Done():
+		shutdown()
+		servers.Wait()
+		return nil
+	}
 }
 
 func logMiddleware(next http.Handler, accessLogger *slog.Logger) http.Handler {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -952,9 +952,9 @@ func Start(
 	// Start API server.
 	go serve(apiServer, apiListener, tlsConfigured)
 
-	shutdown := func() {
+	shutdown := func(ctx context.Context) {
 		shutdownCtx, cancel := context.WithTimeout(
-			context.Background(),
+			context.WithoutCancel(ctx),
 			10*time.Second,
 		)
 		defer cancel()
@@ -975,11 +975,11 @@ func Start(
 
 	select {
 	case err := <-serveErrs:
-		shutdown()
+		shutdown(ctx)
 		servers.Wait()
 		return err
 	case <-ctx.Done():
-		shutdown()
+		shutdown(ctx)
 		servers.Wait()
 		return nil
 	}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -34,6 +34,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -48,6 +49,80 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type notifyingListener struct {
+	net.Listener
+	started chan struct{}
+	once    sync.Once
+}
+
+func (l *notifyingListener) Accept() (net.Conn, error) {
+	l.once.Do(func() { close(l.started) })
+	return l.Listener.Accept()
+}
+
+func TestStartStopsServersOnContextCancellation(t *testing.T) {
+	apiBase, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create API listener: %v", err)
+	}
+	metricsBase, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		apiBase.Close()
+		t.Fatalf("failed to create metrics listener: %v", err)
+	}
+
+	apiListener := &notifyingListener{Listener: apiBase, started: make(chan struct{})}
+	metricsListener := &notifyingListener{Listener: metricsBase, started: make(chan struct{})}
+	cfg := &config.Config{
+		Network: "testnet",
+		Api: config.ApiConfig{
+			ListenAddress: "127.0.0.1",
+			ListenPort:    uint(apiBase.Addr().(*net.TCPAddr).Port),
+		},
+		Metrics: config.MetricsConfig{
+			ListenAddress: "127.0.0.1",
+			ListenPort:    uint(metricsBase.Addr().(*net.TCPAddr).Port),
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		result <- Start(ctx, cfg, apiListener, metricsListener)
+	}()
+
+	select {
+	case <-apiListener.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("API server did not start listening")
+	}
+	select {
+	case <-metricsListener.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("metrics server did not start listening")
+	}
+
+	cancel()
+	select {
+	case err := <-result:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("API Start did not return after context cancellation")
+	}
+
+	apiReplacement, err := net.Listen("tcp", apiBase.Addr().String())
+	assert.NoError(t, err, "API listener remained open after shutdown")
+	if err == nil {
+		apiReplacement.Close()
+	}
+	metricsReplacement, err := net.Listen("tcp", metricsBase.Addr().String())
+	assert.NoError(t, err, "metrics listener remained open after shutdown")
+	if err == nil {
+		metricsReplacement.Close()
+	}
+}
 
 // Mock JSON data for successful wallet restoration
 var mockWalletResponseJSON = `{


### PR DESCRIPTION
## Summary

- Propagate cancellation to API and metrics HTTP servers.
- Wait for both servers to stop cleanly.
- Add regression coverage for coordinated shutdown.

## Validation

- Focused cancellation race test passed.
- Full internal API race suite passed.
- Root tests and API vet passed.

Live deployed-process verification remains outside this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes HTTP server shutdown so the API and metrics servers stop cleanly when the application context is cancelled, instead of leaving their listeners open.

- Shuts both servers down concurrently with a 10-second timeout, using `context.WithoutCancel` so cancellation doesn't cut the drain short.
- Returns a serving error from either server, including when one races with cancellation, instead of reporting a clean shutdown.
- Adds regression tests for listener closure on cancellation and for preserving a serving error that races cancellation.

<sup>Written for commit 38336d109cf96921b2f7310985ef2c5ccd530188. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API and metrics services now shut down gracefully when the application context is canceled.
  * Server listeners are reliably released, preventing lingering ports and improving clean application termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->