### PR TITLE
feat(ui): show curated token names, tickers and decimals from the registry

### DIFF
--- a/ui/internal/chain/blockfrost.go
+++ b/ui/internal/chain/blockfrost.go
@@ -272,6 +272,13 @@ type AssetInfo struct {
 	Fingerprint     string          `json:"fingerprint"`
 	Quantity        string          `json:"quantity"`
 	OnchainMetadata json.RawMessage `json:"onchain_metadata"`
+	// Metadata is the CIP-26 off-chain token-registry entry the node serves
+	// for this asset (name/description/ticker/url/logo/decimals; absent
+	// properties are omitted, and the whole field is null when the registry
+	// has nothing — the common case, since the node's registry sync is
+	// opt-in). Left as raw JSON for the same reason as OnchainMetadata: every
+	// property is optional, so callers parse defensively.
+	Metadata json.RawMessage `json:"metadata"`
 }
 
 const cip25MetadataLabel = 721

--- a/ui/internal/chain/blockfrost_test.go
+++ b/ui/internal/chain/blockfrost_test.go
@@ -1302,3 +1302,50 @@ func TestGovernanceActionsSkipsUnknownVoteKind(t *testing.T) {
 			got[0].YesVotes, got[0].NoVotes, got[0].AbstainVotes)
 	}
 }
+
+func TestAssetRegistryMetadata(t *testing.T) {
+	// The node serves the curated CIP-26 token-registry entry in `metadata`,
+	// separate from the minter's own `onchain_metadata`. Most registered
+	// fungible tokens carry no on-chain metadata at all, so this covers the
+	// realistic shape: a null onchain_metadata (which still runs the CIP-25
+	// enrichment path) alongside a populated registry entry that must survive it.
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"asset":"policy123746f6b656e","policy_id":"policy123","asset_name":"746f6b656e","asset_name_ascii":"token","fingerprint":"asset1xyz","quantity":"1000000","onchain_metadata":null,"metadata":{"name":"Curated Token","ticker":"CTK","decimals":6}}`))
+	})
+	got, err := c.Asset(context.Background(), "policy123746f6b656e")
+	if err != nil {
+		t.Fatalf("Asset: %v", err)
+	}
+	if got.Metadata == nil {
+		t.Fatalf("Metadata = nil, want the registry entry")
+	}
+	var reg struct {
+		Name     string `json:"name"`
+		Ticker   string `json:"ticker"`
+		Decimals int    `json:"decimals"`
+	}
+	if err := json.Unmarshal(got.Metadata, &reg); err != nil {
+		t.Fatalf("unmarshal Metadata: %v", err)
+	}
+	if reg.Name != "Curated Token" || reg.Ticker != "CTK" || reg.Decimals != 6 {
+		t.Fatalf("unexpected registry metadata: %+v", reg)
+	}
+}
+
+func TestAssetNilRegistryMetadata(t *testing.T) {
+	// The node's registry sync is opt-in, so an asset the registry knows
+	// nothing about (metadata: null) is the common case and must decode
+	// cleanly rather than erroring.
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"asset":"policy123746f6b656e","policy_id":"policy123","asset_name":"746f6b656e","asset_name_ascii":"token","fingerprint":"asset1xyz","quantity":"1000000","onchain_metadata":{"name":"Token"},"metadata":null}`))
+	})
+	got, err := c.Asset(context.Background(), "policy123746f6b656e")
+	if err != nil {
+		t.Fatalf("Asset: %v", err)
+	}
+	if string(got.Metadata) != "null" {
+		t.Fatalf("Metadata = %s, want the raw JSON null literal", got.Metadata)
+	}
+}

--- a/ui/web/src/api/hooks.test.tsx
+++ b/ui/web/src/api/hooks.test.tsx
@@ -178,6 +178,7 @@ function fakeAssetInfo(unit: string, name: string): AssetInfo {
     fingerprint: "",
     quantity: "0",
     onchain_metadata: { name },
+    metadata: null,
   };
 }
 

--- a/ui/web/src/api/types.ts
+++ b/ui/web/src/api/types.ts
@@ -363,6 +363,11 @@ export interface AssetInfo {
   fingerprint: string;
   quantity: string;
   onchain_metadata: Record<string, unknown> | null;
+  // metadata is the CIP-26 off-chain token-registry entry (curated: name,
+  // description, ticker, url, logo, decimals). Null when the registry has
+  // nothing for the asset, which is the common case — the node's registry
+  // sync is opt-in. Read defensively via ../tokenMeta.ts.
+  metadata: Record<string, unknown> | null;
 }
 
 export type VoteType = "abstain" | "no_confidence" | "drep" | "register_self";

--- a/ui/web/src/screens/Portfolio.test.tsx
+++ b/ui/web/src/screens/Portfolio.test.tsx
@@ -180,6 +180,7 @@ function makeAssetInfo(unit: string, metadata: Record<string, unknown> | null): 
     fingerprint: "",
     quantity: "0",
     onchain_metadata: metadata,
