### PR TITLE
fix(cli): collect concurrent wallet output errors

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -100,20 +100,7 @@ func RunCreate(cfg *config.Config, output string) {
 		for key, value := range keyFiles {
 			fileMap = append(fileMap, map[string]string{key: value})
 		}
-		var g errgroup.Group
-		for _, m := range fileMap {
-			for k, v := range m {
-				g.Go(func() error {
-					path := filepath.Join(output, k)
-					err = writeWalletOutput(path, []byte(v))
-					if err != nil {
-						return err
-					}
-					return err
-				})
-			}
-		}
-		err = g.Wait()
+		err = writeWalletOutputs(output, fileMap)
 		if err != nil {
 			logger.Error("error occurred", "error", err)
 			os.Exit(1)
@@ -224,20 +211,7 @@ func RunRestore(
 		for key, value := range keyFiles {
 			fileMap = append(fileMap, map[string]string{key: value})
 		}
-		var g errgroup.Group
-		for _, m := range fileMap {
-			for k, v := range m {
-				g.Go(func() error {
-					path := filepath.Join(output, k)
-					err = writeWalletOutput(path, []byte(v))
-					if err != nil {
-						return err
-					}
-					return err
-				})
-			}
-		}
-		err = g.Wait()
+		err = writeWalletOutputs(output, fileMap)
 		if err != nil {
 			logger.Error("error occurred", "error", err)
 			os.Exit(1)
@@ -2634,4 +2608,54 @@ func writeWalletOutput(path string, data []byte) error {
 		return bursa.WriteSecretKeyFile(path, data)
 	}
 	return os.WriteFile(path, data, 0o600)
+}
+
+type walletOutputFile struct {
+	name string
+	data []byte
+}
+
+type walletOutputWriter func(path string, data []byte) error
+
+func writeWalletOutputs(output string, fileMap []map[string]string) error {
+	return writeWalletOutputsWithWriter(output, fileMap, writeWalletOutput)
+}
+
+func writeWalletOutputsWithWriter(
+	output string,
+	fileMap []map[string]string,
+	writer walletOutputWriter,
+) error {
+	files := make([]walletOutputFile, 0)
+	for _, m := range fileMap {
+		for name, value := range m {
+			files = append(files, walletOutputFile{
+				name: name,
+				data: []byte(value),
+			})
+		}
+	}
+	slices.SortFunc(files, func(a, b walletOutputFile) int {
+		return strings.Compare(a.name, b.name)
+	})
+
+	workerErrors := make([]error, len(files))
+	var g errgroup.Group
+	for i, file := range files {
+		i, file := i, file
+		g.Go(func() error {
+			err := writer(filepath.Join(output, file.name), file.data)
+			if err != nil {
+				workerErrors[i] = fmt.Errorf(
+					"failed to write wallet output %s: %w",
+					file.name,
+					err,
+				)
+			}
+			return err
+		})
+	}
+	_ = g.Wait()
+
+	return errors.Join(workerErrors...)
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2642,7 +2642,6 @@ func writeWalletOutputsWithWriter(
 	workerErrors := make([]error, len(files))
 	var g errgroup.Group
 	for i, file := range files {
-		i, file := i, file
 		g.Go(func() error {
 			err := writer(filepath.Join(output, file.name), file.data)
 			if err != nil {

--- a/internal/cli/wallet_output_test.go
+++ b/internal/cli/wallet_output_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteWalletOutputsReturnsAllConcurrentErrors(t *testing.T) {
+	alphaErr := errors.New("alpha failure")
+	betaErr := errors.New("beta failure")
+	fileMap := []map[string]string{
+		{"beta.addr": "beta"},
+		{"ok.addr": "ok"},
+		{"alpha.addr": "alpha"},
+	}
+
+	for range 100 {
+		started := make(chan struct{}, len(fileMap))
+		release := make(chan struct{})
+		var releaseOnce sync.Once
+		go func() {
+			for range fileMap {
+				<-started
+			}
+			releaseOnce.Do(func() { close(release) })
+		}()
+
+		got := writeWalletOutputsWithWriter(
+			"output",
+			fileMap,
+			func(path string, _ []byte) error {
+				started <- struct{}{}
+				<-release
+				switch filepath.Base(path) {
+				case "alpha.addr":
+					return alphaErr
+				case "beta.addr":
+					return betaErr
+				default:
+					return nil
+				}
+			},
+		)
+
+		require.Error(t, got)
+		require.ErrorIs(t, got, alphaErr)
+		require.ErrorIs(t, got, betaErr)
+		require.Equal(
+			t,
+			"failed to write wallet output alpha.addr: alpha failure\n"+
+				"failed to write wallet output beta.addr: beta failure",
+			got.Error(),
+		)
+	}
+}


### PR DESCRIPTION
## Summary

- Collect concurrent wallet output errors in independent slots.
- Join errors deterministically without data races.
- Preserve concurrent execution and cancellation behavior.

## Validation

- Baseline race reproduced.
- Fixed regression passed repeatedly.
- CLI race tests, command tests, vet, and root race suite passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes wallet output error handling in CLI create and restore commands. They now report every failed concurrent write in deterministic file order instead of returning one arbitrary error from a data race.

- Shares the write logic through `writeWalletOutputs`.
- Adds regression coverage that repeatedly exercises concurrent failures and verifies the joined errors.

<sup>Written for commit 4fc5e385083201ad7bc3de1e21480733c88c929e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

