### PR TITLE
test(extension): cover provider method contracts

### DIFF
--- a/ui/extension/e2e/README.md
+++ b/ui/extension/e2e/README.md
@@ -83,8 +83,12 @@ python3 -m http.server 8080 --directory ui/extension/e2e
 # then navigate to http://localhost:8080/sample-dapp.html
 ```
 
-You can also open it as a `file://` URL, but only after enabling
-**Allow access to file URLs** for the Bursa extension in `chrome://extensions`.
+Use the HTTP server for this test. Do not open the sample as a `file://` URL:
+file pages have an opaque (`null`) origin, and the Bursa connector accepts only
+an exact `http://` or `https://` origin with a host and no path, query,
+fragment, or user information. Enabling **Allow access to file URLs** lets the
+extension inject into the page, but it does not make the page origin valid for
+connector authorization.
 
 After the page loads you should see:
 
@@ -106,13 +110,13 @@ Work through the buttons top-to-bottom:
 | `getExtensions()` | Returns `[{ "cip": 95 }]` |
 | `getNetworkId()` | Returns `0` (testnet) or `1` (mainnet) |
 | `getBalance()` | Returns a CBOR-hex encoded `Value` |
-| `getUsedAddresses()` | Returns an array of bech32 addresses (may be empty) |
-| `getUnusedAddresses()` | Returns an array of bech32 addresses |
-| `getChangeAddress()` | Returns a single bech32 address |
-| `getRewardAddresses()` | Returns an array of reward (stake) addresses |
+| `getUsedAddresses()` | Returns an array of hex-encoded raw address bytes (may be empty) |
+| `getUnusedAddresses()` | Returns an array of hex-encoded raw address bytes |
+| `getChangeAddress()` | Returns one hex-encoded raw address |
+| `getRewardAddresses()` | Returns an array of hex-encoded raw reward (stake) address bytes |
 | `getUtxos()` | Returns an array of CBOR-hex encoded UTxOs (may be null) |
 | `getCollateral()` | Returns an array of CBOR-hex UTxOs (may be empty) |
-| `signData(addr, payload)` | Bursa shows a **Sign Data** prompt; accept it. Returns `{ signature, key }`. |
+| `signData(addr, payload)` | Pass the hex address returned by an address method. Bursa shows a **Sign Data** prompt; accept it. Returns `{ signature, key }`. |
 | `signTx(dummyTx)` | Bursa shows a **Sign Transaction** prompt; accept it. The dummy tx is invalid so Bursa may return an error after the prompt — that is expected. |
 | `submitTx(dummyTx)` | Expected to fail with a Bursa/node error (dummy tx is not valid). Verifies the call reaches the daemon. |
 | `cip95.getPubDRepKey()` | Returns a hex-encoded DRep public key |

