### PR TITLE
fix(cli): hash metadata bytes and reject invalid margins

### DIFF
--- a/cmd/bursa/hash.go
+++ b/cmd/bursa/hash.go
@@ -54,7 +54,8 @@ func hashMetadataCommand() *cobra.Command {
 		Long: `Generate a Blake2b-256 hash of a Cardano metadata JSON file.
 
 This is used for pool metadata and DRep metadata registration.
-The hash is calculated from the canonical JSON representation.
+The hash is calculated from the exact bytes in the file. If you need a
+canonical representation, write that representation to the hosted file first.
 
 Supported metadata types:
   - pool: Pool registration metadata

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/go-playground/validator/v10 v10.30.3
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
-	github.com/gowebpki/jcs v1.0.1
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,6 @@ github.com/googleapis/gax-go/v2 v2.24.0 h1:myMaPYyF9MecEmvQqMqomIwn9t/4KCZN9qnws
 github.com/googleapis/gax-go/v2 v2.24.0/go.mod h1:IaTHBDd7NHxSCiu0vEs8pQZu4dGZrWwuSoxCnk16OFM=
 github.com/goware/prefixer v0.0.0-20160118172347-395022866408 h1:Y9iQJfEqnN3/Nce9cOegemcy/9Ai5k3huT6E80F3zaw=
 github.com/goware/prefixer v0.0.0-20160118172347-395022866408/go.mod h1:PE1ycukgRPJ7bJ9a1fdfQ9j8i/cEcRAoLZzbxYpNB/s=
-github.com/gowebpki/jcs v1.0.1 h1:Qjzg8EOkrOTuWP7DqQ1FbYtcpEbeTzUoTN9bptp8FOU=
-github.com/gowebpki/jcs v1.0.1/go.mod h1:CID1cNZ+sHp1CCpAR8mPf6QRtagFBgPJE0FCUQ6+BrI=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/internal/cli/capability_test.go
+++ b/internal/cli/capability_test.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -159,6 +160,17 @@ func TestRunCertPoolRegistration_InvalidMargin(t *testing.T) {
 	assert.Contains(t, err.Error(), "margin")
 }
 
+func TestRunCertPoolRegistration_RejectsNonFiniteMargins(t *testing.T) {
+	for _, margin := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+		err := RunCertPoolRegistration(
+			"cold.vkey", "vrf.vkey", goldenStakeAddr, "",
+			1, 1, margin, "", "",
+		)
+		require.Error(t, err, "margin %v", margin)
+		assert.Contains(t, err.Error(), "margin", "margin %v", margin)
+	}
+}
+
 func TestRunCertPoolRegistration_MetadataPairing(t *testing.T) {
 	err := RunCertPoolRegistration(
 		"cold.vkey", "vrf.vkey", goldenStakeAddr, "",
@@ -273,9 +285,23 @@ func TestFloatToRational(t *testing.T) {
 		{0.0001, 1, 10000},
 	}
 	for _, tc := range tests {
-		num, denom := floatToRational(tc.in)
+		num, denom, err := floatToRational(tc.in)
+		require.NoError(t, err)
 		assert.Equal(t, tc.wantNum, num, "num for %v", tc.in)
 		assert.Equal(t, tc.wantDenom, denom, "denom for %v", tc.in)
+	}
+}
+
+func TestFloatToRationalRejectsInvalidMargins(t *testing.T) {
+	for _, margin := range []float64{-0.01, 1.01, math.NaN(), math.Inf(1), math.Inf(-1)} {
+		_, _, err := floatToRational(margin)
+		require.Error(t, err, "margin %v", margin)
+		assert.EqualError(
+			t,
+			err,
+			"pool margin must be a finite value between 0.0 and 1.0",
+			"margin %v",
+		)
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -35,7 +35,6 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/btcsuite/btcd/btcutil/bech32"
-	"github.com/gowebpki/jcs"
 	"golang.org/x/crypto/blake2b"
 	"golang.org/x/sync/errgroup"
 )
@@ -1135,11 +1134,9 @@ func RunCertPoolRegistration(
 	marginFloat float64,
 	metadataURL, metadataHash string,
 ) error {
-	// Validate margin is within [0, 1]
-	if marginFloat < 0 || marginFloat > 1 {
-		return errors.New(
-			"pool margin must be between 0.0 and 1.0",
-		)
+	marginNum, marginDenom, err := floatToRational(marginFloat)
+	if err != nil {
+		return err
 	}
 
 	// Validate metadata URL and hash are provided together
@@ -1197,9 +1194,6 @@ func RunCertPoolRegistration(
 			err,
 		)
 	}
-
-	// Convert margin float to rational number
-	marginNum, marginDenom := floatToRational(marginFloat)
 
 	// Build pool registration certificate
 	cert := &bursa.PoolRegistrationCertificate{
@@ -1423,14 +1417,20 @@ func parseVRFVerificationKey(data []byte) ([]byte, error) {
 
 // floatToRational converts a floating-point margin to a rational
 // number (numerator/denominator) with reasonable precision.
-func floatToRational(f float64) (int64, int64) {
+func floatToRational(f float64) (int64, int64, error) {
+	if math.IsNaN(f) || math.IsInf(f, 0) || f < 0 || f > 1 {
+		return 0, 0, errors.New(
+			"pool margin must be a finite value between 0.0 and 1.0",
+		)
+	}
+
 	// Use 10000 as denominator for pool margins
 	// This gives 0.01% precision which is sufficient
 	const denom = 10000
 	num := int64(math.Round(f * denom))
 	// Simplify if possible
 	g := gcd(abs64(num), denom)
-	return num / g, denom / g
+	return num / g, denom / g, nil
 }
 
 func gcd(a, b int64) int64 {
@@ -2449,7 +2449,10 @@ func parseBech32VerificationKey(
 	return hash, nil
 }
 
-// RunHashMetadata generates a Blake2b-256 hash of metadata JSON file
+// RunHashMetadata generates a Blake2b-256 hash of the metadata file bytes.
+// Cardano commits to the exact bytes hosted at the metadata URL; callers that
+// want canonical JSON must write that canonical representation before calling
+// this function.
 func RunHashMetadata(filePath, metadataType string) error {
 	logger := logging.GetLogger()
 
@@ -2464,20 +2467,13 @@ func RunHashMetadata(filePath, metadataType string) error {
 		return errors.New("invalid JSON in metadata file")
 	}
 
-	// For Cardano metadata, we need to canonicalize the JSON using RFC 8785 (JCS)
-	// This ensures consistent ordering and formatting for reproducible hashing
-	canonicalJSON, err := jcs.Transform(data)
-	if err != nil {
-		return fmt.Errorf("failed to canonicalize JSON using RFC 8785: %w", err)
-	}
-
 	// Generate Blake2b-256 hash
 	hash, err := blake2b.New256(nil)
 	if err != nil {
 		return fmt.Errorf("failed to create Blake2b hasher: %w", err)
 	}
 
-	_, err = hash.Write(canonicalJSON)
+	_, err = hash.Write(data)
 	if err != nil {
 		return fmt.Errorf("failed to hash metadata: %w", err)
 	}

--- a/internal/cli/hash_test.go
+++ b/internal/cli/hash_test.go
@@ -90,13 +90,14 @@ func TestRunHashMetadata(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestRunHashMetadataCanonicalization(t *testing.T) {
+func TestRunHashMetadataPreservesFileBytes(t *testing.T) {
 	// Create a temporary directory for test files
 	tempDir, err := os.MkdirTemp("", "bursa-hash-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempDir)
 
-	// Test that different JSON formatting produces the same hash
+	// Cardano hashes the bytes of the hosted metadata file. Formatting changes
+	// therefore change the digest, even when both files decode to the same JSON.
 	metadata1 := `{"name":"Test","value":123}`
 	metadata2 := `{
 		"name": "Test",
@@ -122,8 +123,7 @@ func TestRunHashMetadataCanonicalization(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	// Both should produce the same hash due to canonicalization
-	assert.Equal(t, hash1, hash2, "Canonicalization should produce identical hashes for semantically equivalent JSON")
+	assert.NotEqual(t, hash1, hash2, "Metadata hashing must include the file's exact bytes")
 }
 
 func TestRunHashMetadataErrors(t *testing.T) {
@@ -168,6 +168,6 @@ func TestRunHashMetadataKnownHash(t *testing.T) {
 	})
 
 	// Verify the hash matches the expected value
-	expectedHash := "d7157feba618cc73df1d0cace17e12b27a5a4354c9272ca6d030496fc2556133"
+	expectedHash := "8daf56b8e2174d97fbf3928f89b69195194e6b592b01d176bfb3a048211f5e2d"
 	assert.Equal(t, expectedHash, hash, "Hash should match expected Blake2b-256 value")
 }

--- a/ui/internal/poolops/poolops.go
+++ b/ui/internal/poolops/poolops.go
@@ -290,10 +290,10 @@ type MetadataResult struct {
 	HashHex string `json:"hash_hex"`
 }
 
-// buildMetadata canonicalizes the metadata to RFC 8785 (JCS) JSON and hashes it
-// with Blake2b-256, mirroring the parent bursa CLI's RunHashMetadata. Marshaling
-// the struct directly keeps the field set well-formed; JCS then fixes ordering
-// and formatting so the hash is reproducible.
+// buildMetadata canonicalizes the metadata to RFC 8785 (JCS) JSON and hashes
+// those exact output bytes with Blake2b-256. The parent bursa CLI hashes file
+// bytes as supplied; returning the canonical JSON here makes the bytes an
+// intentional, reproducible hosting contract.
 func buildMetadata(in MetadataInput) (MetadataResult, error) {
 	in.Name = strings.TrimSpace(in.Name)
 	in.Ticker = strings.TrimSpace(in.Ticker)


### PR DESCRIPTION
## Summary

- Hash validated metadata using its exact file/wire bytes.
- Document the distinct metadata hash domains in CLI and UI paths.
- Reject NaN, infinite, negative, and greater-than-one pool margins deterministically.
- Remove the unused root JCS dependency.

## Validation

- Focused CLI race tests and Cardano CLI compatibility tests passed.
- CLI vet, module tidy, and diff checks passed.

Direct lower-level certificate callers and broader release adoption remain separate scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes metadata hashing to use the exact file bytes instead of canonicalized JSON, and tightens pool margin validation. The CLI no longer runs JCS canonicalization before hashing, so formatting changes now change the digest. Pool margins now reject NaN, infinite, negative, and greater-than-one values deterministically. Removes the unused `jcs` dependency.

<sup>Written for commit afc2ea31634b0b461151db4331a44a741c644826. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

