### PR TITLE
ci: remove Go 1.25 from Bursa workflows

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.25.x, 1.26.x]
+        go-version: [1.26.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     services:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0 https://github.com/golangci/golangci-lint-action/releases/tag/v9.3.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,7 +123,7 @@ jobs:
           fetch-depth: '0'
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: Build binary
         run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
 

--- a/ui/web/src/hw/keystone.test.ts
+++ b/ui/web/src/hw/keystone.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
+import type { Mock } from "vitest";
 import {
   CardanoSignature,
   CryptoMultiAccounts,
@@ -49,11 +50,11 @@ vi.mock("@keystonehq/hw-transport-webusb", () => ({
 vi.mock("@keystonehq/hw-app-ada", () => ({
   // The neutral→SDK mapping references these enums; concrete values are
   // irrelevant to the witness parity we assert, so stand-ins suffice.
-  default: vi.fn().mockImplementation(() => ({
-    getAppConfig: mockGetAppConfig,
-    getExtendedPublicKeys: mockGetXpubs,
-    signTransaction: mockSignTx,
-  })),
+  default: class MockAda {
+    getAppConfig = mockGetAppConfig;
+    getExtendedPublicKeys = mockGetXpubs;
+    signTransaction = mockSignTx;
+  },
   AddressType: { BASE_PAYMENT_KEY_STAKE_KEY: 0 },
   TransactionSigningMode: { ORDINARY_TRANSACTION: "ordinary_transaction" },
   TxOutputDestinationType: { DEVICE_OWNED: "device_owned", THIRD_PARTY: "third_party" },
@@ -165,10 +166,10 @@ function signatureCborHex(
   return Buffer.from(sig.toUR().cbor).toString("hex");
 }
 
-function makeBridge(): KeystoneQRBridge & {
-  displayRequest: ReturnType<typeof vi.fn>;
-  scanResponse: ReturnType<typeof vi.fn>;
-  close: ReturnType<typeof vi.fn>;
+function makeBridge(): Omit<KeystoneQRBridge, "displayRequest" | "scanResponse" | "close"> & {
+  displayRequest: Mock<KeystoneQRBridge["displayRequest"]>;
+  scanResponse: Mock<KeystoneQRBridge["scanResponse"]>;
+  close: Mock<KeystoneQRBridge["close"]>;
 } {
   return {
     displayRequest: vi.fn(),

--- a/ui/web/src/hw/ledger.test.ts
+++ b/ui/web/src/hw/ledger.test.ts
@@ -32,12 +32,13 @@ const {
     addressFieldHex: "0011",
   });
 
-  const mockAdaInstance = {
-    getExtendedPublicKey: mockGetExtendedPublicKey,
-    signTransaction: mockSignTransaction,
-    signMessage: mockSignMessage,
-  };
-  const mockAdaConstructor = vi.fn().mockImplementation(() => mockAdaInstance);
+  const mockAdaConstructor = vi.fn(
+    class MockAda {
+      getExtendedPublicKey = mockGetExtendedPublicKey;
+      signTransaction = mockSignTransaction;
+      signMessage = mockSignMessage;
+    },
+  );
 
   return {
     mockTransport,
@@ -145,13 +146,13 @@ describe("connectLedger", () => {
       addressFieldHex: "0011",
     });
     mockTransport.close.mockResolvedValue(undefined);
-    // mockAdaConstructor still returns the hoisted mockAdaInstance with the
-    // now-cleared fns; restore default mock returns set above via the fns.
-    mockAdaConstructor.mockImplementation(() => ({
-      getExtendedPublicKey: mockGetExtendedPublicKey,
-      signTransaction: mockSignTransaction,
-      signMessage: mockSignMessage,
-    }));
+    mockAdaConstructor.mockImplementation(
+      class MockAda {
+        getExtendedPublicKey = mockGetExtendedPublicKey;
+        signTransaction = mockSignTransaction;
+        signMessage = mockSignMessage;
+      },
+    );
     setWebHID(true);
   });
 

--- a/ui/web/src/hw/seedsigner.test.ts
+++ b/ui/web/src/hw/seedsigner.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi } from "vitest";
+import type { Mock } from "vitest";
 import {
   connectSeedSigner,
   encodeAccountRequest,
@@ -103,10 +104,10 @@ function txSigResCborHex(pubHex: string, sigHex: string, requestId = "id"): stri
   return "a2" + "01" + cborTextHex(requestId) + "02" + witnessSet;
 }
 
-function makeBridge(): SeedSignerQRBridge & {
-  displayRequest: ReturnType<typeof vi.fn>;
-  scanResponse: ReturnType<typeof vi.fn>;
-  close: ReturnType<typeof vi.fn>;
+function makeBridge(): Omit<SeedSignerQRBridge, "displayRequest" | "scanResponse" | "close"> & {
+  displayRequest: Mock<SeedSignerQRBridge["displayRequest"]>;
+  scanResponse: Mock<SeedSignerQRBridge["scanResponse"]>;
+  close: Mock<SeedSignerQRBridge["close"]>;
 } {
   return {
     displayRequest: vi.fn(),

--- a/ui/web/src/notifications.test.ts
+++ b/ui/web/src/notifications.test.ts
@@ -27,7 +27,7 @@ import type { ActivityEvent } from "./api/types";
 class MockNotification {
   static instances: MockNotification[] = [];
   static permission: NotificationPermission = "default";
-  static requestPermission = vi.fn(async () => {
+  static requestPermission: () => Promise<NotificationPermission> = vi.fn(async () => {
     MockNotification.permission = "granted";
     return MockNotification.permission;
   });
@@ -45,7 +45,7 @@ class MockNotification {
 function installMockNotification(permission: NotificationPermission = "granted") {
   MockNotification.instances = [];
   MockNotification.permission = permission;
-  MockNotification.requestPermission = vi.fn(async () => {
+  MockNotification.requestPermission = vi.fn(async (): Promise<NotificationPermission> => {
     MockNotification.permission = "granted";
     return MockNotification.permission;
   });


### PR DESCRIPTION
## Summary

- Remove the Go 1.25 CI lane and use Go 1.26 for lint and release binaries.
- Keep hardware-wallet test doubles constructible under Vitest 5.
- Update QR bridge and notification test mocks for Vitest 5 type checking.

## Related

- #860


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the Go 1.25 CI lane so Bursa's workflows run on Go 1.26 only, and updates Vitest 5 test mocks to keep the UI test suite passing. Addresses #860.

- Go test, lint, and release workflows now use only Go 1.26.x.
- Hardware-wallet test doubles (Keystone, Ledger, SeedSigner) now use class-based mocks instead of object-returning `vi.fn()` calls.
- Notification test mocks give `requestPermission` an explicit `NotificationPermission` return type to satisfy Vitest 5 type checking.

<sup>Written for commit 8704d4ef87361b288c0b94625b9f2e3c6ea9629f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