--- a/ui/extension/src/injected.ts
+++ b/ui/extension/src/injected.ts
@@ -38,7 +38,7 @@ interface CIP30API {
   getNetworkId(): Promise<number>;
   getUtxos(amount?: string, paginate?: Paginate): Promise<string[] | null>;
   getBalance(): Promise<string>;
-  getCollateral(params?: { amount: string }): Promise<string[]>;
+  getCollateral(params?: { amount: string }): Promise<string[] | null>;
   getUsedAddresses(paginate?: Paginate): Promise<string[]>;
   getUnusedAddresses(): Promise<string[]>;
   getChangeAddress(): Promise<string>;

--- a/ui/extension/tests/injected.test.ts
+++ b/ui/extension/tests/injected.test.ts
@@ -16,8 +16,20 @@ interface TestExtension {
 interface TestCIP30API {
   getExtensions(): Promise<TestExtension[]>;
   getNetworkId(): Promise<number>;
+  getUtxos(amount?: string, paginate?: { page: number; limit: number }): Promise<string[] | null>;
+  getBalance(): Promise<string>;
+  getCollateral(params?: { amount: string }): Promise<string[]>;
+  getUsedAddresses(paginate?: { page: number; limit: number }): Promise<string[]>;
+  getUnusedAddresses(): Promise<string[]>;
+  getChangeAddress(): Promise<string>;
+  getRewardAddresses(): Promise<string[]>;
+  signTx(tx: string, partialSign?: boolean): Promise<string>;
+  signData(addr: string, payload: string): Promise<{ signature: string; key: string }>;
+  submitTx(tx: string): Promise<string>;
   cip95?: {
     getPubDRepKey(): Promise<string>;
+    getRegisteredPubStakeKeys(): Promise<string[]>;
+    getUnregisteredPubStakeKeys(): Promise<string[]>;
   };
 }
 
@@ -25,6 +37,42 @@ interface TestProvider {
   apiVersion: string;
   supportedExtensions: TestExtension[];
   enable(options?: { extensions?: TestExtension[] }): Promise<TestCIP30API>;
+}
+
+type PostedRequest = {
+  id: string;
+  method: string;
+  params: unknown;
+};
+
+async function enableProvider(
+  postMessageSpy: ReturnType<typeof vi.spyOn>,
+  options?: { extensions?: TestExtension[] },
+): Promise<TestCIP30API> {
+  const provider = window.cardano?.bursa as TestProvider;
+  const enablePromise = provider.enable(options);
+  const enableCall = postMessageSpy.mock.calls.at(-1)?.[0] as PostedRequest;
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { source: 'bursa-cip30-reply', id: enableCall.id, result: true },
+      source: window,
+    }),
+  );
+  return enablePromise;
+}
+
+function replyToLatestRequest(
+  postMessageSpy: ReturnType<typeof vi.spyOn>,
+  result: unknown,
+): PostedRequest {
+  const call = postMessageSpy.mock.calls.at(-1)?.[0] as PostedRequest;
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { source: 'bursa-cip30-reply', id: call.id, result },
+      source: window,
+    }),
+  );
+  return call;
 }
 
 describe('injected provider', () => {
@@ -312,5 +360,149 @@ describe('injected provider', () => {
     );
 
     await expect(isEnabledPromise).resolves.toBe(false);
+  });
+
+  it('forwards every CIP-30 method with its contract parameters', async () => {
+    const postMessageSpy = vi.spyOn(window, 'postMessage');
+    const api = await enableProvider(postMessageSpy);
+    postMessageSpy.mockClear();
+
+    const cases: Array<{
+      name: string;
+      invoke: () => Promise<unknown>;
+      method: string;
+      params: unknown;
+      result: unknown;
+    }> = [
+      {
+        name: 'getNetworkId',
+        invoke: () => api.getNetworkId(),
+        method: 'getNetworkId',
+        params: undefined,
+        result: 1,
+      },
+      {
+        name: 'getUtxos',
+        invoke: () => api.getUtxos('100', { page: 2, limit: 3 }),
+        method: 'getUtxos',
+        params: { amount: '100', paginate: { page: 2, limit: 3 } },
+        result: ['utxo'],
+      },
+      {
+        name: 'getBalance',
+        invoke: () => api.getBalance(),
+        method: 'getBalance',
+        params: undefined,
+        result: 'balance-cbor',
+      },
+      {
+        name: 'getCollateral',
+        invoke: () => api.getCollateral({ amount: '42' }),
+        method: 'getCollateral',
+        params: { amount: '42' },
+        result: ['collateral'],
+      },
+      {
+        name: 'getUsedAddresses',
+        invoke: () => api.getUsedAddresses({ page: 1, limit: 5 }),
+        method: 'getUsedAddresses',
+        params: { paginate: { page: 1, limit: 5 } },
+        result: ['used-address'],
+      },
+      {
+        name: 'getUnusedAddresses',
+        invoke: () => api.getUnusedAddresses(),
+        method: 'getUnusedAddresses',
+        params: undefined,
+        result: ['unused-address'],
+      },
+      {
+        name: 'getChangeAddress',
+        invoke: () => api.getChangeAddress(),
+        method: 'getChangeAddress',
+        params: undefined,
+        result: 'change-address',
+      },
+      {
+        name: 'getRewardAddresses',
+        invoke: () => api.getRewardAddresses(),
+        method: 'getRewardAddresses',
+        params: undefined,
+        result: ['reward-address'],
+      },
+      {
+        name: 'signTx',
+        invoke: () => api.signTx('tx-cbor', true),
+        method: 'signTx',
+        params: { tx: 'tx-cbor', partialSign: true },
+        result: 'witness-cbor',
+      },
+      {
+        name: 'signData',
+        invoke: () => api.signData('address', 'payload-cbor'),
+        method: 'signData',
+        params: { addr: 'address', payload: 'payload-cbor' },
+        result: { signature: 'signature', key: 'key' },
+      },
+      {
+        name: 'submitTx',
+        invoke: () => api.submitTx('tx-cbor'),
+        method: 'submitTx',
+        params: { tx: 'tx-cbor' },
+        result: 'tx-hash',
+      },
+    ];
+
+    for (const testCase of cases) {
+      const resultPromise = testCase.invoke();
+      const call = postMessageSpy.mock.calls.at(-1)?.[0] as PostedRequest;
+      expect(call, testCase.name).toMatchObject({
+        source: 'bursa-cip30',
+        method: testCase.method,
+      });
+      expect(call.params, testCase.name).toEqual(testCase.params);
+      replyToLatestRequest(postMessageSpy, testCase.result);
+      await expect(resultPromise, testCase.name).resolves.toEqual(testCase.result);
+    }
+  });
+
+  it('forwards every negotiated CIP-95 method and returns its result', async () => {
+    const postMessageSpy = vi.spyOn(window, 'postMessage');
+    const api = await enableProvider(postMessageSpy, { extensions: [{ cip: 95 }] });
+    postMessageSpy.mockClear();
+
+    const cases: Array<{
+      invoke: () => Promise<unknown>;
+      method: string;
+      result: unknown;
+    }> = [
+      {
+        invoke: () => api.cip95!.getPubDRepKey(),
+        method: 'cip95.getPubDRepKey',
+        result: 'drep-key',
+      },
+      {
+        invoke: () => api.cip95!.getRegisteredPubStakeKeys(),
+        method: 'cip95.getRegisteredPubStakeKeys',
+        result: ['registered-key'],
+      },
+      {
+        invoke: () => api.cip95!.getUnregisteredPubStakeKeys(),
+        method: 'cip95.getUnregisteredPubStakeKeys',
+        result: ['unregistered-key'],
+      },
+    ];
+
+    for (const testCase of cases) {
+      const resultPromise = testCase.invoke();
+      const call = postMessageSpy.mock.calls.at(-1)?.[0] as PostedRequest;
+      expect(call).toMatchObject({
+        source: 'bursa-cip30',
+        method: testCase.method,
+        params: undefined,
+      });
+      replyToLatestRequest(postMessageSpy, testCase.result);
+      await expect(resultPromise).resolves.toEqual(testCase.result);
+    }
   });
 });

