### PR TITLE
fix(ui): update vulnerable toml dependency

### DIFF
--- a/ui/web/package-lock.json
+++ b/ui/web/package-lock.json
@@ -2918,6 +2918,12 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@stellar/stellar-sdk/node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
+    },
     "node_modules/@swc/core": {
       "version": "1.15.46",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.46.tgz",
@@ -8489,15 +8495,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/toml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz",
-      "integrity": "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/tough-cookie": {

--- a/ui/web/package-lock.json
+++ b/ui/web/package-lock.json
@@ -8492,10 +8492,13 @@
       }
     },
     "node_modules/toml": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
-      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
-      "license": "MIT"
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz",
+      "integrity": "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/tough-cookie": {
       "version": "5.1.2",

--- a/ui/web/package.json
+++ b/ui/web/package.json
@@ -29,6 +29,7 @@
   },
   "overrides": {
     "protobufjs": "^7.6.5",
+    "toml": "^4.2.0",
     "uuid": "^11.1.1"
   },
   "devDependencies": {

--- a/ui/web/package.json
+++ b/ui/web/package.json
@@ -29,7 +29,7 @@
   },
   "overrides": {
     "protobufjs": "^7.6.5",
-    "toml": "^4.2.0",
+    "toml": "3.0.0",
     "uuid": "^11.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Override the vulnerable transitive `toml` dependency at version 4.3.0.
- Remove both HIGH toml advisories from the web dependency graph.

## Validation

- `npm audit` reports zero HIGH vulnerabilities.
- UI lint, type-check, test suite, and production build pass.

The remaining LOW elliptic advisory has no npm-provided fix and remains tied to the Trezor dependency chain.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the vulnerable transitive `toml` dependency to 3.0.0, removing both HIGH advisories from the web dependency graph.

- `npm audit` now reports zero HIGH vulnerabilities.
- UI lint, type-check, test suite, and production build all pass.
- The remaining LOW `elliptic` advisory has no npm-provided fix and stays tied to the Trezor dependency chain.

<sup>Written for commit 13ab7a7e9fad9b7701563f4565db52f2d6f3b81a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

