### PR TITLE
fix(transaction): check minimum fee arithmetic

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -14,7 +14,10 @@
 
 package bursa
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestTransactionID(t *testing.T) {
 	id, err := TransactionID(mustTestTx(t))
@@ -54,10 +57,57 @@ func TestInspectTransaction(t *testing.T) {
 func TestMinFee(t *testing.T) {
 	params := ProtocolParams{TxFeePerByte: 44, TxFeeFixed: 155381}
 	size := len(mustTestTx(t))
-	fee := MinFee(size, params)
+	fee, err := MinFee(size, params)
+	if err != nil {
+		t.Fatalf("MinFee: %v", err)
+	}
 	want := uint64(44)*uint64(size) + 155381
 	if fee != want {
 		t.Fatalf("MinFee = %d, want %d", fee, want)
+	}
+}
+
+func TestMinFeeRejectsInvalidAndOverflowingInputs(t *testing.T) {
+	tests := []struct {
+		name   string
+		size   int
+		params ProtocolParams
+	}{
+		{
+			name:   "negative size",
+			size:   -1,
+			params: ProtocolParams{TxFeeFixed: 7},
+		},
+		{
+			name:   "multiplication overflow",
+			size:   2,
+			params: ProtocolParams{TxFeePerByte: math.MaxUint64},
+		},
+		{
+			name:   "addition overflow",
+			size:   1,
+			params: ProtocolParams{TxFeePerByte: math.MaxUint64, TxFeeFixed: 1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := MinFee(tt.size, tt.params); err == nil {
+				t.Fatal("MinFee accepted invalid input")
+			}
+		})
+	}
+}
+
+func TestMinFeeAcceptsProtocolCoinBoundaries(t *testing.T) {
+	fee, err := MinFee(0, ProtocolParams{
+		TxFeePerByte: math.MaxUint64,
+		TxFeeFixed:   math.MaxUint64,
+	})
+	if err != nil {
+		t.Fatalf("MinFee rejected valid zero-size boundary: %v", err)
+	}
+	if fee != math.MaxUint64 {
+		t.Fatalf("MinFee = %d, want %d", fee, uint64(math.MaxUint64))
 	}
 }
 
@@ -81,5 +131,30 @@ func TestParseProtocolParams_RequiresBothFeeFields(t *testing.T) {
 		if _, err := ParseProtocolParams([]byte(js)); err == nil {
 			t.Fatalf("expected error for params %s", js)
 		}
+	}
+}
+
+func TestParseProtocolParamsRejectsOutOfRangeJSON(t *testing.T) {
+	tests := []string{
+		`{"txFeePerByte":-1,"txFeeFixed":0}`,
+		`{"txFeePerByte":18446744073709551616,"txFeeFixed":0}`,
+		`{"txFeePerByte":0.5,"txFeeFixed":0}`,
+	}
+	for _, js := range tests {
+		t.Run(js, func(t *testing.T) {
+			if _, err := ParseProtocolParams([]byte(js)); err == nil {
+				t.Fatal("expected protocol parameter range error")
+			}
+		})
+	}
+}
+
+func TestParseProtocolParamsAcceptsProtocolCoinBoundaries(t *testing.T) {
+	p, err := ParseProtocolParams([]byte(`{"txFeePerByte":18446744073709551615,"txFeeFixed":18446744073709551615}`))
+	if err != nil {
+		t.Fatalf("parse protocol Coin boundaries: %v", err)
+	}
+	if p.TxFeePerByte != math.MaxUint64 || p.TxFeeFixed != math.MaxUint64 {
+		t.Fatalf("unexpected protocol params: %+v", p)
 	}
 }

--- a/internal/cli/tx.go
+++ b/internal/cli/tx.go
@@ -151,7 +151,10 @@ func RunTxDecode(txFile, protocolParamsFile string) error {
 		if err != nil {
 			return err
 		}
-		fee := bursa.MinFee(insp.SizeBytes, params)
+		fee, err := bursa.MinFee(insp.SizeBytes, params)
+		if err != nil {
+			return fmt.Errorf("calculate minimum fee: %w", err)
+		}
 		out.MinFee = &fee
 	}
 	enc, err := json.MarshalIndent(out, "", "  ")

--- a/transaction.go
+++ b/transaction.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/bits"
 
 	"github.com/blinklabs-io/bursa/bip32"
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -435,11 +436,32 @@ func ParseProtocolParams(data []byte) (ProtocolParams, error) {
 // serialized size: fee = txFeePerByte * sizeBytes + txFeeFixed. This base
 // linear formula does not include Plutus execution units or reference-script
 // tiers; for script transactions the result is a lower bound.
-func MinFee(sizeBytes int, params ProtocolParams) uint64 {
+//
+// The fee is a Cardano Coin and must fit in uint64. An invalid size or a fee
+// that cannot be represented as a Coin is returned as an error instead of
+// wrapping around.
+func MinFee(sizeBytes int, params ProtocolParams) (uint64, error) {
 	if sizeBytes < 0 {
-		return params.TxFeeFixed
+		return 0, fmt.Errorf("min fee: negative transaction size %d", sizeBytes)
 	}
-	return params.TxFeePerByte*uint64(sizeBytes) + params.TxFeeFixed
+
+	productHigh, productLow := bits.Mul64(params.TxFeePerByte, uint64(sizeBytes))
+	if productHigh != 0 {
+		return 0, fmt.Errorf(
+			"min fee overflow: %d * %d exceeds uint64",
+			params.TxFeePerByte,
+			sizeBytes,
+		)
+	}
+	fee, carry := bits.Add64(productLow, params.TxFeeFixed, 0)
+	if carry != 0 {
+		return 0, fmt.Errorf(
+			"min fee overflow: %d + %d exceeds uint64",
+			productLow,
+			params.TxFeeFixed,
+		)
+	}
+	return fee, nil
 }
 
 // SignDigest signs an arbitrary message with the loaded key and returns the raw


### PR DESCRIPTION
## Summary

- Reject negative transaction sizes.
- Detect minimum-fee multiplication and addition overflow.
- Propagate fee calculation errors through CLI estimation.

## Validation

- Focused race tests passed repeatedly.
- CLI compatibility tests, full root race tests, and vet passed.

Protocol-valid fee calculations remain unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes minimum fee arithmetic so invalid transaction sizes and overflow return errors instead of wrapping around. Negative sizes previously fell back to the fixed fee, and multiplication/addition overflow silently wrapped; both now propagate as errors through the CLI estimation path.

**Migration**
- `MinFee` now returns `(uint64, error)`; update callers to check the error.

<sup>Written for commit 4aba08f48bfe917ef46310f8a36b75a64e9306b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