--- a/ui/extension/tests/injected.test.ts
+++ b/ui/extension/tests/injected.test.ts
@@ -18,7 +18,7 @@ interface TestCIP30API {
   getNetworkId(): Promise<number>;
   getUtxos(amount?: string, paginate?: { page: number; limit: number }): Promise<string[] | null>;
   getBalance(): Promise<string>;
-  getCollateral(params?: { amount: string }): Promise<string[]>;
+  getCollateral(params?: { amount: string }): Promise<string[] | null>;
   getUsedAddresses(paginate?: { page: number; limit: number }): Promise<string[]>;
   getUnusedAddresses(): Promise<string[]>;
   getChangeAddress(): Promise<string>;
@@ -80,6 +80,48 @@ describe('injected provider', () => {
     vi.restoreAllMocks();
     jsdomEnv.jsdom.reconfigure({ url: 'https://dapp.example/' });
   });
+
+  async function enableWithCIP95(
+    postMessageSpy: ReturnType<typeof vi.spyOn>,
+  ): Promise<TestCIP30API> {
+    const provider = window.cardano?.bursa as TestProvider;
+    const enablePromise = provider.enable({ extensions: [{ cip: 95 }] });
+    const enableCall = postMessageSpy.mock.calls[0][0] as { id: string };
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { source: 'bursa-cip30-reply', id: enableCall.id, result: true },
+        source: window,
+      }),
+    );
+    return enablePromise;
+  }
+
+  async function resolveProviderRequest<T>(
+    postMessageSpy: ReturnType<typeof vi.spyOn>,
+    request: () => Promise<T>,
+    method: string,
+    params: unknown,
+    result: T,
+  ): Promise<void> {
+    postMessageSpy.mockClear();
+    const responsePromise = request();
+    const call = postMessageSpy.mock.calls[0][0] as {
+      source: string;
+      id: string;
+      method: string;
+      params: unknown;
+    };
+    expect(call.source).toBe('bursa-cip30');
+    expect(call.method).toBe(method);
+    expect(call.params).toEqual(params);
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { source: 'bursa-cip30-reply', id: call.id, result },
+        source: window,
+      }),
+    );
+    await expect(responsePromise).resolves.toEqual(result);
+  }
 
   it('sets window.cardano.bursa with name === "Bursa"', () => {
     expect(window.cardano?.bursa).toBeDefined();
@@ -145,6 +187,99 @@ describe('injected provider', () => {
     const api = await enablePromise;
     await expect(api.getExtensions()).resolves.toEqual([]);
     expect(api.cip95).toBeUndefined();
+  });
+
+  it('forwards and resolves every CIP-30 and enabled CIP-95 method', async () => {
+    const postMessageSpy = vi.spyOn(window, 'postMessage');
+    const api = await enableWithCIP95(postMessageSpy);
+    const paginate = { page: 0, limit: 2 };
+
+    await resolveProviderRequest(postMessageSpy, api.getNetworkId, 'getNetworkId', undefined, 0);
+    await resolveProviderRequest(
+      postMessageSpy,
+      () => api.getUtxos('a1', paginate),
+      'getUtxos',
+      { amount: 'a1', paginate },
+      ['utxo-cbor'],
+    );
+    await resolveProviderRequest(postMessageSpy, api.getBalance, 'getBalance', undefined, 'balance-cbor');
+    await resolveProviderRequest(
+      postMessageSpy,
+      () => api.getCollateral({ amount: 'collateral-amount' }),
+      'getCollateral',
+      { amount: 'collateral-amount' },
+      null,
+    );
+    await resolveProviderRequest(
+      postMessageSpy,
+      () => api.getUsedAddresses(paginate),
+      'getUsedAddresses',
+      { paginate },
+      ['used-address'],
+    );
+    await resolveProviderRequest(
+      postMessageSpy,
+      api.getUnusedAddresses,
+      'getUnusedAddresses',
+      undefined,
+      ['unused-address'],
+    );
+    await resolveProviderRequest(
+      postMessageSpy,
+      api.getChangeAddress,
+      'getChangeAddress',
+      undefined,
+      'change-address',
+    );
+    await resolveProviderRequest(
+      postMessageSpy,
+      api.getRewardAddresses,
+      'getRewardAddresses',
+      undefined,
+      ['reward-address'],
+    );
+    await resolveProviderRequest(
+      postMessageSpy,
+      () => api.signTx('transaction-cbor', true),
+      'signTx',
+      { tx: 'transaction-cbor', partialSign: true },
+      'witness-set-cbor',
+    );
+    await resolveProviderRequest(
+      postMessageSpy,
+      () => api.signData('address-bytes', 'payload-bytes'),
+      'signData',
+      { addr: 'address-bytes', payload: 'payload-bytes' },
+      { signature: 'signature-cbor', key: 'key-cbor' },
+    );
+    await resolveProviderRequest(
+      postMessageSpy,
+      () => api.submitTx('signed-transaction-cbor'),
+      'submitTx',
+      { tx: 'signed-transaction-cbor' },
+      'transaction-id',
+    );
+    await resolveProviderRequest(
+      postMessageSpy,
+      api.cip95!.getPubDRepKey,
+      'cip95.getPubDRepKey',
+      undefined,
+      'drep-key',
+    );
+    await resolveProviderRequest(
+      postMessageSpy,
+      api.cip95!.getRegisteredPubStakeKeys,
+      'cip95.getRegisteredPubStakeKeys',
+      undefined,
+      ['registered-stake-key'],
+    );
+    await resolveProviderRequest(
+      postMessageSpy,
+      api.cip95!.getUnregisteredPubStakeKeys,
+      'cip95.getUnregisteredPubStakeKeys',
+      undefined,
+      ['unregistered-stake-key'],
+    );
   });
 
   it('postMessage shape: getNetworkId posts correct message', async () => {

--- a/ui/internal/connector/grants_test.go
+++ b/ui/internal/connector/grants_test.go
@@ -48,6 +48,9 @@ func TestGrantStoreRejectsInvalidOrigins(t *testing.T) {
 		" ",
 		"unknown",
 		"https://a.io/path",
+		"http://localhost:8080/sample-dapp.html",
+		"file:///tmp/sample-dapp.html",
+		"null",
 		"https://user@example.com",
 		"https://user:pass@example.com",
 		"chrome-extension://abc",
@@ -61,6 +64,21 @@ func TestGrantStoreRejectsInvalidOrigins(t *testing.T) {
 	}
 	if got := g.List(); len(got) != 0 {
 		t.Fatalf("invalid grants persisted in memory: %v", got)
+	}
+}
+
+func TestGrantStoreAcceptsExactHTTPOrigins(t *testing.T) {
+	g := NewGrantStore(filepath.Join(t.TempDir(), "grants.json"))
+	for _, origin := range []string{
+		"http://localhost:8080",
+		"https://dapp.example",
+	} {
+		if err := g.Grant(origin); err != nil {
+			t.Fatalf("Grant(%q) err = %v, want success", origin, err)
+		}
+		if !g.IsGranted(origin) {
+			t.Fatalf("origin %q was not granted", origin)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Cover forwarding and results for all CIP-30 provider methods.
- Cover all CIP-95 methods and negotiated API behavior.
- Verify method names and parameters at the provider boundary.

## Validation

- Extension tests, type-check, lint, and build pass.
- Restrictive-CSP Chromium E2E was attempted but failed before provider registration; no browser-runtime result is claimed.

This adds contract coverage without changing production behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds contract tests for all CIP-30 and CIP-95 provider methods, verifying method names, parameters, and forwarded results at the extension boundary. `getCollateral` now returns `null` per the CIP-30 contract, and the E2E guide and grant-store tests now document and enforce exact HTTP(S) origins (rejecting `file://`, paths, and non-HTTP URLs).

<sup>Written for commit ce9a6038855648a1a93a99d41dc6eacae1b52117. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

