### PR TITLE
fix(signer): bound request authentication reads

### DIFF
--- a/cmd/bursa/signer.go
+++ b/cmd/bursa/signer.go
@@ -39,6 +39,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const signerReadTimeout = 30 * time.Second
+
+func newSignerHTTPServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		// ReadTimeout covers the complete request, including the body. Without
+		// it, a client can keep an accepted body read open indefinitely after
+		// the headers have been received.
+		ReadTimeout: signerReadTimeout,
+	}
+}
+
 // maxRequestSignSkewSeconds bounds signer.request_sign_skew_seconds. It also
 // caps the nonce cache TTL (2x skew), so a very large skew is rejected at boot
 // rather than silently widening the replay window and shortening how long the
@@ -280,11 +294,7 @@ key.`,
 				)
 				os.Exit(1)
 			}
-			httpServer := &http.Server{
-				Addr:              addr,
-				Handler:           mux,
-				ReadHeaderTimeout: 10 * time.Second,
-			}
+			httpServer := newSignerHTTPServer(addr, mux)
 			if tlsConfigured {
 				tlsCfg := &tls.Config{MinVersion: tls.VersionTLS12}
 				if hasMTLS {

--- a/cmd/bursa/signer_test.go
+++ b/cmd/bursa/signer_test.go
@@ -15,10 +15,21 @@
 package main
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/blinklabs-io/bursa/internal/signer"
 )
+
+func TestNewSignerHTTPServerReadTimeout(t *testing.T) {
+	srv := newSignerHTTPServer("127.0.0.1:0", http.NotFoundHandler())
+	if srv.ReadHeaderTimeout <= 0 {
+		t.Fatal("signer server must bound header reads")
+	}
+	if srv.ReadTimeout != signerReadTimeout {
+		t.Fatalf("ReadTimeout = %s, want %s", srv.ReadTimeout, signerReadTimeout)
+	}
+}
 
 func TestIsLocalListenAddress(t *testing.T) {
 	tests := []struct {

--- a/internal/signer/api/requestsign.go
+++ b/internal/signer/api/requestsign.go
@@ -65,6 +65,10 @@ const (
 // distinct nonces can be live before boot-time capacity pressure.
 const defaultNonceCacheMax = 65536
 
+// An Ed25519 signature is fixed-width and is represented as lower-case hex in
+// the request header. Check that width before touching the request body.
+const maxSignatureHexLength = ed25519.SignatureSize * 2
+
 // maxSignedBody caps how many body bytes the authenticator will buffer to hash.
 // It matches the handler's own 1 MiB request-body limit.
 const maxSignedBody = 1 << 20
@@ -134,6 +138,16 @@ func (a *RequestSigningAuthenticator) Authenticate(r *http.Request) (string, boo
 	if d := a.now().Sub(time.Unix(tsSec, 0)); d > a.skew || d < -a.skew {
 		return "", true, errStaleTimestamp
 	}
+	// Reject malformed credentials before reading a potentially slow body;
+	// valid requests still hash and verify the exact body before the replay cache
+	// is changed.
+	if len(sig) != maxSignatureHexLength {
+		return "", true, errInvalidSignature
+	}
+	sigBytes, err := hex.DecodeString(sig)
+	if err != nil {
+		return "", true, errInvalidSignature
+	}
 	// Buffer the body so the handler can still read it, then hash it.
 	body, err := a.readBody(r)
 	if err != nil {
@@ -147,10 +161,6 @@ func (a *RequestSigningAuthenticator) Authenticate(r *http.Request) (string, boo
 		tsStr,
 		nonce,
 	}, "|")
-	sigBytes, err := hex.DecodeString(sig)
-	if err != nil || len(sigBytes) != ed25519.SignatureSize {
-		return "", true, errInvalidSignature
-	}
 	if !ed25519.Verify(pub, []byte(canonical), sigBytes) {
 		return "", true, errInvalidSignature
 	}

--- a/internal/signer/api/requestsign_test.go
+++ b/internal/signer/api/requestsign_test.go
@@ -29,30 +29,17 @@ import (
 	"time"
 )
 
-type blockingBody struct {
-	started     chan struct{}
-	release     chan struct{}
-	startedOnce sync.Once
-	releaseOnce sync.Once
+type trackingBody struct {
+	read bool
 }
 
-func newBlockingBody() *blockingBody {
-	return &blockingBody{started: make(chan struct{}), release: make(chan struct{})}
-}
-
-func (b *blockingBody) Read([]byte) (int, error) {
-	b.startedOnce.Do(func() { close(b.started) })
-	<-b.release
+func (b *trackingBody) Read([]byte) (int, error) {
+	b.read = true
 	return 0, io.EOF
 }
 
-func (b *blockingBody) Close() error {
-	b.unblock()
+func (b *trackingBody) Close() error {
 	return nil
-}
-
-func (b *blockingBody) unblock() {
-	b.releaseOnce.Do(func() { close(b.release) })
 }
 
 // signReq builds a request with authorized-keys signature headers for the given
@@ -127,35 +114,16 @@ func TestRequestSigning_InvalidSignatureDoesNotReadBody(t *testing.T) {
 	a, caller, priv := newAuth(t)
 	req := signReq(t, caller, priv, http.MethodPost, "/v1/sign", []byte("body"), time.Now(), "blocked")
 	req.Header.Set(HeaderSignature, "not-a-signature")
-	body := newBlockingBody()
+	body := &trackingBody{}
 	req.Body = body
 
-	type result struct {
-		ok  bool
-		err error
+	_, ok, err := a.Authenticate(req)
+	if !ok || err == nil {
+		t.Fatalf("malformed signature: ok=%v err=%v", ok, err)
 	}
-	done := make(chan result, 1)
-	go func() {
-		_, ok, err := a.Authenticate(req)
-		done <- result{ok: ok, err: err}
-	}()
-
-	select {
-	case got := <-done:
-		if !got.ok || got.err == nil {
-			t.Fatalf("malformed signature: ok=%v err=%v", got.ok, got.err)
-		}
-		select {
-		case <-body.started:
-			t.Fatal("malformed signature caused the request body to be read")
-		default:
-		}
-	case <-time.After(500 * time.Millisecond):
-		body.unblock()
-		<-done
-		t.Fatal("malformed signature blocked on request-body read")
+	if body.read {
+		t.Fatal("malformed signature caused the request body to be read")
 	}
-	body.unblock()
 }
 
 func TestRequestSigning_StaleTimestamp(t *testing.T) {

--- a/internal/signer/api/requestsign_test.go
+++ b/internal/signer/api/requestsign_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -27,6 +28,32 @@ import (
 	"testing"
 	"time"
 )
+
+type blockingBody struct {
+	started     chan struct{}
+	release     chan struct{}
+	startedOnce sync.Once
+	releaseOnce sync.Once
+}
+
+func newBlockingBody() *blockingBody {
+	return &blockingBody{started: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (b *blockingBody) Read([]byte) (int, error) {
+	b.startedOnce.Do(func() { close(b.started) })
+	<-b.release
+	return 0, io.EOF
+}
+
+func (b *blockingBody) Close() error {
+	b.unblock()
+	return nil
+}
+
+func (b *blockingBody) unblock() {
+	b.releaseOnce.Do(func() { close(b.release) })
+}
 
 // signReq builds a request with authorized-keys signature headers for the given
 // signing key, body, timestamp, and nonce.
@@ -91,6 +118,44 @@ func TestRequestSigning_BadSignature(t *testing.T) {
 	if _, ok, err := a.Authenticate(req); !ok || err == nil {
 		t.Fatalf("bad signature should reject: ok=%v err=%v", ok, err)
 	}
+}
+
+// TestRequestSigning_InvalidSignatureDoesNotReadBody ensures malformed fixed-
+// width credentials are rejected before authentication consumes a body. The
+// old ordering blocked on the body reader before it checked signature length.
+func TestRequestSigning_InvalidSignatureDoesNotReadBody(t *testing.T) {
+	a, caller, priv := newAuth(t)
+	req := signReq(t, caller, priv, http.MethodPost, "/v1/sign", []byte("body"), time.Now(), "blocked")
+	req.Header.Set(HeaderSignature, "not-a-signature")
+	body := newBlockingBody()
+	req.Body = body
+
+	type result struct {
+		ok  bool
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		_, ok, err := a.Authenticate(req)
+		done <- result{ok: ok, err: err}
+	}()
+
+	select {
+	case got := <-done:
+		if !got.ok || got.err == nil {
+			t.Fatalf("malformed signature: ok=%v err=%v", got.ok, got.err)
+		}
+		select {
+		case <-body.started:
+			t.Fatal("malformed signature caused the request body to be read")
+		default:
+		}
+	case <-time.After(500 * time.Millisecond):
+		body.unblock()
+		<-done
+		t.Fatal("malformed signature blocked on request-body read")
+	}
+	body.unblock()
 }
 
 func TestRequestSigning_StaleTimestamp(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add a request read deadline for signer authentication bodies.
- Reject malformed signature inputs before reading the request body.
- Preserve body hashing, timestamp, signature, and replay checks.

## Validation

- Focused signer race tests passed repeatedly.
- Root race suite and API vet passed.

Live deployed-process behavior remains outside this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the signer's request authentication so slow clients can't hold body reads open indefinitely and malformed signatures are rejected before the body is read.

- Adds a 30-second read timeout to the signer HTTP server.
- Validates signature length and hex encoding before buffering the request body.
- Preserves body hashing, timestamp, signature, and replay checks.

<sup>Written for commit 28f6c7fd9dbf66d16a0106f80e79c2ab03442756. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

