### PR TITLE
fix(signer): bound PKCS#11 signing waits

### DIFF
--- a/internal/signer/backend/pkcs11.go
+++ b/internal/signer/backend/pkcs11.go
@@ -50,7 +50,7 @@ type pkcs11Key struct {
 	typ         KeyType
 	backendName string
 	priv        pkcs11.ObjectHandle
-	sign        func(priv pkcs11.ObjectHandle, msg []byte) ([]byte, error)
+	sign        func(ctx context.Context, priv pkcs11.ObjectHandle, msg []byte) ([]byte, error)
 }
 
 func (k *pkcs11Key) Hash() KeyHash                { return k.hash }
@@ -63,8 +63,11 @@ func (k *pkcs11Key) Backend() string              { return k.backendName }
 // CKM_EDDSA with no parameter is PureEdDSA, so the token signs digest as the
 // message exactly like ed25519.Sign — byte-for-byte identical to the software
 // and Vault backends for the same key and message (Ed25519 is deterministic).
-func (k *pkcs11Key) Sign(_ context.Context, digest []byte) ([]byte, error) {
-	sig, err := k.sign(k.priv, digest)
+func (k *pkcs11Key) Sign(ctx context.Context, digest []byte) ([]byte, error) {
+	if ctx == nil {
+		return nil, errors.New("pkcs11 sign: nil context")
+	}
+	sig, err := k.sign(ctx, k.priv, digest)
 	if err != nil {
 		return nil, fmt.Errorf("pkcs11 sign: %w", err)
 	}
@@ -79,10 +82,31 @@ type PKCS11Backend struct {
 	name    string
 	ctx     *pkcs11.Ctx
 	session pkcs11.SessionHandle
-	// mu serializes token operations: a PKCS#11 session is single-threaded and
-	// SignInit/Sign form one non-reentrant operation.
-	mu   sync.Mutex
-	keys map[KeyHash]*pkcs11Key
+	// mu protects closed and the request-channel close. The signing worker is
+	// the sole owner of session and ctx during an operation.
+	mu         sync.Mutex
+	closed     bool
+	requests   chan pkcs11SignRequest
+	workerWG   sync.WaitGroup
+	closeOnce  sync.Once
+	closeDone  chan struct{}
+	closeErr   error
+	nativeSign func(priv pkcs11.ObjectHandle, msg []byte) ([]byte, error)
+	keys       map[KeyHash]*pkcs11Key
+}
+
+const maxQueuedPKCS11Signs = 1
+
+type pkcs11SignRequest struct {
+	ctx  context.Context
+	priv pkcs11.ObjectHandle
+	msg  []byte
+	resp chan pkcs11SignResult
+}
+
+type pkcs11SignResult struct {
+	sig []byte
+	err error
 }
 
 // NewPKCS11Backend loads the module, selects the token, logs in with the PIN,
@@ -136,13 +160,64 @@ func NewPKCS11Backend(cfg PKCS11Config) (Backend, error) {
 		_ = b.teardown(true, true)
 		return nil, fmt.Errorf("pkcs11 backend %q: no Ed25519 signing keys found on the token", cfg.Name)
 	}
+	b.requests = make(chan pkcs11SignRequest, maxQueuedPKCS11Signs)
+	b.closeDone = make(chan struct{})
+	b.workerWG.Add(1)
+	go b.signWorker()
 	return b, nil
 }
 
-// signWithSession runs one SignInit+Sign under the session mutex.
-func (b *PKCS11Backend) signWithSession(priv pkcs11.ObjectHandle, msg []byte) ([]byte, error) {
+// signWithSession queues one signing operation. The caller may stop waiting
+// when ctx is canceled; the worker still completes an already-started native
+// operation before it accepts another request or teardown runs.
+func (b *PKCS11Backend) signWithSession(ctx context.Context, priv pkcs11.ObjectHandle, msg []byte) ([]byte, error) {
+	if ctx == nil {
+		return nil, errors.New("pkcs11 sign: nil context")
+	}
+	req := pkcs11SignRequest{
+		ctx:  ctx,
+		priv: priv,
+		msg:  append([]byte(nil), msg...),
+		resp: make(chan pkcs11SignResult, 1),
+	}
 	b.mu.Lock()
-	defer b.mu.Unlock()
+	if b.closed || b.requests == nil {
+		b.mu.Unlock()
+		return nil, errors.New("pkcs11 sign: backend is closed")
+	}
+	select {
+	case b.requests <- req:
+		b.mu.Unlock()
+	case <-ctx.Done():
+		b.mu.Unlock()
+		return nil, ctx.Err()
+	}
+	select {
+	case result := <-req.resp:
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		return result.sig, result.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (b *PKCS11Backend) signWorker() {
+	defer b.workerWG.Done()
+	for req := range b.requests {
+		if err := req.ctx.Err(); err != nil {
+			req.resp <- pkcs11SignResult{err: err}
+			continue
+		}
+		sig, err := b.signOperation(req.priv, req.msg)
+		req.resp <- pkcs11SignResult{sig: sig, err: err}
+	}
+}
+
+// signNative is called only by signWorker. Keeping this operation in one
+// worker preserves the PKCS#11 session's non-reentrant SignInit+Sign pair.
+func (b *PKCS11Backend) signNative(priv pkcs11.ObjectHandle, msg []byte) ([]byte, error) {
 	mech := []*pkcs11.Mechanism{pkcs11.NewMechanism(ckmEDDSA, nil)}
 	if err := b.ctx.SignInit(b.session, mech, priv); err != nil {
 		return nil, fmt.Errorf("sign init: %w", err)
@@ -152,6 +227,13 @@ func (b *PKCS11Backend) signWithSession(priv pkcs11.ObjectHandle, msg []byte) ([
 		return nil, fmt.Errorf("sign: %w", err)
 	}
 	return sig, nil
+}
+
+func (b *PKCS11Backend) signOperation(priv pkcs11.ObjectHandle, msg []byte) ([]byte, error) {
+	if b.nativeSign != nil {
+		return b.nativeSign(priv, msg)
+	}
+	return b.signNative(priv, msg)
 }
 
 func (b *PKCS11Backend) loadKeys(cfg PKCS11Config) error {
@@ -354,14 +436,27 @@ func (b *PKCS11Backend) ListKeys(_ context.Context) ([]KeyRef, error) {
 
 // Close logs out and finalizes the module, releasing the session.
 func (b *PKCS11Backend) Close() error {
-	return b.teardown(true, true)
+	b.closeOnce.Do(func() {
+		b.mu.Lock()
+		b.closed = true
+		if b.closeDone == nil {
+			b.closeDone = make(chan struct{})
+		}
+		if b.requests != nil {
+			close(b.requests)
+		}
+		b.mu.Unlock()
+		b.workerWG.Wait()
+		b.closeErr = b.teardown(true, true)
+		close(b.closeDone)
+	})
+	<-b.closeDone
+	return b.closeErr
 }
 
 // teardown releases resources in reverse order of acquisition. loggedIn and
 // sessionOpen let partially-constructed backends clean up on the error path.
 func (b *PKCS11Backend) teardown(sessionOpen, loggedIn bool) error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
 	if b.ctx == nil {
 		return nil
 	}

--- a/internal/signer/backend/pkcs11_worker_test.go
+++ b/internal/signer/backend/pkcs11_worker_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build pkcs11
+
+package backend
+
+import (
+	"context"
+	"crypto/ed25519"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/miekg/pkcs11"
+)
+
+func newTestPKCS11Backend(nativeSign func(pkcs11.ObjectHandle, []byte) ([]byte, error)) *PKCS11Backend {
+	b := &PKCS11Backend{
+		requests:   make(chan pkcs11SignRequest, maxQueuedPKCS11Signs),
+		closeDone:  make(chan struct{}),
+		nativeSign: nativeSign,
+	}
+	b.workerWG.Add(1)
+	go b.signWorker()
+	return b
+}
+
+func TestPKCS11Sign_ContextCancellationDoesNotConcurrentSessionUse(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var active atomic.Int32
+	var maxActive atomic.Int32
+	b := newTestPKCS11Backend(func(pkcs11.ObjectHandle, []byte) ([]byte, error) {
+		current := active.Add(1)
+		for {
+			old := maxActive.Load()
+			if current <= old || maxActive.CompareAndSwap(old, current) {
+				break
+			}
+		}
+		defer active.Add(-1)
+		select {
+		case <-started:
+		default:
+			close(started)
+		}
+		<-release
+		return make([]byte, ed25519.SignatureSize), nil
+	})
+
+	key := &pkcs11Key{sign: b.signWithSession}
+	ctx, cancel := context.WithCancel(context.Background())
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := key.Sign(ctx, []byte("first"))
+		firstDone <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("native signing did not start")
+	}
+	cancel()
+	select {
+	case err := <-firstDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("sign did not honor canceled context while native call was active")
+	}
+
+	secondCtx, secondCancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer secondCancel()
+	if _, err := key.Sign(secondCtx, []byte("second")); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected bounded queue wait, got %v", err)
+	}
+	if got := maxActive.Load(); got != 1 {
+		t.Fatalf("expected one native operation, got peak concurrency %d", got)
+	}
+
+	close(release)
+	if err := b.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+func TestPKCS11Sign_CanceledQueuedRequestIsNotSentToToken(t *testing.T) {
+	release := make(chan struct{})
+	started := make(chan struct{})
+	var calls atomic.Int32
+	b := newTestPKCS11Backend(func(pkcs11.ObjectHandle, []byte) ([]byte, error) {
+		calls.Add(1)
+		close(started)
+		<-release
+		return make([]byte, ed25519.SignatureSize), nil
+	})
+	key := &pkcs11Key{sign: b.signWithSession}
+
+	firstDone := make(chan struct{})
+	go func() {
+		_, _ = key.Sign(context.Background(), []byte("first"))
+		close(firstDone)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("native signing did not start")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	queuedDone := make(chan error, 1)
+	go func() {
+		_, err := key.Sign(ctx, []byte("queued"))
+		queuedDone <- err
+	}()
+	cancel()
+	select {
+	case err := <-queuedDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected queued cancellation, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("queued sign did not honor cancellation")
+	}
+	close(release)
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("first sign did not finish")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected canceled queued request to be skipped, got %d token calls", got)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}

--- a/internal/signer/backend/pkcs11_worker_test.go
+++ b/internal/signer/backend/pkcs11_worker_test.go
@@ -127,6 +127,15 @@ func TestPKCS11Sign_CanceledQueuedRequestIsNotSentToToken(t *testing.T) {
 		_, err := key.Sign(ctx, []byte("queued"))
 		queuedDone <- err
 	}()
+	deadline := time.After(time.Second)
+	for len(b.requests) != 1 {
+		select {
+		case <-deadline:
+			t.Fatal("queued sign was not enqueued")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
 	cancel()
 	select {
 	case err := <-queuedDone:


### PR DESCRIPTION
## Summary

- Forward cancellation through PKCS#11 signing.
- Serialize native session use through a single-owner worker.
- Bound queued signing work and prevent teardown races.

## Validation

- Cancellation and concurrency regressions pass.
- Tagged backend race suites, SoftHSM signing, ambiguity tests, and vet pass.

A synchronous native `C_Sign` call can still delay worker teardown; real hardware and non-Linux token behavior remain outside this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounded PKCS#11 signing waits so a wedged token can no longer hang signing indefinitely, and serialized native session use through a single worker so concurrent calls can't corrupt the session. When the caller passes an unbounded context, the backend now applies its own 30s ceiling.

**Details**
- Requests queue behind one worker; callers can abort waiting on a full queue, and canceled queued requests are never sent to the token.
- Cancellation is honored while queued and during the native call; an already-started operation still completes.
- `Close` waits for in-flight signing before teardown.
- Added a CI job that runs the tagged PKCS#11 tests with `-race`.
- A synchronous native `C_Sign` call can still delay worker teardown; real hardware and non-Linux token behavior remain outside this change.

<sup>Written for commit df5899d20e7b6502c19180b991ad38eb6f840868. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PKCS#11 signing operations now support caller cancellation, allowing applications to stop active or queued requests promptly.
  * Signing requests are processed in an orderly sequence to improve compatibility with PKCS#11 tokens.

* **Bug Fixes**
  * Prevented canceled queued requests from being sent to the token.
  * Improved backend shutdown handling so in-progress work completes cleanly before resources are released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->