### PR TITLE
fix(ui): encode full CBOR length heads

### DIFF
--- a/ui/web/src/hw/cose.test.ts
+++ b/ui/web/src/hw/cose.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { encodeCoseSign1, encodeCoseKey } from "./cose";
+import { cborUintHead, encodeCoseSign1, encodeCoseKey } from "./cose";
 
 // Ground-truth vectors produced INDEPENDENTLY by the `cbor` library's canonical
 // encoder for the same inputs — the hand-rolled encoder in cose.ts must match
@@ -60,6 +60,39 @@ describe("encodeCoseSign1", () => {
     expect(out).toContain(PAYLOAD_HEX);
     expect(out).toContain(SIGNATURE_HEX);
   });
+
+  test("encodes a payload at the uint32 boundary", () => {
+    const payloadHex = "ab".repeat(65536);
+    const out = encodeCoseSign1(ADDRESS_HEX, payloadHex, SIGNATURE_HEX);
+
+    expect(out).toContain("5a00010000" + payloadHex);
+  });
+});
+
+describe("cborUintHead", () => {
+  test.each([
+    [0, "00"],
+    [23, "17"],
+    [24, "1818"],
+    [255, "18ff"],
+    [256, "190100"],
+    [65535, "19ffff"],
+    [65536, "1a00010000"],
+    [0xffffffff, "1affffffff"],
+    [0x100000000, "1b0000000100000000"],
+    [Number.MAX_SAFE_INTEGER, "1b001fffffffffffff"],
+  ] as const)("encodes %s canonically", (value, expected) => {
+    expect(cborUintHead(value)).toEqual(
+      expected.match(/../g)!.map((byte) => parseInt(byte, 16)),
+    );
+  });
+
+  test.each([-1, Number.NaN, Number.POSITIVE_INFINITY, 1.5, 2 ** 53])(
+    "rejects unsafe or invalid value %s",
+    (value) => {
+      expect(() => cborUintHead(value)).toThrow(RangeError);
+    },
+  );
 });
 
 describe("encodeCoseKey", () => {

--- a/ui/web/src/hw/cose.ts
+++ b/ui/web/src/hw/cose.ts
@@ -35,11 +35,38 @@ const COSE_KTY_OKP = 1;
 const COSE_CRV_ED25519 = 6;
 
 /** Encode a non-negative integer as a CBOR unsigned-int head (major type 0). */
-function cborUintHead(n: number): number[] {
+export function cborUintHead(n: number): number[] {
+  if (!Number.isSafeInteger(n) || n < 0) {
+    throw new RangeError(`cborUintHead: ${n} is not a safe non-negative integer`);
+  }
   if (n < 24) return [n];
-  if (n < 256) return [0x18, n];
-  if (n < 65536) return [0x19, n >> 8, n & 0xff];
-  throw new RangeError(`cborUintHead: ${n} is too large`);
+  if (n <= 0xff) return [0x18, n];
+  if (n <= 0xffff) return [0x19, n >> 8, n & 0xff];
+  if (n <= 0xffffffff) {
+    return [
+      0x1a,
+      (n >>> 24) & 0xff,
+      (n >>> 16) & 0xff,
+      (n >>> 8) & 0xff,
+      n & 0xff,
+    ];
+  }
+
+  // JavaScript numbers are exact through 2^53 - 1. BigInt lets us split
+  // that exact value into the eight bytes required by CBOR additional info
+  // 27 without using lossy bitwise operations on a Number.
+  const wide = BigInt(n);
+  return [
+    0x1b,
+    Number((wide >> 56n) & 0xffn),
+    Number((wide >> 48n) & 0xffn),
+    Number((wide >> 40n) & 0xffn),
+    Number((wide >> 32n) & 0xffn),
+    Number((wide >> 24n) & 0xffn),
+    Number((wide >> 16n) & 0xffn),
+    Number((wide >> 8n) & 0xffn),
+    Number(wide & 0xffn),
+  ];
 }
 
 /** Encode a small negative integer (CBOR major type 1: value = -1 - arg). */


### PR DESCRIPTION
## Summary

- Encode canonical CBOR length heads through the safe integer range.
- Reject negative, fractional, non-finite, and unsafe numeric lengths.
- Add boundary vectors and a large COSE_Sign1 regression.

## Validation

- Focused COSE tests passed.
- Full UI tests, type-check, lint, and production build passed.

Hardware-device runtime validation remains outside this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CBOR unsigned-int length head encoding so COSE payloads larger than 65,535 bytes now encode correctly instead of throwing a RangeError. Invalid lengths (negative, fractional, non-finite, or unsafe) are rejected with a RangeError; hardware-device runtime validation remains outside this change.

**Validation**
- Adds boundary test vectors from 0 to `Number.MAX_SAFE_INTEGER`.
- Adds a uint32-boundary regression for a 65,536-byte payload.

<sup>Written for commit 300e333a9dcb40f7b3e9f2cc4f1af7d837c0fd69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