+    metadata: null,
   };
 }
 

--- a/ui/web/src/tokenMeta.test.ts
+++ b/ui/web/src/tokenMeta.test.ts
@@ -1,7 +1,7 @@
 import { extractAssetMeta, assetDisplayName, assetMatchesQuery } from "./tokenMeta";
 import type { AssetInfo } from "./api/types";
 
-function makeInfo(onchainMetadata: unknown): AssetInfo {
+function makeInfo(onchainMetadata: unknown, registryMetadata: unknown = null): AssetInfo {
   return {
     asset: "policy123746f6b656e",
     policy_id: "policy123",
@@ -10,6 +10,7 @@ function makeInfo(onchainMetadata: unknown): AssetInfo {
     fingerprint: "asset1xyz",
     quantity: "1000000",
     onchain_metadata: onchainMetadata as AssetInfo["onchain_metadata"],
+    metadata: registryMetadata as AssetInfo["metadata"],
   };
 }
 
@@ -94,4 +95,39 @@ test("assetMatchesQuery: matches by raw unit substring when there is no metadata
 
 test("assetMatchesQuery: no match returns false", () => {
   expect(assetMatchesQuery("unit1", { name: "Token" }, "nomatch")).toBe(false);
+});
+
+// --- CIP-26 off-chain token-registry metadata (AssetInfo.metadata) ---
+//
+// The node serves the curated registry entry in `metadata` alongside the
+// minter's self-declared `onchain_metadata`. The registry is the source of
+// truth for fungible-token ticker/decimals, so it wins where both declare a
+// value — getting decimals wrong misstates the holder's balance.
+
+test("extractAssetMeta: reads name/ticker/decimals from the registry metadata", () => {
+  const info = makeInfo(null, { name: "Registry Token", ticker: "RTK", decimals: 6 });
+  expect(extractAssetMeta(info)).toEqual({ name: "Registry Token", ticker: "RTK", decimals: 6 });
+});
+
+test("extractAssetMeta: registry metadata wins over on-chain for name/ticker/decimals", () => {
+  const info = makeInfo(
+    { name: "Minter Name", ticker: "BAD", decimals: 0 },
+    { name: "Curated Name", ticker: "GOOD", decimals: 6 },
+  );
+  expect(extractAssetMeta(info)).toEqual({ name: "Curated Name", ticker: "GOOD", decimals: 6 });
+});
+
+test("extractAssetMeta: honours a registry decimals of 0 (a real declaration)", () => {
+  const info = makeInfo({ decimals: 8 }, { decimals: 0 });
+  expect(extractAssetMeta(info).decimals).toBe(0);
+});
+
+test("extractAssetMeta: falls back to on-chain when registry metadata is null", () => {
+  const info = makeInfo({ name: "Token", ticker: "TOK", decimals: 2 }, null);
+  expect(extractAssetMeta(info)).toEqual({ name: "Token", ticker: "TOK", decimals: 2 });
+});
+
+test("extractAssetMeta: ignores a malformed registry metadata object", () => {
+  const info = makeInfo({ name: "Token" }, { name: 42, ticker: {}, decimals: "six" });
+  expect(extractAssetMeta(info)).toEqual({ name: "Token" });
 });

--- a/ui/web/src/tokenMeta.ts
+++ b/ui/web/src/tokenMeta.ts
@@ -14,31 +14,29 @@ export interface AssetDisplayMeta {
 }
 
 /**
- * Reads a handful of commonly-used on-chain-metadata keys defensively:
- * "name", "ticker" (or "symbol"), and "decimals" (number or numeric string).
- * Anything missing, null, or the wrong shape is silently ignored — a
- * malformed or absent metadata object must never break the Portfolio screen,
- * it just yields {} and callers fall back to the raw unit/quantity.
+ * Reads a handful of commonly-used metadata keys defensively: "name",
+ * "ticker" (or "symbol"), and "decimals" (number or numeric string).
+ * Anything missing, null, or the wrong shape is silently ignored.
  */
-export function extractAssetMeta(info: AssetInfo | undefined): AssetDisplayMeta {
-  const meta = info?.onchain_metadata;
+function readDisplayKeys(meta: unknown): AssetDisplayMeta {
   if (!meta || typeof meta !== "object") return {};
+  const source = meta as Record<string, unknown>;
 
   const result: AssetDisplayMeta = {};
 
-  const name = meta.name;
+  const name = source.name;
   if (typeof name === "string" && name.trim() !== "") {
     result.name = name.trim();
   }
 
-  for (const ticker of [meta.ticker, meta.symbol]) {
+  for (const ticker of [source.ticker, source.symbol]) {
     if (typeof ticker === "string" && ticker.trim() !== "") {
       result.ticker = ticker.trim();
       break;
     }
   }
 
-  const decimalsRaw = meta.decimals;
+  const decimalsRaw = source.decimals;
   if (typeof decimalsRaw === "number" && Number.isInteger(decimalsRaw) && decimalsRaw >= 0) {
     result.decimals = decimalsRaw;
   } else if (typeof decimalsRaw === "string" && /^\d+$/.test(decimalsRaw)) {
@@ -46,6 +44,30 @@ export function extractAssetMeta(info: AssetInfo | undefined): AssetDisplayMeta 
   }
 
   return result;
+}
+
+/**
+ * Display metadata for a native asset, merged from the two sources the node
+ * serves for it:
+ *
+ *   - `onchain_metadata` — the minter's own CIP-25/68 declaration.
+ *   - `metadata` — the curated CIP-26 off-chain token-registry entry.
+ *
+ * Merged per field, with the registry winning where both declare a value: the
+ * registry is reviewed, whereas on-chain metadata is whatever the minter wrote.
+ * That matters most for `decimals`, since a wrong value misstates the holder's
+ * balance. Per-field (rather than whole-object) precedence means a registry
+ * entry that declares only a ticker still keeps the on-chain name.
+ *
+ * Either source being absent, null, or malformed is normal — most assets have
+ * neither, and the node's registry sync is opt-in — so this yields {} and
+ * callers fall back to the raw unit/quantity.
+ */
+export function extractAssetMeta(info: AssetInfo | undefined): AssetDisplayMeta {
+  return {
+    ...readDisplayKeys(info?.onchain_metadata),
+    ...readDisplayKeys(info?.metadata),
+  };
 }
 
 /** Display label for a native asset: metadata name, else ticker, else the raw unit (policy id + hex asset name). */


### PR DESCRIPTION
## Summary
The node now serves the CIP-26 off-chain token-registry entry for an asset in the `metadata` field of `GET /assets/{asset}` (dingo v0.70.5, which `ui/` already pins). The wallet ignored that field. This carries it through and merges it into the display metadata the Portfolio token list already renders, so registered tokens show their curated **name, ticker and decimals** instead of a raw unit and unscaled quantity.

## Change
- `chain.AssetInfo` gains `Metadata json.RawMessage` (raw, like `OnchainMetadata` — every CIP-26 property is optional).
- The wallet's `AssetInfo` type gains `metadata`.
- `extractAssetMeta` now merges both sources **per field**, registry taking precedence.

No screen changes were needed: `assetDisplayName` and the quantity formatter already consume `extractAssetMeta`, so the values flow through.

## Why the registry wins
Registry entries are reviewed; on-chain metadata is whatever the minter wrote. It matters most for `decimals` — a wrong value misstates the holder's balance. Precedence is per field rather than whole-object, so a registry entry declaring only a ticker still keeps an on-chain name.

## Privacy
No new network access. This reads what the embedded node already serves — no per-asset lookup against an external metadata server, which would leak which tokens the holder owns. The `internal/boundary` consent-law test stays green.

## Degradation
Both sources stay optional and are parsed defensively. Most assets have neither, and the node's registry sync is opt-in, so `metadata: null` is the common case — absent or malformed entries fall back to the raw unit/quantity exactly as before.

## Tests
- 5 new `tokenMeta` cases: registry-only read, registry-wins precedence, a registry `decimals: 0` (a real declaration, not "absent"), fallback when `metadata` is null, and a malformed registry entry being ignored. Confirmed each fails against the old parser before the change.
- 2 new `chain` cases: the registry entry decoding on the realistic shape (null `onchain_metadata`, so it also proves the entry survives the CIP-25 enrichment path), and `metadata: null` decoding cleanly.
- Full suites: 870/870 web tests, `go test` chain/api/nft/boundary, `go vet`, nilaway — all clean.

## Note on screenshots
There is no standalone visual diff to capture: this is data plumbing, and the user-visible effect (a curated ticker and correctly scaled quantity on a token row) only appears against a node that has the opt-in registry sync enabled and populated. Happy to capture a Portfolio screenshot against such a node if you'd like one on the PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows CIP-26 token-registry names, tickers, and decimals in the portfolio. Previously the wallet ignored the registry `metadata` field the node serves, so registered tokens fell back to raw units and unscaled quantities; now that field is merged into the display metadata, with the registry taking precedence per field over the minter's on-chain metadata.

- Registry wins per field, so a curated ticker or decimals overrides on-chain values, while a registry entry with only a ticker keeps the on-chain name.
- No new network access; this reads the metadata the embedded node already serves.
- Both sources stay optional, so absent or malformed entries fall back to the raw unit and quantity exactly as before.

<sup>Written for commit 8d323c86d2ef6a67b147b2b9ecad4374f0bb7ceb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/bursa/pull/870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Asset information now includes optional token-registry metadata, such as name, ticker, decimals, description, URL, and logo.
  * Displayed asset details combine on-chain and registry metadata, prioritizing registry values when available.
  * Invalid or missing metadata is safely ignored, with on-chain information used as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->